### PR TITLE
Fixes #27942 - docker distributors have wrong base_path

### DIFF
--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -4,6 +4,10 @@ module Katello
   module Pulp3
     class Repository
       class Docker < ::Katello::Pulp3::Repository
+        def relative_path
+          repo.container_repository_name
+        end
+
         def remote_options
           options = {url: root.url, upstream_name: root.docker_upstream_name}
           if root.docker_tags_whitelist && root.docker_tags_whitelist.any?

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -148,7 +148,8 @@ module Katello
         dist_params[:publication] = options[:publication] if options[:publication]
         dist_params[:repository_version] = version_href if options[:use_repository_version]
         dist_options = distribution_options(path, dist_params)
-        if (distro = repo_service.lookup_distributions(base_path: path).first)
+        if (distro = repo_service.lookup_distributions(base_path: path).first) ||
+          (distro = repo_service.lookup_distributions(name: "#{backend_object_name}").first)
           # update dist
           dist_options = dist_options.except(:name, :base_path)
           api.distributions_api.partial_update(distro.pulp_href, dist_options)

--- a/test/actions/pulp3/orchestration/docker_delete_test.rb
+++ b/test/actions/pulp3/orchestration/docker_delete_test.rb
@@ -7,6 +7,7 @@ module ::Actions::Pulp3
     def setup
       @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
       @repo = katello_repositories(:busybox)
+      ensure_creatable(@repo, @master)
       create_repo(@repo, @master)
       ForemanTasks.sync_task(
         ::Actions::Katello::Repository::MetadataGenerate, @repo)

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units/exclusion_docker_filters.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units/exclusion_docker_filters.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,209 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:32 GMT
+      - Tue, 03 Dec 2019 14:36:37 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '245'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci80YTdiYzg3Yy0xMTc0LTQ2ZjUtOTFjMy1i
-        NDViMGM3YjJiYTIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjox
-        NzoyMy4yNTg2MzJaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci80YTdiYzg3Yy0xMTc0
-        LTQ2ZjUtOTFjMy1iNDViMGM3YjJiYTIvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci80YTdiYzg3Yy0xMTc0LTQ2ZjUtOTFjMy1iNDViMGM3
-        YjJiYTIvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
-        fQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:32 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:32 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5YzQwZWQwLWIzOWEtNDY2
-        OS04N2E3LWFkMDI0ZGFjOGM2Mi8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:32 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:32 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '351'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvODkxY2QzOGYtNmE5Yi00Y2ZjLWE3YmUtYmM1MGJl
-        ODU3ZjZiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MjMu
-        NDc4OTY2WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
-        c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
-        ZXIuaW8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xp
-        ZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3Vy
-        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3
-        OjIzLjQ3ODk4MVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
-        eSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJidXN5Ym94Iiwid2hp
-        dGVsaXN0X3RhZ3MiOlsibGF0ZXN0IiwidWNsaWJjIiwibXVzbCJdfV19
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:32 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/891cd38f-6a9b-4cfc-a7be-bc50be857f6b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:32 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzYzk1Nzc0LTAzNzYtNDYy
-        Mi1iNmU5LWE3YmViNDVkZTVjMy8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:32 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:32 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -244,10 +44,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:32 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:37 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -255,7 +55,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -268,39 +68,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '294'
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci82NWE2ZGVjMS1lMjY2LTQ1ZWItODM5
-        NC02NjA1YzM0YmQ2ZjMvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjI4LjAxNzEyN1oiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWRldiIsImNvbnRlbnRfZ3VhcmQiOm51bGwsInJlZ2lz
-        dHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0FD
-        TUVfQ29ycG9yYXRpb24vbGlicmFyeS9idXN5Ym94In1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:37 GMT
 - request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/65a6dec1-e266-45eb-8394-6605c34bd6f3/
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -308,7 +100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -317,32 +109,77 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiNWRhMTFlLTc4NDktNDcw
-        ZC04MzZiLTU3YmRkOGY1MDBjZC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:37 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:37 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
@@ -353,7 +190,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -366,9 +203,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -387,7 +224,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:38 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -398,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -411,9 +248,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -432,7 +269,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:38 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -443,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,9 +293,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -477,7 +314,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:38 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -488,7 +325,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -501,9 +338,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:33 GMT
+      - Tue, 03 Dec 2019 14:36:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -522,7 +359,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:33 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:38 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -535,7 +372,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -548,13 +385,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/"
+      - "/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -569,17 +406,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFj
-        ODE0OWZlLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MzQu
-        MDYzMjA0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjVkYzBmNWItYTBlMS00NmQ1
-        LWIwMTItYTNkMTFjODE0OWZlL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0NGJk
+        OGYyMGVmLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6Mzgu
+        ODExODUyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00Mzky
+        LTlmNjItZGE0NGJkOGYyMGVmL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFjODE0OWZl
+        b250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0NGJkOGYyMGVm
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:38 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -597,7 +434,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -610,13 +447,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/046dc640-6c79-45d3-b077-bc1a652d02cd/"
+      - "/pulp/api/v3/remotes/container/container/5db60ed6-6442-4cdb-9b08-442c178b41bb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -631,18 +468,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzA0NmRjNjQwLTZjNzktNDVkMy1iMDc3LWJjMWE2NTJkMDJj
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjM0LjIzNzY3
-        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzVkYjYwZWQ2LTY0NDItNGNkYi05YjA4LTQ0MmMxNzhiNDFi
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjM5LjAxMjUz
+        OVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoxNzozNC4y
-        Mzc2ODZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjozOS4w
+        MTI1NTJaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpbImxhdGVzdCIsInVjbGliYyIsIm11c2wiXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
@@ -653,7 +490,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -666,82 +503,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '243'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9lY2M1YjU3My0yNzRkLTRkZWMtOTI0NS1j
-        MDFmZDI4OTI2ZmMvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjox
-        NzoyNS4wNzkwNDRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lY2M1YjU3My0yNzRk
-        LTRkZWMtOTI0NS1jMDFmZDI4OTI2ZmMvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9lY2M1YjU3My0yNzRkLTRkZWMtOTI0NS1jMDFmZDI4
-        OTI2ZmMvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tVGVzdC1idXN5Ym94LWRldiIsImRlc2NyaXB0aW9uIjpudWxsfV19
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4M2MxMzczLTQzYjEtNGI3
-        ZC1hZWIwLTlkNTRjYTQzZThlOS8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
@@ -752,7 +535,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -765,9 +548,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -786,7 +569,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
@@ -797,7 +580,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -810,9 +593,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -831,7 +614,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/dev/busybox
@@ -842,7 +625,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -855,9 +638,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:34 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -876,7 +659,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:34 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
@@ -887,7 +670,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -900,9 +683,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,7 +704,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
@@ -932,7 +715,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -945,9 +728,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -966,7 +749,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
@@ -977,7 +760,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -990,9 +773,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1011,7 +794,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:40 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/dev/busybox
@@ -1022,7 +805,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1035,9 +818,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1056,7 +839,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:40 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -1069,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1082,13 +865,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/"
+      - "/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1103,31 +886,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvN2Y2ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZk
-        ZWYwYmNlLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MzUu
-        NjczNTc2WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2ZDczNGYtN2FmNS00MzM3
-        LWEzYjQtMjI3MDZkZWYwYmNlL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMTkyNGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0
+        ZjAwNGQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDAu
+        NDQwODUyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTkyNGIyYWMtZTE4Ni00MDZh
+        LTliOTQtOGI2ZTk0ZjAwNGQ0L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvN2Y2ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNl
+        b250YWluZXIvMTkyNGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1kZXYiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:40 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/sync/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyLzA0NmRjNjQwLTZjNzktNDVkMy1iMDc3LWJjMWE2NTJkMDJjZC8i
+        dGFpbmVyLzVkYjYwZWQ2LTY0NDItNGNkYi05YjA4LTQ0MmMxNzhiNDFiYi8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1140,9 +923,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:35 GMT
+      - Tue, 03 Dec 2019 14:36:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1158,13 +941,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxMzJkY2Y2LWNlN2MtNDI2
-        Yi1iYmEyLWY0OTNkYTYxNjk5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkNTNmZGE3LTY2ZjUtNDdm
+        Yi05NjYwLTc5NDcyNDU3YjI3Zi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:35 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:40 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e132dcf6-ce7c-426b-bba2-f493da616995/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4d53fda7-66f5-47fb-9660-79472457b27f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1172,7 +955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1185,9 +968,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:37 GMT
+      - Tue, 03 Dec 2019 14:36:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1199,42 +982,42 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '522'
+      - '525'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTEzMmRjZjYtY2U3
-        Yy00MjZiLWJiYTItZjQ5M2RhNjE2OTk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MzUuOTkwMTQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGQ1M2ZkYTctNjZm
+        NS00N2ZiLTk2NjAtNzk0NzI0NTdiMjdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDAuODg1NTY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjE3
-        OjM2LjExMjU0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTc6
-        MzcuMzY4NzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRmYjktYTUxYS00Y2E0MGJiOTM0
-        ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjQxLjAxNDk3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6MzY6
+        NDQuMDA3OTcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRlNjItYWZkZC03YWVlZTI4ZDk4
+        YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
         c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
         IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
         c3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoiZG93bmxv
         YWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
+        bnVsbCwiZG9uZSI6NjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
         b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
         Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NTMs
         InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJvY2Vzc2luZyBUYWdzIiwi
         Y29kZSI6InByb2Nlc3NpbmcudGFnIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
         b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
-        L2NvbnRhaW5lci9mNWRjMGY1Yi1hMGUxLTQ2ZDUtYjAxMi1hM2QxMWM4MTQ5
-        ZmUvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6
-        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWlu
-        ZXIvZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFjODE0OWZlLyIsIi9w
-        dWxwL2FwaS92My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvMDQ2ZGM2
-        NDAtNmM3OS00NWQzLWIwNzctYmMxYTY1MmQwMmNkLyJdfQ==
+        L2NvbnRhaW5lci82NzAzOTMzMS1jNTk1LTQzOTItOWY2Mi1kYTQ0YmQ4ZjIw
+        ZWYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6
+        WyIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzVk
+        YjYwZWQ2LTY0NDItNGNkYi05YjA4LTQ0MmMxNzhiNDFiYi8iLCIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNjcwMzkz
+        MzEtYzU5NS00MzkyLTlmNjItZGE0NGJkOGYyMGVmLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:37 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:44 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1242,7 +1025,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1255,9 +1038,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:37 GMT
+      - Tue, 03 Dec 2019 14:36:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1269,60 +1052,60 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '287'
+      - '288'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFj
-        ODE0OWZlL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoxNzozNi4xNDY4NDNaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0NGJk
+        OGYyMGVmL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo0MS4wNDA5NzdaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
         YmxvYiI6eyJjb3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
         dC9jb250YWluZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        ZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFjODE0OWZlL3ZlcnNpb25z
+        NjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0NGJkOGYyMGVmL3ZlcnNpb25z
         LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYi
         OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9y
         ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9jb250YWluZXIvY29udGFpbmVyL2Y1ZGMwZjViLWEwZTEtNDZkNS1i
-        MDEyLWEzZDExYzgxNDlmZS92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
+        cmllcy9jb250YWluZXIvY29udGFpbmVyLzY3MDM5MzMxLWM1OTUtNDM5Mi05
+        ZjYyLWRhNDRiZDhmMjBlZi92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
         Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
         dGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjVkYzBm
-        NWItYTBlMS00NmQ1LWIwMTItYTNkMTFjODE0OWZlL3ZlcnNpb25zLzEvIn19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNjcwMzkz
+        MzEtYzU5NS00MzkyLTlmNjItZGE0NGJkOGYyMGVmL3ZlcnNpb25zLzEvIn19
         LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6eyJj
         b3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
         ZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjVkYzBmNWItYTBlMS00
-        NmQ1LWIwMTItYTNkMTFjODE0OWZlL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00
+        MzkyLTlmNjItZGE0NGJkOGYyMGVmL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
         ci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYiOiIvcHVscC9hcGkvdjMv
         Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNp
         b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
-        bmVyL2Y1ZGMwZjViLWEwZTEtNDZkNS1iMDEyLWEzZDExYzgxNDlmZS92ZXJz
+        bmVyLzY3MDM5MzMxLWM1OTUtNDM5Mi05ZjYyLWRhNDRiZDhmMjBlZi92ZXJz
         aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjozLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvP3JlcG9zaXRv
         cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvZjVkYzBmNWItYTBlMS00NmQ1LWIwMTItYTNkMTFjODE0
-        OWZlL3ZlcnNpb25zLzEvIn19fX0=
+        ci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0NGJkOGYy
+        MGVmL3ZlcnNpb25zLzEvIn19fX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:37 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:44 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        ZGV2IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2Y1ZGMwZjViLWEwZTEtNDZk
-        NS1iMDEyLWEzZDExYzgxNDlmZS92ZXJzaW9ucy8xLyJ9
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1kZXYiLCJyZXBv
+        c2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Nv
+        bnRhaW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlmNjItZGE0
+        NGJkOGYyMGVmL3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1335,9 +1118,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:37 GMT
+      - Tue, 03 Dec 2019 14:36:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1353,13 +1136,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExYTUyZjBkLTg4NTItNDMy
-        Mi1hMDUwLWM3ZTQ2ODA0OGJiZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmY2FiMTljLWRmMGMtNGY3
+        NS1hY2QxLTFiYWJjNmNmMTIzNi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:37 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:44 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a1a52f0d-8852-4322-a050-c7e468048bbd/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/bfcab19c-df0c-4f75-acd1-1babc6cf1236/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1367,7 +1150,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1380,9 +1163,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:38 GMT
+      - Tue, 03 Dec 2019 14:36:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1394,28 +1177,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '341'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTFhNTJmMGQtODg1
-        Mi00MzIyLWEwNTAtYzdlNDY4MDQ4YmJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MzcuODU4ODMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZjYWIxOWMtZGYw
+        Yy00Zjc1LWFjZDEtMWJhYmM2Y2YxMjM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDQuNDc4NDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTc6MzcuOTY2OTQ0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoxNzozOC4xNDMzNTRa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6MzY6NDQuNjA2MTky
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDozNjo0NC44MDk0NjRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8xMWQwNWM2MC00YzlhLTQ5
-        MDAtODA4NS04NWZhNjM3ZTc0ZjMvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9lOTg4OTk5Ny0yNDQ0LTQ1
+        MDAtODI2Ny1hYTVmMjNkZWE5MzAvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:38 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:44 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/11d05c60-4c9a-4900-8085-85fa637e74f3/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/e9889997-2444-4500-8267-aa5f23dea930/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1423,7 +1206,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1436,9 +1219,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:38 GMT
+      - Tue, 03 Dec 2019 14:36:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1450,26 +1233,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '308'
+      - '295'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvMTFkMDVjNjAtNGM5YS00OTAwLTgwODUtODVm
-        YTYzN2U3NGYzLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mNWRjMGY1Yi1h
-        MGUxLTQ2ZDUtYjAxMi1hM2QxMWM4MTQ5ZmUvdmVyc2lvbnMvMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjM4LjEzNDQzMFoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWRldiIsImNvbnRlbnRfZ3VhcmQiOm51bGwsInJlZ2lzdHJ5
-        X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0FDTUVf
-        Q29ycG9yYXRpb24vbGlicmFyeS9idXN5Ym94In0=
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvNjcwMzkzMzEtYzU5NS00MzkyLTlm
+        NjItZGE0NGJkOGYyMGVmL3ZlcnNpb25zLzEvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9lOTg4OTk5Ny0yNDQ0LTQ1MDAtODI2Ny1h
+        YTVmMjNkZWE5MzAvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6MzY6NDQuNzk4NDk5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwicmVnaXN0cnlfcGF0aCI6InB1
+        bHAzLWRldmVsLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVwcGV0X3Byb2R1Y3Qt
+        YnVzeWJveCJ9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:38 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:45 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1477,7 +1260,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1490,9 +1273,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:38 GMT
+      - Tue, 03 Dec 2019 14:36:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1511,10 +1294,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:38 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:45 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1522,7 +1305,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1535,9 +1318,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:39 GMT
+      - Tue, 03 Dec 2019 14:36:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1549,198 +1332,198 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '2303'
+      - '2298'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzLzIzYmYzODE2LWNkOTgtNGY0MS05NGI2LTI0NThl
-        NDU3OGZmZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3
-        LjEyNzY5NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        MDg5ODFkNjgtZTEwNS00YjM4LTllY2UtNzcxZjE1MDgwNmQ3LyIsImRpZ2Vz
-        dCI6InNoYTI1NjpjZDI3NGZiNjU2MjViZmU2ZjU4YTljY2FlNmE3ZDVkMWRm
-        MzY5YWY5ZGUxMjhiNDE5MzQzOGZhNmYxZTc2OWRiIiwic2NoZW1hX3ZlcnNp
+        YWluZXIvbWFuaWZlc3RzLzA0ZTZiODc2LTJmOTQtNGNjNy1iODAzLWE3M2Zk
+        Yjk0YzNiMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQx
+        Ljg1ODI5OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OTM1MTc4YWItZmMzNC00NWI0LTk2MGQtZGY2MDViNmVhODgzLyIsImRpZ2Vz
+        dCI6InNoYTI1NjpkYWU5MGQzYmQ0NTQwOTIzYWU4NmY5NDVkZWNhMjBhYzY5
+        MzE0M2I5YjdjZTAyYmI4MGJiZmEyYThhZWNiNTc2Iiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzLzE4MTAyZWE0LTEyY2UtNGUxNy04ZjQyLTk4YTRkMzAx
-        ZTBlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvNjEzMWQzZjQtNDE2OS00YjA2LTg1OTYtMjk0ZWNlYTcxYmEx
+        dGFpbmVyL2Jsb2JzLzgwNTA0ZmVhLTMzNDAtNDJiNS05YjY0LTcxNDUwYTJj
+        OTAwYS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvNTUzYWE2YjgtY2MwZi00MzZiLTk0NDEtOTZkOGJhZTM1MDJk
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMjRiMjRmODQtOTRiZC00OWQzLThlMjMtN2UxYmQ3
-        ZjcyNTBhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcu
-        MDk4NjU1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
-        MjA2YmMxMy0zMjY0LTRkNmItOTUwMi0wMmY3NjlmNWVlMWMvIiwiZGlnZXN0
-        Ijoic2hhMjU2OmIwMjAzODYzMzI1NTUyNjEzY2E0MTdjNmI2OTQxMDJhYWM0
-        YWEyY2E2NjNmNzM0YmMxZDZjNGM3YjE5NTYxMTEiLCJzY2hlbWFfdmVyc2lv
+        aW5lci9tYW5pZmVzdHMvMTQxZTI1YmQtNjI5ZS00OTUxLTg0NTYtYzZiNWU0
+        M2I4ZmQwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        Nzk0NDExWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ODdiYzg5ZS1mMTZmLTQ1ZGUtYmQ3NS02NDcyMDVhMzgwODIvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmYzNTA2MDkzMTM0NWEzMTUxZWU3M2YxMTkzYzc4MmQyYzJm
+        Yjg5ZjVjNjJiMjMyOWNhM2UxOTc2OTg5MTcxZTIiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvMmVlZmNiNDEtZTllZC00OWE3LTlhM2YtZDRkMTAxZTlk
-        MzQxLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8wYzE1YWQ1ZC1kNDU2LTRhNDEtOWU5NS1lNzdlYjJiNjA1N2Ev
+        YWluZXIvYmxvYnMvYmExNmM3YWEtMTMzOS00ODUwLWIxNWMtZmNmZWJkYzAy
+        YmZhLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy9iNTljZTFjYy04ZDg3LTQ5NTAtYmY2MC0yMDkxOTBmNGI3MTQv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy8yYzE2NDc3YS1kOTQ2LTQzMzctYjA2My1lMDA4ZWVm
-        YzBlMmUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4w
-        MzkyNDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Fi
-        N2UyMjdiLTM1ZWMtNDRlYS1hYTRkLTFhNTUyYmQ4YWVmZC8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6NjNjNjJkNDRiNTZjZGE4OTA0YTc1YTE5MGZkMTk2ZmIwYjg5
-        NDdkY2MxMTliYTkxMzEzYzQ2ZjIyOTlmMzAzNCIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8zMGQyM2ZhMS1lMDdiLTQ4YTktOTk0Zi1jYmIyMjRm
+        ODVjZWUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43
+        NjYyNjZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4
+        MjE1MzExLTA0MjMtNGRhNS05NmEyLTU2MGI5YTQ2MDdjZS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6MTAzMDU1Nzc0NGFhZTlhMjdhYTZlZTgzMGNiOThhMmM2M2Zh
+        ZGViMzlmYmZkY2Y0NTdjMDk1ZDlmNDYwMDgwNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9lN2QxOWYxZi1iN2U0LTRkZjUtOWY3OC1kZjA3YjUyM2Nl
-        MGQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzL2U0MWIxZjg3LTQwMDYtNGNiMC1iODQ4LTg4MTViY2JjMmMwNS8i
+        aW5lci9ibG9icy85MDg2NDdkNi04ZWI4LTQ3OWMtYjk1Yy1jMzQzZDg3Njhl
+        ZjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2Y4Nzg2MzAyLTg3MmQtNGVjNS1iODk0LTVkZGQ1YmIxNGI4OS8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ3NjM2NTEzLTU0MWEtNDhiYy04OGZiLWJjOThhNGY3
-        ZDZhNi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEy
-        NjM2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODkz
-        MTg3NjgtMjk3My00OTc0LWEzMTEtMjRiODlmMzA1NTJjLyIsImRpZ2VzdCI6
-        InNoYTI1Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5
-        ODdmZWZlNDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjc4
+        OTYzOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjYw
+        MmUzMzUtM2E2MC00NzcxLWFjNDYtY2IzMzRmMTAxZjkzLyIsImRpZ2VzdCI6
+        InNoYTI1NjpiYmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkz
+        MGQxMWUwZWE0ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzL2JiYzg5ZWFjLTdlYmEtNGVlNy1hZmExLTNjMTdjN2Q0YWRh
+        bmVyL2Jsb2JzL2Q3NTdkNzliLTM3MmUtNDI1Ni1hYjUyLTZiZjJlMTQ0YzE3
         NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvNmQ3NmQ4OGUtZjIzNS00MzBjLTgyZGQtNmFjMTllMjJjOWZhLyJd
+        YmxvYnMvYmRiOGRjZmEtOTk3Ny00MjAwLWI2M2UtZDM1YjhlYmQ1ZWIzLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjU4Y2FmN2UtNWM5MS00ZWFlLTkyZDEtZGUwMTM0OGEw
-        ZmEyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTU0
-        MjI1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zZWZl
-        Y2Y3Ny1hOWJhLTRiNGItOGMzNC0yOGQ0NTRmMGI4MmYvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OjEwMzA1NTc3NDRhYWU5YTI3YWE2ZWU4MzBjYjk4YTJjNjNmYWRl
-        YjM5ZmJmZGNmNDU3YzA5NWQ5ZjQ2MDA4MDciLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00Yzk0LWFmODAtYWQ1YjdjYjBk
+        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzYz
+        ODg5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kYjEw
+        YWYwYS1kZTIwLTQxNzAtYmExMC01YmRkYWY5YTI0MDEvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjJkMzFmOWQxMGMwNGE0ZWJjNjUwMDI3OWZkZGYzM2ViN2ViZGZj
+        NTE4MDQyZDU2MWZmYjdiYzZhNTY4YjQ0YTUiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvY2JjMTlhMjUtNzhlOS00OTA3LTk0MzItOWQ4NmFjNDc2ZDJl
+        ZXIvYmxvYnMvMWMxMjQ3YjYtMTQ5OC00MDk0LWI0YTUtMDFhZTM1ZDI0OTk5
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9lMDc2YTRmYS1jNDE4LTQ4MzYtYjFjOC0xZDZlZWE1NWJkODUvIl19
+        bG9icy9hOGZmYjY1Ny0yMjE5LTQ2NjctOTIzYS00YmEyNmExY2ExYTAvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy82ZDEyZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1
-        ZjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4xMDQ0
-        OThaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VhMGE1
-        MmJlLTgyNjctNDA1YS05ZTFhLTYwZTU2NjM0MDk0Yy8iLCJkaWdlc3QiOiJz
-        aGEyNTY6ZGFlOTBkM2JkNDU0MDkyM2FlODZmOTQ1ZGVjYTIwYWM2OTMxNDNi
-        OWI3Y2UwMmJiODBiYmZhMmE4YWVjYjU3NiIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1LTQyMDgtOWE3OC05YzEyZjUzMjg5
+        NWIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS44NDA1
+        NzFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3NDc0
+        NDhiLWZiMjEtNGQ1Mi05YjJkLTU5OTUxMWYyYmFiNS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6Y2QyNzRmYjY1NjI1YmZlNmY1OGE5Y2NhZTZhN2Q1ZDFkZjM2OWFm
+        OWRlMTI4YjQxOTM0MzhmYTZmMWU3NjlkYiIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy85ZGZhY2IwOC1jODgzLTRlMzItOTNjYS02NDQ1Y2ZhOWNlYWQv
+        ci9ibG9icy9kNGVlZDljNi02YjA2LTQ1YzEtODcxYi1iMGU0NjIxNWNlZjgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2ZhNDJkMGFiLWJlZDYtNGY0MC04YmJjLWRjNmVmMDI3MjI3ZC8iXX0s
+        b2JzLzExYWQ5ZjM5LTkzZTAtNDk1MC05NzU5LTFkNTQ4OTFlZTM3Yy8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEyODg4
-        OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODBiNDFk
-        OTYtMzdkNy00ZTBmLWI1YTUtOGQ2NWFkMTE1YzdmLyIsImRpZ2VzdCI6InNo
-        YTI1NjoyZDMxZjlkMTBjMDRhNGViYzY1MDAyNzlmZGRmMzNlYjdlYmRmYzUx
-        ODA0MmQ1NjFmZmI3YmM2YTU2OGI0NGE1Iiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzLzg1YjJhZjM4LTI1N2UtNDkxNC1iYWEyLTE1ODk4OTQ1NDJk
+        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg1OTU3
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGJmNmYw
+        ZjYtNDRlYy00ZWVmLTgwOWUtNjFmNThhNDgzOGZjLyIsImRpZ2VzdCI6InNo
+        YTI1NjpiMDIwMzg2MzMyNTU1MjYxM2NhNDE3YzZiNjk0MTAyYWFjNGFhMmNh
+        NjYzZjczNGJjMWQ2YzRjN2IxOTU2MTExIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzBhNjZkMzI1LTRkZDktNDEwOS05NDgxLWRmMzYyZTFlOTdmYi8i
+        L2Jsb2JzLzA5YmI0YTcxLTNkMDctNDQzZC05YTg3LTcyNmVkNjVkN2E4My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYzQ1OTAyN2QtNjgwOS00MGNiLWEyNmEtY2ZiMzJkNDQ3ZjU0LyJdfSx7
+        YnMvOWJkMTM1ZTQtNmQ3Zi00MTRhLWJhOTItNjE0ZTk3ZjAxZGNhLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvODQ3MWNhOTAtOGFjZi00NjBjLWJkZTEtN2Y1ZjdhNzEyZGZk
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTA0ODIx
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84ZmJiNmE2
-        MC0yOWQzLTRhZjItYWJmNy04OGJiYmM4NThjNzcvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjA5M2U2MzljOGI3ZmY2N2Q4NzgxMTZkM2RlOWUzZTkxZmYxYmQwZDZl
-        NDE0MWFlNDAxOWNhM2ZiM2U0OTNkZjkiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTk5ZGExM2YtYjJmMC00ZWVmLWI5M2ItY2ZhZGMwNTkzZGQ0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzkzMTEy
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mNmQ2NzY3
+        Yy03NjdkLTQwOTktOWY1Ni1mOTRjYzM2ODE2ZGEvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjY3OWIxYzEwNThjMWYyZGM1OWEzZWU3MGVlZDk4NmE4ODgxMWMwMjA1
+        YzhjZWVhNTdjZWM1ZjIyZDJjM2ZiYjEiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvM2MzYzY0OWYtM2VkMy00MDYyLTkwMjItMzkzZjNiYjI4NjJiLyIs
+        YmxvYnMvODUxZTAyZWUtNTNjYi00Yjc1LTlhMDYtZjAzZWVhYmFkNTIxLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9hNDFmYjBjZS1kZTU1LTRjMGEtYTNiNi1kOGMxNTdlYmQ5MTMvIl19LHsi
+        cy8wZTMwM2IzYy0yNGQ2LTQ5YjQtODc3Mi02ZDdkYTQ3YjVhZWIvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUzODhhMjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wMzc3MTNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRmZjJlYTJm
-        LTkzYTAtNDNiMi1hOWRiLTM2NWZlMGVjMDg4ZC8iLCJkaWdlc3QiOiJzaGEy
-        NTY6Njc5YjFjMTA1OGMxZjJkYzU5YTNlZTcwZWVkOTg2YTg4ODExYzAyMDVj
-        OGNlZWE1N2NlYzVmMjJkMmMzZmJiMSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy9iMzk1MmI1My01OGZlLTQ5ODktOTg4Yy0zMDJiYzM1MzRhNmYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS42Mjk0MzJa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJhMmQ0ZmIy
+        LTdkNDctNDdmMS05MDZkLTM5ZWZiYTZkY2M2OS8iLCJkaWdlc3QiOiJzaGEy
+        NTY6MDkzZTYzOWM4YjdmZjY3ZDg3ODExNmQzZGU5ZTNlOTFmZjFiZDBkNmU0
+        MTQxYWU0MDE5Y2EzZmIzZTQ5M2RmOSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy80ZDdiNjUxZC03MGFlLTRkNDMtOTBkZC05NzlhMjA1NGRmMDEvIiwi
+        bG9icy82ZWJmNDRkNy1jZjhiLTQ3OGQtYTJiZi1kOWMwMDlmNTA5NmUvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        L2U3ZWJkMjU0LWFjMmEtNGQzMy1hNjE3LWUyZDE4M2Q0OWY1Ny8iXX0seyJw
+        LzBmZDgzYjA1LTdhMjAtNDNiYS05MWI0LTNiNmFkMzdhMWZhNy8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzL2I0YTE5YjY5LThmMTctNGQ2OS05MTE5LTAxNTE4MDJhNzExMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEwMjE3Nloi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTg2ZjZlMzAt
-        YzdiNC00ZDU5LTlhMTUtYTA2Y2IxNWU1ZDdkLyIsImRpZ2VzdCI6InNoYTI1
-        NjowNmU0ZjMwNDdkMmU5YTc4MjIyZmYxNjg2MTI3MTc0N2FkMTJlZDFlZGMz
-        YjFhNTVkMmI5ZGZlODgxNDRhZWQzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzL2I3YjE2OTI5LWJmNGUtNDJmYS04YTU5LWE1MzcwMGQ0ZmNiZC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg2MTI3MVoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYWJhMTkzOGUt
+        NjdkOS00MmZhLWI4YjItNTJkYWJiMjY3MDViLyIsImRpZ2VzdCI6InNoYTI1
+        Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5ODdmZWZl
+        NDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzFmNjE0MWYzLTI3ZDAtNDNjOC1iMzVjLWFkZjhkMzBkZDExOC8iLCJi
+        b2JzLzNkZDNkZTgzLWFhNzctNDg3Ni1hNTEyLTBkNGI1NDhhYTMzYi8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MTI3YWI3ODctYzExOC00YjU5LWEwZjItZWM4MzkzOGQ4OTg2LyJdfSx7InB1
+        MWJjYmE3NTItYTQ3MS00MDRkLWI5N2YtNjliNWFlMWU0ZGFlLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvYjgyN2NjMGUtYjZjMS00NDUzLTkwMjQtOTIzNWJiMzg4MDQ0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMTAzMzQxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80NmRiNjNmYy0z
-        ZWMwLTQ0OGEtOWQ2ZC0wNTVjOTM4YTA4NDAvIiwiZGlnZXN0Ijoic2hhMjU2
+        ZmVzdHMvYmY3MzhhMDItZTU3MC00YTU0LWE3NGEtNzgyMDkyODA4M2MxLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuODM5MzIxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84YmE0OTNkMy01
+        YzhmLTRjODAtYmRmYS0yODZiZDRhYThjNDIvIiwiZGlnZXN0Ijoic2hhMjU2
         OjI1MGI4NzcyNDczNjQ4M2E4OTYyMzEzYjE4N2ZiNmFkNDAyODg5MzE3MTVl
         N2YzODRmYjRjMDBjNDgxOTA0NmYiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvNDUzMmEwOGMtMWZmZS00NjcwLWEwYzYtZjUzMWVmY2EyMDViLyIsImJs
+        YnMvZmJhMjAyOTItNGNiNi00N2Y5LWEwNTItYmY1MmM3YWM5YWQ1LyIsImJs
         b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy81
-        NWJhMWFiNi1jNTgzLTRkMmYtODYxNS1iMGZmMThjM2MxOTUvIl19LHsicHVs
+        NmQ0MGE4Mi1jMjEyLTRkNmUtYmFlMC1kOTI4ZjdjOTUxMDcvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9kN2E1ZDM5NS1iNDc4LTRmMjYtYjdiOS1lNWMzY2M1NzYzOWUvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wOTk4NDBaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U0YmYzZDdmLWY5
-        ZGYtNGU4OC05YWVkLWEzMDYyNDVkN2Q4ZC8iLCJkaWdlc3QiOiJzaGEyNTY6
-        MWU4ZTc3MTYyMjczYzlkZDc4ZGU3OTMwYjg3MDE5NGYyOTZjMjNiNTkwYmY5
-        OTUyYTEzOTlkMDgzYmJhMjI2ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        ZXN0cy9jMDMwY2IxMS04ZDBmLTQxZGMtYTczZS01YjVjNDgyODFjMTEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43ODgxOTZaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2NkMTE0OTkzLTBi
+        YmYtNGNkMC1iMGM4LWViMzRjOWRkYzI1OC8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MDZlNGYzMDQ3ZDJlOWE3ODIyMmZmMTY4NjEyNzE3NDdhZDEyZWQxZWRjM2Ix
+        YTU1ZDJiOWRmZTg4MTQ0YWVkMyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9iODgzMWE2Ni0zMThmLTRmOTctOTJlYi1jNzc5YzZmYmZhYTMvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzAy
-        MGU3Y2M5LTlmNzUtNGFkMS1iZWQxLTk4MTVkYzRkOWQyNi8iXX0seyJwdWxw
+        cy9mMGVkZWJlMy0xZDU4LTQwNmEtOTM2OC0wOTE0NGJkYTNkMGMvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzY4
+        OTdmMGJlLTFjNWUtNGUyYi05ZmVmLWI0OGFjY2UwNjQzOS8iXX0seyJwdWxw
         X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2U4ZTA5YzhlLWRkZTItNGIxNi1hOTg1LWEzMzQ3OTI1MjE2MS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjA0NTA4OFoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDk3YmM2MGEtYzcx
-        NS00NzAyLTk4MzktYzA4MzNhYTUwNzg3LyIsImRpZ2VzdCI6InNoYTI1Njpi
-        YmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkzMGQxMWUwZWE0
-        ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
+        c3RzL2RhNWQ4ZTFiLTE1ZjEtNDZlOS05ZmJiLTI2NTQ4OWUyMGFiMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjgzODEwMVoiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNWE3OGFiMTUtODQy
+        Ny00NWYzLWIwMzYtZWE1NjhlYmJkY2RmLyIsImRpZ2VzdCI6InNoYTI1Njox
+        ZThlNzcxNjIyNzNjOWRkNzhkZTc5MzBiODcwMTk0ZjI5NmMyM2I1OTBiZjk5
+        NTJhMTM5OWQwODNiYmEyMjZlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
         X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
         YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
         Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzllZGVjYmM0LThlYTYtNDhhNS1iMWIyLTNhZjNkN2ZkZjExMC8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvNmRj
-        ZGM0NGMtMjFlYS00OTE2LWExZWYtNTAwYmFjYjk3MjhlLyJdfSx7InB1bHBf
+        LzQwZDYxNjIwLWIxM2YtNDU2Ny05NzhhLWE5MDU5ZTBjNjg5OS8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvZWE0
+        NGRhMzAtYWU4Zi00Y2M3LWJiOGMtMjdkODhiYWMwMDQyLyJdfSx7InB1bHBf
         aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZWVjOTcxNWQtZjg4Ni00ZWEwLTk0NTYtNGNiMzM3MWFkNzUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMTAxMDIyWiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80NWU5ODZjNi05YTc0
-        LTRhMGItOWNlNC1kMTk2N2NhY2UxMDkvIiwiZGlnZXN0Ijoic2hhMjU2OmYz
-        NTA2MDkzMTM0NWEzMTUxZWU3M2YxMTkzYzc4MmQyYzJmYjg5ZjVjNjJiMjMy
-        OWNhM2UxOTc2OTg5MTcxZTIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHMvZTIxNTUwMzItYTMwMS00NzEwLTk4ZjktMTgyYmUxZjgyNzEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzg2NjI2WiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lM2UwMmVkNy0yMzA5
+        LTQzZjEtYjViMS05ZTJlYTNlMzg2MWYvIiwiZGlnZXN0Ijoic2hhMjU2OjYz
+        YzYyZDQ0YjU2Y2RhODkwNGE3NWExOTBmZDE5NmZiMGI4OTQ3ZGNjMTE5YmE5
+        MTMxM2M0NmYyMjk5ZjMwMzQiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
         dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
         bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
         X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        ZTUwMTA4YmEtZmEyYS00OTgzLWE3N2YtNjdjNzNlOTNlZTVjLyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9jNGIz
-        OGZhNi03Nzk1LTRmOGYtOGFiOC02ZmIwOWRkYzViYWQvIl19XX0=
+        Y2IyMzEwMDAtNmE1Mi00NmM1LTlhYWItZTAxNWMwYmFmYzUyLyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy85NmQ5
+        NDUxNi05MGY0LTRhOWYtOTdmMy05YmRmYThlNWQwMDYvIl19XX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:39 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:45 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1748,7 +1531,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1761,9 +1544,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:39 GMT
+      - Tue, 03 Dec 2019 14:36:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1775,82 +1558,82 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '916'
+      - '911'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMDQ4YTg2YTUtN2ExZS00ZTdhLWJiYTMtOWRhZTI1
-        OWRiM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYu
-        ODkzODU4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84
-        ZWM1MGUwYS1mMzFjLTRiODUtOTJjMy1kN2E3ZjhiODk3NjEvIiwiZGlnZXN0
-        Ijoic2hhMjU2OjEzMDNkYmYxMTBjNTdmM2VkZjY4ZDlmNWExNmMwODJlYzA2
-        YzRjZjc2MDQ4MzE2NjlmYWYyYzcxMjI2MGI1YTAiLCJzY2hlbWFfdmVyc2lv
+        aW5lci9tYW5pZmVzdHMvN2NhNzkyZjgtNDdmYS00YzI1LThjYzktN2U0NzFm
+        MGYyNzgyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        NjIzODM5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
+        ZDFiYjE5ZC1lMzY2LTRiMzYtYTY5Zi1jOWJhMjE3YWYwMzgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmEwNGVjNDI3YjI0OGQ2NzI3NTA3YjI1ZDg0MTM4YzdmNGMw
+        OTJmMTZmZmRmOTU0MjE2MTI2OGU5YmRiYTE2OGIiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy82NThjYWY3ZS01YzkxLTRlYWUtOTJkMS1kZTAxMzQ4YTBmYTIvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9lOGUw
-        OWM4ZS1kZGUyLTRiMTYtYTk4NS1hMzM0NzkyNTIxNjEvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iNGExOWI2OS04ZjE3
-        LTRkNjktOTExOS0wMTUxODAyYTcxMTAvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy83ZDk2NTFkMy0yYTM0LTQ4NGEtYjA0
-        ZS1iNDVkZmM3MTllNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUz
-        ODhhMjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy84NDcxY2E5MC04YWNmLTQ2MGMtYmRlMS03ZjVmN2E3MTJkZmQvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82ZDEy
-        ZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1ZjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iODI3Y2MwZS1iNmMx
-        LTQ0NTMtOTAyNC05MjM1YmIzODgwNDQvIl0sImNvbmZpZ19ibG9iIjpudWxs
-        LCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1kMGVmLTRjYjktOWE3
-        Yy1jMzhiMGQ5MTVkODUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQx
-        NjowMDo1Ni44OTgxODJaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
-        aWZhY3RzLzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5YS8i
-        LCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkxMzI0MDZiYWQ3
-        ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5YSIsInNjaGVt
-        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
-        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlz
-        dGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzY1OGNhZjdlLTVjOTEtNGVhZS05MmQxLWRlMDEzNDhh
-        MGZhMi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2U4ZTA5YzhlLWRkZTItNGIxNi1hOTg1LWEzMzQ3OTI1MjE2MS8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzdkOTY1
-        MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0OC8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzMjhkMDZlLTI4MDMt
-        NGMzYS04NTk3LWQ1MWIxZTM4OGEyMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzLzg0NzFjYTkwLThhY2YtNDYwYy1iZGUx
-        LTdmNWY3YTcxMmRmZC8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
-        XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzczZWM0ZTQyLTc4ZjYtNDU1My1iYTQzLTQwODJkNzdh
-        M2MyNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2Ljkw
-        MTc4NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODNi
-        M2ZhNzYtYzE5NS00NWI4LWEyZmYtNWQ5NmQ3ZmE4NjNlLyIsImRpZ2VzdCI6
-        InNoYTI1NjphMDRlYzQyN2IyNDhkNjcyNzUwN2IyNWQ4NDEzOGM3ZjRjMDky
-        ZjE2ZmZkZjk1NDIxNjEyNjhlOWJkYmExNjhiIiwic2NoZW1hX3ZlcnNpb24i
-        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
-        aWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZl
-        c3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvMmMxNjQ3N2EtZDk0Ni00MzM3LWIwNjMtZTAwOGVlZmMwZTJlLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNDc2MzY1
-        MTMtNTQxYS00OGJjLTg4ZmItYmM5OGE0ZjdkNmE2LyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvZDdhNWQzOTUtYjQ3OC00
-        ZjI2LWI3YjktZTVjM2NjNTc2MzllLyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L2NvbnRhaW5lci9tYW5pZmVzdHMvMjNiZjM4MTYtY2Q5OC00ZjQxLTk0YjYt
-        MjQ1OGU0NTc4ZmZkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvZWVjOTcxNWQtZjg4Ni00ZWEwLTk0NTYtNGNiMzM3MWFk
-        NzUyLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvNmQxMmYxYWMtMWJjMy00ODY4LWFjODktZTljY2Q0NTg4NWY1LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvMjRiMjRm
-        ODQtOTRiZC00OWQzLThlMjMtN2UxYmQ3ZjcyNTBhLyJdLCJjb25maWdfYmxv
+        ZXN0cy8wNGU2Yjg3Ni0yZjk0LTRjYzctYjgwMy1hNzNmZGI5NGMzYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xNDFl
+        MjViZC02MjllLTQ5NTEtODQ1Ni1jNmI1ZTQzYjhmZDAvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1
+        LTQyMDgtOWE3OC05YzEyZjUzMjg5NWIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy84NWIyYWYzOC0yNTdlLTQ5MTQtYmFh
+        Mi0xNTg5ODk0NTQyZGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iN2IxNjkyOS1iZjRlLTQyZmEtOGE1OS1hNTM3MDBk
+        NGZjYmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9kYTVkOGUxYi0xNWYxLTQ2ZTktOWZiYi0yNjU0ODllMjBhYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9lMjE1
+        NTAzMi1hMzAxLTQ3MTAtOThmOS0xODJiZTFmODI3MTMvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iMzdmMTUzOC03NmIy
+        LTQxNTMtYTYyMS05ZjFhMzU0MWYzODgvIiwicHVscF9jcmVhdGVkIjoiMjAx
+        OS0xMi0wM1QxNDozNjo0MS42MjY3MDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzMxNzNhNWFkLTE5OGItNDNmNC1hNjU2LTFiZWE1
+        ZmJkYTU0ZC8iLCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkx
+        MzI0MDZiYWQ3ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5
+        YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzMwZDIzZmExLWUwN2ItNDhhOS05OTRm
+        LWNiYjIyNGY4NWNlZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzYzYmI5MTQ0LWFjMmUtNGM5NC1hZjgwLWFkNWI3Y2IwZDc2Mi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5OWRh
+        MTNmLWIyZjAtNGVlZi1iOTNiLWNmYWRjMDU5M2RkNC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzOTUyYjUzLTU4ZmUt
+        NDk4OS05ODhjLTMwMmJjMzUzNGE2Zi8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ImJsb2JzIjpbXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzL2ZlNTlkZGYxLTlhZTgtNDI2Yi05NmMx
+        LTJjODU1MWRiYWQ1Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0
+        OjM2OjQxLjYyMDYyOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvNjY1YTM0NTgtMjA3Yy00MzFjLWI5NjYtNjM0ODU0NDNkMDBkLyIs
+        ImRpZ2VzdCI6InNoYTI1NjoxMzAzZGJmMTEwYzU3ZjNlZGY2OGQ5ZjVhMTZj
+        MDgyZWMwNmM0Y2Y3NjA0ODMxNjY5ZmFmMmM3MTIyNjBiNWEwIiwic2NoZW1h
+        X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
+        a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0
+        ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvMDRlNmI4NzYtMmY5NC00Y2M3LWI4MDMtYTczZmRiOTRj
+        M2IwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvMzBkMjNmYTEtZTA3Yi00OGE5LTk5NGYtY2JiMjI0Zjg1Y2VlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNDEyMzQy
+        NGEtM2FlNC00ZmM5LThkNTYtNDc0NGVmNmNkNjgzLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00
+        Yzk0LWFmODAtYWQ1YjdjYjBkNzYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2NvbnRhaW5lci9tYW5pZmVzdHMvOTk5ZGExM2YtYjJmMC00ZWVmLWI5M2It
+        Y2ZhZGMwNTkzZGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvYjM5NTJiNTMtNThmZS00OTg5LTk4OGMtMzAyYmMzNTM0
+        YTZmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvYmY3MzhhMDItZTU3MC00YTU0LWE3NGEtNzgyMDkyODA4M2MxLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYzAzMGNi
+        MTEtOGQwZi00MWRjLWE3M2UtNWI1YzQ4MjgxYzExLyJdLCJjb25maWdfYmxv
         YiI6bnVsbCwiYmxvYnMiOltdfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:39 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:45 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1858,7 +1641,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1871,9 +1654,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:39 GMT
+      - Tue, 03 Dec 2019 14:36:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1885,38 +1668,38 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '436'
+      - '434'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2VjYjA2NWVjLWQ4ZDAtNDNhOC05NmQ0LTQ2MDUzMGM0NGRk
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2LjkwMzU3
-        N1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODNiM2Zh
-        NzYtYzE5NS00NWI4LWEyZmYtNWQ5NmQ3ZmE4NjNlLyIsIm5hbWUiOiJtdXNs
-        IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL21hbmlmZXN0cy83M2VjNGU0Mi03OGY2LTQ1NTMtYmE0My00MDgy
-        ZDc3YTNjMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvdGFncy9hMGVjNGRjNC0wNzQ1LTRiOWMtYjIzNC1lYzcx
-        N2JlMDUwMTIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1
-        Ni44OTYxMjlaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
-        LzhlYzUwZTBhLWYzMWMtNGI4NS05MmMzLWQ3YTdmOGI4OTc2MS8iLCJuYW1l
-        IjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8wNDhhODZhNS03YTFlLTRlN2Et
-        YmJhMy05ZGFlMjU5ZGIzZjEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvdGFncy82ODc4NjhiNy02MzliLTQ5NjAt
-        OWZhOS02MmMyZjZjMjMyNDEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjowMDo1Ni44OTk5ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5
-        YS8iLCJuYW1lIjoidWNsaWJjIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1k
-        MGVmLTRjYjktOWE3Yy1jMzhiMGQ5MTVkODUvIn1dfQ==
+        aW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBkNWI4ZDZiMzYz
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjYyODEy
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMzE3M2E1
+        YWQtMTk4Yi00M2Y0LWE2NTYtMWJlYTVmYmRhNTRkLyIsIm5hbWUiOiJ1Y2xp
+        YmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
+        b250YWluZXIvbWFuaWZlc3RzL2IzN2YxNTM4LTc2YjItNDE1My1hNjIxLTlm
+        MWEzNTQxZjM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2NvbnRhaW5lci90YWdzL2NlYTBkNTJkLTEwZGEtNDYwYi1hMWIwLWI4
+        ODVkMTAxNDg3Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjQxLjYyNTI3OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
+        dHMvNWQxYmIxOWQtZTM2Ni00YjM2LWE2OWYtYzliYTIxN2FmMDM4LyIsIm5h
+        bWUiOiJtdXNsIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83Y2E3OTJmOC00N2ZhLTRjMjUt
+        OGNjOS03ZTQ3MWYwZjI3ODIvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvdGFncy9lZDM4MDM5ZS0zYzhhLTRjNWUt
+        YmI1MC1kZTZmOTkzMWIyNTQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo0MS42MjIzNTBaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzY2NWEzNDU4LTIwN2MtNDMxYy1iOTY2LTYzNDg1NDQzZDAw
+        ZC8iLCJuYW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mZTU5ZGRmMS05
+        YWU4LTQyNmItOTZjMS0yYzg1NTFkYmFkNWMvIn1dfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:39 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:46 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/remove/
     body:
       encoding: UTF-8
       base64_string: 'eyJjb250ZW50X3VuaXRzIjpbIioiXX0=
@@ -1926,7 +1709,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1939,9 +1722,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:39 GMT
+      - Tue, 03 Dec 2019 14:36:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1957,25 +1740,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlNGVmYzlmLWNkYjMtNGE5
-        Mi05OTEzLWI2MzUwYzY2NWMwOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3ZWEwMjZhLTQ5ZWItNGQ4
+        NS1iYWFjLWI2OTJhOWY0YTVkZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:39 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:46 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/add/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzLzY4Nzg2OGI3LTYzOWItNDk2MC05ZmE5LTYyYzJmNmMyMzI0
-        MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9lY2Iw
-        NjVlYy1kOGQwLTQzYTgtOTZkNC00NjA1MzBjNDRkZGQvIl19
+        aW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBkNWI4ZDZiMzYz
+        MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9jZWEw
+        ZDUyZC0xMGRhLTQ2MGItYTFiMC1iODg1ZDEwMTQ4N2MvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1988,9 +1771,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:39 GMT
+      - Tue, 03 Dec 2019 14:36:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2006,13 +1789,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkNGI2MDU3LTk4NDAtNDc0
-        Ni1iYjVjLTQ1YzcyM2Y5MjE2Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZGUzOTRjLTEzNjUtNDFi
+        Ny05NmZmLTI4YTlhNjlkZjc0MC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:39 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:46 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/be4efc9f-cdb3-4a92-9913-b6350c665c08/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/47ea026a-49eb-4d85-baac-b692a9f4a5dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2020,7 +1803,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -2033,9 +1816,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:40 GMT
+      - Tue, 03 Dec 2019 14:36:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2051,24 +1834,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmU0ZWZjOWYtY2Ri
-        My00YTkyLTk5MTMtYjYzNTBjNjY1YzA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MzkuODMxNDk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDdlYTAyNmEtNDll
+        Yi00ZDg1LWJhYWMtYjY5MmE5ZjRhNWRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDYuNjUyNjY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjE3OjM5LjkyNDAxN1oiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MTc6MzkuOTg3MzIyWiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjM2OjQ2Ljc2MDIyOFoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6MzY6NDYuODA4MjcyWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2
-        ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNlLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTky
+        NGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:46 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/be4efc9f-cdb3-4a92-9913-b6350c665c08/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/47ea026a-49eb-4d85-baac-b692a9f4a5dd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2076,7 +1859,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -2089,9 +1872,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:40 GMT
+      - Tue, 03 Dec 2019 14:36:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2107,24 +1890,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmU0ZWZjOWYtY2Ri
-        My00YTkyLTk5MTMtYjYzNTBjNjY1YzA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MzkuODMxNDk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDdlYTAyNmEtNDll
+        Yi00ZDg1LWJhYWMtYjY5MmE5ZjRhNWRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDYuNjUyNjY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjE3OjM5LjkyNDAxN1oiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MTc6MzkuOTg3MzIyWiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjM2OjQ2Ljc2MDIyOFoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6MzY6NDYuODA4MjcyWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2
-        ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNlLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTky
+        NGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6d4b6057-9840-4746-bb5c-45c723f9216c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/09de394c-1365-41b7-96ff-28a9a69df740/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2132,7 +1915,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -2145,9 +1928,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:40 GMT
+      - Tue, 03 Dec 2019 14:36:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2159,30 +1942,30 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '351'
+      - '349'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQ0YjYwNTctOTg0
-        MC00NzQ2LWJiNWMtNDVjNzIzZjkyMTZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MzkuOTYyNTk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDlkZTM5NGMtMTM2
+        NS00MWI3LTk2ZmYtMjhhOWE2OWRmNzQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDYuNzg3MTUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsInN0YXJ0ZWRfYXQiOiIyMDE5
-        LTExLTIyVDE2OjE3OjQwLjEyMzg0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMTkt
-        MTEtMjJUMTY6MTc6NDAuMzA1MzEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRkOWEtYjI3
-        MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tz
+        LTEyLTAzVDE0OjM2OjQ2Ljk1MTc5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMTkt
+        MTItMDNUMTQ6MzY6NDcuMTc5MzA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRhMjItOWUx
+        YS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tz
         IjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRh
-        aW5lci83ZjZkNzM0Zi03YWY1LTQzMzctYTNiNC0yMjcwNmRlZjBiY2UvdmVy
+        aW5lci8xOTI0YjJhYy1lMTg2LTQwNmEtOWI5NC04YjZlOTRmMDA0ZDQvdmVy
         c2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2
-        ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNlLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTky
+        NGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2190,7 +1973,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2203,9 +1986,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:40 GMT
+      - Tue, 03 Dec 2019 14:36:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2217,47 +2000,47 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '287'
+      - '286'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvN2Y2ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZk
-        ZWYwYmNlL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoxNzo0MC4xNTkxODhaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMTkyNGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0
+        ZjAwNGQ0L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo0Ni45OTU5NjdaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
         YmxvYiI6eyJjb3VudCI6MjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
         dC9jb250YWluZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        N2Y2ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNlL3ZlcnNpb25z
+        MTkyNGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0L3ZlcnNpb25z
         LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTQsImhyZWYi
         OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9y
         ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9jb250YWluZXIvY29udGFpbmVyLzdmNmQ3MzRmLTdhZjUtNDMzNy1h
-        M2I0LTIyNzA2ZGVmMGJjZS92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
+        cmllcy9jb250YWluZXIvY29udGFpbmVyLzE5MjRiMmFjLWUxODYtNDA2YS05
+        Yjk0LThiNmU5NGYwMDRkNC92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
         Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
         dGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2ZDcz
-        NGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYwYmNlL3ZlcnNpb25zLzEvIn19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTkyNGIy
+        YWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0L3ZlcnNpb25zLzEvIn19
         LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6eyJj
         b3VudCI6MjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
         ZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2Y2ZDczNGYtN2FmNS00
-        MzM3LWEzYjQtMjI3MDZkZWYwYmNlL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTkyNGIyYWMtZTE4Ni00
+        MDZhLTliOTQtOGI2ZTk0ZjAwNGQ0L3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
         ci5tYW5pZmVzdCI6eyJjb3VudCI6MTQsImhyZWYiOiIvcHVscC9hcGkvdjMv
         Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNp
         b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
-        bmVyLzdmNmQ3MzRmLTdhZjUtNDMzNy1hM2I0LTIyNzA2ZGVmMGJjZS92ZXJz
+        bmVyLzE5MjRiMmFjLWUxODYtNDA2YS05Yjk0LThiNmU5NGYwMDRkNC92ZXJz
         aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjoyLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvP3JlcG9zaXRv
         cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvN2Y2ZDczNGYtN2FmNS00MzM3LWEzYjQtMjI3MDZkZWYw
-        YmNlL3ZlcnNpb25zLzEvIn19fX0=
+        ci9jb250YWluZXIvMTkyNGIyYWMtZTE4Ni00MDZhLTliOTQtOGI2ZTk0ZjAw
+        NGQ0L3ZlcnNpb25zLzEvIn19fX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2265,7 +2048,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2278,9 +2061,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:40 GMT
+      - Tue, 03 Dec 2019 14:36:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2299,10 +2082,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2310,7 +2093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2323,9 +2106,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:41 GMT
+      - Tue, 03 Dec 2019 14:36:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2337,172 +2120,172 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '2013'
+      - '2009'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MTIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
         bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzLzIzYmYzODE2LWNkOTgtNGY0MS05NGI2LTI0NThl
-        NDU3OGZmZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3
-        LjEyNzY5NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        MDg5ODFkNjgtZTEwNS00YjM4LTllY2UtNzcxZjE1MDgwNmQ3LyIsImRpZ2Vz
-        dCI6InNoYTI1NjpjZDI3NGZiNjU2MjViZmU2ZjU4YTljY2FlNmE3ZDVkMWRm
-        MzY5YWY5ZGUxMjhiNDE5MzQzOGZhNmYxZTc2OWRiIiwic2NoZW1hX3ZlcnNp
+        YWluZXIvbWFuaWZlc3RzLzA0ZTZiODc2LTJmOTQtNGNjNy1iODAzLWE3M2Zk
+        Yjk0YzNiMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQx
+        Ljg1ODI5OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OTM1MTc4YWItZmMzNC00NWI0LTk2MGQtZGY2MDViNmVhODgzLyIsImRpZ2Vz
+        dCI6InNoYTI1NjpkYWU5MGQzYmQ0NTQwOTIzYWU4NmY5NDVkZWNhMjBhYzY5
+        MzE0M2I5YjdjZTAyYmI4MGJiZmEyYThhZWNiNTc2Iiwic2NoZW1hX3ZlcnNp
         b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
         c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
         cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzLzE4MTAyZWE0LTEyY2UtNGUxNy04ZjQyLTk4YTRkMzAx
-        ZTBlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvNjEzMWQzZjQtNDE2OS00YjA2LTg1OTYtMjk0ZWNlYTcxYmEx
+        dGFpbmVyL2Jsb2JzLzgwNTA0ZmVhLTMzNDAtNDJiNS05YjY0LTcxNDUwYTJj
+        OTAwYS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvNTUzYWE2YjgtY2MwZi00MzZiLTk0NDEtOTZkOGJhZTM1MDJk
         LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMjRiMjRmODQtOTRiZC00OWQzLThlMjMtN2UxYmQ3
-        ZjcyNTBhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcu
-        MDk4NjU1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
-        MjA2YmMxMy0zMjY0LTRkNmItOTUwMi0wMmY3NjlmNWVlMWMvIiwiZGlnZXN0
-        Ijoic2hhMjU2OmIwMjAzODYzMzI1NTUyNjEzY2E0MTdjNmI2OTQxMDJhYWM0
-        YWEyY2E2NjNmNzM0YmMxZDZjNGM3YjE5NTYxMTEiLCJzY2hlbWFfdmVyc2lv
+        aW5lci9tYW5pZmVzdHMvMTQxZTI1YmQtNjI5ZS00OTUxLTg0NTYtYzZiNWU0
+        M2I4ZmQwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        Nzk0NDExWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ODdiYzg5ZS1mMTZmLTQ1ZGUtYmQ3NS02NDcyMDVhMzgwODIvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmYzNTA2MDkzMTM0NWEzMTUxZWU3M2YxMTkzYzc4MmQyYzJm
+        Yjg5ZjVjNjJiMjMyOWNhM2UxOTc2OTg5MTcxZTIiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvMmVlZmNiNDEtZTllZC00OWE3LTlhM2YtZDRkMTAxZTlk
-        MzQxLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8wYzE1YWQ1ZC1kNDU2LTRhNDEtOWU5NS1lNzdlYjJiNjA1N2Ev
+        YWluZXIvYmxvYnMvYmExNmM3YWEtMTMzOS00ODUwLWIxNWMtZmNmZWJkYzAy
+        YmZhLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy9iNTljZTFjYy04ZDg3LTQ5NTAtYmY2MC0yMDkxOTBmNGI3MTQv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy8yYzE2NDc3YS1kOTQ2LTQzMzctYjA2My1lMDA4ZWVm
-        YzBlMmUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4w
-        MzkyNDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Fi
-        N2UyMjdiLTM1ZWMtNDRlYS1hYTRkLTFhNTUyYmQ4YWVmZC8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6NjNjNjJkNDRiNTZjZGE4OTA0YTc1YTE5MGZkMTk2ZmIwYjg5
-        NDdkY2MxMTliYTkxMzEzYzQ2ZjIyOTlmMzAzNCIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8zMGQyM2ZhMS1lMDdiLTQ4YTktOTk0Zi1jYmIyMjRm
+        ODVjZWUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43
+        NjYyNjZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4
+        MjE1MzExLTA0MjMtNGRhNS05NmEyLTU2MGI5YTQ2MDdjZS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6MTAzMDU1Nzc0NGFhZTlhMjdhYTZlZTgzMGNiOThhMmM2M2Zh
+        ZGViMzlmYmZkY2Y0NTdjMDk1ZDlmNDYwMDgwNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9lN2QxOWYxZi1iN2U0LTRkZjUtOWY3OC1kZjA3YjUyM2Nl
-        MGQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzL2U0MWIxZjg3LTQwMDYtNGNiMC1iODQ4LTg4MTViY2JjMmMwNS8i
+        aW5lci9ibG9icy85MDg2NDdkNi04ZWI4LTQ3OWMtYjk1Yy1jMzQzZDg3Njhl
+        ZjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2Y4Nzg2MzAyLTg3MmQtNGVjNS1iODk0LTVkZGQ1YmIxNGI4OS8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ3NjM2NTEzLTU0MWEtNDhiYy04OGZiLWJjOThhNGY3
-        ZDZhNi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEy
-        NjM2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODkz
-        MTg3NjgtMjk3My00OTc0LWEzMTEtMjRiODlmMzA1NTJjLyIsImRpZ2VzdCI6
-        InNoYTI1Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5
-        ODdmZWZlNDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjc4
+        OTYzOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjYw
+        MmUzMzUtM2E2MC00NzcxLWFjNDYtY2IzMzRmMTAxZjkzLyIsImRpZ2VzdCI6
+        InNoYTI1NjpiYmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkz
+        MGQxMWUwZWE0ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzL2JiYzg5ZWFjLTdlYmEtNGVlNy1hZmExLTNjMTdjN2Q0YWRh
+        bmVyL2Jsb2JzL2Q3NTdkNzliLTM3MmUtNDI1Ni1hYjUyLTZiZjJlMTQ0YzE3
         NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvNmQ3NmQ4OGUtZjIzNS00MzBjLTgyZGQtNmFjMTllMjJjOWZhLyJd
+        YmxvYnMvYmRiOGRjZmEtOTk3Ny00MjAwLWI2M2UtZDM1YjhlYmQ1ZWIzLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjU4Y2FmN2UtNWM5MS00ZWFlLTkyZDEtZGUwMTM0OGEw
-        ZmEyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTU0
-        MjI1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zZWZl
-        Y2Y3Ny1hOWJhLTRiNGItOGMzNC0yOGQ0NTRmMGI4MmYvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OjEwMzA1NTc3NDRhYWU5YTI3YWE2ZWU4MzBjYjk4YTJjNjNmYWRl
-        YjM5ZmJmZGNmNDU3YzA5NWQ5ZjQ2MDA4MDciLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00Yzk0LWFmODAtYWQ1YjdjYjBk
+        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzYz
+        ODg5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kYjEw
+        YWYwYS1kZTIwLTQxNzAtYmExMC01YmRkYWY5YTI0MDEvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjJkMzFmOWQxMGMwNGE0ZWJjNjUwMDI3OWZkZGYzM2ViN2ViZGZj
+        NTE4MDQyZDU2MWZmYjdiYzZhNTY4YjQ0YTUiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvY2JjMTlhMjUtNzhlOS00OTA3LTk0MzItOWQ4NmFjNDc2ZDJl
+        ZXIvYmxvYnMvMWMxMjQ3YjYtMTQ5OC00MDk0LWI0YTUtMDFhZTM1ZDI0OTk5
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9lMDc2YTRmYS1jNDE4LTQ4MzYtYjFjOC0xZDZlZWE1NWJkODUvIl19
+        bG9icy9hOGZmYjY1Ny0yMjE5LTQ2NjctOTIzYS00YmEyNmExY2ExYTAvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy82ZDEyZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1
-        ZjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4xMDQ0
-        OThaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VhMGE1
-        MmJlLTgyNjctNDA1YS05ZTFhLTYwZTU2NjM0MDk0Yy8iLCJkaWdlc3QiOiJz
-        aGEyNTY6ZGFlOTBkM2JkNDU0MDkyM2FlODZmOTQ1ZGVjYTIwYWM2OTMxNDNi
-        OWI3Y2UwMmJiODBiYmZhMmE4YWVjYjU3NiIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1LTQyMDgtOWE3OC05YzEyZjUzMjg5
+        NWIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS44NDA1
+        NzFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3NDc0
+        NDhiLWZiMjEtNGQ1Mi05YjJkLTU5OTUxMWYyYmFiNS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6Y2QyNzRmYjY1NjI1YmZlNmY1OGE5Y2NhZTZhN2Q1ZDFkZjM2OWFm
+        OWRlMTI4YjQxOTM0MzhmYTZmMWU3NjlkYiIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy85ZGZhY2IwOC1jODgzLTRlMzItOTNjYS02NDQ1Y2ZhOWNlYWQv
+        ci9ibG9icy9kNGVlZDljNi02YjA2LTQ1YzEtODcxYi1iMGU0NjIxNWNlZjgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2ZhNDJkMGFiLWJlZDYtNGY0MC04YmJjLWRjNmVmMDI3MjI3ZC8iXX0s
+        b2JzLzExYWQ5ZjM5LTkzZTAtNDk1MC05NzU5LTFkNTQ4OTFlZTM3Yy8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEyODg4
-        OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODBiNDFk
-        OTYtMzdkNy00ZTBmLWI1YTUtOGQ2NWFkMTE1YzdmLyIsImRpZ2VzdCI6InNo
-        YTI1NjoyZDMxZjlkMTBjMDRhNGViYzY1MDAyNzlmZGRmMzNlYjdlYmRmYzUx
-        ODA0MmQ1NjFmZmI3YmM2YTU2OGI0NGE1Iiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzLzg1YjJhZjM4LTI1N2UtNDkxNC1iYWEyLTE1ODk4OTQ1NDJk
+        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg1OTU3
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGJmNmYw
+        ZjYtNDRlYy00ZWVmLTgwOWUtNjFmNThhNDgzOGZjLyIsImRpZ2VzdCI6InNo
+        YTI1NjpiMDIwMzg2MzMyNTU1MjYxM2NhNDE3YzZiNjk0MTAyYWFjNGFhMmNh
+        NjYzZjczNGJjMWQ2YzRjN2IxOTU2MTExIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzBhNjZkMzI1LTRkZDktNDEwOS05NDgxLWRmMzYyZTFlOTdmYi8i
+        L2Jsb2JzLzA5YmI0YTcxLTNkMDctNDQzZC05YTg3LTcyNmVkNjVkN2E4My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYzQ1OTAyN2QtNjgwOS00MGNiLWEyNmEtY2ZiMzJkNDQ3ZjU0LyJdfSx7
+        YnMvOWJkMTM1ZTQtNmQ3Zi00MTRhLWJhOTItNjE0ZTk3ZjAxZGNhLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvODQ3MWNhOTAtOGFjZi00NjBjLWJkZTEtN2Y1ZjdhNzEyZGZk
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTA0ODIx
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84ZmJiNmE2
-        MC0yOWQzLTRhZjItYWJmNy04OGJiYmM4NThjNzcvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjA5M2U2MzljOGI3ZmY2N2Q4NzgxMTZkM2RlOWUzZTkxZmYxYmQwZDZl
-        NDE0MWFlNDAxOWNhM2ZiM2U0OTNkZjkiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTk5ZGExM2YtYjJmMC00ZWVmLWI5M2ItY2ZhZGMwNTkzZGQ0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzkzMTEy
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mNmQ2NzY3
+        Yy03NjdkLTQwOTktOWY1Ni1mOTRjYzM2ODE2ZGEvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjY3OWIxYzEwNThjMWYyZGM1OWEzZWU3MGVlZDk4NmE4ODgxMWMwMjA1
+        YzhjZWVhNTdjZWM1ZjIyZDJjM2ZiYjEiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvM2MzYzY0OWYtM2VkMy00MDYyLTkwMjItMzkzZjNiYjI4NjJiLyIs
+        YmxvYnMvODUxZTAyZWUtNTNjYi00Yjc1LTlhMDYtZjAzZWVhYmFkNTIxLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9hNDFmYjBjZS1kZTU1LTRjMGEtYTNiNi1kOGMxNTdlYmQ5MTMvIl19LHsi
+        cy8wZTMwM2IzYy0yNGQ2LTQ5YjQtODc3Mi02ZDdkYTQ3YjVhZWIvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUzODhhMjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wMzc3MTNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRmZjJlYTJm
-        LTkzYTAtNDNiMi1hOWRiLTM2NWZlMGVjMDg4ZC8iLCJkaWdlc3QiOiJzaGEy
-        NTY6Njc5YjFjMTA1OGMxZjJkYzU5YTNlZTcwZWVkOTg2YTg4ODExYzAyMDVj
-        OGNlZWE1N2NlYzVmMjJkMmMzZmJiMSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy9iMzk1MmI1My01OGZlLTQ5ODktOTg4Yy0zMDJiYzM1MzRhNmYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS42Mjk0MzJa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJhMmQ0ZmIy
+        LTdkNDctNDdmMS05MDZkLTM5ZWZiYTZkY2M2OS8iLCJkaWdlc3QiOiJzaGEy
+        NTY6MDkzZTYzOWM4YjdmZjY3ZDg3ODExNmQzZGU5ZTNlOTFmZjFiZDBkNmU0
+        MTQxYWU0MDE5Y2EzZmIzZTQ5M2RmOSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy80ZDdiNjUxZC03MGFlLTRkNDMtOTBkZC05NzlhMjA1NGRmMDEvIiwi
+        bG9icy82ZWJmNDRkNy1jZjhiLTQ3OGQtYTJiZi1kOWMwMDlmNTA5NmUvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        L2U3ZWJkMjU0LWFjMmEtNGQzMy1hNjE3LWUyZDE4M2Q0OWY1Ny8iXX0seyJw
+        LzBmZDgzYjA1LTdhMjAtNDNiYS05MWI0LTNiNmFkMzdhMWZhNy8iXX0seyJw
         dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzL2Q3YTVkMzk1LWI0NzgtNGYyNi1iN2I5LWU1YzNjYzU3NjM5ZS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjA5OTg0MFoi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTRiZjNkN2Yt
-        ZjlkZi00ZTg4LTlhZWQtYTMwNjI0NWQ3ZDhkLyIsImRpZ2VzdCI6InNoYTI1
-        NjoxZThlNzcxNjIyNzNjOWRkNzhkZTc5MzBiODcwMTk0ZjI5NmMyM2I1OTBi
-        Zjk5NTJhMTM5OWQwODNiYmEyMjZlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        aWZlc3RzL2I3YjE2OTI5LWJmNGUtNDJmYS04YTU5LWE1MzcwMGQ0ZmNiZC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg2MTI3MVoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYWJhMTkzOGUt
+        NjdkOS00MmZhLWI4YjItNTJkYWJiMjY3MDViLyIsImRpZ2VzdCI6InNoYTI1
+        Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5ODdmZWZl
+        NDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
         ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
         bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
         bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2I4ODMxYTY2LTMxOGYtNGY5Ny05MmViLWM3NzljNmZiZmFhMy8iLCJi
+        b2JzLzNkZDNkZTgzLWFhNzctNDg3Ni1hNTEyLTBkNGI1NDhhYTMzYi8iLCJi
         bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MDIwZTdjYzktOWY3NS00YWQxLWJlZDEtOTgxNWRjNGQ5ZDI2LyJdfSx7InB1
+        MWJjYmE3NTItYTQ3MS00MDRkLWI5N2YtNjliNWFlMWU0ZGFlLyJdfSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvZThlMDljOGUtZGRlMi00YjE2LWE5ODUtYTMzNDc5MjUyMTYxLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMDQ1MDg4WiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOTdiYzYwYS1j
-        NzE1LTQ3MDItOTgzOS1jMDgzM2FhNTA3ODcvIiwiZGlnZXN0Ijoic2hhMjU2
-        OmJiYTIxOTQ5MmU0YWRlOWRjNWU2MjAzMmY3ZDVjMzhmN2E1OTMwZDExZTBl
-        YTRlNDYyYWZiZTZmNjhlZmFiY2IiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        ZmVzdHMvZGE1ZDhlMWItMTVmMS00NmU5LTlmYmItMjY1NDg5ZTIwYWIwLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuODM4MTAxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81YTc4YWIxNS04
+        NDI3LTQ1ZjMtYjAzNi1lYTU2OGViYmRjZGYvIiwiZGlnZXN0Ijoic2hhMjU2
+        OjFlOGU3NzE2MjI3M2M5ZGQ3OGRlNzkzMGI4NzAxOTRmMjk2YzIzYjU5MGJm
+        OTk1MmExMzk5ZDA4M2JiYTIyNmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
         aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
         Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
         ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvOWVkZWNiYzQtOGVhNi00OGE1LWIxYjItM2FmM2Q3ZmRmMTEwLyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy82
-        ZGNkYzQ0Yy0yMWVhLTQ5MTYtYTFlZi01MDBiYWNiOTcyOGUvIl19LHsicHVs
+        YnMvNDBkNjE2MjAtYjEzZi00NTY3LTk3OGEtYTkwNTllMGM2ODk5LyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9l
+        YTQ0ZGEzMC1hZThmLTRjYzctYmI4Yy0yN2Q4OGJhYzAwNDIvIl19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9lZWM5NzE1ZC1mODg2LTRlYTAtOTQ1Ni00Y2IzMzcxYWQ3NTIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4xMDEwMjJaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzQ1ZTk4NmM2LTlh
-        NzQtNGEwYi05Y2U0LWQxOTY3Y2FjZTEwOS8iLCJkaWdlc3QiOiJzaGEyNTY6
-        ZjM1MDYwOTMxMzQ1YTMxNTFlZTczZjExOTNjNzgyZDJjMmZiODlmNWM2MmIy
-        MzI5Y2EzZTE5NzY5ODkxNzFlMiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        ZXN0cy9lMjE1NTAzMi1hMzAxLTQ3MTAtOThmOS0xODJiZTFmODI3MTMvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43ODY2MjZaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2UzZTAyZWQ3LTIz
+        MDktNDNmMS1iNWIxLTllMmVhM2UzODYxZi8iLCJkaWdlc3QiOiJzaGEyNTY6
+        NjNjNjJkNDRiNTZjZGE4OTA0YTc1YTE5MGZkMTk2ZmIwYjg5NDdkY2MxMTli
+        YTkxMzEzYzQ2ZjIyOTlmMzAzNCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
         YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
         bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
         aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9lNTAxMDhiYS1mYTJhLTQ5ODMtYTc3Zi02N2M3M2U5M2VlNWMvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2M0
-        YjM4ZmE2LTc3OTUtNGY4Zi04YWI4LTZmYjA5ZGRjNWJhZC8iXX1dfQ==
+        cy9jYjIzMTAwMC02YTUyLTQ2YzUtOWFhYi1lMDE1YzBiYWZjNTIvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzk2
+        ZDk0NTE2LTkwZjQtNGE5Zi05N2YzLTliZGZhOGU1ZDAwNi8iXX1dfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:48 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2510,7 +2293,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2523,9 +2306,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:41 GMT
+      - Tue, 03 Dec 2019 14:36:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2537,58 +2320,58 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '754'
+      - '748'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMTNmNzI1OTUtZDBlZi00Y2I5LTlhN2MtYzM4YjBk
-        OTE1ZDg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYu
-        ODk4MTgyWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8y
-        NmY1ZmY2ZS01YTRiLTQ0ZGQtYTMxYi0xZTI1ZjEwNTlmOWEvIiwiZGlnZXN0
-        Ijoic2hhMjU2OjgxN2U0NTljYTczYzU2N2U5MTMyNDA2YmFkNzg4NDVhYWY3
-        MmQyZTBjMDk2NWZmNjg4NjFiMzE4NTkxZTk0OWEiLCJzY2hlbWFfdmVyc2lv
+        aW5lci9tYW5pZmVzdHMvN2NhNzkyZjgtNDdmYS00YzI1LThjYzktN2U0NzFm
+        MGYyNzgyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        NjIzODM5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
+        ZDFiYjE5ZC1lMzY2LTRiMzYtYTY5Zi1jOWJhMjE3YWYwMzgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmEwNGVjNDI3YjI0OGQ2NzI3NTA3YjI1ZDg0MTM4YzdmNGMw
+        OTJmMTZmZmRmOTU0MjE2MTI2OGU5YmRiYTE2OGIiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy82NThjYWY3ZS01YzkxLTRlYWUtOTJkMS1kZTAxMzQ4YTBmYTIvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9lOGUw
-        OWM4ZS1kZGUyLTRiMTYtYTk4NS1hMzM0NzkyNTIxNjEvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83ZDk2NTFkMy0yYTM0
-        LTQ4NGEtYjA0ZS1iNDVkZmM3MTllNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5
-        Ny1kNTFiMWUzODhhMjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy84NDcxY2E5MC04YWNmLTQ2MGMtYmRlMS03ZjVmN2E3
-        MTJkZmQvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy83M2VjNGU0Mi03OGY2LTQ1NTMtYmE0My00MDgyZDc3YTNjMjcvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ni45MDE3ODVaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzgzYjNmYTc2LWMx
-        OTUtNDViOC1hMmZmLTVkOTZkN2ZhODYzZS8iLCJkaWdlc3QiOiJzaGEyNTY6
-        YTA0ZWM0MjdiMjQ4ZDY3Mjc1MDdiMjVkODQxMzhjN2Y0YzA5MmYxNmZmZGY5
-        NTQyMTYxMjY4ZTliZGJhMTY4YiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
-        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
-        bWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzJjMTY0
-        NzdhLWQ5NDYtNDMzNy1iMDYzLWUwMDhlZWZjMGUyZS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzQ3NjM2NTEzLTU0MWEt
-        NDhiYy04OGZiLWJjOThhNGY3ZDZhNi8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzL2Q3YTVkMzk1LWI0NzgtNGYyNi1iN2I5
-        LWU1YzNjYzU3NjM5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzIzYmYzODE2LWNkOTgtNGY0MS05NGI2LTI0NThlNDU3
-        OGZmZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2VlYzk3MTVkLWY4ODYtNGVhMC05NDU2LTRjYjMzNzFhZDc1Mi8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzZkMTJm
-        MWFjLTFiYzMtNDg2OC1hYzg5LWU5Y2NkNDU4ODVmNS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzI0YjI0Zjg0LTk0YmQt
-        NDlkMy04ZTIzLTdlMWJkN2Y3MjUwYS8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ZXN0cy8wNGU2Yjg3Ni0yZjk0LTRjYzctYjgwMy1hNzNmZGI5NGMzYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xNDFl
+        MjViZC02MjllLTQ5NTEtODQ1Ni1jNmI1ZTQzYjhmZDAvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1
+        LTQyMDgtOWE3OC05YzEyZjUzMjg5NWIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy84NWIyYWYzOC0yNTdlLTQ5MTQtYmFh
+        Mi0xNTg5ODk0NTQyZGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iN2IxNjkyOS1iZjRlLTQyZmEtOGE1OS1hNTM3MDBk
+        NGZjYmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9kYTVkOGUxYi0xNWYxLTQ2ZTktOWZiYi0yNjU0ODllMjBhYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9lMjE1
+        NTAzMi1hMzAxLTQ3MTAtOThmOS0xODJiZTFmODI3MTMvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iMzdmMTUzOC03NmIy
+        LTQxNTMtYTYyMS05ZjFhMzU0MWYzODgvIiwicHVscF9jcmVhdGVkIjoiMjAx
+        OS0xMi0wM1QxNDozNjo0MS42MjY3MDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzMxNzNhNWFkLTE5OGItNDNmNC1hNjU2LTFiZWE1
+        ZmJkYTU0ZC8iLCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkx
+        MzI0MDZiYWQ3ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5
+        YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzMwZDIzZmExLWUwN2ItNDhhOS05OTRm
+        LWNiYjIyNGY4NWNlZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzYzYmI5MTQ0LWFjMmUtNGM5NC1hZjgwLWFkNWI3Y2IwZDc2Mi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5OWRh
+        MTNmLWIyZjAtNGVlZi1iOTNiLWNmYWRjMDU5M2RkNC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzOTUyYjUzLTU4ZmUt
+        NDk4OS05ODhjLTMwMmJjMzUzNGE2Zi8iXSwiY29uZmlnX2Jsb2IiOm51bGws
         ImJsb2JzIjpbXX1dfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:48 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/7f6d734f-7af5-4337-a3b4-22706def0bce/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2596,7 +2379,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2609,9 +2392,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:41 GMT
+      - Tue, 03 Dec 2019 14:36:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2623,26 +2406,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '352'
+      - '346'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2VjYjA2NWVjLWQ4ZDAtNDNhOC05NmQ0LTQ2MDUzMGM0NGRk
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2LjkwMzU3
-        N1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODNiM2Zh
-        NzYtYzE5NS00NWI4LWEyZmYtNWQ5NmQ3ZmE4NjNlLyIsIm5hbWUiOiJtdXNs
-        IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL21hbmlmZXN0cy83M2VjNGU0Mi03OGY2LTQ1NTMtYmE0My00MDgy
-        ZDc3YTNjMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvdGFncy82ODc4NjhiNy02MzliLTQ5NjAtOWZhOS02MmMy
-        ZjZjMjMyNDEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1
-        Ni44OTk5ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
-        LzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5YS8iLCJuYW1l
-        IjoidWNsaWJjIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1kMGVmLTRjYjkt
-        OWE3Yy1jMzhiMGQ5MTVkODUvIn1dfQ==
+        aW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBkNWI4ZDZiMzYz
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjYyODEy
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMzE3M2E1
+        YWQtMTk4Yi00M2Y0LWE2NTYtMWJlYTVmYmRhNTRkLyIsIm5hbWUiOiJ1Y2xp
+        YmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
+        b250YWluZXIvbWFuaWZlc3RzL2IzN2YxNTM4LTc2YjItNDE1My1hNjIxLTlm
+        MWEzNTQxZjM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2NvbnRhaW5lci90YWdzL2NlYTBkNTJkLTEwZGEtNDYwYi1hMWIwLWI4
+        ODVkMTAxNDg3Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjQxLjYyNTI3OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
+        dHMvNWQxYmIxOWQtZTM2Ni00YjM2LWE2OWYtYzliYTIxN2FmMDM4LyIsIm5h
+        bWUiOiJtdXNsIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83Y2E3OTJmOC00N2ZhLTRjMjUt
+        OGNjOS03ZTQ3MWYwZjI3ODIvIn1dfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:48 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units/inclusion_docker_filters.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/copy_all_units/inclusion_docker_filters.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:21 GMT
+      - Tue, 03 Dec 2019 14:36:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -37,27 +37,27 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '245'
+      - '246'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9mMTdhZjU5NC1jNjllLTQ0MmQtYTg0Yy0w
-        NjgyN2M0YzNiNmMvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjow
-        NjoxMC4xMDkxODdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mMTdhZjU5NC1jNjll
-        LTQ0MmQtYTg0Yy0wNjgyN2M0YzNiNmMvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci82NzAzOTMzMS1jNTk1LTQzOTItOWY2Mi1k
+        YTQ0YmQ4ZjIwZWYvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDoz
+        NjozOC44MTE4NTJaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci82NzAzOTMzMS1jNTk1
+        LTQzOTItOWY2Mi1kYTQ0YmQ4ZjIwZWYvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9mMTdhZjU5NC1jNjllLTQ0MmQtYTg0Yy0wNjgyN2M0
-        YzNiNmMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci82NzAzOTMzMS1jNTk1LTQzOTItOWY2Mi1kYTQ0YmQ4
+        ZjIwZWYvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:21 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:49 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f17af594-c69e-442d-a84c-06827c4c3b6c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/67039331-c595-4392-9f62-da44bd8f20ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:21 GMT
+      - Tue, 03 Dec 2019 14:36:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlYmRkNGNjLTQ1NjQtNDgw
-        Zi1hNjY3LTE3NzE2NWNiZDYwYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZWU3YjQ3LWI3NTItNDJh
+        ZS1iYjY4LTM0MjEwOGQ5M2VlYi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:21 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:49 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:21 GMT
+      - Tue, 03 Dec 2019 14:36:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -137,27 +137,27 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '337'
+      - '349'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGVlYzYyOGQtYjc5Mi00Y2NiLTk1MWYtNTI5ZWE4
-        YTYwMzc1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDY6MTAu
-        MzE5NzU1WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvNWRiNjBlZDYtNjQ0Mi00Y2RiLTliMDgtNDQyYzE3
+        OGI0MWJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6Mzku
+        MDEyNTM5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xp
         ZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3Vy
-        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIyVDE2OjA2
-        OjEwLjMxOTc3MloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
+        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjM5LjAxMjU1MloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
         eSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJidXN5Ym94Iiwid2hp
-        dGVsaXN0X3RhZ3MiOm51bGx9XX0=
+        dGVsaXN0X3RhZ3MiOlsibGF0ZXN0IiwidWNsaWJjIiwibXVzbCJdfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:21 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:49 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/8eec628d-b792-4ccb-951f-529ea8a60375/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/5db60ed6-6442-4cdb-9b08-442c178b41bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -178,9 +178,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -196,10 +196,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5NTMzNzNkLWViZDctNGQ0
-        ZC05MTRjLTcwZWI0NDAyMWRmMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhNWNkN2RmLTllZjgtNGRh
+        OC04OTFhLWNlY2YwMTZlNGI4Yi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:49 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -210,7 +210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -244,7 +244,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:49 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -255,7 +255,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -268,9 +268,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -289,7 +289,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
@@ -300,7 +300,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -313,9 +313,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -334,7 +334,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -345,7 +345,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -358,9 +358,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -379,7 +379,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -390,7 +390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -403,9 +403,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -424,7 +424,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,9 +448,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:22 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -469,7 +469,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:22 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -482,7 +482,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -495,13 +495,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:23 GMT
+      - Tue, 03 Dec 2019 14:36:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/"
+      - "/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -516,17 +516,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBj
-        N2IyYmEyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MjMu
-        MjU4NjMyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNGE3YmM4N2MtMTE3NC00NmY1
-        LTkxYzMtYjQ1YjBjN2IyYmEyL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4
+        ODA2NDFkLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NTAu
+        OTEyNDc4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMw
+        LTgwOTItMzVjMTA4ODA2NDFkL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvNGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBjN2IyYmEy
+        b250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4ODA2NDFk
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:23 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:50 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -544,7 +544,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -557,13 +557,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:23 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/891cd38f-6a9b-4cfc-a7be-bc50be857f6b/"
+      - "/pulp/api/v3/remotes/container/container/515aaaac-38cc-4ea6-91b4-ef6ae9d933d7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -578,18 +578,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzg5MWNkMzhmLTZhOWItNGNmYy1hN2JlLWJjNTBiZTg1N2Y2
-        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjIzLjQ3ODk2
-        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzUxNWFhYWFjLTM4Y2MtNGVhNi05MWI0LWVmNmFlOWQ5MzNk
+        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjUxLjEwNTk5
+        MVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoxNzoyMy40
-        Nzg5ODFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo1MS4x
+        MDYwMzRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpbImxhdGVzdCIsInVjbGliYyIsIm11c2wiXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:23 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
@@ -600,7 +600,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -613,9 +613,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:23 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -627,26 +627,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '243'
+      - '242'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci82NGQxNDVlOC00ZTBjLTQzNmQtOTI2Yy0w
-        NWI3ZTMwYjBiZGUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjow
-        MTowOC4wOTY1NzlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci82NGQxNDVlOC00ZTBj
-        LTQzNmQtOTI2Yy0wNWI3ZTMwYjBiZGUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8xOTI0YjJhYy1lMTg2LTQwNmEtOWI5NC04
+        YjZlOTRmMDA0ZDQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDoz
+        Njo0MC40NDA4NTJaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8xOTI0YjJhYy1lMTg2
+        LTQwNmEtOWI5NC04YjZlOTRmMDA0ZDQvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci82NGQxNDVlOC00ZTBjLTQzNmQtOTI2Yy0wNWI3ZTMw
-        YjBiZGUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8xOTI0YjJhYy1lMTg2LTQwNmEtOWI5NC04YjZlOTRm
+        MDA0ZDQvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWRldiIsImRlc2NyaXB0aW9uIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:23 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/64d145e8-4e0c-436d-926c-05b7e30b0bde/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/1924b2ac-e186-406a-9b94-8b6e94f004d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -654,7 +654,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -667,9 +667,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:23 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -685,10 +685,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyNWM2YTNmLWVjY2UtNDI2
-        Ni05ZjZmLTk5NmVhM2FiMGI2Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhNWZhZDMzLWNlOTctNDI2
+        NC1hNjFiLTJjNjRkNGJiOWY4MS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:23 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
@@ -699,7 +699,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -712,9 +712,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:23 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -733,7 +733,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:23 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
@@ -744,7 +744,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -757,28 +757,81 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci9lOTg4OTk5Ny0yNDQ0LTQ1MDAtODI2
+        Ny1hYTVmMjNkZWE5MzAvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NDQuNzk4NDk5WiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwicmVnaXN0cnlfcGF0aCI6
+        InB1bHAzLWRldmVsLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVwcGV0X3Byb2R1
+        Y3QtYnVzeWJveCJ9XX0=
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/e9889997-2444-4500-8267-aa5f23dea930/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:51 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkNjYwOGQzLTU4MTYtNGNl
+        NS1iMTM1LWFkMmU0NWZmMTc2ZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/dev/busybox
@@ -789,7 +842,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -802,9 +855,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -823,7 +876,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:51 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-dev
@@ -834,7 +887,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -847,9 +900,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -868,7 +921,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:52 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-dev
@@ -879,7 +932,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -892,9 +945,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -913,7 +966,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:52 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-dev
@@ -924,7 +977,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,9 +990,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -958,7 +1011,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:52 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/dev/busybox
@@ -969,7 +1022,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -982,9 +1035,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:24 GMT
+      - Tue, 03 Dec 2019 14:36:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1003,7 +1056,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:24 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:52 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -1016,7 +1069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1029,13 +1082,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:25 GMT
+      - Tue, 03 Dec 2019 14:36:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/"
+      - "/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1050,31 +1103,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZWNjNWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQy
-        ODkyNmZjLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MjUu
-        MDc5MDQ0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNjNWI1NzMtMjc0ZC00ZGVj
-        LTkyNDUtYzAxZmQyODkyNmZjL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMDhjODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRh
+        MWE1M2ZiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NTIu
+        NjkwMjI2WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhjODM4NzQtMTNlMC00Y2Rm
+        LThlMjctZGQ1ZmRhMWE1M2ZiL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZWNjNWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZj
+        b250YWluZXIvMDhjODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2Zi
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1kZXYiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:25 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:52 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/sync/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyLzg5MWNkMzhmLTZhOWItNGNmYy1hN2JlLWJjNTBiZTg1N2Y2Yi8i
+        dGFpbmVyLzUxNWFhYWFjLTM4Y2MtNGVhNi05MWI0LWVmNmFlOWQ5MzNkNy8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1087,9 +1140,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:25 GMT
+      - Tue, 03 Dec 2019 14:36:53 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1105,13 +1158,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUxMjU3MjFjLTY4NzItNGY4
-        ZC05MDVmLTlhZjU5YmY0MmI0Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0MzgxNjVhLTg1ZGEtNGVl
+        OC05NTVmLTYxYjI0ZjE5YjNhOC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:25 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:53 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/5125721c-6872-4f8d-905f-9af59bf42b47/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0438165a-85da-4ee8-955f-61b24f19b3a8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1119,7 +1172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1132,9 +1185,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:27 GMT
+      - Tue, 03 Dec 2019 14:36:54 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1146,42 +1199,42 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '521'
+      - '522'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTEyNTcyMWMtNjg3
-        Mi00ZjhkLTkwNWYtOWFmNTliZjQyYjQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MjUuNTAxNTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQzODE2NWEtODVk
+        YS00ZWU4LTk1NWYtNjFiMjRmMTliM2E4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NTMuMDI1MTk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjE3
-        OjI1LjYyODE5NloiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTc6
-        MjcuMTU3MjQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRkOWEtYjI3MS0xNzFhNzQyZGQw
-        MTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
-        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsImNv
-        ZGUiOiJwcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
-        YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93
-        bmxvYWRpbmcgdGFnIGxpc3QiLCJjb2RlIjoiZG93bmxvYWRpbmcudGFnX2xp
-        c3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
-        cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoyMCwic3VmZml4IjpudWxs
-        fSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFz
-        c29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1Mywic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjUzLjExOTU3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6MzY6
+        NTQuMzk2NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRhMjItOWUxYS1mZWNjNGZmNTFk
+        OTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
+        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
+        IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoiZG93bmxv
+        YWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        bnVsbCwiZG9uZSI6MjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
+        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6NTEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJvY2Vzc2luZyBUYWdzIiwi
+        Y29kZSI6InByb2Nlc3NpbmcudGFnIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
-        L2NvbnRhaW5lci80YTdiYzg3Yy0xMTc0LTQ2ZjUtOTFjMy1iNDViMGM3YjJi
-        YTIvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6
+        L2NvbnRhaW5lci8zYTE2ODdhMC1lYTE2LTQ2YzAtODA5Mi0zNWMxMDg4MDY0
+        MWQvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6
         WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWlu
-        ZXIvNGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBjN2IyYmEyLyIsIi9w
-        dWxwL2FwaS92My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvODkxY2Qz
-        OGYtNmE5Yi00Y2ZjLWE3YmUtYmM1MGJlODU3ZjZiLyJdfQ==
+        ZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4ODA2NDFkLyIsIi9w
+        dWxwL2FwaS92My9yZW1vdGVzL2NvbnRhaW5lci9jb250YWluZXIvNTE1YWFh
+        YWMtMzhjYy00ZWE2LTkxYjQtZWY2YWU5ZDkzM2Q3LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:27 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:54 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1189,7 +1242,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1202,957 +1255,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:27 GMT
+      - Tue, 03 Dec 2019 14:36:54 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '288'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBj
-        N2IyYmEyL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoxNzoyNS42NTkzMTdaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
-        Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
-        YmxvYiI6eyJjb3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        NGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBjN2IyYmEyL3ZlcnNpb25z
-        LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9jb250YWluZXIvY29udGFpbmVyLzRhN2JjODdjLTExNzQtNDZmNS05
-        MWMzLWI0NWIwYzdiMmJhMi92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
-        Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNGE3YmM4
-        N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBjN2IyYmEyL3ZlcnNpb25zLzEvIn19
-        LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6eyJj
-        b3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNGE3YmM4N2MtMTE3NC00
-        NmY1LTkxYzMtYjQ1YjBjN2IyYmEyL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
-        ci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
-        bmVyLzRhN2JjODdjLTExNzQtNDZmNS05MWMzLWI0NWIwYzdiMmJhMi92ZXJz
-        aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjozLCJocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvP3JlcG9zaXRv
-        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvNGE3YmM4N2MtMTE3NC00NmY1LTkxYzMtYjQ1YjBjN2Iy
-        YmEyL3ZlcnNpb25zLzEvIn19fX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:27 GMT
-- request:
-    method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        ZGV2IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzRhN2JjODdjLTExNzQtNDZm
-        NS05MWMzLWI0NWIwYzdiMmJhMi92ZXJzaW9ucy8xLyJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:27 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4NTk4N2ZiLWVkMzctNGVl
-        NS04Mzk3LWE4NWM1ZWYyMzYzMi8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:27 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/585987fb-ed37-4ee5-8397-a85c5ef23632/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:28 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '341'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTg1OTg3ZmItZWQz
-        Ny00ZWU1LTgzOTctYTg1YzVlZjIzNjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MjcuNzMzMTc3WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTc6MjcuODQ1MDkz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoxNzoyOC4wMjU2NTZa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
-        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci82NWE2ZGVjMS1lMjY2LTQ1
-        ZWItODM5NC02NjA1YzM0YmQ2ZjMvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:28 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/65a6dec1-e266-45eb-8394-6605c34bd6f3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:28 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '307'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvNjVhNmRlYzEtZTI2Ni00NWViLTgzOTQtNjYw
-        NWMzNGJkNmYzLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci80YTdiYzg3Yy0x
-        MTc0LTQ2ZjUtOTFjMy1iNDViMGM3YjJiYTIvdmVyc2lvbnMvMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjI4LjAxNzEyN1oiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWRldiIsImNvbnRlbnRfZ3VhcmQiOm51bGwsInJlZ2lzdHJ5
-        X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0FDTUVf
-        Q29ycG9yYXRpb24vbGlicmFyeS9idXN5Ym94In0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:28 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:28 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:28 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:28 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '2303'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
-        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvbWFuaWZlc3RzLzIzYmYzODE2LWNkOTgtNGY0MS05NGI2LTI0NThl
-        NDU3OGZmZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3
-        LjEyNzY5NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        MDg5ODFkNjgtZTEwNS00YjM4LTllY2UtNzcxZjE1MDgwNmQ3LyIsImRpZ2Vz
-        dCI6InNoYTI1NjpjZDI3NGZiNjU2MjViZmU2ZjU4YTljY2FlNmE3ZDVkMWRm
-        MzY5YWY5ZGUxMjhiNDE5MzQzOGZhNmYxZTc2OWRiIiwic2NoZW1hX3ZlcnNp
-        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
-        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
-        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL2Jsb2JzLzE4MTAyZWE0LTEyY2UtNGUxNy04ZjQyLTk4YTRkMzAx
-        ZTBlOC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvNjEzMWQzZjQtNDE2OS00YjA2LTg1OTYtMjk0ZWNlYTcxYmEx
-        LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMjRiMjRmODQtOTRiZC00OWQzLThlMjMtN2UxYmQ3
-        ZjcyNTBhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcu
-        MDk4NjU1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
-        MjA2YmMxMy0zMjY0LTRkNmItOTUwMi0wMmY3NjlmNWVlMWMvIiwiZGlnZXN0
-        Ijoic2hhMjU2OmIwMjAzODYzMzI1NTUyNjEzY2E0MTdjNmI2OTQxMDJhYWM0
-        YWEyY2E2NjNmNzM0YmMxZDZjNGM3YjE5NTYxMTEiLCJzY2hlbWFfdmVyc2lv
-        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
-        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
-        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvMmVlZmNiNDEtZTllZC00OWE3LTlhM2YtZDRkMTAxZTlk
-        MzQxLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy8wYzE1YWQ1ZC1kNDU2LTRhNDEtOWU5NS1lNzdlYjJiNjA1N2Ev
-        Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy8yYzE2NDc3YS1kOTQ2LTQzMzctYjA2My1lMDA4ZWVm
-        YzBlMmUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4w
-        MzkyNDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Fi
-        N2UyMjdiLTM1ZWMtNDRlYS1hYTRkLTFhNTUyYmQ4YWVmZC8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6NjNjNjJkNDRiNTZjZGE4OTA0YTc1YTE5MGZkMTk2ZmIwYjg5
-        NDdkY2MxMTliYTkxMzEzYzQ2ZjIyOTlmMzAzNCIsInNjaGVtYV92ZXJzaW9u
-        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
-        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
-        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy9lN2QxOWYxZi1iN2U0LTRkZjUtOWY3OC1kZjA3YjUyM2Nl
-        MGQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzL2U0MWIxZjg3LTQwMDYtNGNiMC1iODQ4LTg4MTViY2JjMmMwNS8i
-        XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzQ3NjM2NTEzLTU0MWEtNDhiYy04OGZiLWJjOThhNGY3
-        ZDZhNi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEy
-        NjM2MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODkz
-        MTg3NjgtMjk3My00OTc0LWEzMTEtMjRiODlmMzA1NTJjLyIsImRpZ2VzdCI6
-        InNoYTI1Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5
-        ODdmZWZlNDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24i
-        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
-        aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
-        W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzL2JiYzg5ZWFjLTdlYmEtNGVlNy1hZmExLTNjMTdjN2Q0YWRh
-        NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvNmQ3NmQ4OGUtZjIzNS00MzBjLTgyZGQtNmFjMTllMjJjOWZhLyJd
-        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvNjU4Y2FmN2UtNWM5MS00ZWFlLTkyZDEtZGUwMTM0OGEw
-        ZmEyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTU0
-        MjI1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zZWZl
-        Y2Y3Ny1hOWJhLTRiNGItOGMzNC0yOGQ0NTRmMGI4MmYvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OjEwMzA1NTc3NDRhYWU5YTI3YWE2ZWU4MzBjYjk4YTJjNjNmYWRl
-        YjM5ZmJmZGNmNDU3YzA5NWQ5ZjQ2MDA4MDciLCJzY2hlbWFfdmVyc2lvbiI6
-        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
-        YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
-        XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvY2JjMTlhMjUtNzhlOS00OTA3LTk0MzItOWQ4NmFjNDc2ZDJl
-        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9lMDc2YTRmYS1jNDE4LTQ4MzYtYjFjOC0xZDZlZWE1NWJkODUvIl19
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy82ZDEyZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1
-        ZjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4xMDQ0
-        OThaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VhMGE1
-        MmJlLTgyNjctNDA1YS05ZTFhLTYwZTU2NjM0MDk0Yy8iLCJkaWdlc3QiOiJz
-        aGEyNTY6ZGFlOTBkM2JkNDU0MDkyM2FlODZmOTQ1ZGVjYTIwYWM2OTMxNDNi
-        OWI3Y2UwMmJiODBiYmZhMmE4YWVjYjU3NiIsInNjaGVtYV92ZXJzaW9uIjoy
-        LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
-        dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
-        LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy85ZGZhY2IwOC1jODgzLTRlMzItOTNjYS02NDQ1Y2ZhOWNlYWQv
-        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2ZhNDJkMGFiLWJlZDYtNGY0MC04YmJjLWRjNmVmMDI3MjI3ZC8iXX0s
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEyODg4
-        OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODBiNDFk
-        OTYtMzdkNy00ZTBmLWI1YTUtOGQ2NWFkMTE1YzdmLyIsImRpZ2VzdCI6InNo
-        YTI1NjoyZDMxZjlkMTBjMDRhNGViYzY1MDAyNzlmZGRmMzNlYjdlYmRmYzUx
-        ODA0MmQ1NjFmZmI3YmM2YTU2OGI0NGE1Iiwic2NoZW1hX3ZlcnNpb24iOjIs
-        Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
-        dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
-        ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzBhNjZkMzI1LTRkZDktNDEwOS05NDgxLWRmMzYyZTFlOTdmYi8i
-        LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvYzQ1OTAyN2QtNjgwOS00MGNiLWEyNmEtY2ZiMzJkNDQ3ZjU0LyJdfSx7
-        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvODQ3MWNhOTAtOGFjZi00NjBjLWJkZTEtN2Y1ZjdhNzEyZGZk
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTA0ODIx
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84ZmJiNmE2
-        MC0yOWQzLTRhZjItYWJmNy04OGJiYmM4NThjNzcvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjA5M2U2MzljOGI3ZmY2N2Q4NzgxMTZkM2RlOWUzZTkxZmYxYmQwZDZl
-        NDE0MWFlNDAxOWNhM2ZiM2U0OTNkZjkiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
-        bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
-        aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
-        Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvM2MzYzY0OWYtM2VkMy00MDYyLTkwMjItMzkzZjNiYjI4NjJiLyIs
-        ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9hNDFmYjBjZS1kZTU1LTRjMGEtYTNiNi1kOGMxNTdlYmQ5MTMvIl19LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUzODhhMjAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wMzc3MTNa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRmZjJlYTJm
-        LTkzYTAtNDNiMi1hOWRiLTM2NWZlMGVjMDg4ZC8iLCJkaWdlc3QiOiJzaGEy
-        NTY6Njc5YjFjMTA1OGMxZjJkYzU5YTNlZTcwZWVkOTg2YTg4ODExYzAyMDVj
-        OGNlZWE1N2NlYzVmMjJkMmMzZmJiMSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
-        ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
-        b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
-        b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy80ZDdiNjUxZC03MGFlLTRkNDMtOTBkZC05NzlhMjA1NGRmMDEvIiwi
-        YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        L2U3ZWJkMjU0LWFjMmEtNGQzMy1hNjE3LWUyZDE4M2Q0OWY1Ny8iXX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
-        aWZlc3RzL2I0YTE5YjY5LThmMTctNGQ2OS05MTE5LTAxNTE4MDJhNzExMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEwMjE3Nloi
-        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTg2ZjZlMzAt
-        YzdiNC00ZDU5LTlhMTUtYTA2Y2IxNWU1ZDdkLyIsImRpZ2VzdCI6InNoYTI1
-        NjowNmU0ZjMwNDdkMmU5YTc4MjIyZmYxNjg2MTI3MTc0N2FkMTJlZDFlZGMz
-        YjFhNTVkMmI5ZGZlODgxNDRhZWQzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
-        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
-        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
-        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzLzFmNjE0MWYzLTI3ZDAtNDNjOC1iMzVjLWFkZjhkMzBkZDExOC8iLCJi
-        bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        MTI3YWI3ODctYzExOC00YjU5LWEwZjItZWM4MzkzOGQ4OTg2LyJdfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
-        ZmVzdHMvYjgyN2NjMGUtYjZjMS00NDUzLTkwMjQtOTIzNWJiMzg4MDQ0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMTAzMzQxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80NmRiNjNmYy0z
-        ZWMwLTQ0OGEtOWQ2ZC0wNTVjOTM4YTA4NDAvIiwiZGlnZXN0Ijoic2hhMjU2
-        OjI1MGI4NzcyNDczNjQ4M2E4OTYyMzEzYjE4N2ZiNmFkNDAyODg5MzE3MTVl
-        N2YzODRmYjRjMDBjNDgxOTA0NmYiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
-        aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
-        Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
-        ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvNDUzMmEwOGMtMWZmZS00NjcwLWEwYzYtZjUzMWVmY2EyMDViLyIsImJs
-        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy81
-        NWJhMWFiNi1jNTgzLTRkMmYtODYxNS1iMGZmMThjM2MxOTUvIl19LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9kN2E1ZDM5NS1iNDc4LTRmMjYtYjdiOS1lNWMzY2M1NzYzOWUvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wOTk4NDBaIiwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U0YmYzZDdmLWY5
-        ZGYtNGU4OC05YWVkLWEzMDYyNDVkN2Q4ZC8iLCJkaWdlc3QiOiJzaGEyNTY6
-        MWU4ZTc3MTYyMjczYzlkZDc4ZGU3OTMwYjg3MDE5NGYyOTZjMjNiNTkwYmY5
-        OTUyYTEzOTlkMDgzYmJhMjI2ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
-        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
-        bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
-        aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy9iODgzMWE2Ni0zMThmLTRmOTctOTJlYi1jNzc5YzZmYmZhYTMvIiwiYmxv
-        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzAy
-        MGU3Y2M5LTlmNzUtNGFkMS1iZWQxLTk4MTVkYzRkOWQyNi8iXX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzL2U4ZTA5YzhlLWRkZTItNGIxNi1hOTg1LWEzMzQ3OTI1MjE2MS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjA0NTA4OFoiLCJh
-        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDk3YmM2MGEtYzcx
-        NS00NzAyLTk4MzktYzA4MzNhYTUwNzg3LyIsImRpZ2VzdCI6InNoYTI1Njpi
-        YmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkzMGQxMWUwZWE0
-        ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
-        X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
-        YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
-        Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzllZGVjYmM0LThlYTYtNDhhNS1iMWIyLTNhZjNkN2ZkZjExMC8iLCJibG9i
-        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvNmRj
-        ZGM0NGMtMjFlYS00OTE2LWExZWYtNTAwYmFjYjk3MjhlLyJdfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvZWVjOTcxNWQtZjg4Ni00ZWEwLTk0NTYtNGNiMzM3MWFkNzUyLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMTAxMDIyWiIsImFy
-        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80NWU5ODZjNi05YTc0
-        LTRhMGItOWNlNC1kMTk2N2NhY2UxMDkvIiwiZGlnZXN0Ijoic2hhMjU2OmYz
-        NTA2MDkzMTM0NWEzMTUxZWU3M2YxMTkzYzc4MmQyYzJmYjg5ZjVjNjJiMjMy
-        OWNhM2UxOTc2OTg5MTcxZTIiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
-        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
-        bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
-        X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
-        ZTUwMTA4YmEtZmEyYS00OTgzLWE3N2YtNjdjNzNlOTNlZTVjLyIsImJsb2Jz
-        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy9jNGIz
-        OGZhNi03Nzk1LTRmOGYtOGFiOC02ZmIwOWRkYzViYWQvIl19XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:28 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:29 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '914'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMDQ4YTg2YTUtN2ExZS00ZTdhLWJiYTMtOWRhZTI1
-        OWRiM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYu
-        ODkzODU4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84
-        ZWM1MGUwYS1mMzFjLTRiODUtOTJjMy1kN2E3ZjhiODk3NjEvIiwiZGlnZXN0
-        Ijoic2hhMjU2OjEzMDNkYmYxMTBjNTdmM2VkZjY4ZDlmNWExNmMwODJlYzA2
-        YzRjZjc2MDQ4MzE2NjlmYWYyYzcxMjI2MGI1YTAiLCJzY2hlbWFfdmVyc2lv
-        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
-        dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
-        ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9iODI3Y2MwZS1iNmMxLTQ0NTMtOTAyNC05MjM1YmIzODgwNDQvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy84NDcx
-        Y2E5MC04YWNmLTQ2MGMtYmRlMS03ZjVmN2E3MTJkZmQvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83ZDk2NTFkMy0yYTM0
-        LTQ4NGEtYjA0ZS1iNDVkZmM3MTllNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9lOGUwOWM4ZS1kZGUyLTRiMTYtYTk4
-        NS1hMzM0NzkyNTIxNjEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUz
-        ODhhMjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy82NThjYWY3ZS01YzkxLTRlYWUtOTJkMS1kZTAxMzQ4YTBmYTIvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82ZDEy
-        ZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1ZjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iNGExOWI2OS04ZjE3
-        LTRkNjktOTExOS0wMTUxODAyYTcxMTAvIl0sImNvbmZpZ19ibG9iIjpudWxs
-        LCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1kMGVmLTRjYjktOWE3
-        Yy1jMzhiMGQ5MTVkODUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQx
-        NjowMDo1Ni44OTgxODJaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
-        aWZhY3RzLzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5YS8i
-        LCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkxMzI0MDZiYWQ3
-        ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5YSIsInNjaGVt
-        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
-        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlz
-        dGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzg0NzFjYTkwLThhY2YtNDYwYy1iZGUxLTdmNWY3YTcx
-        MmRmZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0OC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2U4ZTA5
-        YzhlLWRkZTItNGIxNi1hOTg1LWEzMzQ3OTI1MjE2MS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzMjhkMDZlLTI4MDMt
-        NGMzYS04NTk3LWQ1MWIxZTM4OGEyMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzLzY1OGNhZjdlLTVjOTEtNGVhZS05MmQx
-        LWRlMDEzNDhhMGZhMi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
-        XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzczZWM0ZTQyLTc4ZjYtNDU1My1iYTQzLTQwODJkNzdh
-        M2MyNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2Ljkw
-        MTc4NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODNi
-        M2ZhNzYtYzE5NS00NWI4LWEyZmYtNWQ5NmQ3ZmE4NjNlLyIsImRpZ2VzdCI6
-        InNoYTI1NjphMDRlYzQyN2IyNDhkNjcyNzUwN2IyNWQ4NDEzOGM3ZjRjMDky
-        ZjE2ZmZkZjk1NDIxNjEyNjhlOWJkYmExNjhiIiwic2NoZW1hX3ZlcnNpb24i
-        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
-        aWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZl
-        c3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvNmQxMmYxYWMtMWJjMy00ODY4LWFjODktZTljY2Q0NTg4NWY1LyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvZWVjOTcx
-        NWQtZjg4Ni00ZWEwLTk0NTYtNGNiMzM3MWFkNzUyLyIsIi9wdWxwL2FwaS92
-        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNDc2MzY1MTMtNTQxYS00
-        OGJjLTg4ZmItYmM5OGE0ZjdkNmE2LyIsIi9wdWxwL2FwaS92My9jb250ZW50
-        L2NvbnRhaW5lci9tYW5pZmVzdHMvMmMxNjQ3N2EtZDk0Ni00MzM3LWIwNjMt
-        ZTAwOGVlZmMwZTJlLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvMjNiZjM4MTYtY2Q5OC00ZjQxLTk0YjYtMjQ1OGU0NTc4
-        ZmZkLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
-        dHMvMjRiMjRmODQtOTRiZC00OWQzLThlMjMtN2UxYmQ3ZjcyNTBhLyIsIi9w
-        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvZDdhNWQz
-        OTUtYjQ3OC00ZjI2LWI3YjktZTVjM2NjNTc2MzllLyJdLCJjb25maWdfYmxv
-        YiI6bnVsbCwiYmxvYnMiOltdfV19
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:29 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/4a7bc87c-1174-46f5-91c3-b45b0c7b2ba2/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:29 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '436'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2VjYjA2NWVjLWQ4ZDAtNDNhOC05NmQ0LTQ2MDUzMGM0NGRk
-        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2LjkwMzU3
-        N1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODNiM2Zh
-        NzYtYzE5NS00NWI4LWEyZmYtNWQ5NmQ3ZmE4NjNlLyIsIm5hbWUiOiJtdXNs
-        IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
-        dGFpbmVyL21hbmlmZXN0cy83M2VjNGU0Mi03OGY2LTQ1NTMtYmE0My00MDgy
-        ZDc3YTNjMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvdGFncy9hMGVjNGRjNC0wNzQ1LTRiOWMtYjIzNC1lYzcx
-        N2JlMDUwMTIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1
-        Ni44OTYxMjlaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
-        LzhlYzUwZTBhLWYzMWMtNGI4NS05MmMzLWQ3YTdmOGI4OTc2MS8iLCJuYW1l
-        IjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8wNDhhODZhNS03YTFlLTRlN2Et
-        YmJhMy05ZGFlMjU5ZGIzZjEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvdGFncy82ODc4NjhiNy02MzliLTQ5NjAt
-        OWZhOS02MmMyZjZjMjMyNDEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjowMDo1Ni44OTk5ODhaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5
-        YS8iLCJuYW1lIjoidWNsaWJjIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1k
-        MGVmLTRjYjktOWE3Yy1jMzhiMGQ5MTVkODUvIn1dfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:29 GMT
-- request:
-    method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/remove/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJjb250ZW50X3VuaXRzIjpbIioiXX0=
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:29 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - POST, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmMzkzYTk0LTdiZjctNGE5
-        NC1iMzU0LTRmMTVmODA0MzdlNi8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:29 GMT
-- request:
-    method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/add/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzLzY4Nzg2OGI3LTYzOWItNDk2MC05ZmE5LTYyYzJmNmMyMzI0
-        MS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9hMGVj
-        NGRjNC0wNzQ1LTRiOWMtYjIzNC1lYzcxN2JlMDUwMTIvIl19
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:29 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - POST, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExOTRjMzkzLTdmYjAtNGFi
-        NC04MmRjLWUxNjU3NGM3MTZhOC8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:29 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/5f393a94-7bf7-4a94-b354-4f15f80437e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:30 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '338'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWYzOTNhOTQtN2Jm
-        Ny00YTk0LWIzNTQtNGYxNWY4MDQzN2U2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MjkuNzYzMTcyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjE3OjI5Ljg2ODY5MVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MTc6MjkuOTE3MTU0WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
-        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
-        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNj
-        NWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZjLyJdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:30 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/5f393a94-7bf7-4a94-b354-4f15f80437e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:30 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '338'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWYzOTNhOTQtN2Jm
-        Ny00YTk0LWIzNTQtNGYxNWY4MDQzN2U2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MjkuNzYzMTcyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjE3OjI5Ljg2ODY5MVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MTc6MjkuOTE3MTU0WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
-        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
-        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNj
-        NWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZjLyJdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:30 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a194c393-7fb0-4ab4-82dc-e16574c716a8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:30 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '351'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTE5NGMzOTMtN2Zi
-        MC00YWI0LTgyZGMtZTE2NTc0YzcxNmE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTc6MjkuOTEyNTk1WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsInN0YXJ0ZWRfYXQiOiIyMDE5
-        LTExLTIyVDE2OjE3OjMwLjA3NDI2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMTkt
-        MTEtMjJUMTY6MTc6MzAuMjM5MjM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRmYjktYTUx
-        YS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tz
-        IjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRh
-        aW5lci9lY2M1YjU3My0yNzRkLTRkZWMtOTI0NS1jMDFmZDI4OTI2ZmMvdmVy
-        c2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNj
-        NWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZjLyJdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:30 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:17:30 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2169,42 +1274,92 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZWNjNWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQy
-        ODkyNmZjL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoxNzozMC4xMDE3MTlaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4
+        ODA2NDFkL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo1My4xMzg4MzBaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
-        YmxvYiI6eyJjb3VudCI6MTYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        YmxvYiI6eyJjb3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
         dC9jb250YWluZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        ZWNjNWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZjL3ZlcnNpb25z
-        LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTAsImhyZWYi
+        M2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4ODA2NDFkL3ZlcnNpb25z
+        LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYi
         OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9y
         ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9jb250YWluZXIvY29udGFpbmVyL2VjYzViNTczLTI3NGQtNGRlYy05
-        MjQ1LWMwMWZkMjg5MjZmYy92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
-        Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
+        cmllcy9jb250YWluZXIvY29udGFpbmVyLzNhMTY4N2EwLWVhMTYtNDZjMC04
+        MDkyLTM1YzEwODgwNjQxZC92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
+        Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
         dGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNjNWI1
-        NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODkyNmZjL3ZlcnNpb25zLzEvIn19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvM2ExNjg3
+        YTAtZWExNi00NmMwLTgwOTItMzVjMTA4ODA2NDFkL3ZlcnNpb25zLzEvIn19
         LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6eyJj
-        b3VudCI6MTYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        b3VudCI6MjgsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
         ZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWNjNWI1NzMtMjc0ZC00
-        ZGVjLTkyNDUtYzAxZmQyODkyNmZjL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
-        ci5tYW5pZmVzdCI6eyJjb3VudCI6MTAsImhyZWYiOiIvcHVscC9hcGkvdjMv
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00
+        NmMwLTgwOTItMzVjMTA4ODA2NDFkL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
+        ci5tYW5pZmVzdCI6eyJjb3VudCI6MTcsImhyZWYiOiIvcHVscC9hcGkvdjMv
         Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNp
         b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
-        bmVyL2VjYzViNTczLTI3NGQtNGRlYy05MjQ1LWMwMWZkMjg5MjZmYy92ZXJz
-        aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjoyLCJocmVmIjoi
+        bmVyLzNhMTY4N2EwLWVhMTYtNDZjMC04MDkyLTM1YzEwODgwNjQxZC92ZXJz
+        aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjozLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvP3JlcG9zaXRv
         cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvZWNjNWI1NzMtMjc0ZC00ZGVjLTkyNDUtYzAxZmQyODky
-        NmZjL3ZlcnNpb25zLzEvIn19fX0=
+        ci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVjMTA4ODA2
+        NDFkL3ZlcnNpb25zLzEvIn19fX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:30 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:54 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1kZXYiLCJyZXBv
+        c2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Nv
+        bnRhaW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgwOTItMzVj
+        MTA4ODA2NDFkL3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:54 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxZGM0YzU5LWRlYzktNGFi
+        Zi1iMDgzLThmNjY4ODk2NDczMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:54 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/71dc4c59-dec9-4abf-b083-8f6688964731/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2212,7 +1367,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -2225,9 +1380,119 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:30 GMT
+      - Tue, 03 Dec 2019 14:36:55 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzFkYzRjNTktZGVj
+        OS00YWJmLWIwODMtOGY2Njg4OTY0NzMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NTQuODQ2NzYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6MzY6NTQuOTQ4ODMx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDozNjo1NS4xNjIxNTVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8zZTU2MDhmOC1iMTQ1LTRh
+        YWUtODBkMC04MmI3MGQyNzYwZTQvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/3e5608f8-b145-4aae-80d0-82b70d2760e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:55 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '294'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvM2ExNjg3YTAtZWExNi00NmMwLTgw
+        OTItMzVjMTA4ODA2NDFkL3ZlcnNpb25zLzEvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci8zZTU2MDhmOC1iMTQ1LTRhYWUtODBkMC04
+        MmI3MGQyNzYwZTQvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6MzY6NTUuMTUzNDgxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwicmVnaXN0cnlfcGF0aCI6InB1
+        bHAzLWRldmVsLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVwcGV0X3Byb2R1Y3Qt
+        YnVzeWJveCJ9
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:55 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2246,10 +1511,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:30 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:55 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2257,7 +1522,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2270,9 +1535,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:31 GMT
+      - Tue, 03 Dec 2019 14:36:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2284,120 +1549,198 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '1433'
+      - '2298'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6OCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvNjU4Y2FmN2UtNWM5MS00ZWFlLTkyZDEtZGUwMTM0
-        OGEwZmEyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYu
-        OTU0MjI1WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8z
-        ZWZlY2Y3Ny1hOWJhLTRiNGItOGMzNC0yOGQ0NTRmMGI4MmYvIiwiZGlnZXN0
-        Ijoic2hhMjU2OjEwMzA1NTc3NDRhYWU5YTI3YWE2ZWU4MzBjYjk4YTJjNjNm
-        YWRlYjM5ZmJmZGNmNDU3YzA5NWQ5ZjQ2MDA4MDciLCJzY2hlbWFfdmVyc2lv
+        eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
+        YWluZXIvbWFuaWZlc3RzLzA0ZTZiODc2LTJmOTQtNGNjNy1iODAzLWE3M2Zk
+        Yjk0YzNiMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQx
+        Ljg1ODI5OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OTM1MTc4YWItZmMzNC00NWI0LTk2MGQtZGY2MDViNmVhODgzLyIsImRpZ2Vz
+        dCI6InNoYTI1NjpkYWU5MGQzYmQ0NTQwOTIzYWU4NmY5NDVkZWNhMjBhYzY5
+        MzE0M2I5YjdjZTAyYmI4MGJiZmEyYThhZWNiNTc2Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
+        dGFpbmVyL2Jsb2JzLzgwNTA0ZmVhLTMzNDAtNDJiNS05YjY0LTcxNDUwYTJj
+        OTAwYS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvNTUzYWE2YjgtY2MwZi00MzZiLTk0NDEtOTZkOGJhZTM1MDJk
+        LyJdfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci9tYW5pZmVzdHMvMTQxZTI1YmQtNjI5ZS00OTUxLTg0NTYtYzZiNWU0
+        M2I4ZmQwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        Nzk0NDExWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9h
+        ODdiYzg5ZS1mMTZmLTQ1ZGUtYmQ3NS02NDcyMDVhMzgwODIvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmYzNTA2MDkzMTM0NWEzMTUxZWU3M2YxMTkzYzc4MmQyYzJm
+        Yjg5ZjVjNjJiMjMyOWNhM2UxOTc2OTg5MTcxZTIiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvY2JjMTlhMjUtNzhlOS00OTA3LTk0MzItOWQ4NmFjNDc2
-        ZDJlLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9lMDc2YTRmYS1jNDE4LTQ4MzYtYjFjOC0xZDZlZWE1NWJkODUv
+        YWluZXIvYmxvYnMvYmExNmM3YWEtMTMzOS00ODUwLWIxNWMtZmNmZWJkYzAy
+        YmZhLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy9iNTljZTFjYy04ZDg3LTQ5NTAtYmY2MC0yMDkxOTBmNGI3MTQv
         Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy82ZDEyZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1
-        ODg1ZjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4x
-        MDQ0OThaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Vh
-        MGE1MmJlLTgyNjctNDA1YS05ZTFhLTYwZTU2NjM0MDk0Yy8iLCJkaWdlc3Qi
-        OiJzaGEyNTY6ZGFlOTBkM2JkNDU0MDkyM2FlODZmOTQ1ZGVjYTIwYWM2OTMx
-        NDNiOWI3Y2UwMmJiODBiYmZhMmE4YWVjYjU3NiIsInNjaGVtYV92ZXJzaW9u
+        bmVyL21hbmlmZXN0cy8zMGQyM2ZhMS1lMDdiLTQ4YTktOTk0Zi1jYmIyMjRm
+        ODVjZWUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43
+        NjYyNjZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4
+        MjE1MzExLTA0MjMtNGRhNS05NmEyLTU2MGI5YTQ2MDdjZS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6MTAzMDU1Nzc0NGFhZTlhMjdhYTZlZTgzMGNiOThhMmM2M2Zh
+        ZGViMzlmYmZkY2Y0NTdjMDk1ZDlmNDYwMDgwNyIsInNjaGVtYV92ZXJzaW9u
         IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
         cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
         OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy85ZGZhY2IwOC1jODgzLTRlMzItOTNjYS02NDQ1Y2ZhOWNl
-        YWQvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzL2ZhNDJkMGFiLWJlZDYtNGY0MC04YmJjLWRjNmVmMDI3MjI3ZC8i
+        aW5lci9ibG9icy85MDg2NDdkNi04ZWI4LTQ3OWMtYjk1Yy1jMzQzZDg3Njhl
+        ZjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2Y4Nzg2MzAyLTg3MmQtNGVjNS1iODk0LTVkZGQ1YmIxNGI4OS8i
         XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcx
-        OWU0OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEy
-        ODg4OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODBi
-        NDFkOTYtMzdkNy00ZTBmLWI1YTUtOGQ2NWFkMTE1YzdmLyIsImRpZ2VzdCI6
-        InNoYTI1NjoyZDMxZjlkMTBjMDRhNGViYzY1MDAyNzlmZGRmMzNlYjdlYmRm
-        YzUxODA0MmQ1NjFmZmI3YmM2YTU2OGI0NGE1Iiwic2NoZW1hX3ZlcnNpb24i
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjc4
+        OTYzOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjYw
+        MmUzMzUtM2E2MC00NzcxLWFjNDYtY2IzMzRmMTAxZjkzLyIsImRpZ2VzdCI6
+        InNoYTI1NjpiYmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkz
+        MGQxMWUwZWE0ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24i
         OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
         aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
         W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL2Jsb2JzLzBhNjZkMzI1LTRkZDktNDEwOS05NDgxLWRmMzYyZTFlOTdm
-        Yi8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvYzQ1OTAyN2QtNjgwOS00MGNiLWEyNmEtY2ZiMzJkNDQ3ZjU0LyJd
+        bmVyL2Jsb2JzL2Q3NTdkNzliLTM3MmUtNDI1Ni1hYjUyLTZiZjJlMTQ0YzE3
+        NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvYmRiOGRjZmEtOTk3Ny00MjAwLWI2M2UtZDM1YjhlYmQ1ZWIzLyJd
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9tYW5pZmVzdHMvODQ3MWNhOTAtOGFjZi00NjBjLWJkZTEtN2Y1ZjdhNzEy
-        ZGZkLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYuOTA0
-        ODIxWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84ZmJi
-        NmE2MC0yOWQzLTRhZjItYWJmNy04OGJiYmM4NThjNzcvIiwiZGlnZXN0Ijoi
-        c2hhMjU2OjA5M2U2MzljOGI3ZmY2N2Q4NzgxMTZkM2RlOWUzZTkxZmYxYmQw
-        ZDZlNDE0MWFlNDAxOWNhM2ZiM2U0OTNkZjkiLCJzY2hlbWFfdmVyc2lvbiI6
+        ci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00Yzk0LWFmODAtYWQ1YjdjYjBk
+        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzYz
+        ODg5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kYjEw
+        YWYwYS1kZTIwLTQxNzAtYmExMC01YmRkYWY5YTI0MDEvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjJkMzFmOWQxMGMwNGE0ZWJjNjUwMDI3OWZkZGYzM2ViN2ViZGZj
+        NTE4MDQyZDU2MWZmYjdiYzZhNTY4YjQ0YTUiLCJzY2hlbWFfdmVyc2lvbiI6
         MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
         YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
         XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvYmxvYnMvM2MzYzY0OWYtM2VkMy00MDYyLTkwMjItMzkzZjNiYjI4NjJi
+        ZXIvYmxvYnMvMWMxMjQ3YjYtMTQ5OC00MDk0LWI0YTUtMDFhZTM1ZDI0OTk5
         LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy9hNDFmYjBjZS1kZTU1LTRjMGEtYTNiNi1kOGMxNTdlYmQ5MTMvIl19
+        bG9icy9hOGZmYjY1Ny0yMjE5LTQ2NjctOTIzYS00YmEyNmExY2ExYTAvIl19
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L21hbmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUzODhh
-        MjAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wMzc3
-        MTNaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzRmZjJl
-        YTJmLTkzYTAtNDNiMi1hOWRiLTM2NWZlMGVjMDg4ZC8iLCJkaWdlc3QiOiJz
-        aGEyNTY6Njc5YjFjMTA1OGMxZjJkYzU5YTNlZTcwZWVkOTg2YTg4ODExYzAy
-        MDVjOGNlZWE1N2NlYzVmMjJkMmMzZmJiMSIsInNjaGVtYV92ZXJzaW9uIjoy
+        L21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1LTQyMDgtOWE3OC05YzEyZjUzMjg5
+        NWIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS44NDA1
+        NzFaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3NDc0
+        NDhiLWZiMjEtNGQ1Mi05YjJkLTU5OTUxMWYyYmFiNS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6Y2QyNzRmYjY1NjI1YmZlNmY1OGE5Y2NhZTZhN2Q1ZDFkZjM2OWFm
+        OWRlMTI4YjQxOTM0MzhmYTZmMWU3NjlkYiIsInNjaGVtYV92ZXJzaW9uIjoy
         LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
         dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
         LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy80ZDdiNjUxZC03MGFlLTRkNDMtOTBkZC05NzlhMjA1NGRmMDEv
+        ci9ibG9icy9kNGVlZDljNi02YjA2LTQ1YzEtODcxYi1iMGU0NjIxNWNlZjgv
         IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
-        b2JzL2U3ZWJkMjU0LWFjMmEtNGQzMy1hNjE3LWUyZDE4M2Q0OWY1Ny8iXX0s
+        b2JzLzExYWQ5ZjM5LTkzZTAtNDk1MC05NzU5LTFkNTQ4OTFlZTM3Yy8iXX0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        bWFuaWZlc3RzL2I0YTE5YjY5LThmMTctNGQ2OS05MTE5LTAxNTE4MDJhNzEx
-        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU3LjEwMjE3
-        NloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTg2ZjZl
-        MzAtYzdiNC00ZDU5LTlhMTUtYTA2Y2IxNWU1ZDdkLyIsImRpZ2VzdCI6InNo
-        YTI1NjowNmU0ZjMwNDdkMmU5YTc4MjIyZmYxNjg2MTI3MTc0N2FkMTJlZDFl
-        ZGMzYjFhNTVkMmI5ZGZlODgxNDRhZWQzIiwic2NoZW1hX3ZlcnNpb24iOjIs
+        bWFuaWZlc3RzLzg1YjJhZjM4LTI1N2UtNDkxNC1iYWEyLTE1ODk4OTQ1NDJk
+        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg1OTU3
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZGJmNmYw
+        ZjYtNDRlYy00ZWVmLTgwOWUtNjFmNThhNDgzOGZjLyIsImRpZ2VzdCI6InNo
+        YTI1NjpiMDIwMzg2MzMyNTU1MjYxM2NhNDE3YzZiNjk0MTAyYWFjNGFhMmNh
+        NjYzZjczNGJjMWQ2YzRjN2IxOTU2MTExIiwic2NoZW1hX3ZlcnNpb24iOjIs
         Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
         dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
         ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
-        L2Jsb2JzLzFmNjE0MWYzLTI3ZDAtNDNjOC1iMzVjLWFkZjhkMzBkZDExOC8i
+        L2Jsb2JzLzA5YmI0YTcxLTNkMDctNDQzZC05YTg3LTcyNmVkNjVkN2E4My8i
         LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
-        YnMvMTI3YWI3ODctYzExOC00YjU5LWEwZjItZWM4MzkzOGQ4OTg2LyJdfSx7
+        YnMvOWJkMTM1ZTQtNmQ3Zi00MTRhLWJhOTItNjE0ZTk3ZjAxZGNhLyJdfSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
-        YW5pZmVzdHMvYjgyN2NjMGUtYjZjMS00NDUzLTkwMjQtOTIzNWJiMzg4MDQ0
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTcuMTAzMzQx
-        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80NmRiNjNm
-        Yy0zZWMwLTQ0OGEtOWQ2ZC0wNTVjOTM4YTA4NDAvIiwiZGlnZXN0Ijoic2hh
-        MjU2OjI1MGI4NzcyNDczNjQ4M2E4OTYyMzEzYjE4N2ZiNmFkNDAyODg5MzE3
-        MTVlN2YzODRmYjRjMDBjNDgxOTA0NmYiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        YW5pZmVzdHMvOTk5ZGExM2YtYjJmMC00ZWVmLWI5M2ItY2ZhZGMwNTkzZGQ0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzkzMTEy
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mNmQ2NzY3
+        Yy03NjdkLTQwOTktOWY1Ni1mOTRjYzM2ODE2ZGEvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjY3OWIxYzEwNThjMWYyZGM1OWEzZWU3MGVlZDk4NmE4ODgxMWMwMjA1
+        YzhjZWVhNTdjZWM1ZjIyZDJjM2ZiYjEiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
         bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
         aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
         Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
-        YmxvYnMvNDUzMmEwOGMtMWZmZS00NjcwLWEwYzYtZjUzMWVmY2EyMDViLyIs
+        YmxvYnMvODUxZTAyZWUtNTNjYi00Yjc1LTlhMDYtZjAzZWVhYmFkNTIxLyIs
         ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
-        cy81NWJhMWFiNi1jNTgzLTRkMmYtODYxNS1iMGZmMThjM2MxOTUvIl19LHsi
+        cy8wZTMwM2IzYy0yNGQ2LTQ5YjQtODc3Mi02ZDdkYTQ3YjVhZWIvIl19LHsi
         cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
-        bmlmZXN0cy9lOGUwOWM4ZS1kZGUyLTRiMTYtYTk4NS1hMzM0NzkyNTIxNjEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjowMDo1Ny4wNDUwODha
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzA5N2JjNjBh
-        LWM3MTUtNDcwMi05ODM5LWMwODMzYWE1MDc4Ny8iLCJkaWdlc3QiOiJzaGEy
-        NTY6YmJhMjE5NDkyZTRhZGU5ZGM1ZTYyMDMyZjdkNWMzOGY3YTU5MzBkMTFl
-        MGVhNGU0NjJhZmJlNmY2OGVmYWJjYiIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        bmlmZXN0cy9iMzk1MmI1My01OGZlLTQ5ODktOTg4Yy0zMDJiYzM1MzRhNmYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS42Mjk0MzJa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJhMmQ0ZmIy
+        LTdkNDctNDdmMS05MDZkLTM5ZWZiYTZkY2M2OS8iLCJkaWdlc3QiOiJzaGEy
+        NTY6MDkzZTYzOWM4YjdmZjY3ZDg3ODExNmQzZGU5ZTNlOTFmZjFiZDBkNmU0
+        MTQxYWU0MDE5Y2EzZmIzZTQ5M2RmOSIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
         ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
         b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
         b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
-        bG9icy85ZWRlY2JjNC04ZWE2LTQ4YTUtYjFiMi0zYWYzZDdmZGYxMTAvIiwi
+        bG9icy82ZWJmNDRkNy1jZjhiLTQ3OGQtYTJiZi1kOWMwMDlmNTA5NmUvIiwi
         YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
-        LzZkY2RjNDRjLTIxZWEtNDkxNi1hMWVmLTUwMGJhY2I5NzI4ZS8iXX1dfQ==
+        LzBmZDgzYjA1LTdhMjAtNDNiYS05MWI0LTNiNmFkMzdhMWZhNy8iXX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFu
+        aWZlc3RzL2I3YjE2OTI5LWJmNGUtNDJmYS04YTU5LWE1MzcwMGQ0ZmNiZC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjg2MTI3MVoi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYWJhMTkzOGUt
+        NjdkOS00MmZhLWI4YjItNTJkYWJiMjY3MDViLyIsImRpZ2VzdCI6InNoYTI1
+        Njo2N2NiMWU3MDZkMzdhMDM3ZDQzOTRiNDE2MmE2ZWU3ZDI3OGM5ODdmZWZl
+        NDVlMDJlY2I0M2E2OGVjOWQwZGEyIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
+        b2JzLzNkZDNkZTgzLWFhNzctNDg3Ni1hNTEyLTBkNGI1NDhhYTMzYi8iLCJi
+        bG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
+        MWJjYmE3NTItYTQ3MS00MDRkLWI5N2YtNjliNWFlMWU0ZGFlLyJdfSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5p
+        ZmVzdHMvYmY3MzhhMDItZTU3MC00YTU0LWE3NGEtNzgyMDkyODA4M2MxLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuODM5MzIxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84YmE0OTNkMy01
+        YzhmLTRjODAtYmRmYS0yODZiZDRhYThjNDIvIiwiZGlnZXN0Ijoic2hhMjU2
+        OjI1MGI4NzcyNDczNjQ4M2E4OTYyMzEzYjE4N2ZiNmFkNDAyODg5MzE3MTVl
+        N2YzODRmYjRjMDBjNDgxOTA0NmYiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
+        Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
+        ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
+        YnMvZmJhMjAyOTItNGNiNi00N2Y5LWEwNTItYmY1MmM3YWM5YWQ1LyIsImJs
+        b2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy81
+        NmQ0MGE4Mi1jMjEyLTRkNmUtYmFlMC1kOTI4ZjdjOTUxMDcvIl19LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9jMDMwY2IxMS04ZDBmLTQxZGMtYTczZS01YjVjNDgyODFjMTEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43ODgxOTZaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2NkMTE0OTkzLTBi
+        YmYtNGNkMC1iMGM4LWViMzRjOWRkYzI1OC8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MDZlNGYzMDQ3ZDJlOWE3ODIyMmZmMTY4NjEyNzE3NDdhZDEyZWQxZWRjM2Ix
+        YTU1ZDJiOWRmZTg4MTQ0YWVkMyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
+        bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
+        aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
+        cy9mMGVkZWJlMy0xZDU4LTQwNmEtOTM2OC0wOTE0NGJkYTNkMGMvIiwiYmxv
+        YnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzY4
+        OTdmMGJlLTFjNWUtNGUyYi05ZmVmLWI0OGFjY2UwNjQzOS8iXX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzL2RhNWQ4ZTFiLTE1ZjEtNDZlOS05ZmJiLTI2NTQ4OWUyMGFiMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjgzODEwMVoiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNWE3OGFiMTUtODQy
+        Ny00NWYzLWIwMzYtZWE1NjhlYmJkY2RmLyIsImRpZ2VzdCI6InNoYTI1Njox
+        ZThlNzcxNjIyNzNjOWRkNzhkZTc5MzBiODcwMTk0ZjI5NmMyM2I1OTBiZjk5
+        NTJhMTM5OWQwODNiYmEyMjZlIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlh
+        X3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5t
+        YW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZp
+        Z19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
+        LzQwZDYxNjIwLWIxM2YtNDU2Ny05NzhhLWE5MDU5ZTBjNjg5OS8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMvZWE0
+        NGRhMzAtYWU4Zi00Y2M3LWJiOGMtMjdkODhiYWMwMDQyLyJdfSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvZTIxNTUwMzItYTMwMS00NzEwLTk4ZjktMTgyYmUxZjgyNzEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzg2NjI2WiIsImFy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9lM2UwMmVkNy0yMzA5
+        LTQzZjEtYjViMS05ZTJlYTNlMzg2MWYvIiwiZGlnZXN0Ijoic2hhMjU2OjYz
+        YzYyZDQ0YjU2Y2RhODkwNGE3NWExOTBmZDE5NmZiMGI4OTQ3ZGNjMTE5YmE5
+        MTMxM2M0NmYyMjk5ZjMwMzQiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
+        X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxvYnMv
+        Y2IyMzEwMDAtNmE1Mi00NmM1LTlhYWItZTAxNWMwYmFmYzUyLyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9icy85NmQ5
+        NDUxNi05MGY0LTRhOWYtOTdmMy05YmRmYThlNWQwMDYvIl19XX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:31 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:56 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2405,7 +1748,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2418,9 +1761,719 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:31 GMT
+      - Tue, 03 Dec 2019 14:36:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '911'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci9tYW5pZmVzdHMvN2NhNzkyZjgtNDdmYS00YzI1LThjYzktN2U0NzFm
+        MGYyNzgyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        NjIzODM5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81
+        ZDFiYjE5ZC1lMzY2LTRiMzYtYTY5Zi1jOWJhMjE3YWYwMzgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmEwNGVjNDI3YjI0OGQ2NzI3NTA3YjI1ZDg0MTM4YzdmNGMw
+        OTJmMTZmZmRmOTU0MjE2MTI2OGU5YmRiYTE2OGIiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy8wNGU2Yjg3Ni0yZjk0LTRjYzctYjgwMy1hNzNmZGI5NGMzYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8xNDFl
+        MjViZC02MjllLTQ5NTEtODQ1Ni1jNmI1ZTQzYjhmZDAvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83NWQ4ZjIyYS0zNzY1
+        LTQyMDgtOWE3OC05YzEyZjUzMjg5NWIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy84NWIyYWYzOC0yNTdlLTQ5MTQtYmFh
+        Mi0xNTg5ODk0NTQyZGUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iN2IxNjkyOS1iZjRlLTQyZmEtOGE1OS1hNTM3MDBk
+        NGZjYmQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9kYTVkOGUxYi0xNWYxLTQ2ZTktOWZiYi0yNjU0ODllMjBhYjAvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9lMjE1
+        NTAzMi1hMzAxLTQ3MTAtOThmOS0xODJiZTFmODI3MTMvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iMzdmMTUzOC03NmIy
+        LTQxNTMtYTYyMS05ZjFhMzU0MWYzODgvIiwicHVscF9jcmVhdGVkIjoiMjAx
+        OS0xMi0wM1QxNDozNjo0MS42MjY3MDFaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzMxNzNhNWFkLTE5OGItNDNmNC1hNjU2LTFiZWE1
+        ZmJkYTU0ZC8iLCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkx
+        MzI0MDZiYWQ3ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5
+        YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzMwZDIzZmExLWUwN2ItNDhhOS05OTRm
+        LWNiYjIyNGY4NWNlZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzYzYmI5MTQ0LWFjMmUtNGM5NC1hZjgwLWFkNWI3Y2IwZDc2Mi8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzk5OWRh
+        MTNmLWIyZjAtNGVlZi1iOTNiLWNmYWRjMDU5M2RkNC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzOTUyYjUzLTU4ZmUt
+        NDk4OS05ODhjLTMwMmJjMzUzNGE2Zi8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ImJsb2JzIjpbXX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzL2ZlNTlkZGYxLTlhZTgtNDI2Yi05NmMx
+        LTJjODU1MWRiYWQ1Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0
+        OjM2OjQxLjYyMDYyOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvNjY1YTM0NTgtMjA3Yy00MzFjLWI5NjYtNjM0ODU0NDNkMDBkLyIs
+        ImRpZ2VzdCI6InNoYTI1NjoxMzAzZGJmMTEwYzU3ZjNlZGY2OGQ5ZjVhMTZj
+        MDgyZWMwNmM0Y2Y3NjA0ODMxNjY5ZmFmMmM3MTIyNjBiNWEwIiwic2NoZW1h
+        X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
+        a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC5saXN0LnYyK2pzb24iLCJsaXN0
+        ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvMDRlNmI4NzYtMmY5NC00Y2M3LWI4MDMtYTczZmRiOTRj
+        M2IwLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvMzBkMjNmYTEtZTA3Yi00OGE5LTk5NGYtY2JiMjI0Zjg1Y2VlLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNDEyMzQy
+        NGEtM2FlNC00ZmM5LThkNTYtNDc0NGVmNmNkNjgzLyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00
+        Yzk0LWFmODAtYWQ1YjdjYjBkNzYyLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2NvbnRhaW5lci9tYW5pZmVzdHMvOTk5ZGExM2YtYjJmMC00ZWVmLWI5M2It
+        Y2ZhZGMwNTkzZGQ0LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvYjM5NTJiNTMtNThmZS00OTg5LTk4OGMtMzAyYmMzNTM0
+        YTZmLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVz
+        dHMvYmY3MzhhMDItZTU3MC00YTU0LWE3NGEtNzgyMDkyODA4M2MxLyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvYzAzMGNi
+        MTEtOGQwZi00MWRjLWE3M2UtNWI1YzQ4MjgxYzExLyJdLCJjb25maWdfYmxv
+        YiI6bnVsbCwiYmxvYnMiOltdfV19
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:56 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '434'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBkNWI4ZDZiMzYz
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjYyODEy
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMzE3M2E1
+        YWQtMTk4Yi00M2Y0LWE2NTYtMWJlYTVmYmRhNTRkLyIsIm5hbWUiOiJ1Y2xp
+        YmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
+        b250YWluZXIvbWFuaWZlc3RzL2IzN2YxNTM4LTc2YjItNDE1My1hNjIxLTlm
+        MWEzNTQxZjM4OC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2NvbnRhaW5lci90YWdzL2NlYTBkNTJkLTEwZGEtNDYwYi1hMWIwLWI4
+        ODVkMTAxNDg3Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjQxLjYyNTI3OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
+        dHMvNWQxYmIxOWQtZTM2Ni00YjM2LWE2OWYtYzliYTIxN2FmMDM4LyIsIm5h
+        bWUiOiJtdXNsIiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83Y2E3OTJmOC00N2ZhLTRjMjUt
+        OGNjOS03ZTQ3MWYwZjI3ODIvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvdGFncy9lZDM4MDM5ZS0zYzhhLTRjNWUt
+        YmI1MC1kZTZmOTkzMWIyNTQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo0MS42MjIzNTBaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzY2NWEzNDU4LTIwN2MtNDMxYy1iOTY2LTYzNDg1NDQzZDAw
+        ZC8iLCJuYW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9mZTU5ZGRmMS05
+        YWU4LTQyNmItOTZjMS0yYzg1NTFkYmFkNWMvIn1dfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:56 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/remove/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJjb250ZW50X3VuaXRzIjpbIioiXX0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:56 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1NWRlZGEyLTllMDgtNDMy
+        OC1hMmE4LWZkMGIzNWY4YTU3MS8ifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:56 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/add/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBkNWI4ZDZiMzYz
+        MC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy9lZDM4
+        MDM5ZS0zYzhhLTRjNWUtYmI1MC1kZTZmOTkzMWIyNTQvIl19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:57 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdhODY2MjdhLWU5OGMtNDMx
+        MC04Y2I1LTQxYzY5NjI1MGY0YS8ifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/455deda2-9e08-4328-a2a8-fd0b35f8a571/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:57 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '339'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU1ZGVkYTItOWUw
+        OC00MzI4LWEyYTgtZmQwYjM1ZjhhNTcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NTYuOTE0MjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
+        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
+        OiIyMDE5LTEyLTAzVDE0OjM2OjU3LjAyNDU5NVoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6MzY6NTcuMDcyNDIxWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhj
+        ODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/455deda2-9e08-4328-a2a8-fd0b35f8a571/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:57 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '339'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU1ZGVkYTItOWUw
+        OC00MzI4LWEyYTgtZmQwYjM1ZjhhNTcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NTYuOTE0MjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
+        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
+        OiIyMDE5LTEyLTAzVDE0OjM2OjU3LjAyNDU5NVoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6MzY6NTcuMDcyNDIxWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhj
+        ODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7a86627a-e98c-4310-8cb5-41c696250f4a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:57 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '349'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2E4NjYyN2EtZTk4
+        Yy00MzEwLThjYjUtNDFjNjk2MjUwZjRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6MzY6NTcuMDU5MzQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
+        YWRkLnJlY3Vyc2l2ZV9hZGRfY29udGVudCIsInN0YXJ0ZWRfYXQiOiIyMDE5
+        LTEyLTAzVDE0OjM2OjU3LjE5NzQzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMTkt
+        MTItMDNUMTQ6MzY6NTcuMzYyNjg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRlNjItYWZk
+        ZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tz
+        IjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRh
+        aW5lci8wOGM4Mzg3NC0xM2UwLTRjZGYtOGUyNy1kZDVmZGExYTUzZmIvdmVy
+        c2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhj
+        ODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:57 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
+        aW5lci9jb250YWluZXIvMDhjODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRh
+        MWE1M2ZiL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDozNjo1Ny4yMzQ0NTZaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
+        YmxvYiI6eyJjb3VudCI6MTYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
+        MDhjODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiL3ZlcnNpb25z
+        LzEvIn0sImNvbnRhaW5lci5tYW5pZmVzdCI6eyJjb3VudCI6MTAsImhyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9jb250YWluZXIvY29udGFpbmVyLzA4YzgzODc0LTEzZTAtNGNkZi04
+        ZTI3LWRkNWZkYTFhNTNmYi92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIudGFn
+        Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29u
+        dGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhjODM4
+        NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiL3ZlcnNpb25zLzEvIn19
+        LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6eyJj
+        b3VudCI6MTYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMDhjODM4NzQtMTNlMC00
+        Y2RmLThlMjctZGQ1ZmRhMWE1M2ZiL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5l
+        ci5tYW5pZmVzdCI6eyJjb3VudCI6MTAsImhyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
+        bmVyLzA4YzgzODc0LTEzZTAtNGNkZi04ZTI3LWRkNWZkYTFhNTNmYi92ZXJz
+        aW9ucy8xLyJ9LCJjb250YWluZXIudGFnIjp7ImNvdW50IjoyLCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL3RhZ3MvP3JlcG9zaXRv
+        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
+        ci9jb250YWluZXIvMDhjODM4NzQtMTNlMC00Y2RmLThlMjctZGQ1ZmRhMWE1
+        M2ZiL3ZlcnNpb25zLzEvIn19fX0=
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:58 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:58 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '1432'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6OCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci9tYW5pZmVzdHMvMDRlNmI4NzYtMmY5NC00Y2M3LWI4MDMtYTczZmRi
+        OTRjM2IwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        ODU4Mjk4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        MzUxNzhhYi1mYzM0LTQ1YjQtOTYwZC1kZjYwNWI2ZWE4ODMvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmRhZTkwZDNiZDQ1NDA5MjNhZTg2Zjk0NWRlY2EyMGFjNjkz
+        MTQzYjliN2NlMDJiYjgwYmJmYTJhOGFlY2I1NzYiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
+        YWluZXIvYmxvYnMvODA1MDRmZWEtMzM0MC00MmI1LTliNjQtNzE0NTBhMmM5
+        MDBhLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy81NTNhYTZiOC1jYzBmLTQzNmItOTQ0MS05NmQ4YmFlMzUwMmQv
+        Il19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy8zMGQyM2ZhMS1lMDdiLTQ4YTktOTk0Zi1jYmIyMjRm
+        ODVjZWUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43
+        NjYyNjZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4
+        MjE1MzExLTA0MjMtNGRhNS05NmEyLTU2MGI5YTQ2MDdjZS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6MTAzMDU1Nzc0NGFhZTlhMjdhYTZlZTgzMGNiOThhMmM2M2Zh
+        ZGViMzlmYmZkY2Y0NTdjMDk1ZDlmNDYwMDgwNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
+        aW5lci9ibG9icy85MDg2NDdkNi04ZWI4LTQ3OWMtYjk1Yy1jMzQzZDg3Njhl
+        ZjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzL2Y4Nzg2MzAyLTg3MmQtNGVjNS1iODk0LTVkZGQ1YmIxNGI4OS8i
+        XX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2LTQ3NDRlZjZj
+        ZDY4My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjc4
+        OTYzOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjYw
+        MmUzMzUtM2E2MC00NzcxLWFjNDYtY2IzMzRmMTAxZjkzLyIsImRpZ2VzdCI6
+        InNoYTI1NjpiYmEyMTk0OTJlNGFkZTlkYzVlNjIwMzJmN2Q1YzM4ZjdhNTkz
+        MGQxMWUwZWE0ZTQ2MmFmYmU2ZjY4ZWZhYmNiIiwic2NoZW1hX3ZlcnNpb24i
+        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
+        aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
+        W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL2Jsb2JzL2Q3NTdkNzliLTM3MmUtNDI1Ni1hYjUyLTZiZjJlMTQ0YzE3
+        NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvYmRiOGRjZmEtOTk3Ny00MjAwLWI2M2UtZDM1YjhlYmQ1ZWIzLyJd
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9tYW5pZmVzdHMvNjNiYjkxNDQtYWMyZS00Yzk0LWFmODAtYWQ1YjdjYjBk
+        NzYyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuNzYz
+        ODg5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9kYjEw
+        YWYwYS1kZTIwLTQxNzAtYmExMC01YmRkYWY5YTI0MDEvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OjJkMzFmOWQxMGMwNGE0ZWJjNjUwMDI3OWZkZGYzM2ViN2ViZGZj
+        NTE4MDQyZDU2MWZmYjdiYzZhNTY4YjQ0YTUiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
+        XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvYmxvYnMvMWMxMjQ3YjYtMTQ5OC00MDk0LWI0YTUtMDFhZTM1ZDI0OTk5
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
+        bG9icy9hOGZmYjY1Ny0yMjE5LTQ2NjctOTIzYS00YmEyNmExY2ExYTAvIl19
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L21hbmlmZXN0cy85OTlkYTEzZi1iMmYwLTRlZWYtYjkzYi1jZmFkYzA1OTNk
+        ZDQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43OTMx
+        MTJaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2Y2ZDY3
+        NjdjLTc2N2QtNDA5OS05ZjU2LWY5NGNjMzY4MTZkYS8iLCJkaWdlc3QiOiJz
+        aGEyNTY6Njc5YjFjMTA1OGMxZjJkYzU5YTNlZTcwZWVkOTg2YTg4ODExYzAy
+        MDVjOGNlZWE1N2NlYzVmMjJkMmMzZmJiMSIsInNjaGVtYV92ZXJzaW9uIjoy
+        LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
+        dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
+        LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy84NTFlMDJlZS01M2NiLTRiNzUtOWEwNi1mMDNlZWFiYWQ1MjEv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Js
+        b2JzLzBlMzAzYjNjLTI0ZDYtNDliNC04NzcyLTZkN2RhNDdiNWFlYi8iXX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        bWFuaWZlc3RzL2IzOTUyYjUzLTU4ZmUtNDk4OS05ODhjLTMwMmJjMzUzNGE2
+        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjYyOTQz
+        MloiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMmEyZDRm
+        YjItN2Q0Ny00N2YxLTkwNmQtMzllZmJhNmRjYzY5LyIsImRpZ2VzdCI6InNo
+        YTI1NjowOTNlNjM5YzhiN2ZmNjdkODc4MTE2ZDNkZTllM2U5MWZmMWJkMGQ2
+        ZTQxNDFhZTQwMTljYTNmYjNlNDkzZGY5Iiwic2NoZW1hX3ZlcnNpb24iOjIs
+        Im1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1
+        dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10s
+        ImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVy
+        L2Jsb2JzLzZlYmY0NGQ3LWNmOGItNDc4ZC1hMmJmLWQ5YzAwOWY1MDk2ZS8i
+        LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvYmxv
+        YnMvMGZkODNiMDUtN2EyMC00M2JhLTkxYjQtM2I2YWQzN2ExZmE3LyJdfSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9t
+        YW5pZmVzdHMvYmY3MzhhMDItZTU3MC00YTU0LWE3NGEtNzgyMDkyODA4M2Mx
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEuODM5MzIx
+        WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84YmE0OTNk
+        My01YzhmLTRjODAtYmRmYS0yODZiZDRhYThjNDIvIiwiZGlnZXN0Ijoic2hh
+        MjU2OjI1MGI4NzcyNDczNjQ4M2E4OTYyMzEzYjE4N2ZiNmFkNDAyODg5MzE3
+        MTVlN2YzODRmYjRjMDBjNDgxOTA0NmYiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
+        aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwi
+        Y29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
+        YmxvYnMvZmJhMjAyOTItNGNiNi00N2Y5LWEwNTItYmY1MmM3YWM5YWQ1LyIs
+        ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9ibG9i
+        cy81NmQ0MGE4Mi1jMjEyLTRkNmUtYmFlMC1kOTI4ZjdjOTUxMDcvIl19LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
+        bmlmZXN0cy9jMDMwY2IxMS04ZDBmLTQxZGMtYTczZS01YjVjNDgyODFjMTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS43ODgxOTZa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2NkMTE0OTkz
+        LTBiYmYtNGNkMC1iMGM4LWViMzRjOWRkYzI1OC8iLCJkaWdlc3QiOiJzaGEy
+        NTY6MDZlNGYzMDQ3ZDJlOWE3ODIyMmZmMTY4NjEyNzE3NDdhZDEyZWQxZWRj
+        M2IxYTU1ZDJiOWRmZTg4MTQ0YWVkMyIsInNjaGVtYV92ZXJzaW9uIjoyLCJt
+        ZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRp
+        b24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJj
+        b25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci9i
+        bG9icy9mMGVkZWJlMy0xZDU4LTQwNmEtOTM2OC0wOTE0NGJkYTNkMGMvIiwi
+        YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2Jz
+        LzY4OTdmMGJlLTFjNWUtNGUyYi05ZmVmLWI0OGFjY2UwNjQzOS8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:36:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:36:58 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2438,54 +2491,54 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvMDQ4YTg2YTUtN2ExZS00ZTdhLWJiYTMtOWRhZTI1
-        OWRiM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MDA6NTYu
-        ODkzODU4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84
-        ZWM1MGUwYS1mMzFjLTRiODUtOTJjMy1kN2E3ZjhiODk3NjEvIiwiZGlnZXN0
-        Ijoic2hhMjU2OjEzMDNkYmYxMTBjNTdmM2VkZjY4ZDlmNWExNmMwODJlYzA2
-        YzRjZjc2MDQ4MzE2NjlmYWYyYzcxMjI2MGI1YTAiLCJzY2hlbWFfdmVyc2lv
+        aW5lci9tYW5pZmVzdHMvYjM3ZjE1MzgtNzZiMi00MTUzLWE2MjEtOWYxYTM1
+        NDFmMzg4LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NDEu
+        NjI2NzAxWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8z
+        MTczYTVhZC0xOThiLTQzZjQtYTY1Ni0xYmVhNWZiZGE1NGQvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjgxN2U0NTljYTczYzU2N2U5MTMyNDA2YmFkNzg4NDVhYWY3
+        MmQyZTBjMDk2NWZmNjg4NjFiMzE4NTkxZTk0OWEiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
         ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy9iODI3Y2MwZS1iNmMxLTQ0NTMtOTAyNC05MjM1YmIzODgwNDQvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy84NDcx
-        Y2E5MC04YWNmLTQ2MGMtYmRlMS03ZjVmN2E3MTJkZmQvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy83ZDk2NTFkMy0yYTM0
-        LTQ4NGEtYjA0ZS1iNDVkZmM3MTllNDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy9lOGUwOWM4ZS1kZGUyLTRiMTYtYTk4
-        NS1hMzM0NzkyNTIxNjEvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
-        bmVyL21hbmlmZXN0cy9iMzI4ZDA2ZS0yODAzLTRjM2EtODU5Ny1kNTFiMWUz
-        ODhhMjAvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
-        ZXN0cy82NThjYWY3ZS01YzkxLTRlYWUtOTJkMS1kZTAxMzQ4YTBmYTIvIiwi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82ZDEy
-        ZjFhYy0xYmMzLTQ4NjgtYWM4OS1lOWNjZDQ1ODg1ZjUvIiwiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy9iNGExOWI2OS04ZjE3
-        LTRkNjktOTExOS0wMTUxODAyYTcxMTAvIl0sImNvbmZpZ19ibG9iIjpudWxs
-        LCJibG9icyI6W119LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvY29udGFpbmVyL21hbmlmZXN0cy8xM2Y3MjU5NS1kMGVmLTRjYjktOWE3
-        Yy1jMzhiMGQ5MTVkODUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQx
-        NjowMDo1Ni44OTgxODJaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
-        aWZhY3RzLzI2ZjVmZjZlLTVhNGItNDRkZC1hMzFiLTFlMjVmMTA1OWY5YS8i
-        LCJkaWdlc3QiOiJzaGEyNTY6ODE3ZTQ1OWNhNzNjNTY3ZTkxMzI0MDZiYWQ3
-        ODg0NWFhZjcyZDJlMGMwOTY1ZmY2ODg2MWIzMTg1OTFlOTQ5YSIsInNjaGVt
-        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
-        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlz
-        dGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
-        ZXIvbWFuaWZlc3RzLzg0NzFjYTkwLThhY2YtNDYwYy1iZGUxLTdmNWY3YTcx
-        MmRmZC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
-        c3RzLzdkOTY1MWQzLTJhMzQtNDg0YS1iMDRlLWI0NWRmYzcxOWU0OC8iLCIv
-        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2U4ZTA5
-        YzhlLWRkZTItNGIxNi1hOTg1LWEzMzQ3OTI1MjE2MS8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzMjhkMDZlLTI4MDMt
-        NGMzYS04NTk3LWQ1MWIxZTM4OGEyMC8iLCIvcHVscC9hcGkvdjMvY29udGVu
-        dC9jb250YWluZXIvbWFuaWZlc3RzLzY1OGNhZjdlLTVjOTEtNGVhZS05MmQx
-        LWRlMDEzNDhhMGZhMi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
+        ZXN0cy8zMGQyM2ZhMS1lMDdiLTQ4YTktOTk0Zi1jYmIyMjRmODVjZWUvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy80MTIz
+        NDI0YS0zYWU0LTRmYzktOGQ1Ni00NzQ0ZWY2Y2Q2ODMvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy82M2JiOTE0NC1hYzJl
+        LTRjOTQtYWY4MC1hZDViN2NiMGQ3NjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvY29udGFpbmVyL21hbmlmZXN0cy85OTlkYTEzZi1iMmYwLTRlZWYtYjkz
+        Yi1jZmFkYzA1OTNkZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFp
+        bmVyL21hbmlmZXN0cy9iMzk1MmI1My01OGZlLTQ5ODktOTg4Yy0zMDJiYzM1
+        MzRhNmYvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9mZTU5ZGRmMS05YWU4LTQyNmItOTZjMS0yYzg1NTFkYmFkNWMvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDozNjo0MS42MjA2MjlaIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzY2NWEzNDU4LTIw
+        N2MtNDMxYy1iOTY2LTYzNDg1NDQzZDAwZC8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MTMwM2RiZjExMGM1N2YzZWRmNjhkOWY1YTE2YzA4MmVjMDZjNGNmNzYwNDgz
+        MTY2OWZhZjJjNzEyMjYwYjVhMCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
+        bWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzA0ZTZi
+        ODc2LTJmOTQtNGNjNy1iODAzLWE3M2ZkYjk0YzNiMC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzMwZDIzZmExLWUwN2It
+        NDhhOS05OTRmLWNiYjIyNGY4NWNlZS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzLzQxMjM0MjRhLTNhZTQtNGZjOS04ZDU2
+        LTQ3NDRlZjZjZDY4My8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWlu
+        ZXIvbWFuaWZlc3RzLzYzYmI5MTQ0LWFjMmUtNGM5NC1hZjgwLWFkNWI3Y2Iw
+        ZDc2Mi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzk5OWRhMTNmLWIyZjAtNGVlZi1iOTNiLWNmYWRjMDU5M2RkNC8iLCIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzOTUy
+        YjUzLTU4ZmUtNDk4OS05ODhjLTMwMmJjMzUzNGE2Zi8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2JmNzM4YTAyLWU1NzAt
+        NGE1NC1hNzRhLTc4MjA5MjgwODNjMS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9jb250YWluZXIvbWFuaWZlc3RzL2MwMzBjYjExLThkMGYtNDFkYy1hNzNl
+        LTViNWM0ODI4MWMxMS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
         XX1dfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:31 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:58 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/ecc5b573-274d-4dec-9245-c01fd28926fc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/08c83874-13e0-4cdf-8e27-dd5fda1a53fb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2493,7 +2546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -2506,9 +2559,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:17:31 GMT
+      - Tue, 03 Dec 2019 14:36:58 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -2520,26 +2573,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '351'
+      - '349'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzLzY4Nzg2OGI3LTYzOWItNDk2MC05ZmE5LTYyYzJmNmMyMzI0
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAwOjU2Ljg5OTk4
-        OFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjZmNWZm
-        NmUtNWE0Yi00NGRkLWEzMWItMWUyNWYxMDU5ZjlhLyIsIm5hbWUiOiJ1Y2xp
-        YmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
-        b250YWluZXIvbWFuaWZlc3RzLzEzZjcyNTk1LWQwZWYtNGNiOS05YTdjLWMz
-        OGIwZDkxNWQ4NS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L2NvbnRhaW5lci90YWdzL2EwZWM0ZGM0LTA3NDUtNGI5Yy1iMjM0LWVj
-        NzE3YmUwNTAxMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjAw
-        OjU2Ljg5NjEyOVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
-        dHMvOGVjNTBlMGEtZjMxYy00Yjg1LTkyYzMtZDdhN2Y4Yjg5NzYxLyIsIm5h
-        bWUiOiJsYXRlc3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzA0OGE4NmE1LTdhMWUtNGU3
-        YS1iYmEzLTlkYWUyNTlkYjNmMS8ifV19
+        aW5lci90YWdzL2VkMzgwMzllLTNjOGEtNGM1ZS1iYjUwLWRlNmY5OTMxYjI1
+        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2OjQxLjYyMjM1
+        MFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjY1YTM0
+        NTgtMjA3Yy00MzFjLWI5NjYtNjM0ODU0NDNkMDBkLyIsIm5hbWUiOiJsYXRl
+        c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
+        b250YWluZXIvbWFuaWZlc3RzL2ZlNTlkZGYxLTlhZTgtNDI2Yi05NmMxLTJj
+        ODU1MWRiYWQ1Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2NvbnRhaW5lci90YWdzLzMwOThmMGY0LWQ0MmItNDk1OC05MzcyLTBk
+        NWI4ZDZiMzYzMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjQxLjYyODEyMFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
+        dHMvMzE3M2E1YWQtMTk4Yi00M2Y0LWE2NTYtMWJlYTVmYmRhNTRkLyIsIm5h
+        bWUiOiJ1Y2xpYmMiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2IzN2YxNTM4LTc2YjItNDE1
+        My1hNjIxLTlmMWEzNTQxZjM4OC8ifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:17:31 GMT
+  recorded_at: Tue, 03 Dec 2019 14:36:58 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_create/create.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_create/create.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9mNWRjMGY1Yi1hMGUxLTQ2ZDUtYjAxMi1h
-        M2QxMWM4MTQ5ZmUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjox
-        NzozNC4wNjMyMDRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mNWRjMGY1Yi1hMGUx
-        LTQ2ZDUtYjAxMi1hM2QxMWM4MTQ5ZmUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8zYTE2ODdhMC1lYTE2LTQ2YzAtODA5Mi0z
+        NWMxMDg4MDY0MWQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDoz
+        Njo1MC45MTI0NzhaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zYTE2ODdhMC1lYTE2
+        LTQ2YzAtODA5Mi0zNWMxMDg4MDY0MWQvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9mNWRjMGY1Yi1hMGUxLTQ2ZDUtYjAxMi1hM2QxMWM4
-        MTQ5ZmUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8zYTE2ODdhMC1lYTE2LTQ2YzAtODA5Mi0zNWMxMDg4
+        MDY0MWQvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:32 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f5dc0f5b-a0e1-46d5-b012-a3d11c8149fe/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3a1687a0-ea16-46c0-8092-35c10880641d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3NGU5MDIyLTI1OWMtNDcz
-        OS1hMWNmLWE5NWRjMjVhMjZlMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5YmRkZTY0LWU2YzYtNDA5
+        Yy1iMzc1LWFiYTI1ZTA1MmQwZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:32 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -143,21 +143,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMDQ2ZGM2NDAtNmM3OS00NWQzLWIwNzctYmMxYTY1
-        MmQwMmNkLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTc6MzQu
-        MjM3NjczWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvNTE1YWFhYWMtMzhjYy00ZWE2LTkxYjQtZWY2YWU5
+        ZDkzM2Q3LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6MzY6NTEu
+        MTA1OTkxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xp
         ZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3Vy
-        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3
-        OjM0LjIzNzY4NloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
+        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM2
+        OjUxLjEwNjAzNFoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
         eSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJidXN5Ym94Iiwid2hp
         dGVsaXN0X3RhZ3MiOlsibGF0ZXN0IiwidWNsaWJjIiwibXVzbCJdfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/046dc640-6c79-45d3-b077-bc1a652d02cd/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/515aaaac-38cc-4ea6-91b4-ef6ae9d933d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -178,9 +178,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -196,10 +196,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5ODAxZWU5LWVmYTYtNDFh
-        Yi1iMmJmLWYxZDQ1NjQwZDRmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3NjYxN2I5LTY2NzgtNGE1
+        Yi1iMGMwLTM2NDRkYTI2OThlOS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -210,7 +210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -244,7 +244,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -255,7 +255,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -268,81 +268,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '295'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci8xMWQwNWM2MC00YzlhLTQ5MDAtODA4
-        NS04NWZhNjM3ZTc0ZjMvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE3OjM4LjEzNDQzMFoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWRldiIsImNvbnRlbnRfZ3VhcmQiOm51bGwsInJlZ2lz
-        dHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0FD
-        TUVfQ29ycG9yYXRpb24vbGlicmFyeS9idXN5Ym94In1dfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/11d05c60-4c9a-4900-8085-85fa637e74f3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:18:11 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiOTRlZTA4LTNmNzgtNGQx
-        NS1iMGU4LWY4MjBkZGZlYzJlMi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:11 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -355,7 +302,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -368,13 +315,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:12 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/d1ba7e98-dea3-449a-a51c-3d398dabe18b/"
+      - "/pulp/api/v3/repositories/container/container/3d96f9ce-aa29-4ec0-861c-451b13c76269/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -389,17 +336,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZDFiYTdlOTgtZGVhMy00NDlhLWE1MWMtM2QzOThk
-        YWJlMThiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTg6MTIu
-        MTY1MDI3WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDFiYTdlOTgtZGVhMy00NDlh
-        LWE1MWMtM2QzOThkYWJlMThiL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvM2Q5NmY5Y2UtYWEyOS00ZWMwLTg2MWMtNDUxYjEz
+        Yzc2MjY5LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6Mzc6MzMu
+        NzQ3OTcyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvM2Q5NmY5Y2UtYWEyOS00ZWMw
+        LTg2MWMtNDUxYjEzYzc2MjY5L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZDFiYTdlOTgtZGVhMy00NDlhLWE1MWMtM2QzOThkYWJlMThi
+        b250YWluZXIvM2Q5NmY5Y2UtYWEyOS00ZWMwLTg2MWMtNDUxYjEzYzc2MjY5
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:12 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -416,7 +363,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -429,13 +376,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:12 GMT
+      - Tue, 03 Dec 2019 14:37:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/dc422de8-d14e-42cd-a329-f9245313cfa3/"
+      - "/pulp/api/v3/remotes/container/container/55e65980-3c98-45c0-b6fa-8e6e44fe1a23/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -450,16 +397,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2RjNDIyZGU4LWQxNGUtNDJjZC1hMzI5LWY5MjQ1MzEzY2Zh
-        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE4OjEyLjM2MzE4
-        OFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzU1ZTY1OTgwLTNjOTgtNDVjMC1iNmZhLThlNmU0NGZlMWEy
+        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjM3OjMzLjk1MDI5
+        N1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoxODoxMi4z
-        NjMyMDJaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDozNzozMy45
+        NTAzMTZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:12 GMT
+  recorded_at: Tue, 03 Dec 2019 14:37:33 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_delete/repository_reference_is_deleted.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_delete/repository_reference_is_deleted.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:47 GMT
+      - Tue, 03 Dec 2019 14:51:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -37,27 +37,27 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '245'
+      - '246'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kMWJhN2U5OC1kZWEzLTQ0OWEtYTUxYy0z
-        ZDM5OGRhYmUxOGIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjox
-        ODoxMi4xNjUwMjdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kMWJhN2U5OC1kZWEz
-        LTQ0OWEtYTUxYy0zZDM5OGRhYmUxOGIvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8yN2QyODA1Ny00YTMwLTRiNDYtYjA0Mi1i
+        YjMzNDRjMTdiMjAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo0
+        OToyOS4yNTg3MDdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yN2QyODA1Ny00YTMw
+        LTRiNDYtYjA0Mi1iYjMzNDRjMTdiMjAvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kMWJhN2U5OC1kZWEzLTQ0OWEtYTUxYy0zZDM5OGRh
-        YmUxOGIvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8yN2QyODA1Ny00YTMwLTRiNDYtYjA0Mi1iYjMzNDRj
+        MTdiMjAvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:33 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/d1ba7e98-dea3-449a-a51c-3d398dabe18b/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/27d28057-4a30-4b46-b042-bb3344c17b20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:47 GMT
+      - Tue, 03 Dec 2019 14:51:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBmNGU2YTMxLTIzZTgtNDMy
-        YS1hZjU2LWFlZDczNDE5MmU1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhZDZlMTY0LTBhNmUtNGM0
+        NS05YTFhLWJjOWNjODdhNTg5ZS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:33 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:47 GMT
+      - Tue, 03 Dec 2019 14:51:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -143,21 +143,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZGM0MjJkZTgtZDE0ZS00MmNkLWEzMjktZjkyNDUz
-        MTNjZmEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTg6MTIu
-        MzYzMTg4WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvNDIyZDFjN2UtMTU2YS00MmI0LWI0OTctNmVmNmU1
+        MGRlYTNhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NDk6Mjku
+        NDU5NTMxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xp
         ZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3Vy
-        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIyVDE2OjE4
-        OjEyLjM2MzIwMloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
+        bCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTAzVDE0OjQ5
+        OjI5LjQ1OTU0NVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGlj
         eSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJidXN5Ym94Iiwid2hp
         dGVsaXN0X3RhZ3MiOm51bGx9XX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/dc422de8-d14e-42cd-a329-f9245313cfa3/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/422d1c7e-156a-42b4-b497-6ef6e50dea3a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -178,9 +178,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:47 GMT
+      - Tue, 03 Dec 2019 14:51:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -196,10 +196,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwNmVjYmZiLWI0MzItNGQ2
-        Zi1iOTc2LTZjNDVkNjQyZGRjOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ2OTM0ODg2LTcxMGUtNDk1
+        My1iODhiLTlkZTBjMTU0NzNlMC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -210,7 +210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:47 GMT
+      - Tue, 03 Dec 2019 14:51:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -244,7 +244,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -255,7 +255,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -268,9 +268,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:48 GMT
+      - Tue, 03 Dec 2019 14:51:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -289,7 +289,187 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:51:34 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:51:34 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:51:34 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:51:34 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:51:34 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -302,7 +482,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -315,13 +495,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:48 GMT
+      - Tue, 03 Dec 2019 14:51:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/f57b0061-2d60-444a-b9db-204494c53e02/"
+      - "/pulp/api/v3/repositories/container/container/274a0e43-1dde-4870-acda-586baca171b3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -336,17 +516,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZjU3YjAwNjEtMmQ2MC00NDRhLWI5ZGItMjA0NDk0
-        YzUzZTAyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTg6NDgu
-        NDQxNDc1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjU3YjAwNjEtMmQ2MC00NDRh
-        LWI5ZGItMjA0NDk0YzUzZTAyL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcwLWFjZGEtNTg2YmFj
+        YTE3MWIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTE6MzUu
+        MjcxMDYzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcw
+        LWFjZGEtNTg2YmFjYTE3MWIzL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZjU3YjAwNjEtMmQ2MC00NDRhLWI5ZGItMjA0NDk0YzUzZTAy
+        b250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcwLWFjZGEtNTg2YmFjYTE3MWIz
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:35 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -363,7 +543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -376,13 +556,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:48 GMT
+      - Tue, 03 Dec 2019 14:51:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/0ccf024d-3a69-431f-b71a-bc1061a0aafe/"
+      - "/pulp/api/v3/remotes/container/container/f5a7aa35-8c1d-487c-8949-f57f1b2b1cae/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -397,21 +577,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzBjY2YwMjRkLTNhNjktNDMxZi1iNzFhLWJjMTA2MWEwYWFm
-        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE4OjQ4LjYxODI2
+        Y29udGFpbmVyL2Y1YTdhYTM1LThjMWQtNDg3Yy04OTQ5LWY1N2YxYjJiMWNh
+        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjUxOjM1LjQ3NDA1
         OVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoxODo0OC42
-        MTgyODVaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1MTozNS40
+        NzQwNzNaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:35 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f57b0061-2d60-444a-b9db-204494c53e02/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/274a0e43-1dde-4870-acda-586baca171b3/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -421,7 +601,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -434,9 +614,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:49 GMT
+      - Tue, 03 Dec 2019 14:51:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -452,13 +632,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2YzUxOTU2LTc2M2MtNGQ0
-        My1hOGM3LTgxZTliMmYxYjU5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2MjJlYTYxLWE3YzQtNGFh
+        Zi05NzdlLWJlNmUxNGUyMDA3ZS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:35 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f57b0061-2d60-444a-b9db-204494c53e02/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/274a0e43-1dde-4870-acda-586baca171b3/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -468,7 +648,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -481,9 +661,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:49 GMT
+      - Tue, 03 Dec 2019 14:51:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -499,13 +679,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1ZDdlMjRlLWU2YWItNGVi
-        Yi1iN2Y0LWI2YWUzNGU3NGEzYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2ZjQ1MjFlLTU1ZjMtNDM3
+        My1iMDZkLTU5Njk1ZTY5MzM5OC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:35 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/05d7e24e-e6ab-4ebb-b7f4-b6ae34e74a3b/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f6f4521e-55f3-4373-b06d-59695e693398/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -513,7 +693,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -526,9 +706,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:49 GMT
+      - Tue, 03 Dec 2019 14:51:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -540,28 +720,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '337'
+      - '339'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDVkN2UyNGUtZTZh
-        Yi00ZWJiLWI3ZjQtYjZhZTM0ZTc0YTNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTg6NDkuMTk3OTQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjZmNDUyMWUtNTVm
+        My00MzczLWIwNmQtNTk2OTVlNjkzMzk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTE6MzUuOTY2MDU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjE4OjQ5LjMwMDEyMFoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MTg6NDkuMzY5Nzk4WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjUxOjM2LjEyODI3MFoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTE6MzYuMjIwMTQwWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZjU3
-        YjAwNjEtMmQ2MC00NDRhLWI5ZGItMjA0NDk0YzUzZTAyLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjc0
+        YTBlNDMtMWRkZS00ODcwLWFjZGEtNTg2YmFjYTE3MWIzLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:36 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f57b0061-2d60-444a-b9db-204494c53e02/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/274a0e43-1dde-4870-acda-586baca171b3/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -569,7 +749,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -582,9 +762,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:49 GMT
+      - Tue, 03 Dec 2019 14:51:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -596,34 +776,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '198'
+      - '196'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZjU3YjAwNjEtMmQ2MC00NDRhLWI5ZGItMjA0NDk0
-        YzUzZTAyL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoxODo0OC40NDMwMTZaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcwLWFjZGEtNTg2YmFj
+        YTE3MWIzL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1MTozNS4yNzI3MjFaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:51:36 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mNTdiMDA2MS0yZDYw
-        LTQ0NGEtYjlkYi0yMDQ0OTRjNTNlMDIvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyLzI3NGEwZTQzLTFkZGUtNDg3MC1hY2Rh
+        LTU4NmJhY2ExNzFiMy92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,9 +816,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:49 GMT
+      - Tue, 03 Dec 2019 14:52:55 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -654,13 +834,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1YzQxY2M2LWRkODktNGY1
-        ZS05ZWIxLWZiODNmZDYwZmU1My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzMGYyOWQ1LTYwODItNDMz
+        NC04Zjc1LTAyNmZhMzY0ZDNlZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:55 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/15c41cc6-dd89-4f5e-9eb1-fb83fd60fe53/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/130f29d5-6082-4334-8f75-026fa364d3ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -668,7 +848,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -681,9 +861,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:50 GMT
+      - Tue, 03 Dec 2019 14:52:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -695,28 +875,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '343'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTVjNDFjYzYtZGQ4
-        OS00ZjVlLTllYjEtZmI4M2ZkNjBmZTUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTg6NDkuODAwMjA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTMwZjI5ZDUtNjA4
+        Mi00MzM0LThmNzUtMDI2ZmEzNjRkM2VmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTI6NTUuODE3MjI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTg6NDkuOTE2MzE0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoxODo1MC4xNTE2Mjha
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTI6NTUuOTExNjc1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1Mjo1Ni4wOTE4NzFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci82ZDA3N2RhMC01NTZmLTQ0
-        ODItYWE3Zi1jOGZhYzQ1NTlhMTIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9jNGU4YjJmYi0zNjFlLTQ1
+        ZTQtYTNjNC1iMTFiZWM4NDk5NzkvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:56 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/6d077da0-556f-4482-aa7f-c8fac4559a12/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/c4e8b2fb-361e-45e4-a3c4-b11bec849979/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -724,7 +904,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -737,9 +917,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:50 GMT
+      - Tue, 03 Dec 2019 14:52:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -751,26 +931,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '310'
+      - '297'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvNmQwNzdkYTAtNTU2Zi00NDgyLWFhN2YtYzhm
-        YWM0NTU5YTEyLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mNTdiMDA2MS0y
-        ZDYwLTQ0NGEtYjlkYi0yMDQ0OTRjNTNlMDIvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjE4OjUwLjEzOTQzNFoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcwLWFj
+        ZGEtNTg2YmFjYTE3MWIzL3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9jNGU4YjJmYi0zNjFlLTQ1ZTQtYTNjNC1i
+        MTFiZWM4NDk5NzkvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTI6NTYuMDgzMTMxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:56 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/0ccf024d-3a69-431f-b71a-bc1061a0aafe/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/f5a7aa35-8c1d-487c-8949-f57f1b2b1cae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -778,7 +958,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -791,9 +971,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:50 GMT
+      - Tue, 03 Dec 2019 14:52:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -809,13 +989,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjNzQ0YjM0LTFhMzctNDg2
-        Yi1iMmViLTkyNDJmNDQ2N2UxYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwNjlkM2UwLTM0YTktNGU2
+        Zi1iNWRjLTJmNTRkNzhhZDJkYS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:56 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2c744b34-1a37-486b-b2eb-9242f4467e1b/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f069d3e0-34a9-4e6f-b5dc-2f54d78ad2da/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -823,7 +1003,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -836,9 +1016,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:50 GMT
+      - Tue, 03 Dec 2019 14:52:56 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -854,21 +1034,21 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmM3NDRiMzQtMWEz
-        Ny00ODZiLWIyZWItOTI0MmY0NDY3ZTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTg6NTAuNzM5ODM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjA2OWQzZTAtMzRh
+        OS00ZTZmLWI1ZGMtMmY1NGQ3OGFkMmRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTI6NTYuNzU1NjUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTg6NTAuODUxMzUz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoxODo1MC44ODA2NDha
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTI6NTYuODUwODg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1Mjo1Ni44NzY3ODRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMGNjZjAyNGQtM2E2OS00MzFmLWI3MWEtYmMxMDYxYTBhYWZl
+        b250YWluZXIvZjVhN2FhMzUtOGMxZC00ODdjLTg5NDktZjU3ZjFiMmIxY2Fl
         LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:56 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -879,7 +1059,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -892,41 +1072,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:51 GMT
+      - Tue, 03 Dec 2019 14:52:57 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '336'
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci82ZDA3N2RhMC01NTZmLTQ0ODItYWE3
-        Zi1jOGZhYzQ1NTlhMTIvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2Y1N2Iw
-        MDYxLTJkNjAtNDQ0YS1iOWRiLTIwNDQ5NGM1M2UwMi92ZXJzaW9ucy8wLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MTg6NTAuMTM5NDM0WiIs
-        InJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        InJlZ2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUu
-        Y29tL0FDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9idXN5Ym94In1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:57 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/6d077da0-556f-4482-aa7f-c8fac4559a12/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/274a0e43-1dde-4870-acda-586baca171b3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,7 +1104,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -947,9 +1117,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:51 GMT
+      - Tue, 03 Dec 2019 14:52:57 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -965,58 +1135,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYWRiMDczLWE1MTMtNDNj
-        NS1hY2E3LTNlMzIxZGZjMGYwYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjODIzMzZiLWExMGQtNDI0
+        MS1iNjYyLTBiYWZlOTg1ODFlMy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:51 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/f57b0061-2d60-444a-b9db-204494c53e02/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:18:51 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyODQ3ZTE4LTI2ZTMtNDA1
-        Yy1iZjkyLTY2YWZjNzU4OGM2Mi8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:57 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/22847e18-26e3-405c-bf92-66afc7588c62/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cc82336b-a10d-4241-b662-0bafe98581e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1024,7 +1149,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1037,9 +1162,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:18:51 GMT
+      - Tue, 03 Dec 2019 14:52:57 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1051,23 +1176,23 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '331'
+      - '330'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI4NDdlMTgtMjZl
-        My00MDVjLWJmOTItNjZhZmM3NTg4YzYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MTg6NTEuMzE3ODE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2M4MjMzNmItYTEw
+        ZC00MjQxLWI2NjItMGJhZmU5ODU4MWUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTI6NTcuMTkwMDE1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjE4OjUxLjM5NjUxOFoi
-        LCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6MTg6NTEuNDMyMjEyWiIs
-        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82
-        YWZiMmRlZC0wNjkyLTRkOWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjUyOjU3LjMwMzY5OFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTI6NTcuMzQ1NTc3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83
+        MTZhYjNlOS0zYzczLTRlNjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50
         IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
         X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvZjU3YjAwNjEtMmQ2MC00NDRhLWI5ZGItMjA0NDk0YzUz
-        ZTAyLyJdfQ==
+        ci9jb250YWluZXIvMjc0YTBlNDMtMWRkZS00ODcwLWFjZGEtNTg2YmFjYTE3
+        MWIzLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:18:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:52:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_sync/sync.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,28 +23,81 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:00 GMT
+      - Tue, 03 Dec 2019 14:53:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '244'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9hZjFjMWM2Yy0wNjM2LTQzMDktYmNiMy00
+        MzVmOTI0NjUyNDUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yNlQxODoy
+        NDozMi4wNTExODBaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZjFjMWM2Yy0wNjM2
+        LTQzMDktYmNiMy00MzVmOTI0NjUyNDUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
+        fQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:39 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/af1c1c6c-0636-4309-bcb3-435f92465245/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:39 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkY2MzOWZiLWQ0OWEtNDg1
+        Zi1hOWY0LTVhOWQ5NjgxODQ3Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:39 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -55,7 +108,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -68,28 +121,83 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:00 GMT
+      - Tue, 03 Dec 2019 14:53:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '340'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
+        aW5lci9jb250YWluZXIvMjk2MTUyNWEtZTM1MC00NTJjLTg3MWItYjk4ZmJl
+        NjdhNDJmLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjZUMTg6MjQ6MzIu
+        MjMxMTQzWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
+        LXB1bHAzX0RvY2tlcl8xIiwidXJsIjoiaHR0cHM6Ly9yZWdpc3RyeS0xLmRv
+        Y2tlci5pby8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwi
+        Y2xpZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5
+        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTI2VDE4
+        OjI0OjMyLjIzMTE1NloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
+        bGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3No
+        Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9XX0=
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:39 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/2961525a-e350-452c-871b-b98fbe67a42f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:40 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5YjVjNGJkLThkZGYtNDNi
+        ZS1hMDg2LTc4MzcyNTRmODJhNS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -100,7 +208,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -113,28 +221,82 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:00 GMT
+      - Tue, 03 Dec 2019 14:53:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci8yNDBjYTM5ZC1iZDhhLTQyYTItOGFl
+        Mi1kMDhjYzRmNjk1NjkvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19Eb2NrZXJf
+        MSIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjZUMTg6MjQ6MzMuOTI5NjQy
+        WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X0RvY2tlcl8xIiwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLmNhbm5v
+        bG8uZXhhbXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
+        dWxwM19Eb2NrZXJfMSJ9XX0=
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/240ca39d-bd8a-42a2-8ae2-d08cc4f69569/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:40 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzNDQyMmRlLWE5NTQtNGY0
+        ZC04OGI5LWRkZTA5MWQ5YmY1Ni8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -145,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -158,9 +320,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:00 GMT
+      - Tue, 03 Dec 2019 14:53:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -179,7 +341,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -192,7 +354,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -205,13 +367,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:01 GMT
+      - Tue, 03 Dec 2019 14:53:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/"
+      - "/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -226,17 +388,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0
-        M2ZjOWE5LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6MDEu
-        MzM5OTE4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIx
-        LWJiZTYtY2I5MjE0M2ZjOWE5L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1
+        MmZhYjYwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTM6NDAu
+        NzMwMjE5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMw
+        LTkxNWQtOTUyNWQ1MmZhYjYwL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5
+        b250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1MmZhYjYw
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
         YmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -253,7 +415,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -266,13 +428,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:01 GMT
+      - Tue, 03 Dec 2019 14:53:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/dc3c0f79-f4d0-450a-a5be-655a2be7c1eb/"
+      - "/pulp/api/v3/remotes/container/container/3406d74c-9b55-4608-817c-dd6b5b79032d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -287,21 +449,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2RjM2MwZjc5LWY0ZDAtNDUwYS1hNWJlLTY1NWEyYmU3YzFl
-        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjAxLjUyNzg0
-        MVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        Y29udGFpbmVyLzM0MDZkNzRjLTliNTUtNDYwOC04MTdjLWRkNmI1Yjc5MDMy
+        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjUzOjQwLjkxNDM5
+        NVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
         M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
         aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
         dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTow
-        MS41Mjc4NTVaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1Mzo0
+        MC45MTQ0MTBaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
         OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIsIndo
         aXRlbGlzdF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:40 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -311,7 +473,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -324,9 +486,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:01 GMT
+      - Tue, 03 Dec 2019 14:53:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -342,13 +504,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmZTRkYjc1LWFmMmItNDcx
-        YS04MzQwLTIyMGJiNWIzYzg5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjMjQyNzFlLWM4OTItNDEz
+        ZS04NmZiLTA0NTkxZDFmZGJjOC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:41 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -358,7 +520,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -371,9 +533,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:02 GMT
+      - Tue, 03 Dec 2019 14:53:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -389,13 +551,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyNGVkNGQ3LTlhYWItNGM0
-        Yy1hZDJhLTI5YjExMGYyMzExMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4MzFiZTg3LTIzYWMtNDYx
+        ZC04ZDhlLWMzNzA3ZDlmZjNiZS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:02 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:41 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/424ed4d7-9aab-4c4c-ad2a-29b110f23111/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c831be87-23ac-461d-8d8e-c3707d9ff3be/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -403,7 +565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -416,165 +578,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:02 GMT
+      - Tue, 03 Dec 2019 14:53:41 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '337'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDI0ZWQ0ZDctOWFh
-        Yi00YzRjLWFkMmEtMjliMTEwZjIzMTExLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDIuMDc1MjI5WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
-        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIxOjAyLjI1MjE1N1oiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjE6MDIuMzMxOTI4WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
-        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
-        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNDky
-        Yjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5LyJdfQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:02 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/versions/0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:02 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '196'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0
-        M2ZjOWE5L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTowMS4zNDE0OTRaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
-        Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
-        Ont9LCJwcmVzZW50Ijp7fX19
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:02 GMT
-- request:
-    method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
-        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        NDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5L3ZlcnNpb25z
-        LzAvIn0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:02 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4ZWE3MDA3LWY2YWItNGJj
-        ZS1iMDExLWZjNGFlMzRjMTY1Ni8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:02 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/58ea7007-f6ab-4bce-b011-fc4ae34c1656/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:03 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -590,24 +596,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNThlYTcwMDctZjZh
-        Yi00YmNlLWIwMTEtZmM0YWUzNGMxNjU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDIuNjYxNjUzWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6MDIuNzcyMDU2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTowMi45NzA1MjVa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
-        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci81MGRmZmM1My0yMDMwLTRj
-        MjItODk4NC0xN2U2N2NhMDRiMGMvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzgzMWJlODctMjNh
+        Yy00NjFkLThkOGUtYzM3MDdkOWZmM2JlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDEuMzgzNDA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
+        cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
+        OiIyMDE5LTEyLTAzVDE0OjUzOjQxLjU2MjM4OVoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTM6NDEuNjQxNjkxWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTBj
+        ZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1MmZhYjYwLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:03 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:41 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/50dffc53-2030-4c22-8984-17e67ca04b0c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -615,7 +621,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -628,52 +634,48 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:03 GMT
+      - Tue, 03 Dec 2019 14:53:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '296'
+      - '198'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci81MGRmZmM1My0yMDMwLTRj
-        MjItODk4NC0xN2U2N2NhMDRiMGMvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzQ5MmI5N2VkLWJhNmEtNGMyMS1iYmU2LWNiOTIxNDNmYzlhOS92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6MDIuOTYy
-        MDI0WiIsInJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwiY29udGVudF9ndWFy
-        ZCI6bnVsbCwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLmNhbm5vbG8u
-        ZXhhbXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxw
-        M19Eb2NrZXJfMSJ9
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
+        aW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1
+        MmZhYjYwL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1Mzo0MC43MzE4MTNaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
+        Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:03 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:41 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/sync/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyL2RjM2MwZjc5LWY0ZDAtNDUwYS1hNWJlLTY1NWEyYmU3YzFlYi8i
-        LCJtaXJyb3IiOnRydWV9
+        eyJiYXNlX3BhdGgiOiJmZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8xMGNmOTFhYi02MjBmLTQy
+        MzAtOTE1ZC05NTI1ZDUyZmFiNjAvdmVyc2lvbnMvMC8ifQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -686,9 +688,167 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:03 GMT
+      - Tue, 03 Dec 2019 14:53:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiYWVlYzYwLTVmYzItNGYw
+        Ny1hNjhhLTk1YmVjZWI2YWZjMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1baeec60-5fc2-4f07-a68a-95beceb6afc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:42 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWJhZWVjNjAtNWZj
+        Mi00ZjA3LWE2OGEtOTViZWNlYjZhZmMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDEuOTc2OTc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTM6NDIuMDgzNzAw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1Mzo0Mi4zMjU5Nzla
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci85NWM0NGQ2Zi1mMzQ0LTRj
+        ZjQtYTgzYi05MDdlMGExYmMxYTUvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:42 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/95c44d6f-f344-4cf4-a83b-907e0a1bc1a5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:42 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '299'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkx
+        NWQtOTUyNWQ1MmZhYjYwL3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci85NWM0NGQ2Zi1mMzQ0LTRjZjQtYTgzYi05
+        MDdlMGExYmMxYTUvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        ZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9jcmVhdGVkIjoi
+        MjAxOS0xMi0wM1QxNDo1Mzo0Mi4zMTU0OTBaIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZWdpc3Ry
+        eV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9mZWRv
+        cmFfbGFiZWwtcHVscDNfZG9ja2VyXzEifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:53:42 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
+        dGFpbmVyLzM0MDZkNzRjLTliNTUtNDYwOC04MTdjLWRkNmI1Yjc5MDMyZC8i
+        LCJtaXJyb3IiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:53:42 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -704,13 +864,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwNDVlMzMyLTE2Y2EtNGQ3
-        My05ZTlkLTU3MzZmNzM5ZDI1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwYWExODc1LWNjNWMtNGIw
+        NS1hMzVjLThlNjM0NjRmNGVhZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:03 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:42 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0045e332-16ca-4d73-9e9d-5736f739d250/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/90aa1875-cc5c-4b05-a35c-8e63464f4eaf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -718,7 +878,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -731,9 +891,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:04 GMT
+      - Tue, 03 Dec 2019 14:53:43 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -745,24 +905,24 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '519'
+      - '516'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDA0NWUzMzItMTZj
-        YS00ZDczLTllOWQtNTczNmY3MzlkMjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDMuNzIwMTYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBhYTE4NzUtY2M1
+        Yy00YjA1LWEzNWMtOGU2MzQ2NGY0ZWFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDIuOTQxMDM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjIx
-        OjAzLjgyODY3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6
-        MDQuNDE4Mjc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRmYjktYTUxYS00Y2E0MGJiOTM0
-        ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
-        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
-        IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoicHJvY2Vzc2luZy50
-        YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjUz
+        OjQzLjA1MTgyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTM6
+        NDMuNjk5NDM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRlNjItYWZkZC03YWVlZTI4ZDk4
+        YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
+        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsImNv
+        ZGUiOiJwcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93
+        bmxvYWRpbmcgdGFnIGxpc3QiLCJjb2RlIjoiZG93bmxvYWRpbmcudGFnX2xp
+        c3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
         dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
         cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
         bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9
@@ -770,17 +930,17 @@ http_interactions:
         b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         Om51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
         cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5
+        b250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1MmZhYjYw
         L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
         L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzQ5MmI5N2VkLWJhNmEtNGMyMS1iYmU2LWNiOTIxNDNmYzlhOS8iLCIvcHVs
-        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2RjM2MwZjc5
-        LWY0ZDAtNDUwYS1hNWJlLTY1NWEyYmU3YzFlYi8iXX0=
+        LzEwY2Y5MWFiLTYyMGYtNDIzMC05MTVkLTk1MjVkNTJmYWI2MC8iLCIvcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzM0MDZkNzRj
+        LTliNTUtNDYwOC04MTdjLWRkNmI1Yjc5MDMyZC8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:43 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -788,7 +948,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -801,9 +961,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:04 GMT
+      - Tue, 03 Dec 2019 14:53:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -820,53 +980,53 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0
-        M2ZjOWE5L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTowMy44NTI1NDhaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1
+        MmZhYjYwL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1Mzo0My4wNzU5OTJaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
         YmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
         L2NvbnRhaW5lci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci80
-        OTJiOTdlZC1iYTZhLTRjMjEtYmJlNi1jYjkyMTQzZmM5YTkvdmVyc2lvbnMv
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8x
+        MGNmOTFhYi02MjBmLTQyMzAtOTE1ZC05NTI1ZDUyZmFiNjAvdmVyc2lvbnMv
         MS8ifSwiY29udGFpbmVyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvY29udGFpbmVyL2NvbnRhaW5lci80OTJiOTdlZC1iYTZhLTRjMjEtYmJl
-        Ni1jYjkyMTQzZmM5YTkvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
+        ZXMvY29udGFpbmVyL2NvbnRhaW5lci8xMGNmOTFhYi02MjBmLTQyMzAtOTE1
+        ZC05NTI1ZDUyZmFiNjAvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
         eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
         aW5lci90YWdzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzQ5MmI5N2Vk
-        LWJhNmEtNGMyMS1iYmU2LWNiOTIxNDNmYzlhOS92ZXJzaW9ucy8xLyJ9fSwi
+        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzEwY2Y5MWFi
+        LTYyMGYtNDIzMC05MTVkLTk1MjVkNTJmYWI2MC92ZXJzaW9ucy8xLyJ9fSwi
         cmVtb3ZlZCI6e30sInByZXNlbnQiOnsiY29udGFpbmVyLmJsb2IiOnsiY291
         bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
         YmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIx
-        LWJiZTYtY2I5MjE0M2ZjOWE5L3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMw
+        LTkxNWQtOTUyNWQ1MmZhYjYwL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
         YW5pZmVzdCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
         ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        NDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5L3ZlcnNpb25z
+        MTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1MmZhYjYwL3ZlcnNpb25z
         LzEvIn0sImNvbnRhaW5lci50YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
         cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy8/cmVwb3NpdG9yeV92
         ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2Nv
-        bnRhaW5lci80OTJiOTdlZC1iYTZhLTRjMjEtYmJlNi1jYjkyMTQzZmM5YTkv
+        bnRhaW5lci8xMGNmOTFhYi02MjBmLTQyMzAtOTE1ZC05NTI1ZDUyZmFiNjAv
         dmVyc2lvbnMvMS8ifX19fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:44 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/50dffc53-2030-4c22-8984-17e67ca04b0c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/95c44d6f-f344-4cf4-a83b-907e0a1bc1a5/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2NvbnRhaW5lci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJi
-        ZTYtY2I5MjE0M2ZjOWE5L3ZlcnNpb25zLzEvIn0=
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkx
+        NWQtOTUyNWQ1MmZhYjYwL3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -879,9 +1039,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:04 GMT
+      - Tue, 03 Dec 2019 14:53:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -897,13 +1057,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjZDIwM2E4LWY0NGUtNDli
-        OC04NmQzLTZlNTE4ZjgxM2I5Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1NDdkZjM1LTE4NGMtNDBl
+        Yy04MWZkLTdhZGRhNDY1NWY2YS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:44 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/fcd203a8-f44e-49b8-86d3-6e518f813b97/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3547df35-184c-40ec-81fd-7adda4655f6a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -911,7 +1071,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -924,9 +1084,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:05 GMT
+      - Tue, 03 Dec 2019 14:53:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -938,26 +1098,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '308'
+      - '305'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmNkMjAzYTgtZjQ0
-        ZS00OWI4LTg2ZDMtNmU1MThmODEzYjk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDQuOTI2MjE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzU0N2RmMzUtMTg0
+        Yy00MGVjLTgxZmQtN2FkZGE0NjU1ZjZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDQuMjE1NDU3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6MDUuMDM1NTM4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTowNS4xMTI5NjRa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTM6NDQuMzI1NjIz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1Mzo0NC40MTYyOTJa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:44 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/dc3c0f79-f4d0-450a-a5be-655a2be7c1eb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/3406d74c-9b55-4608-817c-dd6b5b79032d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -965,7 +1125,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -978,9 +1138,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:05 GMT
+      - Tue, 03 Dec 2019 14:53:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -996,13 +1156,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiZDFiYzk0LWUxZGUtNGI1
-        MS1hYTcxLTlhMzAyOTNmMmI1ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5ZWZiZGU2LWNjMjAtNGQ1
+        ZC1hZTIxLTY1NTgxZTJlZmQzZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:44 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8bd1bc94-e1de-4b51-aa71-9a30293f2b5e/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/39efbde6-cc20-4d5d-ae21-65581e2efd3f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1010,7 +1170,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1023,9 +1183,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:05 GMT
+      - Tue, 03 Dec 2019 14:53:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1037,25 +1197,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '329'
+      - '331'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGJkMWJjOTQtZTFk
-        ZS00YjUxLWFhNzEtOWEzMDI5M2YyYjVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDUuNjEwMTQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzllZmJkZTYtY2My
+        MC00ZDVkLWFlMjEtNjU1ODFlMmVmZDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDQuODY3Mjk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6MDUuNzIyMzA1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTowNS43NDgyMzha
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTM6NDQuOTYyNjkz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1Mzo0NC45OTM4MDFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZGMzYzBmNzktZjRkMC00NTBhLWE1YmUtNjU1YTJiZTdjMWVi
+        b250YWluZXIvMzQwNmQ3NGMtOWI1NS00NjA4LTgxN2MtZGQ2YjViNzkwMzJk
         LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:45 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -1066,7 +1226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1079,42 +1239,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:05 GMT
+      - Tue, 03 Dec 2019 14:53:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '323'
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
-        cnkvcHVscDNfRG9ja2VyXzEiLCJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        ZGlzdHJpYnV0aW9ucy9jb250YWluZXIvY29udGFpbmVyLzUwZGZmYzUzLTIw
-        MzAtNGMyMi04OTg0LTE3ZTY3Y2EwNGIwYy8iLCJyZXBvc2l0b3J5X3ZlcnNp
-        b24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2ZjOWE5L3Zl
-        cnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTow
-        Mi45NjIwMjRaIiwicmVwb3NpdG9yeSI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJjb250ZW50
-        X2d1YXJkIjpudWxsLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fu
-        bm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5
-        L3B1bHAzX0RvY2tlcl8xIn1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:45 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/50dffc53-2030-4c22-8984-17e67ca04b0c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/10cf91ab-620f-4230-915d-9525d52fab60/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1122,7 +1271,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1135,9 +1284,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:06 GMT
+      - Tue, 03 Dec 2019 14:53:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1153,58 +1302,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5OWZiZGI3LWY0MDctNDMw
-        Zi04Nzk3LTFlYWNkZDE2NzI1YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczOWNjZWZmLTg3ODgtNDIw
+        Zi05ODMyLTMxNWZkYjA3ZGNhZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:06 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/492b97ed-ba6a-4c21-bbe6-cb92143fc9a9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:06 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzNzE0M2ZmLTNmYTktNGVh
-        Yy1iZjc3LTQzNGUzZTEzOTRjZi8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:06 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:45 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/137143ff-3fa9-4eac-bf77-434e3e1394cf/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/739cceff-8788-420f-9832-315fdb07dcad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1212,7 +1316,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1225,9 +1329,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:06 GMT
+      - Tue, 03 Dec 2019 14:53:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1239,23 +1343,23 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '330'
+      - '331'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM3MTQzZmYtM2Zh
-        OS00ZWFjLWJmNzctNDM0ZTNlMTM5NGNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6MDYuMTkzODEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzM5Y2NlZmYtODc4
+        OC00MjBmLTk4MzItMzE1ZmRiMDdkY2FkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTM6NDUuMzI4NDAzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjIxOjA2LjI3NzY1M1oi
-        LCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6MDYuMzI3NjA1WiIs
-        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82
-        YWZiMmRlZC0wNjkyLTRkOWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjUzOjQ1LjQxNzc2N1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTM6NDUuNDU5Mzc2WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9i
+        NDczOGU1OS04Mzc0LTRhMjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50
         IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
         X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5l
-        ci9jb250YWluZXIvNDkyYjk3ZWQtYmE2YS00YzIxLWJiZTYtY2I5MjE0M2Zj
-        OWE5LyJdfQ==
+        ci9jb250YWluZXIvMTBjZjkxYWItNjIwZi00MjMwLTkxNWQtOTUyNWQ1MmZh
+        YjYwLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:06 GMT
+  recorded_at: Tue, 03 Dec 2019 14:53:45 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_set_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_set_unprotected.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,28 +23,83 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:40 GMT
+      - Tue, 03 Dec 2019 14:55:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '245'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9iMGI2M2EyOC04Y2ViLTQzYjItYmM1NS0y
+        YzUwNDUwMDUyYTMvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NTo0MS44OTE0MzlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iMGI2M2EyOC04Y2Vi
+        LTQzYjItYmM1NS0yYzUwNDUwMDUyYTMvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
+        bmVyL2NvbnRhaW5lci9iMGI2M2EyOC04Y2ViLTQzYjItYmM1NS0yYzUwNDUw
+        MDUyYTMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
+        fQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:45 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjZDI1M2FhLTQ0NjctNDA4
+        MS1iNTFiLTliNzJmNDdlMGU4OC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:40 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -55,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -68,28 +123,87 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:41 GMT
+      - Tue, 03 Dec 2019 14:55:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
+        aW5lci9jb250YWluZXIvODg0NDkxZDctOGQ1Ny00NmNhLTgzOTEtNTUzOTlj
+        MWM4M2EwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6NDIu
+        MDY4MjYwWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
+        ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
+        MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
+        dF9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFkMWUzMjg5ZDMw
+        ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
+        ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
+        NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
+        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTo0NC4zOTYzMThaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
+        LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJv
+        eCIsIndoaXRlbGlzdF90YWdzIjpudWxsfV19
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/884491d7-8d57-46ca-8391-55399c1c83a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:45 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1ZmQ3MTA1LWJkMDItNDBi
+        Ny05ZTg0LTRhMDhmNWFiOWEyNS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -100,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -113,28 +227,81 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:41 GMT
+      - Tue, 03 Dec 2019 14:55:45 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci9iYjZmNDliNi02OWZjLTQ2YWUtOThl
+        Ny03NGVhYzBmZWFlZTUvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDMuNTYyNzEyWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/bb6f49b6-69fc-46ae-98e7-74eac0feaee5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:45 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4ZmNlNzRjLTBiY2MtNGM5
+        NS1iYmEwLTc1ZTRmODU1YmE0Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:45 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -145,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -158,9 +325,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:41 GMT
+      - Tue, 03 Dec 2019 14:55:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -179,7 +346,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:46 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -192,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -205,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:41 GMT
+      - Tue, 03 Dec 2019 14:55:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/"
+      - "/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -226,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMjEyYWNiN2MtZWUwYS00ZDU2LWJjN2YtYzNkMTJh
-        NmQyNWRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NDEu
-        Njc1MzYwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjEyYWNiN2MtZWUwYS00ZDU2
-        LWJjN2YtYzNkMTJhNmQyNWRhL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvY2Y1ZWE1YjEtMzYyYy00Y2VmLTk1OWUtNmI4NjJl
+        YzkwMGM0LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6NDYu
+        MjU4OTU2WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvY2Y1ZWE1YjEtMzYyYy00Y2Vm
+        LTk1OWUtNmI4NjJlYzkwMGM0L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMjEyYWNiN2MtZWUwYS00ZDU2LWJjN2YtYzNkMTJhNmQyNWRh
+        b250YWluZXIvY2Y1ZWE1YjEtMzYyYy00Y2VmLTk1OWUtNmI4NjJlYzkwMGM0
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:46 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -253,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -266,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:41 GMT
+      - Tue, 03 Dec 2019 14:55:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/1bbb0e73-1761-46eb-a415-72c997ae80ff/"
+      - "/pulp/api/v3/remotes/container/container/f5d97820-08c8-4a15-905f-4a4b3697caa1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -287,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzFiYmIwZTczLTE3NjEtNDZlYi1hNDE1LTcyYzk5N2FlODBm
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQxLjg4MjA2
-        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyL2Y1ZDk3ODIwLTA4YzgtNGExNS05MDVmLTRhNGIzNjk3Y2Fh
+        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjQ2LjQzOTEx
+        NFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTo0MS44
-        ODIwODFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTo0Ni40
+        MzkxMjlaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:46 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -311,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -324,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:42 GMT
+      - Tue, 03 Dec 2019 14:55:46 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -342,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxNmE4NzI3LTY2ODYtNGE1
-        My1iZjQyLTY4MjhlNDcwMTFjMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNmE2NjAzLTBhMWQtNGM1
+        Yi1hOTkxLWYzOTc2Y2VhMTVjYy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:46 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -358,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -371,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:42 GMT
+      - Tue, 03 Dec 2019 14:55:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -389,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyY2JmOTliLTUwN2QtNGM1
-        My04ZThiLWI0YzQ4ZDBhNjBkYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5MWVmMmMxLWViZGItNDdm
+        OC1hYjhjLTdhNTg1ZTM4NzNlNy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f2cbf99b-507d-4c53-8e8b-b4c48d0a60db/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/491ef2c1-ebdb-47f8-ab8c-7a585e3873e7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -403,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -416,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:42 GMT
+      - Tue, 03 Dec 2019 14:55:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -430,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '338'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjJjYmY5OWItNTA3
-        ZC00YzUzLThlOGItYjRjNDhkMGE2MGRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NDIuMzg0NTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDkxZWYyYzEtZWJk
+        Yi00N2Y4LWFiOGMtN2E1ODVlMzg3M2U3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDcuMDczMzgxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIxOjQyLjU3NjU2MVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjE6NDIuNjU5OTg2WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjQ3LjE5NDgzMVoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6NDcuMjgwODA1WiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjEy
-        YWNiN2MtZWUwYS00ZDU2LWJjN2YtYzNkMTJhNmQyNWRhLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvY2Y1
+        ZWE1YjEtMzYyYy00Y2VmLTk1OWUtNmI4NjJlYzkwMGM0LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -459,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -472,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:42 GMT
+      - Tue, 03 Dec 2019 14:55:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -486,34 +653,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '197'
+      - '196'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMjEyYWNiN2MtZWUwYS00ZDU2LWJjN2YtYzNkMTJh
-        NmQyNWRhL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo0MS42NzY5NDNaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvY2Y1ZWE1YjEtMzYyYy00Y2VmLTk1OWUtNmI4NjJl
+        YzkwMGM0L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTo0Ni4yNjA1MjdaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:47 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTJhY2I3Yy1lZTBh
-        LTRkNTYtYmM3Zi1jM2QxMmE2ZDI1ZGEvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyL2NmNWVhNWIxLTM2MmMtNGNlZi05NTll
+        LTZiODYyZWM5MDBjNC92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -526,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:42 GMT
+      - Tue, 03 Dec 2019 14:55:47 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -544,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5Zjk4OTkzLTJiMWUtNDBj
-        Yi05ZmJkLWQyN2I3ZmFmZjJjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NmM2U5NmI4LWNjZTctNGRi
+        MC1hMzU0LTBiZjAxZGZhZGY2YS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:47 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a9f98993-2b1e-40cb-9fbd-d27b7faff2c8/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cf3e96b8-cce7-4db0-a354-0bf01dfadf6a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -558,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -571,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:43 GMT
+      - Tue, 03 Dec 2019 14:55:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -585,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '342'
+      - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTlmOTg5OTMtMmIx
-        ZS00MGNiLTlmYmQtZDI3YjdmYWZmMmM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NDIuOTQ3MjcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2YzZTk2YjgtY2Nl
+        Ny00ZGIwLWEzNTQtMGJmMDFkZmFkZjZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDcuNjg3Njc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6NDMuMDU4MjMw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTo0My4yMjc2NDBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6NDcuODA0OTU2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTo0Ny45ODc1Mjla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci82YWNlYzNkNC04NGNmLTQ0
-        MDAtODAzZC01ZmJlYjMxN2Y5ZjgvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8zYjA0MWQyZC0xMWY1LTQw
+        ZjktYmYwYy0zMzc0Nzg1ODE5YjAvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:48 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/6acec3d4-84cf-4400-803d-5fbeb317f9f8/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/3b041d2d-11f5-40f9-bf0c-3374785819b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -614,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -627,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:43 GMT
+      - Tue, 03 Dec 2019 14:55:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -641,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '309'
+      - '297'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvNmFjZWMzZDQtODRjZi00NDAwLTgwM2QtNWZi
-        ZWIzMTdmOWY4LyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTJhY2I3Yy1l
-        ZTBhLTRkNTYtYmM3Zi1jM2QxMmE2ZDI1ZGEvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQzLjIxODkxNFoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvY2Y1ZWE1YjEtMzYyYy00Y2VmLTk1
+        OWUtNmI4NjJlYzkwMGM0L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci8zYjA0MWQyZC0xMWY1LTQwZjktYmYwYy0z
+        Mzc0Nzg1ODE5YjAvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6NDcuOTc4NjkyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:48 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -670,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -683,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:43 GMT
+      - Tue, 03 Dec 2019 14:55:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -701,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmOThkMWY5LTY5Y2ItNDJl
-        Yy1hOGQ0LWVlMzhiOTFlM2NlMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1Mjg2MjljLWQyZmItNDc4
+        MC1hNzI4LWE4YzRlZjUyZjg3ZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:48 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/1bbb0e73-1761-46eb-a415-72c997ae80ff/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/f5d97820-08c8-4a15-905f-4a4b3697caa1/
     body:
       encoding: UTF-8
       base64_string: |
@@ -723,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -736,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:43 GMT
+      - Tue, 03 Dec 2019 14:55:48 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -754,13 +921,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjOGIyYTI4LTgwY2MtNGFj
-        ZS1hMTYzLWQ2ZmJjZTAyMjYwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3Zjk0MmEzLTAxNWYtNDYw
+        Yi04ZGE1LWM0YmMzOTg0ZGE3MC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:48 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -770,7 +937,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -783,9 +950,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:44 GMT
+      - Tue, 03 Dec 2019 14:55:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -801,13 +968,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExN2E3NmYxLWNjOGMtNDli
-        YS1hZmY3LWY2NWM2ODNkY2NkNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4YjNiYTU1LTNmMGYtNDdj
+        ZC04YzRhLTk1YmViNmM5OGNkZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:49 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/1bbb0e73-1761-46eb-a415-72c997ae80ff/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/f5d97820-08c8-4a15-905f-4a4b3697caa1/
     body:
       encoding: UTF-8
       base64_string: |
@@ -823,7 +990,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -836,9 +1003,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:44 GMT
+      - Tue, 03 Dec 2019 14:55:49 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -854,8 +1021,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1MGQ3ZTUxLWMyOTAtNDM3
-        Ni04MTBiLTBjNGVmZDA0NzczOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYyY2VhY2Y2LTBmNWYtNGUz
+        Yi1iNGVlLTEzNmI4NGFiYzk4Yy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:49 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_ssl_validation.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_ssl_validation.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:54 GMT
+      - Tue, 03 Dec 2019 14:55:27 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9lMDg4NTI1ZC1kODA5LTRlMzktYjdhMi04
-        Zjc2NTg3ODc4NTkvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MTo1MC43MTY0NjJaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMDg4NTI1ZC1kODA5
-        LTRlMzktYjdhMi04Zjc2NTg3ODc4NTkvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci85NzY5Y2Q0MS04NWQ2LTQ1MzYtODhmNi01
+        ZTFhODFhMjJjNWIvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NToyNC4yNjY5NzVaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci85NzY5Y2Q0MS04NWQ2
+        LTQ1MzYtODhmNi01ZTFhODFhMjJjNWIvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9lMDg4NTI1ZC1kODA5LTRlMzktYjdhMi04Zjc2NTg3
-        ODc4NTkvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci85NzY5Y2Q0MS04NWQ2LTQ1MzYtODhmNi01ZTFhODFh
+        MjJjNWIvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:27 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:54 GMT
+      - Tue, 03 Dec 2019 14:55:27 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExMDJmM2JmLTE2ZTEtNDA4
-        Ni04MWY1LTg2MTNhYzhkNmI0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwNzVkZTk4LTMwOWYtNDBl
+        Mi1iNmU3LTE0OGQ5NDU0MzYwZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:27 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:54 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -137,15 +137,15 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '392'
+      - '391'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMDI4NzQ5MmYtMTRhMi00ZmE0LTkwOGItYjdkY2U2
-        OTllOGU3LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NTAu
-        ODk4NzcxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvMzMwNzlmNzYtMjM1Mi00MjI2LWI2NDItZTRiZjYx
+        ZDJiZjM5LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6MjQu
+        NDUyNDk4WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
         MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
@@ -153,15 +153,15 @@ http_interactions:
         ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
         ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
         NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
-        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo1My42MjQwNjdaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
+        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NToyNi45OTAyOThaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
         LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJv
         eCIsIndoaXRlbGlzdF90YWdzIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/0287492f-14a2-4fa4-908b-b7dce699e8e7/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/33079f76-2352-4226-b642-e4bf61d2bf39/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:54 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -200,10 +200,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyYjZlYTVmLWQ5NmItNDdj
-        ZC1hMTNmLTQ3YTY0NjlmOTUzZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyNzc3MWMxLTBlZGQtNDA2
+        Ni1iYzIzLTM2MzFjNmQ2NDk2MC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -227,9 +227,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:54 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -241,25 +241,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '299'
+      - '286'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci9hZmEzODc3Ni05NjIyLTQ3MDEtYjMy
-        Yi1kMjUxOTNkN2MxODkvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjUyLjU2MzczMFoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci82MDFkZGU3MC00NGFjLTRmMmEtYWRi
+        NS1iMGQxNTRjZWYzNmIvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MjYuMDY5MjgxWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/afa38776-9622-4701-b32b-d25193d7c189/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/601dde70-44ac-4f2a-adb5-b0d154cef36b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -280,9 +280,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:55 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -298,10 +298,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiYTFkYTY1LWU4ODUtNDYw
-        OS05NTc4LTcyN2JhMmYyM2JkZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1ZGE3NzMzLWMxZWItNDIx
+        OC05ODRhLWFjMTJlNjY4MDgwYS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:55 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -325,81 +325,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:55 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '299'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci9hZmEzODc3Ni05NjIyLTQ3MDEtYjMy
-        Yi1kMjUxOTNkN2MxODkvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjUyLjU2MzczMFoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:55 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/afa38776-9622-4701-b32b-d25193d7c189/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:55 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '23'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:55 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -412,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -425,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:55 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/"
+      - "/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -446,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOTEwNzU2MjAtMzg5MC00OTQxLTg5OWEtOGIzYTdm
-        ZjU4NThjLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NTUu
-        NTQ4MDU5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOTEwNzU2MjAtMzg5MC00OTQx
-        LTg5OWEtOGIzYTdmZjU4NThjL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMjk2Nzk0MGEtMGM5NC00MjZhLThiMGYtODYzYTdl
+        YzdlNWY1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6Mjgu
+        Nzg4NjI1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjk2Nzk0MGEtMGM5NC00MjZh
+        LThiMGYtODYzYTdlYzdlNWY1L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvOTEwNzU2MjAtMzg5MC00OTQxLTg5OWEtOGIzYTdmZjU4NThj
+        b250YWluZXIvMjk2Nzk0MGEtMGM5NC00MjZhLThiMGYtODYzYTdlYzdlNWY1
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:55 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -473,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -486,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:55 GMT
+      - Tue, 03 Dec 2019 14:55:28 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/8298e0c8-499f-4fb4-b8d5-64ebb19aded4/"
+      - "/pulp/api/v3/remotes/container/container/34082a2b-b8cc-483b-8f20-34c888ef8d71/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -507,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzgyOThlMGM4LTQ5OWYtNGZiNC1iOGQ1LTY0ZWJiMTlhZGVk
-        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjU1LjcwNjcw
-        MloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzM0MDgyYTJiLWI4Y2MtNDgzYi04ZjIwLTM0Yzg4OGVmOGQ3
+        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjI4Ljk2NjA4
+        OVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTo1NS43
-        MDY3MTdaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NToyOC45
+        NjYxMDNaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:55 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:28 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -531,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -544,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:56 GMT
+      - Tue, 03 Dec 2019 14:55:29 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -562,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzNDhkODdhLTgwZWItNGE1
-        Mi05OTZhLThkNGE4ZGZjODQ2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxMzA1YzBmLWU0ZDQtNDJh
+        NS1iYTBiLTM1ZDU5NTEyYzM3OS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:56 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:29 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -578,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -591,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:56 GMT
+      - Tue, 03 Dec 2019 14:55:29 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -609,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwNmExMGEwLWRiYTItNDQy
-        Ny1iYmEzLTA5OWMxOWU4M2MwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyY2I0NjY0LTlmODEtNGE2
+        NC1hNjllLTI5ZDJiMGE5YTY5OS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:56 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:29 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/506a10a0-dba2-4427-bba3-099c19e83c0f/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d2cb4664-9f81-4a64-a69e-29d2b0a9a699/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -623,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:56 GMT
+      - Tue, 03 Dec 2019 14:55:29 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -650,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA2YTEwYTAtZGJh
-        Mi00NDI3LWJiYTMtMDk5YzE5ZTgzYzBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NTYuMjY3NzU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJjYjQ2NjQtOWY4
+        MS00YTY0LWE2OWUtMjlkMmIwYTlhNjk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MjkuNDYxMTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIxOjU2LjQ2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjE6NTYuNTQ0MTYxWiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjI5LjY3NTE2MloiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6MjkuNzY5NjI4WiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOTEw
-        NzU2MjAtMzg5MC00OTQxLTg5OWEtOGIzYTdmZjU4NThjLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjk2
+        Nzk0MGEtMGM5NC00MjZhLThiMGYtODYzYTdlYzdlNWY1LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:56 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:29 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -679,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -692,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:56 GMT
+      - Tue, 03 Dec 2019 14:55:29 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -711,29 +658,29 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOTEwNzU2MjAtMzg5MC00OTQxLTg5OWEtOGIzYTdm
-        ZjU4NThjL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo1NS41NDk2NzFaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMjk2Nzk0MGEtMGM5NC00MjZhLThiMGYtODYzYTdl
+        YzdlNWY1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NToyOC43OTAxOTZaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:56 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:29 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci85MTA3NTYyMC0zODkw
-        LTQ5NDEtODk5YS04YjNhN2ZmNTg1OGMvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyLzI5Njc5NDBhLTBjOTQtNDI2YS04YjBm
+        LTg2M2E3ZWM3ZTVmNS92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -746,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:56 GMT
+      - Tue, 03 Dec 2019 14:55:30 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -764,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ2NDlhYWNjLWMzYTEtNDRj
-        ZS04NjM0LTk3Mzk5ODBmMjFhNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxYTgyZDZjLTkyNDktNDAy
+        My1hNmZjLTczZWI5NTRiZThiOC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:56 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:30 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4649aacc-c3a1-44ce-8634-9739980f21a7/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/31a82d6c-9249-4023-a6fc-73eb954be8b8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -778,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -791,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:57 GMT
+      - Tue, 03 Dec 2019 14:55:30 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -805,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '340'
+      - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDY0OWFhY2MtYzNh
-        MS00NGNlLTg2MzQtOTczOTk4MGYyMWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NTYuODcxMTEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzFhODJkNmMtOTI0
+        OS00MDIzLWE2ZmMtNzNlYjk1NGJlOGI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzAuMTg0MjUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6NTYuOTU5OTUy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTo1Ny4xNDE3NDla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6MzAuMjk0MDQ4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTozMC40ODM1MzBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8xNjQzZTkzZC0yZmRjLTRj
-        NmUtYTRlNS1iNjMxNzJhMTUzZDQvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci81ZjNlMmExOC0zNDg3LTQw
+        MzYtOTg3MC0wOWQwOGY5MTkyNjIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:57 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:30 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/1643e93d-2fdc-4c6e-a4e5-b63172a153d4/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/5f3e2a18-3487-4036-9870-09d08f919262/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -834,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -847,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:57 GMT
+      - Tue, 03 Dec 2019 14:55:30 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -861,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '308'
+      - '299'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvMTY0M2U5M2QtMmZkYy00YzZlLWE0ZTUtYjYz
-        MTcyYTE1M2Q0LyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci85MTA3NTYyMC0z
-        ODkwLTQ5NDEtODk5YS04YjNhN2ZmNTg1OGMvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjU3LjEzMzMwN1oiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMjk2Nzk0MGEtMGM5NC00MjZhLThi
+        MGYtODYzYTdlYzdlNWY1L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci81ZjNlMmExOC0zNDg3LTQwMzYtOTg3MC0w
+        OWQwOGY5MTkyNjIvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6MzAuNDc0NjExWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:57 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:30 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:57 GMT
+      - Tue, 03 Dec 2019 14:55:31 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3MDRjOTkxLTc1YmYtNDk2
-        Ny1hNDExLTVmZmMxYWZkZjZhNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VjMWU3MzhlLTg5NzYtNDc5
+        MS1hZTZkLTgyMDI0NTE2NjFiNC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:57 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:31 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/8298e0c8-499f-4fb4-b8d5-64ebb19aded4/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/34082a2b-b8cc-483b-8f20-34c888ef8d71/
     body:
       encoding: UTF-8
       base64_string: |
@@ -943,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -956,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:57 GMT
+      - Tue, 03 Dec 2019 14:55:31 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -974,8 +921,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0MTZmYzVlLTVmMDYtNGU2
-        OC1hMmFkLWMwY2MwODNiMGZhYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyZWMyMjYyLTVkMWEtNDQx
+        YS1iMTZmLWM1NzJiNGE3OTE2Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:57 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:31 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_unset_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_unset_unprotected.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:40 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -37,27 +37,27 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '245'
+      - '246'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8yMTJhY2I3Yy1lZTBhLTRkNTYtYmM3Zi1j
-        M2QxMmE2ZDI1ZGEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MTo0MS42NzUzNjBaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTJhY2I3Yy1lZTBh
-        LTRkNTYtYmM3Zi1jM2QxMmE2ZDI1ZGEvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci9hZTUwMjcxMS02ZWZhLTQwZDktOTU3Yi02
+        MDgxZjhjM2VlNDcvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NTozNy41MTU2NzlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZTUwMjcxMS02ZWZh
+        LTQwZDktOTU3Yi02MDgxZjhjM2VlNDcvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci8yMTJhY2I3Yy1lZTBhLTRkNTYtYmM3Zi1jM2QxMmE2
-        ZDI1ZGEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci9hZTUwMjcxMS02ZWZhLTQwZDktOTU3Yi02MDgxZjhj
+        M2VlNDcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:40 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/212acb7c-ee0a-4d56-bc7f-c3d12a6d25da/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlNjBiY2EzLWJhZGQtNDNm
-        NC1iODFkLTU2MDhiMzY5ZmJkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmNDA4ZDg0LTY0MzAtNDNk
+        NS04NTVhLTdmNzYyODYwMjk1Ny8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -137,31 +137,31 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '391'
+      - '384'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMWJiYjBlNzMtMTc2MS00NmViLWE0MTUtNzJjOTk3
-        YWU4MGZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NDEu
-        ODgyMDY2WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
-        c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
-        ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
-        MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
-        dF9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFkMWUzMjg5ZDMw
-        ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
-        ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
-        NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
-        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo0NC40MTk1OTlaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
-        LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJv
-        eCIsIndoaXRlbGlzdF90YWdzIjpudWxsfV19
+        aW5lci9jb250YWluZXIvZTNkNTgxOGUtNDE5MC00NzFjLTkxMzUtZDkxZDAx
+        MzhiOTRmLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6Mzcu
+        NjgzMjk3WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHA6Ly93ZWJzaXRlLmNvbS8iLCJj
+        YV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFkMWUzMjg5ZDMw
+        ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9jZXJ0Ijoi
+        Mjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFkMWUzMjg5ZDMwZTcyYjhlMGY1
+        ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIyODZkYmVlZjRl
+        MjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4NzZhZTMzNDkz
+        OTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJwcm94eV91cmwi
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTo0
+        MC4wNjg3MDRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRl
+        bGlzdF90YWdzIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/1bbb0e73-1761-46eb-a415-72c997ae80ff/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/e3d5818e-4190-471c-9135-d91d0138b94f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -200,10 +200,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyYWM5M2ZhLWZmMWQtNDli
-        MC04ZTljLTZiZmY4MTQ4OGExZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlMmY0M2IwLWRlODktNDk0
+        Mi04NDI0LTYyODA3MTZjNDcxOC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -227,9 +227,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -241,25 +241,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '298'
+      - '287'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci82YWNlYzNkNC04NGNmLTQ0MDAtODAz
-        ZC01ZmJlYjMxN2Y5ZjgvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQzLjIxODkxNFoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci8xMTcxMjgyNC1kYTc4LTQwYzUtYTli
+        Yy1jYzJiMjQ5NDQzYzQvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzkuMTcwMDcwWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/6acec3d4-84cf-4400-803d-5fbeb317f9f8/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/11712824-da78-40c5-a9bc-cc2b249443c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -280,9 +280,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -298,10 +298,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2ZjAyMDZhLTdiYjQtNDIw
-        Yi1hNGFkLWQ3OThjZDA5NzFkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlM2EyMzRjLTcwMDgtNGEz
+        MS1hYzFmLWZmNDRmOTdjM2M4NS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -325,81 +325,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:45 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '298'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci82YWNlYzNkNC04NGNmLTQ0MDAtODAz
-        ZC01ZmJlYjMxN2Y5ZjgvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQzLjIxODkxNFoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:45 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/6acec3d4-84cf-4400-803d-5fbeb317f9f8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:46 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '23'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -412,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -425,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:46 GMT
+      - Tue, 03 Dec 2019 14:55:41 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/"
+      - "/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -446,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvYjVhOWVjNDEtNjE2OS00YWFmLWFlYWYtYTAyOTBl
-        ZTVlMzA3LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NDYu
-        MzQwNjU1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjVhOWVjNDEtNjE2OS00YWFm
-        LWFlYWYtYTAyOTBlZTVlMzA3L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvYjBiNjNhMjgtOGNlYi00M2IyLWJjNTUtMmM1MDQ1
+        MDA1MmEzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6NDEu
+        ODkxNDM5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjBiNjNhMjgtOGNlYi00M2Iy
+        LWJjNTUtMmM1MDQ1MDA1MmEzL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvYjVhOWVjNDEtNjE2OS00YWFmLWFlYWYtYTAyOTBlZTVlMzA3
+        b250YWluZXIvYjBiNjNhMjgtOGNlYi00M2IyLWJjNTUtMmM1MDQ1MDA1MmEz
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:41 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -473,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -486,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:46 GMT
+      - Tue, 03 Dec 2019 14:55:42 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/1088ae5b-57da-460d-81df-ecc159ce5937/"
+      - "/pulp/api/v3/remotes/container/container/884491d7-8d57-46ca-8391-55399c1c83a0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -507,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzEwODhhZTViLTU3ZGEtNDYwZC04MWRmLWVjYzE1OWNlNTkz
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQ2LjUyNTkw
-        OVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzg4NDQ5MWQ3LThkNTctNDZjYS04MzkxLTU1Mzk5YzFjODNh
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjQyLjA2ODI2
+        MFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTo0Ni41
-        MjU5MjNaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTo0Mi4w
+        NjgyNzRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:42 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -531,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -544,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:46 GMT
+      - Tue, 03 Dec 2019 14:55:42 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -562,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyYmRlY2I5LTY2OGYtNDEx
-        Mi05OGY2LTAzYTk2MzI1MmExYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyMmJmOTkyLWY2NGItNGEz
+        ZC04NjJlLTVjZTA5YTQyMzI3OS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:42 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -578,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -591,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:47 GMT
+      - Tue, 03 Dec 2019 14:55:42 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -609,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4MmYzOTY3LThjMDEtNDRk
-        OS1hMWE4LTBkNjUzMThiNmU4MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxZWU0NTQxLWJkOWEtNDA5
+        Yi1iYmQxLTU4NjcwMWRjYTYyNS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:42 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e82f3967-8c01-44d9-a1a8-0d65318b6e81/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/01ee4541-bd9a-409b-bbd1-586701dca625/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -623,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:47 GMT
+      - Tue, 03 Dec 2019 14:55:42 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -650,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '338'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTgyZjM5NjctOGMw
-        MS00NGQ5LWExYTgtMGQ2NTMxOGI2ZTgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NDYuOTk4NTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFlZTQ1NDEtYmQ5
+        YS00MDliLWJiZDEtNTg2NzAxZGNhNjI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDIuNTk0NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIxOjQ3LjIwNjE5OVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjE6NDcuMjg5Mzk0WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjQyLjc0Nzk4NloiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6NDIuODM1NTE2WiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjVh
-        OWVjNDEtNjE2OS00YWFmLWFlYWYtYTAyOTBlZTVlMzA3LyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYjBi
+        NjNhMjgtOGNlYi00M2IyLWJjNTUtMmM1MDQ1MDA1MmEzLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:42 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -679,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -692,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:47 GMT
+      - Tue, 03 Dec 2019 14:55:43 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -706,34 +653,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '196'
+      - '197'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvYjVhOWVjNDEtNjE2OS00YWFmLWFlYWYtYTAyOTBl
-        ZTVlMzA3L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo0Ni4zNDUyMTZaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvYjBiNjNhMjgtOGNlYi00M2IyLWJjNTUtMmM1MDQ1
+        MDA1MmEzL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTo0MS44OTMwMzNaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:43 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iNWE5ZWM0MS02MTY5
-        LTRhYWYtYWVhZi1hMDI5MGVlNWUzMDcvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyL2IwYjYzYTI4LThjZWItNDNiMi1iYzU1
+        LTJjNTA0NTAwNTJhMy92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -746,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:47 GMT
+      - Tue, 03 Dec 2019 14:55:43 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -764,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4OTI3Y2Y0LWQzM2YtNDFl
-        ZC05OGJlLThhNzM4NjI5YTQwYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2YWRiZTc4LTJjODAtNGI4
+        MS1hNGQ1LTkzMDRmMjZiYjdkMi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:43 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/58927cf4-d33f-41ed-98be-8a738629a40b/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/16adbe78-2c80-4b81-a4d5-9304f26bb7d2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -778,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -791,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:48 GMT
+      - Tue, 03 Dec 2019 14:55:43 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -805,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '340'
+      - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTg5MjdjZjQtZDMz
-        Zi00MWVkLTk4YmUtOGE3Mzg2MjlhNDBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NDcuNzk0MDE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTZhZGJlNzgtMmM4
+        MC00YjgxLWE0ZDUtOTMwNGYyNmJiN2QyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDMuMjYwMjYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6NDcuODg1Mjk2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTo0OC4wNTU1NjFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6NDMuMzY2MTE0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTo0My41NzE1NTNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci85MjgyYzBjMi0wY2FlLTQ1
-        NzEtYWE5OS1jYzIzYzUxMDg5YWUvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9iYjZmNDliNi02OWZjLTQ2
+        YWUtOThlNy03NGVhYzBmZWFlZTUvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:43 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/9282c0c2-0cae-4571-aa99-cc23c51089ae/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/bb6f49b6-69fc-46ae-98e7-74eac0feaee5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -834,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -847,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:48 GMT
+      - Tue, 03 Dec 2019 14:55:43 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -861,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '307'
+      - '296'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvOTI4MmMwYzItMGNhZS00NTcxLWFhOTktY2My
-        M2M1MTA4OWFlLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iNWE5ZWM0MS02
-        MTY5LTRhYWYtYWVhZi1hMDI5MGVlNWUzMDcvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQ4LjA0NTg0MloiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvYjBiNjNhMjgtOGNlYi00M2IyLWJj
+        NTUtMmM1MDQ1MDA1MmEzL3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9iYjZmNDliNi02OWZjLTQ2YWUtOThlNy03
+        NGVhYzBmZWFlZTUvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6NDMuNTYyNzEyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:43 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b0b63a28-8ceb-43b2-bc55-2c50450052a3/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:48 GMT
+      - Tue, 03 Dec 2019 14:55:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBmZDA5NGYzLWQ1MTktNDE4
-        OS04MGYwLTAxMDdiYjI1OWUyZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlNzE4YWEyLTkyNzctNGRm
+        Mi05ZDcwLWY2YWMyNDRlMTg0Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:44 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/1088ae5b-57da-460d-81df-ecc159ce5937/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/884491d7-8d57-46ca-8391-55399c1c83a0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -943,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -956,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:48 GMT
+      - Tue, 03 Dec 2019 14:55:44 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -974,8 +921,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlN2U4NzdjLWNkZDktNGUx
-        My04YjNlLWYwYjcxZDE4YjgxOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4NDIwYjM5LTA1ZjctNGEy
+        MC1hYWU0LTJmNmYwYTI1YjUzMi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:44 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_upstream_name.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_upstream_name.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:58 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci85MTA3NTYyMC0zODkwLTQ5NDEtODk5YS04
-        YjNhN2ZmNTg1OGMvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MTo1NS41NDgwNTlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci85MTA3NTYyMC0zODkw
-        LTQ5NDEtODk5YS04YjNhN2ZmNTg1OGMvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8yOTY3OTQwYS0wYzk0LTQyNmEtOGIwZi04
+        NjNhN2VjN2U1ZjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NToyOC43ODg2MjVaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yOTY3OTQwYS0wYzk0
+        LTQyNmEtOGIwZi04NjNhN2VjN2U1ZjUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci85MTA3NTYyMC0zODkwLTQ5NDEtODk5YS04YjNhN2Zm
-        NTg1OGMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8yOTY3OTQwYS0wYzk0LTQyNmEtOGIwZi04NjNhN2Vj
+        N2U1ZjUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:58 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/91075620-3890-4941-899a-8b3a7ff5858c/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/2967940a-0c94-426a-8b0f-863a7ec7e5f5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:58 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1MWJkNDFiLWVmNTgtNDAx
-        Yi1iMGE5LTE5YjUyYWQyMDliOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1MmUxMWFiLTcxNWItNDFi
+        Zi05MmI0LTBkMzI3ZjlmZjRmYS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:58 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:58 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -137,15 +137,15 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '391'
+      - '392'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvODI5OGUwYzgtNDk5Zi00ZmI0LWI4ZDUtNjRlYmIx
-        OWFkZWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NTUu
-        NzA2NzAyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvMzQwODJhMmItYjhjYy00ODNiLThmMjAtMzRjODg4
+        ZWY4ZDcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6Mjgu
+        OTY2MDg5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
         MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
@@ -153,15 +153,15 @@ http_interactions:
         ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
         ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
         NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOnRydWUsInBy
-        b3h5X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIy
-        VDE2OjIxOjU3LjkxMTA2MVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAs
+        b3h5X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTAz
+        VDE0OjU1OjMxLjQ1NTM3NloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAs
         InBvbGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJidXN5Ym94
         Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9XX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:58 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/8298e0c8-499f-4fb4-b8d5-64ebb19aded4/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/34082a2b-b8cc-483b-8f20-34c888ef8d71/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -200,10 +200,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNTk2YjFlLThhOTEtNDk4
-        My1hOWQyLWQ2YTRkNGYzNzNmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3OGI4MGIwLTg3ZWUtNGMw
+        YS1iMmE3LTk4MmZhNzFlMmEwZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -227,9 +227,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -241,25 +241,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '297'
+      - '289'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci8xNjQzZTkzZC0yZmRjLTRjNmUtYTRl
-        NS1iNjMxNzJhMTUzZDQvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjU3LjEzMzMwN1oiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci81ZjNlMmExOC0zNDg3LTQwMzYtOTg3
+        MC0wOWQwOGY5MTkyNjIvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzAuNDc0NjExWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/1643e93d-2fdc-4c6e-a4e5-b63172a153d4/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/5f3e2a18-3487-4036-9870-09d08f919262/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -280,9 +280,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -298,10 +298,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzMjRkNTc5LWUxYzUtNDEx
-        YS1hMjQyLTU2ZGYwNjE3ODA3Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2MzM5YjAzLWM1MzYtNDZm
+        My04MTVhLWQ4M2I4ZjdhMjg4MS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -325,81 +325,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
+      - Tue, 03 Dec 2019 14:55:32 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '297'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci8xNjQzZTkzZC0yZmRjLTRjNmUtYTRl
-        NS1iNjMxNzJhMTUzZDQvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjU3LjEzMzMwN1oiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/1643e93d-2fdc-4c6e-a4e5-b63172a153d4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '23'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:32 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -412,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -425,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:59 GMT
+      - Tue, 03 Dec 2019 14:55:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/"
+      - "/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -446,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZTI0MjU3ODAtODE4MS00M2Y0LTk2ODMtOTlkZjli
-        YTRhMGQ1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NTku
-        ODQ0Nzg5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZTI0MjU3ODAtODE4MS00M2Y0
-        LTk2ODMtOTlkZjliYTRhMGQ1L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMjkwNjU0ZmUtMjA2MS00ZDE3LWFkMTUtYzcxMDhk
+        MjcyOGM2LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6MzMu
+        MTYxOTEwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjkwNjU0ZmUtMjA2MS00ZDE3
+        LWFkMTUtYzcxMDhkMjcyOGM2L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZTI0MjU3ODAtODE4MS00M2Y0LTk2ODMtOTlkZjliYTRhMGQ1
+        b250YWluZXIvMjkwNjU0ZmUtMjA2MS00ZDE3LWFkMTUtYzcxMDhkMjcyOGM2
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:59 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:33 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -473,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -486,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:00 GMT
+      - Tue, 03 Dec 2019 14:55:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/7f64cb81-bb4b-45d2-ab9e-8dfeb52f8434/"
+      - "/pulp/api/v3/remotes/container/container/69037a80-6e96-443e-89ce-a838ba70ae4a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -507,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzdmNjRjYjgxLWJiNGItNDVkMi1hYjllLThkZmViNTJmODQz
-        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjAwLjAwMDE5
-        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzY5MDM3YTgwLTZlOTYtNDQzZS04OWNlLWE4MzhiYTcwYWU0
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjMzLjM0NDU0
+        MloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMjowMC4w
-        MDAyMDlaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTozMy4z
+        NDQ1NTZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:33 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -531,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -544,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:00 GMT
+      - Tue, 03 Dec 2019 14:55:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -562,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0YzMwMGJiLTczNTgtNDhh
-        Yy1hMmNjLWMyYTMxYWI5OWJkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3YmVlODEzLWQ3ZDItNGFi
+        ZS05MTZmLWJkNDFkYjhlMzkxZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:33 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -578,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -591,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:00 GMT
+      - Tue, 03 Dec 2019 14:55:33 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -609,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3YzRjYTIzLTkzOTctNGE2
-        NC04M2ZhLTY5ZjYzODEyZDU0OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYyMDA1ZDkxLWEwODgtNDNi
+        Yi1hYmI1LWYxMTA4ODA2MzI4MS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:33 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/67c4ca23-9397-4a64-83fa-69f63812d548/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/62005d91-a088-43bb-abb5-f11088063281/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -623,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:00 GMT
+      - Tue, 03 Dec 2019 14:55:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -650,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '339'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjdjNGNhMjMtOTM5
-        Ny00YTY0LTgzZmEtNjlmNjM4MTJkNTQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDAuNTgxMjQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjIwMDVkOTEtYTA4
+        OC00M2JiLWFiYjUtZjExMDg4MDYzMjgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzMuOTUzNzgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIyOjAwLjc4ODYyMVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjI6MDAuODc2NTM4WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjM0LjExOTA0MFoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6MzQuMjA2MDgyWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZTI0
-        MjU3ODAtODE4MS00M2Y0LTk2ODMtOTlkZjliYTRhMGQ1LyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjkw
+        NjU0ZmUtMjA2MS00ZDE3LWFkMTUtYzcxMDhkMjcyOGM2LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:00 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:34 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -679,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -692,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:01 GMT
+      - Tue, 03 Dec 2019 14:55:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -706,34 +653,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '198'
+      - '197'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZTI0MjU3ODAtODE4MS00M2Y0LTk2ODMtOTlkZjli
-        YTRhMGQ1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo1OS44NDY0NThaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMjkwNjU0ZmUtMjA2MS00ZDE3LWFkMTUtYzcxMDhk
+        MjcyOGM2L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTozMy4xNjM0NjdaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:34 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMjQyNTc4MC04MTgx
-        LTQzZjQtOTY4My05OWRmOWJhNGEwZDUvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyLzI5MDY1NGZlLTIwNjEtNGQxNy1hZDE1
+        LWM3MTA4ZDI3MjhjNi92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -746,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:01 GMT
+      - Tue, 03 Dec 2019 14:55:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -764,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyYzU0MDMzLWE0MzAtNGVi
-        Yi04YzZkLTQ4ZTMzM2E2MjQ4ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzZjgzODYyLTZhNTMtNGU1
+        YS05OGFiLWFkMDVjNjM3NDVjZS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:34 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d2c54033-a430-4ebb-8c6d-48e333a6248d/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/63f83862-6a53-4e5a-98ab-ad05c63745ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -778,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -791,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:01 GMT
+      - Tue, 03 Dec 2019 14:55:34 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -805,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '341'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJjNTQwMzMtYTQz
-        MC00ZWJiLThjNmQtNDhlMzMzYTYyNDhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDEuMTgyMjk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjNmODM4NjItNmE1
+        My00ZTVhLTk4YWItYWQwNWM2Mzc0NWNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzQuNTE2MTUzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjI6MDEuMjY0OTA3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMjowMS40MzI3MzVa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6MzQuNjI0MDM5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTozNC44MjA0MTNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci82NTRiYzk0NC1kZDYxLTQ5
-        YmUtOTA0Ny1jNWFmMDMzZDllMWQvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9iYmY0NjRmNy0wYmVjLTQ4
+        OGItOGY2Yy1hY2Q0ZGYxYTg5ZWEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:34 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/654bc944-dd61-49be-9047-c5af033d9e1d/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/bbf464f7-0bec-488b-8f6c-acd4df1a89ea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -834,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -847,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:01 GMT
+      - Tue, 03 Dec 2019 14:55:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -861,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '310'
+      - '299'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvNjU0YmM5NDQtZGQ2MS00OWJlLTkwNDctYzVh
-        ZjAzM2Q5ZTFkLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMjQyNTc4MC04
-        MTgxLTQzZjQtOTY4My05OWRmOWJhNGEwZDUvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjAxLjQyNDM1OVoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMjkwNjU0ZmUtMjA2MS00ZDE3LWFk
+        MTUtYzcxMDhkMjcyOGM2L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9iYmY0NjRmNy0wYmVjLTQ4OGItOGY2Yy1h
+        Y2Q0ZGYxYTg5ZWEvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6MzQuODExNjU5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:01 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:35 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:02 GMT
+      - Tue, 03 Dec 2019 14:55:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ZTRmNGQ1LTk4ZmYtNDc0
-        ZS05OGQxLTgwYzJiNTUwMjcwMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyYzgxMzdlLWIzY2YtNDgy
+        Zi1hZjRlLWFjMDczYjMzZTdkOC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:02 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:35 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/7f64cb81-bb4b-45d2-ab9e-8dfeb52f8434/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/69037a80-6e96-443e-89ce-a838ba70ae4a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -943,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -956,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:02 GMT
+      - Tue, 03 Dec 2019 14:55:35 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -974,8 +921,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4MmJmZjNmLWVhMmYtNDJl
-        MS05MTcxLTRmMDRmMWQzYmNjYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmZjYxNjM0LWY0OTktNGYw
+        Mi1hOGZkLWRmNmU2YTY5MzJkMC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:02 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_url.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_url.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:07 GMT
+      - Tue, 03 Dec 2019 14:55:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci84ZjI1MzcwMy02YmU3LTRmN2EtOTM1ZC1m
-        N2I1NTUyYWM5MGUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MjowNC4xMTExNjVaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci84ZjI1MzcwMy02YmU3
-        LTRmN2EtOTM1ZC1mN2I1NTUyYWM5MGUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8yOTA2NTRmZS0yMDYxLTRkMTctYWQxNS1j
+        NzEwOGQyNzI4YzYvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NTozMy4xNjE5MTBaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yOTA2NTRmZS0yMDYx
+        LTRkMTctYWQxNS1jNzEwOGQyNzI4YzYvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci84ZjI1MzcwMy02YmU3LTRmN2EtOTM1ZC1mN2I1NTUy
-        YWM5MGUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8yOTA2NTRmZS0yMDYxLTRkMTctYWQxNS1jNzEwOGQy
+        NzI4YzYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:07 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:36 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/290654fe-2061-4d17-ad15-c7108d2728c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:07 GMT
+      - Tue, 03 Dec 2019 14:55:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmN2YxMDhjLWY1MDktNDBk
-        NS1hYjIyLTIwZDAyY2FlOTY5Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0YTZhMDBlLTk3NjgtNGIw
+        ZC1hYjAzLWQxN2JhOGMxYjFiYi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:07 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:36 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:07 GMT
+      - Tue, 03 Dec 2019 14:55:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -143,9 +143,9 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvN2VhNjFiMzctYzgxNS00ZTgzLWFkYzctNTgzMTc2
-        NmU0NDAxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjI6MDQu
-        MjkwMjcwWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvNjkwMzdhODAtNmU5Ni00NDNlLTg5Y2UtYTgzOGJh
+        NzBhZTRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6MzMu
+        MzQ0NTQyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
         MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
@@ -153,15 +153,15 @@ http_interactions:
         ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
         ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
         NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
-        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMjowNi41OTA5ODVaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
-        LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJv
-        eCIsIndoaXRlbGlzdF90YWdzIjpudWxsfV19
+        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTozNS43NjU0NzdaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
+        LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoidGVzdCIs
+        IndoaXRlbGlzdF90YWdzIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:07 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:36 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/7ea61b37-c815-4e83-adc7-5831766e4401/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/69037a80-6e96-443e-89ce-a838ba70ae4a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:07 GMT
+      - Tue, 03 Dec 2019 14:55:36 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -200,10 +200,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1NzYxMDk3LTZlZjEtNDRm
-        YS05ZDNmLWU0NmZkMjNhMzcyYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2MjFiNTc0LTFkNjctNGZh
+        My1hNWY4LTJjNDlmMTUwNTliNy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:07 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:36 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -227,9 +227,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:07 GMT
+      - Tue, 03 Dec 2019 14:55:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -241,25 +241,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '297'
+      - '287'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci8wM2EyY2NiMy1kZDJkLTRlZmItOTVk
-        Yi05YmZiYzVhNDcyYjcvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjA1LjcyODg5MloiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci9iYmY0NjRmNy0wYmVjLTQ4OGItOGY2
+        Yy1hY2Q0ZGYxYTg5ZWEvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzQuODExNjU5WiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:07 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:37 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/03a2ccb3-dd2d-4efb-95db-9bfbc5a472b7/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/bbf464f7-0bec-488b-8f6c-acd4df1a89ea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -280,9 +280,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:08 GMT
+      - Tue, 03 Dec 2019 14:55:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -298,10 +298,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhYjU2ZDU3LWY1OWUtNDc0
-        Mi1iZDM2LTY4M2IwN2U2YzYwNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhOGYxYTQ2LTRiODAtNDQ1
+        ZS1iMDY0LWZjOTI3YjEyNDg5Ny8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:08 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:37 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -325,9 +325,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:08 GMT
+      - Tue, 03 Dec 2019 14:55:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -346,7 +346,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:08 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:37 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -359,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -372,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:08 GMT
+      - Tue, 03 Dec 2019 14:55:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/3232f817-4495-4f91-8490-7539e979eabb/"
+      - "/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -393,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMzIzMmY4MTctNDQ5NS00ZjkxLTg0OTAtNzUzOWU5
-        NzllYWJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjI6MDgu
-        MzY0NzgwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMzIzMmY4MTctNDQ5NS00Zjkx
-        LTg0OTAtNzUzOWU5NzllYWJiL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvYWU1MDI3MTEtNmVmYS00MGQ5LTk1N2ItNjA4MWY4
+        YzNlZTQ3LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6Mzcu
+        NTE1Njc5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYWU1MDI3MTEtNmVmYS00MGQ5
+        LTk1N2ItNjA4MWY4YzNlZTQ3L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMzIzMmY4MTctNDQ5NS00ZjkxLTg0OTAtNzUzOWU5NzllYWJi
+        b250YWluZXIvYWU1MDI3MTEtNmVmYS00MGQ5LTk1N2ItNjA4MWY4YzNlZTQ3
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:08 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:37 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -420,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -433,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:08 GMT
+      - Tue, 03 Dec 2019 14:55:37 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/bcfabc7f-a4d7-4832-af8e-2e5552d65889/"
+      - "/pulp/api/v3/remotes/container/container/e3d5818e-4190-471c-9135-d91d0138b94f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -454,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2JjZmFiYzdmLWE0ZDctNDgzMi1hZjhlLTJlNTU1MmQ2NTg4
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjA4LjU1NjQx
-        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyL2UzZDU4MThlLTQxOTAtNDcxYy05MTM1LWQ5MWQwMTM4Yjk0
+        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjM3LjY4MzI5
+        N1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMjowOC41
-        NTY0NDhaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTozNy42
+        ODMzMjBaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:08 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:37 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3232f817-4495-4f91-8490-7539e979eabb/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -478,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -491,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:08 GMT
+      - Tue, 03 Dec 2019 14:55:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -509,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxZmUzZTc4LWI2ODctNDEy
-        My05YTMxLTA0OWU5OWFiZTk1MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5MGRmM2YwLTU2OTEtNDAz
+        Ny04MDMyLWZlMTMxMjA0NmEzZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:08 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:38 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3232f817-4495-4f91-8490-7539e979eabb/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -525,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -538,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:09 GMT
+      - Tue, 03 Dec 2019 14:55:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -556,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZDE5NDQxLTM3OWItNDM3
-        ZS05Zjc2LThjMmQ2NDNhMjgwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiOTM4ZjMwLTg0YmQtNGFk
+        OS1iODQzLWI5ODZlYjFlMDc5Yi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:09 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:38 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/09d19441-379b-437e-9f76-8c2d643a280f/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b938f30-84bd-4ad9-b843-b986eb1e079b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -570,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -583,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:09 GMT
+      - Tue, 03 Dec 2019 14:55:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -597,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '339'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDlkMTk0NDEtMzc5
-        Yi00MzdlLTlmNzYtOGMyZDY0M2EyODBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDkuMDgwOTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI5MzhmMzAtODRi
+        ZC00YWQ5LWI4NDMtYjk4NmViMWUwNzliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzguMjI0ODk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIyOjA5LjIwMjQ4NVoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjI6MDkuMjc1NzYwWiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjM4LjM4NjU0NloiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6MzguNDYyNjIxWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMzIz
-        MmY4MTctNDQ5NS00ZjkxLTg0OTAtNzUzOWU5NzllYWJiLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYWU1
+        MDI3MTEtNmVmYS00MGQ5LTk1N2ItNjA4MWY4YzNlZTQ3LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:09 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:38 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3232f817-4495-4f91-8490-7539e979eabb/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -626,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -639,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:09 GMT
+      - Tue, 03 Dec 2019 14:55:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -658,29 +658,29 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMzIzMmY4MTctNDQ5NS00ZjkxLTg0OTAtNzUzOWU5
-        NzllYWJiL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMjowOC4zNjY0NjBaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvYWU1MDI3MTEtNmVmYS00MGQ5LTk1N2ItNjA4MWY4
+        YzNlZTQ3L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTozNy41MTczOTlaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:09 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:38 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zMjMyZjgxNy00NDk1
-        LTRmOTEtODQ5MC03NTM5ZTk3OWVhYmIvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyL2FlNTAyNzExLTZlZmEtNDBkOS05NTdi
+        LTYwODFmOGMzZWU0Ny92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -693,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:09 GMT
+      - Tue, 03 Dec 2019 14:55:38 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -711,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViNWFkNGE4LWE3NWYtNGY4
-        MC04NjNmLWE2Yzc5M2IyZmE4OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExMWI5ZTUyLTYzMzItNGVi
+        Yi1hY2NlLTFkOTYyMzUxM2Y3NC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:09 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:38 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/5b5ad4a8-a75f-4f80-863f-a6c793b2fa89/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/111b9e52-6332-4ebb-acce-1d9623513f74/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -725,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -738,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:10 GMT
+      - Tue, 03 Dec 2019 14:55:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -752,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '341'
+      - '342'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWI1YWQ0YTgtYTc1
-        Zi00ZjgwLTg2M2YtYTZjNzkzYjJmYTg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDkuNjc1NTgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTExYjllNTItNjMz
+        Mi00ZWJiLWFjY2UtMWQ5NjIzNTEzZjc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MzguODc4OTI0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjI6MDkuODE3MTY5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMjoxMC4wMDMyNTFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6MzkuMDAyMDAw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTozOS4xNzkwMTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci84YzZkMzYzNC1lZjU5LTQ1
-        OTEtOTMwZi0wNTkxZmU1NmFjZWQvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8xMTcxMjgyNC1kYTc4LTQw
+        YzUtYTliYy1jYzJiMjQ5NDQzYzQvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:10 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:39 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/8c6d3634-ef59-4591-930f-0591fe56aced/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/11712824-da78-40c5-a9bc-cc2b249443c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -794,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:10 GMT
+      - Tue, 03 Dec 2019 14:55:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -808,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '310'
+      - '299'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvOGM2ZDM2MzQtZWY1OS00NTkxLTkzMGYtMDU5
-        MWZlNTZhY2VkLyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zMjMyZjgxNy00
-        NDk1LTRmOTEtODQ5MC03NTM5ZTk3OWVhYmIvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjA5Ljk5MjgxMFoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvYWU1MDI3MTEtNmVmYS00MGQ5LTk1
+        N2ItNjA4MWY4YzNlZTQ3L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci8xMTcxMjgyNC1kYTc4LTQwYzUtYTliYy1j
+        YzJiMjQ5NDQzYzQvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6MzkuMTcwMDcwWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:10 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:39 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/3232f817-4495-4f91-8490-7539e979eabb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/ae502711-6efa-40d9-957b-6081f8c3ee47/
     body:
       encoding: UTF-8
       base64_string: |
@@ -837,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -850,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:10 GMT
+      - Tue, 03 Dec 2019 14:55:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -868,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjNmExYmRkLWUzN2MtNDM3
-        Zi1hZjg4LTliNmQxY2JhNDlmMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1ZjZiYzFhLWYyYzQtNDdj
+        Mi05MTgyLTgyNDdjZDJkMTA4Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:10 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:39 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/bcfabc7f-a4d7-4832-af8e-2e5552d65889/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/e3d5818e-4190-471c-9135-d91d0138b94f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:10 GMT
+      - Tue, 03 Dec 2019 14:55:39 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,8 +921,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMzkzZDg0LTE5N2QtNDZk
-        Ny1iOWEzLWIzMTg2MjU1NGU2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyZGFkYzY2LTMyZTAtNGI4
+        OS04ODhkLWVlZWMwZDRiOGM5NC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:10 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_whitelist_tags.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_whitelist_tags.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,311 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
+      - Tue, 03 Dec 2019 14:55:23 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '246'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9lMjQyNTc4MC04MTgxLTQzZjQtOTY4My05
-        OWRmOWJhNGEwZDUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MTo1OS44NDQ3ODlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMjQyNTc4MC04MTgx
-        LTQzZjQtOTY4My05OWRmOWJhNGEwZDUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9lMjQyNTc4MC04MTgxLTQzZjQtOTY4My05OWRmOWJh
-        NGEwZDUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
-        fQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e2425780-8181-43f4-9683-99df9ba4a0d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMTY1NTJhLWRmYTAtNDc5
-        Yi1hN2QxLTQ4MTBhZWI0NjU1MS8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '391'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvN2Y2NGNiODEtYmI0Yi00NWQyLWFiOWUtOGRmZWI1
-        MmY4NDM0LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjI6MDAu
-        MDAwMTkzWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
-        c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
-        ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
-        MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
-        dF9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFkMWUzMjg5ZDMw
-        ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
-        ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
-        NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
-        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMjowMi4yNzg3NjFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
-        LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoidGVzdCIs
-        IndoaXRlbGlzdF90YWdzIjpudWxsfV19
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/7f64cb81-bb4b-45d2-ab9e-8dfeb52f8434/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmMDkyMTYyLTZjZGUtNDdh
-        YS05OTBhLWFiZDg0YjhkMWE3Yy8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '298'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci82NTRiYzk0NC1kZDYxLTQ5YmUtOTA0
-        Ny1jNWFmMDMzZDllMWQvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjAxLjQyNDM1OVoiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/654bc944-dd61-49be-9047-c5af033d9e1d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5ZWYzYmY2LTViYzktNDk1
-        Ni1hZGZmLTU5ZDA2Yjk3YjM2ZS8ifQ==
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
-- request:
-    method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:22:03 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -346,7 +44,195 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:03 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:23 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:23 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci9jNGU4YjJmYi0zNjFlLTQ1ZTQtYTNj
+        NC1iMTFiZWM4NDk5NzkvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTI6NTYuMDgzMTMxWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:23 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/c4e8b2fb-361e-45e4-a3c4-b11bec849979/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:23 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMDI1ZjNmLTk5YmEtNDUz
+        OS04NzUzLTA3ZWEzODc5ZGY1Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:55:23 GMT
+      Server:
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:55:23 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -359,7 +245,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -372,13 +258,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:04 GMT
+      - Tue, 03 Dec 2019 14:55:24 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/"
+      - "/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -393,17 +279,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGYyNTM3MDMtNmJlNy00ZjdhLTkzNWQtZjdiNTU1
-        MmFjOTBlLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjI6MDQu
-        MTExMTY1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOGYyNTM3MDMtNmJlNy00Zjdh
-        LTkzNWQtZjdiNTU1MmFjOTBlL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvOTc2OWNkNDEtODVkNi00NTM2LTg4ZjYtNWUxYTgx
+        YTIyYzViLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6MjQu
+        MjY2OTc1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOTc2OWNkNDEtODVkNi00NTM2
+        LTg4ZjYtNWUxYTgxYTIyYzViL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvOGYyNTM3MDMtNmJlNy00ZjdhLTkzNWQtZjdiNTU1MmFjOTBl
+        b250YWluZXIvOTc2OWNkNDEtODVkNi00NTM2LTg4ZjYtNWUxYTgxYTIyYzVi
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:24 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -420,7 +306,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -433,13 +319,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:04 GMT
+      - Tue, 03 Dec 2019 14:55:24 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/7ea61b37-c815-4e83-adc7-5831766e4401/"
+      - "/pulp/api/v3/remotes/container/container/33079f76-2352-4226-b642-e4bf61d2bf39/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -454,21 +340,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzdlYTYxYjM3LWM4MTUtNGU4My1hZGM3LTU4MzE3NjZlNDQw
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjA0LjI5MDI3
-        MFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        Y29udGFpbmVyLzMzMDc5Zjc2LTIzNTItNDIyNi1iNjQyLWU0YmY2MWQyYmYz
+        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjI0LjQ1MjQ5
+        OFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMjowNC4y
-        OTAyODVaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NToyNC40
+        NTI1MTJaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:24 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -478,7 +364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -491,9 +377,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:04 GMT
+      - Tue, 03 Dec 2019 14:55:24 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -509,13 +395,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0MGY0MmFjLTM1MzUtNGMx
-        Yi05YTI4LWM1NmE3OTg0YjZhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4MmZkMDZiLWFhMDEtNGI3
+        Ni05NWUzLTI3YjAyZmEwMWFlOS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:24 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -525,7 +411,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -538,9 +424,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:04 GMT
+      - Tue, 03 Dec 2019 14:55:25 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -556,13 +442,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkNjY5YTMzLWVhZDItNGE4
-        Yi05MmQwLWQ0OGJhMmE1OWZmYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxZDY3MzUxLTg5MzItNDhm
+        MS05NjYwLTlmY2RiMmE4Zjg4My8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:04 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:25 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1d669a33-ead2-4a8b-92d0-d48ba2a59ffb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f1d67351-8932-48f1-9660-9fcdb2a8f883/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -570,7 +456,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -583,9 +469,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:05 GMT
+      - Tue, 03 Dec 2019 14:55:25 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -601,24 +487,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWQ2NjlhMzMtZWFk
-        Mi00YThiLTkyZDAtZDQ4YmEyYTU5ZmZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDQuODQwODAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjFkNjczNTEtODkz
+        Mi00OGYxLTk2NjAtOWZjZGIyYThmODgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MjUuMDUwNzA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIyOjA1LjAyMTMyN1oiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjI6MDUuMTEzNTI0WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjI1LjIzNzg5MFoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6MjUuMzE4MTA3WiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOGYy
-        NTM3MDMtNmJlNy00ZjdhLTkzNWQtZjdiNTU1MmFjOTBlLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOTc2
+        OWNkNDEtODVkNi00NTM2LTg4ZjYtNWUxYTgxYTIyYzViLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:25 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -626,7 +512,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -639,9 +525,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:05 GMT
+      - Tue, 03 Dec 2019 14:55:25 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -658,29 +544,29 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGYyNTM3MDMtNmJlNy00ZjdhLTkzNWQtZjdiNTU1
-        MmFjOTBlL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMjowNC4xMTI3MzNaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvOTc2OWNkNDEtODVkNi00NTM2LTg4ZjYtNWUxYTgx
+        YTIyYzViL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NToyNC4yNjg2MTZaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:25 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci84ZjI1MzcwMy02YmU3
-        LTRmN2EtOTM1ZC1mN2I1NTUyYWM5MGUvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyLzk3NjljZDQxLTg1ZDYtNDUzNi04OGY2
+        LTVlMWE4MWEyMmM1Yi92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -693,9 +579,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:05 GMT
+      - Tue, 03 Dec 2019 14:55:25 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -711,13 +597,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmN2YwMmYwLTRmZGItNGI4
-        Ni1hM2QxLWM1NzQwOTBjNjViMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNWUyYTJiLTAyMTMtNDhi
+        Ny1iYjMzLTc5YzA4MGFjNTExOS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:25 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6f7f02f0-4fdb-4b86-a3d1-c574090c65b0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3d5e2a2b-0213-48b7-bb33-79c080ac5119/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -725,7 +611,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -738,9 +624,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:05 GMT
+      - Tue, 03 Dec 2019 14:55:26 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -752,28 +638,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '341'
+      - '342'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmY3ZjAyZjAtNGZk
-        Yi00Yjg2LWEzZDEtYzU3NDA5MGM2NWIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjI6MDUuNDYzMTU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Q1ZTJhMmItMDIx
+        My00OGI3LWJiMzMtNzljMDgwYWM1MTE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6MjUuNzk0NTc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjI6MDUuNTY5NDM4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMjowNS43Mzc1ODBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6MjUuODg1NTM2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NToyNi4wNzc5OTBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8wM2EyY2NiMy1kZDJkLTRl
-        ZmItOTVkYi05YmZiYzVhNDcyYjcvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci82MDFkZGU3MC00NGFjLTRm
+        MmEtYWRiNS1iMGQxNTRjZWYzNmIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:26 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/03a2ccb3-dd2d-4efb-95db-9bfbc5a472b7/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/601dde70-44ac-4f2a-adb5-b0d154cef36b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,7 +667,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -794,9 +680,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:05 GMT
+      - Tue, 03 Dec 2019 14:55:26 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -808,26 +694,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '310'
+      - '298'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvMDNhMmNjYjMtZGQyZC00ZWZiLTk1ZGItOWJm
-        YmM1YTQ3MmI3LyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci84ZjI1MzcwMy02
-        YmU3LTRmN2EtOTM1ZC1mN2I1NTUyYWM5MGUvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIyOjA1LjcyODg5MloiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvOTc2OWNkNDEtODVkNi00NTM2LTg4
+        ZjYtNWUxYTgxYTIyYzViL3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci82MDFkZGU3MC00NGFjLTRmMmEtYWRiNS1i
+        MGQxNTRjZWYzNmIvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6MjYuMDY5MjgxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:05 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:26 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8f253703-6be7-4f7a-935d-f7b5552ac90e/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/9769cd41-85d6-4536-88f6-5e1a81a22c5b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -837,7 +723,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -850,9 +736,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:06 GMT
+      - Tue, 03 Dec 2019 14:55:26 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -868,13 +754,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4MjMwOGQ0LWFiYjItNGNi
-        Ny1iNmY0LTkxN2ZmNWYxMTlhYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkNjdiNjc1LWMwNTAtNDBl
+        OC04NjQ3LTMyOWIyZWE3ZjhmZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:06 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:26 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/7ea61b37-c815-4e83-adc7-5831766e4401/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/33079f76-2352-4226-b642-e4bf61d2bf39/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +776,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +789,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:22:06 GMT
+      - Tue, 03 Dec 2019 14:55:26 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,8 +807,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlYzY0OTU2LTQwZGItNGE1
-        Yi1hZGM0LWMyZjkzOTlhOTA4YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3ZTc2MTFhLTFmZDItNDg1
+        Mi1hMDMwLTRkYjZhYjM0YWUxNC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:22:06 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_whitelist_tags_empty.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_update/update_whitelist_tags_empty.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:49 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9iNWE5ZWM0MS02MTY5LTRhYWYtYWVhZi1h
-        MDI5MGVlNWUzMDcvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjoy
-        MTo0Ni4zNDA2NTVaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iNWE5ZWM0MS02MTY5
-        LTRhYWYtYWVhZi1hMDI5MGVlNWUzMDcvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci9jZjVlYTViMS0zNjJjLTRjZWYtOTU5ZS02
+        Yjg2MmVjOTAwYzQvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NTo0Ni4yNTg5NTZaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9jZjVlYTViMS0zNjJj
+        LTRjZWYtOTU5ZS02Yjg2MmVjOTAwYzQvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9iNWE5ZWM0MS02MTY5LTRhYWYtYWVhZi1hMDI5MGVl
-        NWUzMDcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci9jZjVlYTViMS0zNjJjLTRjZWYtOTU5ZS02Yjg2MmVj
+        OTAwYzQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH1d
         fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/b5a9ec41-6169-4aaf-aeaf-a0290ee5e307/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/cf5ea5b1-362c-4cef-959e-6b862ec900c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:49 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxNmVkMzRmLTZkYTQtNDdh
-        Yy05ODQwLTAwZTcwMjgzZTkwMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3YzFlY2JjLTk3NGMtNGI3
+        MC04ZjAwLThiN2VjODE3NTRiZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Test-busybox-library
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:49 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -143,9 +143,9 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMTA4OGFlNWItNTdkYS00NjBkLTgxZGYtZWNjMTU5
-        Y2U1OTM3LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NDYu
-        NTI1OTA5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        aW5lci9jb250YWluZXIvZjVkOTc4MjAtMDhjOC00YTE1LTkwNWYtNGE0YjM2
+        OTdjYWExLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6NDYu
+        NDM5MTE0WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
         c3lib3gtbGlicmFyeSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2Nr
         ZXIuaW8iLCJjYV9jZXJ0IjoiMjg2ZGJlZWY0ZTIwNmYzMGI5YjUzOGIxNWFk
         MWUzMjg5ZDMwZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVu
@@ -153,15 +153,15 @@ http_interactions:
         ZTcyYjhlMGY1ODc2YWUzMzQ5Mzk3ZmViOTFjZCIsImNsaWVudF9rZXkiOiIy
         ODZkYmVlZjRlMjA2ZjMwYjliNTM4YjE1YWQxZTMyODlkMzBlNzJiOGUwZjU4
         NzZhZTMzNDkzOTdmZWI5MWNkIiwidGxzX3ZhbGlkYXRpb24iOmZhbHNlLCJw
-        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo0OC43ODE1MThaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
+        cm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTo0OS4zNTUzODVaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIw
         LCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJv
         eCIsIndoaXRlbGlzdF90YWdzIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/1088ae5b-57da-460d-81df-ecc159ce5937/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/f5d97820-08c8-4a15-905f-4a4b3697caa1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:49 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -200,10 +200,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA2MzhlMTIzLWY1ZTktNDQ3
-        MS1iMTM5LWY0ZjZlOTYxMDU0ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2YjU1OGI4LTNiMmQtNDc2
+        Ni1hZDM4LTQwZjg5ZDNjMmM1MS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Test-busybox-library
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -227,9 +227,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -241,25 +241,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '297'
+      - '289'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci85MjgyYzBjMi0wY2FlLTQ1NzEtYWE5
-        OS1jYzIzYzUxMDg5YWUvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQ4LjA0NTg0MloiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci8zYjA0MWQyZC0xMWY1LTQwZjktYmYw
+        Yy0zMzc0Nzg1ODE5YjAvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoicHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NDcuOTc4NjkyWiIsIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3Bh
+        dGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9w
+        cm9kdWN0LWJ1c3lib3gifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/9282c0c2-0cae-4571-aa99-cc23c51089ae/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/3b041d2d-11f5-40f9-bf0c-3374785819b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -280,9 +280,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -298,10 +298,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5NTJlZDZkLWY4ZTQtNDY5
-        MC1iYjUxLTZhMzljMjM3YmI2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1YWQ1MThmLTZjZjgtNGVm
+        Ni05NTdjLTU1YzIyMDg5NTQ5NC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=ACME_Corporation/library/busybox
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -325,81 +325,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
+      - Tue, 03 Dec 2019 14:55:50 GMT
       Server:
-      - gunicorn/20.0.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 pulp3-devel.cannolo.example.com
-      Content-Length:
-      - '297'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9i
-        dXN5Ym94IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvY29udGFpbmVyL2NvbnRhaW5lci85MjgyYzBjMi0wY2FlLTQ1NzEtYWE5
-        OS1jYzIzYzUxMDg5YWUvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjpudWxsLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjQ4LjA0NTg0MloiLCJy
-        ZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
-        VGVzdC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJy
-        ZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNv
-        bS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9XX0=
-    http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
-- request:
-    method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/9282c0c2-0cae-4571-aa99-cc23c51089ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
-      Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '23'
+      - '52'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:50 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -412,7 +359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -425,13 +372,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
+      - Tue, 03 Dec 2019 14:55:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/"
+      - "/pulp/api/v3/repositories/container/container/c138de8f-9f02-4faa-99e4-622ea42ed4e3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -446,17 +393,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZTA4ODUyNWQtZDgwOS00ZTM5LWI3YTItOGY3NjU4
-        Nzg3ODU5LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjE6NTAu
-        NzE2NDYyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZTA4ODUyNWQtZDgwOS00ZTM5
-        LWI3YTItOGY3NjU4Nzg3ODU5L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvYzEzOGRlOGYtOWYwMi00ZmFhLTk5ZTQtNjIyZWE0
+        MmVkNGUzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTU6NTEu
+        MTM3ODg1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYzEzOGRlOGYtOWYwMi00ZmFh
+        LTk5ZTQtNjIyZWE0MmVkNGUzL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvZTA4ODUyNWQtZDgwOS00ZTM5LWI3YTItOGY3NjU4Nzg3ODU5
+        b250YWluZXIvYzEzOGRlOGYtOWYwMi00ZmFhLTk5ZTQtNjIyZWE0MmVkNGUz
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
         c3QtYnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:51 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -473,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -486,13 +433,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:50 GMT
+      - Tue, 03 Dec 2019 14:55:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/0287492f-14a2-4fa4-908b-b7dce699e8e7/"
+      - "/pulp/api/v3/remotes/container/container/a1507333-d551-4ce0-b4ed-11976d1f4a3d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -507,21 +454,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzAyODc0OTJmLTE0YTItNGZhNC05MDhiLWI3ZGNlNjk5ZThl
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjUwLjg5ODc3
+        Y29udGFpbmVyL2ExNTA3MzMzLWQ1NTEtNGNlMC1iNGVkLTExOTc2ZDFmNGEz
+        ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU1OjUxLjI5NzQ5
         MVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
         LWxpYnJhcnkiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5LTEuZG9ja2VyLmlv
         IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
         ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
-        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjoyMTo1MC44
-        OTg3ODZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
+        bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1NTo1MS4y
+        OTc1MDRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJp
         bW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiYnVzeWJveCIsIndoaXRlbGlz
         dF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:51 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/c138de8f-9f02-4faa-99e4-622ea42ed4e3/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -531,7 +478,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -544,9 +491,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:51 GMT
+      - Tue, 03 Dec 2019 14:55:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -562,13 +509,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMTIxZGVhLWUyOTMtNDg5
-        MS05MGFlLTgzNzAwMjM0OTBhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwMDdlYWQ1LTBjY2EtNDgy
+        YS1iYWQwLTk2NThkZWYyYzU4Zi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:51 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/c138de8f-9f02-4faa-99e4-622ea42ed4e3/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -578,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -591,9 +538,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:51 GMT
+      - Tue, 03 Dec 2019 14:55:51 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -609,13 +556,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4MmExNDc3LWE3ZTMtNDcy
-        ZC04YTBlLWRkNzYxYTNlYjUyOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3NDRhOTQwLTRlOTQtNGQx
+        OS04NzA4LTkzMmJhMjEyZDIzNy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:51 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/982a1477-a7e3-472d-8a0e-dd761a3eb528/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3744a940-4e94-4d19-8708-932ba212d237/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -623,7 +570,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,9 +583,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:51 GMT
+      - Tue, 03 Dec 2019 14:55:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -650,28 +597,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '338'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTgyYTE0NzctYTdl
-        My00NzJkLThhMGUtZGQ3NjFhM2ViNTI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NTEuNTE0NzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc0NGE5NDAtNGU5
+        NC00ZDE5LTg3MDgtOTMyYmEyMTJkMjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NTEuODc3NTAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjIxOjUxLjcxMDI2OFoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6MjE6NTEuODA1ODA0WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU1OjUxLjk5OTE5MVoiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTU6NTIuMDgyNjkyWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZTA4
-        ODUyNWQtZDgwOS00ZTM5LWI3YTItOGY3NjU4Nzg3ODU5LyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYzEz
+        OGRlOGYtOWYwMi00ZmFhLTk5ZTQtNjIyZWE0MmVkNGUzLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:52 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/c138de8f-9f02-4faa-99e4-622ea42ed4e3/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -679,7 +626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -692,9 +639,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:52 GMT
+      - Tue, 03 Dec 2019 14:55:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -706,34 +653,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '198'
+      - '196'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZTA4ODUyNWQtZDgwOS00ZTM5LWI3YTItOGY3NjU4
-        Nzg3ODU5L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjoyMTo1MC43MTgwNTdaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvYzEzOGRlOGYtOWYwMi00ZmFhLTk5ZTQtNjIyZWE0
+        MmVkNGUzL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NTo1MS4xMzk0NDBaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:52 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
-        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMDg4NTI1ZC1kODA5
-        LTRlMzktYjdhMi04Zjc2NTg3ODc4NTkvdmVyc2lvbnMvMC8ifQ==
+        eyJiYXNlX3BhdGgiOiJwdXBwZXRfcHJvZHVjdC1idXN5Ym94IiwibmFtZSI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9jb250YWluZXIvY29udGFpbmVyL2MxMzhkZThmLTlmMDItNGZhYS05OWU0
+        LTYyMmVhNDJlZDRlMy92ZXJzaW9ucy8wLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -746,9 +693,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:52 GMT
+      - Tue, 03 Dec 2019 14:55:52 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -764,13 +711,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhODJmNjg0LTBkZTQtNGJi
-        MS1hZWMxLWE1ZmRkNmZkYmE1NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyM2VhNDcwLTFhOTQtNGZh
+        ZC1iYWNkLWU5Njk5NTRjMWVhMS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:52 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2a82f684-0de4-4bb1-aec1-a5fdd6fdba55/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/823ea470-1a94-4fad-bacd-e969954c1ea1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -778,7 +725,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -791,9 +738,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:52 GMT
+      - Tue, 03 Dec 2019 14:55:53 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -805,28 +752,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '339'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE4MmY2ODQtMGRl
-        NC00YmIxLWFlYzEtYTVmZGQ2ZmRiYTU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6MjE6NTIuMjUyNzU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODIzZWE0NzAtMWE5
+        NC00ZmFkLWJhY2QtZTk2OTk1NGMxZWExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTU6NTIuNTAxNzg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6MjE6NTIuMzc0NDU5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjoyMTo1Mi41NzIyNzNa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTU6NTIuNjA5NTI1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NTo1Mi44NDcyNDZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9hZmEzODc3Ni05NjIyLTQ3
-        MDEtYjMyYi1kMjUxOTNkN2MxODkvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci80NjYyYmYyNi00Yzk1LTQ5
+        ZDYtOTM0NC02MDcyZTg4MzIzNzAvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:53 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/afa38776-9622-4701-b32b-d25193d7c189/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/4662bf26-4c95-49d6-9344-6072e8832370/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -834,7 +781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -847,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:52 GMT
+      - Tue, 03 Dec 2019 14:55:53 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -861,26 +808,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '310'
+      - '297'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
-        eCIsInB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Nv
-        bnRhaW5lci9jb250YWluZXIvYWZhMzg3NzYtOTYyMi00NzAxLWIzMmItZDI1
-        MTkzZDdjMTg5LyIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9lMDg4NTI1ZC1k
-        ODA5LTRlMzktYjdhMi04Zjc2NTg3ODc4NTkvdmVyc2lvbnMvMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIxOjUyLjU2MzczMFoiLCJyZXBv
-        c2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
-        dC1idXN5Ym94LWxpYnJhcnkiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
-        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9B
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJveCJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvYzEzOGRlOGYtOWYwMi00ZmFhLTk5
+        ZTQtNjIyZWE0MmVkNGUzL3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci80NjYyYmYyNi00Yzk1LTQ5ZDYtOTM0NC02
+        MDcyZTg4MzIzNzAvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        cHVwcGV0X3Byb2R1Y3QtYnVzeWJveCIsInB1bHBfY3JlYXRlZCI6IjIwMTkt
+        MTItMDNUMTQ6NTU6NTIuODM1ODY1WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsInJlZ2lzdHJ5X3BhdGgi
+        OiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1cHBldF9wcm9k
+        dWN0LWJ1c3lib3gifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:53 GMT
 - request:
     method: put
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/e088525d-d809-4e39-b7a2-8f7658787859/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/c138de8f-9f02-4faa-99e4-622ea42ed4e3/
     body:
       encoding: UTF-8
       base64_string: |
@@ -890,7 +837,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -903,9 +850,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:53 GMT
+      - Tue, 03 Dec 2019 14:55:53 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -921,13 +868,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4ODFiMDk5LWJkMDgtNDZj
-        Ny05OGNiLThlZGZiYzhkMmE0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZTljMjA0LTg4NjAtNDlh
+        Ny1iMjI0LWNjNTYwMzExNDU2OS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:53 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/0287492f-14a2-4fa4-908b-b7dce699e8e7/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/a1507333-d551-4ce0-b4ed-11976d1f4a3d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -943,7 +890,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -956,9 +903,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:21:53 GMT
+      - Tue, 03 Dec 2019 14:55:53 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -974,8 +921,8 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3ZDJmYWMyLTNlZDMtNGE0
-        OC1hM2IxLTcwZjM4YzI2ZDQ0YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxMjVmYzA5LWQ3ODAtNDYw
+        Ni05OTY1LTgxMmJjMjQzZTBhMy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:21:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:55:53 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_model.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_model.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:41 GMT
+      - Tue, 03 Dec 2019 14:57:01 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -44,7 +44,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -55,7 +55,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -68,9 +68,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:41 GMT
+      - Tue, 03 Dec 2019 14:57:01 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -89,7 +89,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:41 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -100,7 +100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -113,28 +113,81 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:01 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '289'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci85NWM0NGQ2Zi1mMzQ0LTRjZjQtYTgz
+        Yi05MDdlMGExYmMxYTUvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoiZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9jcmVhdGVk
+        IjoiMjAxOS0xMi0wM1QxNDo1Mzo0Mi4zMTU0OTBaIiwibmFtZSI6IkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZWdp
+        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9m
+        ZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEifV19
+    http_version: 
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/95c44d6f-f344-4cf4-a83b-907e0a1bc1a5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 03 Dec 2019 14:57:01 GMT
+      Server:
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2ZWQyNmY0LTgzM2MtNDcy
+        NS04YmIzLWYwMTVkMDNjODkyYi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -145,7 +198,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -158,9 +211,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:01 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -179,7 +232,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -190,7 +243,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -203,9 +256,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:01 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -224,7 +277,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:01 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -235,7 +288,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,9 +301,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:02 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -269,7 +322,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:02 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -280,7 +333,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,9 +346,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:02 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -314,7 +367,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:02 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -325,7 +378,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -338,9 +391,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:02 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -359,7 +412,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:02 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -372,7 +425,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -385,13 +438,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:42 GMT
+      - Tue, 03 Dec 2019 14:57:02 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/"
+      - "/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -406,17 +459,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJm
-        ZGI2NGI1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NDIu
-        OTQ2MjA5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgx
-        LWJiYzgtNmIwZWJmZGI2NGI1L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUx
+        ZjI4MjI1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTc6MDIu
+        NjM0NTQyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNl
+        LThkMWYtNmY4MDUxZjI4MjI1L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJmZGI2NGI1
+        b250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUxZjI4MjI1
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
         YmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:42 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:02 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -433,7 +486,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -446,13 +499,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:43 GMT
+      - Tue, 03 Dec 2019 14:57:02 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/130e6ab1-b921-48a8-9e80-b5f0a3556701/"
+      - "/pulp/api/v3/remotes/container/container/f055f511-9087-4702-910f-e9c5664461fb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -467,21 +520,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzEzMGU2YWIxLWI5MjEtNDhhOC05ZTgwLWI1ZjBhMzU1Njcw
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjU1OjQzLjEyNzM0
-        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        Y29udGFpbmVyL2YwNTVmNTExLTkwODctNDcwMi05MTBmLWU5YzU2NjQ0NjFm
+        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU3OjAyLjgxOTYx
+        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
         M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
         aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
         dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjo1NTo0
-        My4xMjczNTlaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1Nzow
+        Mi44MTk2MzBaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
         OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIsIndo
         aXRlbGlzdF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:02 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -491,7 +544,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -504,9 +557,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:43 GMT
+      - Tue, 03 Dec 2019 14:57:03 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -522,13 +575,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2NTI4Mzk2LTk1ZmMtNDJj
-        OS04NDc4LTkwNDFlMjI0NjE4OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhMWQ1N2ExLTA3MGUtNDll
+        Ni1iYjk1LTk0ZGZkODQ4ZDY1My8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:03 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -538,7 +591,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -551,9 +604,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:43 GMT
+      - Tue, 03 Dec 2019 14:57:03 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -569,13 +622,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2NzU4YTI4LTA4MDUtNGI3
-        My05MTE1LWVjZjliYTI2ZjJjMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkZjU2MzIyLTQ0YzgtNDYz
+        Mi1hMjRmLTlmZDY0OTkyMjkxNC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:03 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56758a28-0805-4b73-9115-ecf9ba26f2c0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/edf56322-44c8-4632-a24f-9fd649922914/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -583,7 +636,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -596,9 +649,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:43 GMT
+      - Tue, 03 Dec 2019 14:57:03 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -610,28 +663,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '339'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTY3NThhMjgtMDgw
-        NS00YjczLTkxMTUtZWNmOWJhMjZmMmMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NDMuNjUzMzM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRmNTYzMjItNDRj
+        OC00NjMyLWEyNGYtOWZkNjQ5OTIyOTE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MDMuMzcxODIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjU1OjQzLjgxMTUzMFoiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6NTU6NDMuODg2NDE5WiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRk
-        OWEtYjI3MS0xNzFhNzQyZGQwMTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU3OjAzLjU0NjIyNloiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTc6MDMuNjIzMDU1WiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9iNDczOGU1OS04Mzc0LTRh
+        MjItOWUxYS1mZWNjNGZmNTFkOTYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNTk4
-        ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJmZGI2NGI1LyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjEx
+        YjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUxZjI4MjI1LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:43 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:03 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -639,7 +692,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -652,9 +705,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:44 GMT
+      - Tue, 03 Dec 2019 14:57:03 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -666,35 +719,34 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '196'
+      - '199'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJm
-        ZGI2NGI1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjo1NTo0Mi45NDgwMTRaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUx
+        ZjI4MjI1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NzowMi42MzYxMDRaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:03 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
-        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        NTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJmZGI2NGI1L3ZlcnNpb25z
-        LzAvIn0=
+        eyJiYXNlX3BhdGgiOiJmZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTFiMTRjNy1mYjNhLTRm
+        Y2UtOGQxZi02ZjgwNTFmMjgyMjUvdmVyc2lvbnMvMC8ifQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -707,9 +759,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:44 GMT
+      - Tue, 03 Dec 2019 14:57:03 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -725,13 +777,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5ZWM0ZWJhLTlmMjktNGRk
-        Zi04ZTE4LTM1YWUwM2ZmZmMwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0MmQyMmUxLTM4NTgtNDRm
+        MC04ZDJkLWU0NDA2YWQxMTliZi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:03 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/59ec4eba-9f29-4ddf-8e18-35ae03fffc01/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/542d22e1-3858-44f0-8d2d-e4406ad119bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -739,7 +791,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -752,9 +804,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:44 GMT
+      - Tue, 03 Dec 2019 14:57:04 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -770,24 +822,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTllYzRlYmEtOWYy
-        OS00ZGRmLThlMTgtMzVhZTAzZmZmYzAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NDQuMjI2ODUyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTQyZDIyZTEtMzg1
+        OC00NGYwLThkMmQtZTQ0MDZhZDExOWJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MDMuOTY4MDY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6NDQuMzE5Mjg2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjo1NTo0NC41MTM4NzFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6MDQuMDkwOTcw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NzowNC4yODQ1MTZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci83NzBmYzVlMC0zZmY5LTRi
-        NDctYmU3OS0yNzY4YmRkMmYxY2IvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci85NGNhYTdlYS02YTk3LTQw
+        OTQtYjE1Mi1kMWI4NDJmZWUyMzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:04 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/770fc5e0-3ff9-4b47-be79-2768bdd2f1cb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/94caa7ea-6a97-4094-b152-d1b842fee231/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -795,7 +847,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -808,9 +860,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:44 GMT
+      - Tue, 03 Dec 2019 14:57:04 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -822,38 +874,37 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '296'
+      - '300'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci83NzBmYzVlMC0zZmY5LTRi
-        NDctYmU3OS0yNzY4YmRkMmYxY2IvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzU5OGVlMDY3LWZlNGUtNDg4MS1iYmM4LTZiMGViZmRiNjRiNS92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NDQuNTA0
-        OTUzWiIsInJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwiY29udGVudF9ndWFy
-        ZCI6bnVsbCwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLmNhbm5vbG8u
-        ZXhhbXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxw
-        M19Eb2NrZXJfMSJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThk
+        MWYtNmY4MDUxZjI4MjI1L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci85NGNhYTdlYS02YTk3LTQwOTQtYjE1Mi1k
+        MWI4NDJmZWUyMzEvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        ZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9jcmVhdGVkIjoi
+        MjAxOS0xMi0wM1QxNDo1NzowNC4yNzA5MjZaIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZWdpc3Ry
+        eV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9mZWRv
+        cmFfbGFiZWwtcHVscDNfZG9ja2VyXzEifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:44 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:04 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/sync/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyLzEzMGU2YWIxLWI5MjEtNDhhOC05ZTgwLWI1ZjBhMzU1NjcwMS8i
+        dGFpbmVyL2YwNTVmNTExLTkwODctNDcwMi05MTBmLWU5YzU2NjQ0NjFmYi8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -866,9 +917,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:45 GMT
+      - Tue, 03 Dec 2019 14:57:05 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -884,13 +935,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzMjA1MTliLTFlZDItNGIx
-        ZC05MmQ2LWJjZDgyN2U3NTA3ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0ZWJkN2IzLTEzNzQtNGU2
+        OS05MzFlLWY2ZTdlYzJkZGI5My8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:05 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c320519b-1ed2-4b1d-92d6-bcd827e7507d/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e4ebd7b3-1374-4e69-931e-f6e7ec2ddb93/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -898,7 +949,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -911,9 +962,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:45 GMT
+      - Tue, 03 Dec 2019 14:57:06 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -925,42 +976,42 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '517'
+      - '515'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzMyMDUxOWItMWVk
-        Mi00YjFkLTkyZDYtYmNkODI3ZTc1MDdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NDUuMTcyNTAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTRlYmQ3YjMtMTM3
+        NC00ZTY5LTkzMWUtZjZlN2VjMmRkYjkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MDUuMDAwMTE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjU1
-        OjQ1LjI4ODUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6
-        NDUuODgwMzIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRkOWEtYjI3MS0xNzFhNzQyZGQw
-        MTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjU3
+        OjA1LjExMzkyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6
+        MDUuODI0OTc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRlNjItYWZkZC03YWVlZTI4ZDk4
+        YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
         c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
         IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoicHJvY2Vzc2luZy50
-        YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
-        cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9
-        LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNz
-        b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
+        c3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoiZG93bmxv
+        YWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3Nv
+        Y2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo2LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsImNv
+        ZGUiOiJwcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
         cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJmZGI2NGI1
+        b250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUxZjI4MjI1
         L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
         L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzU5OGVlMDY3LWZlNGUtNDg4MS1iYmM4LTZiMGViZmRiNjRiNS8iLCIvcHVs
-        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzEzMGU2YWIx
-        LWI5MjEtNDhhOC05ZTgwLWI1ZjBhMzU1NjcwMS8iXX0=
+        LzIxMWIxNGM3LWZiM2EtNGZjZS04ZDFmLTZmODA1MWYyODIyNS8iLCIvcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2YwNTVmNTEx
+        LTkwODctNDcwMi05MTBmLWU5YzU2NjQ0NjFmYi8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:45 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:06 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -968,7 +1019,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -981,9 +1032,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:46 GMT
+      - Tue, 03 Dec 2019 14:57:06 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -995,58 +1046,58 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '284'
+      - '283'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJm
-        ZGI2NGI1L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjo1NTo0NS4zMjQwNzZaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUx
+        ZjI4MjI1L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NzowNS4xMzIwNTFaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
         YmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
         L2NvbnRhaW5lci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci81
-        OThlZTA2Ny1mZTRlLTQ4ODEtYmJjOC02YjBlYmZkYjY0YjUvdmVyc2lvbnMv
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8y
+        MTFiMTRjNy1mYjNhLTRmY2UtOGQxZi02ZjgwNTFmMjgyMjUvdmVyc2lvbnMv
         MS8ifSwiY29udGFpbmVyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvY29udGFpbmVyL2NvbnRhaW5lci81OThlZTA2Ny1mZTRlLTQ4ODEtYmJj
-        OC02YjBlYmZkYjY0YjUvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
+        ZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTFiMTRjNy1mYjNhLTRmY2UtOGQx
+        Zi02ZjgwNTFmMjgyMjUvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
         eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
         aW5lci90YWdzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzU5OGVlMDY3
-        LWZlNGUtNDg4MS1iYmM4LTZiMGViZmRiNjRiNS92ZXJzaW9ucy8xLyJ9fSwi
+        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzIxMWIxNGM3
+        LWZiM2EtNGZjZS04ZDFmLTZmODA1MWYyODIyNS92ZXJzaW9ucy8xLyJ9fSwi
         cmVtb3ZlZCI6e30sInByZXNlbnQiOnsiY29udGFpbmVyLmJsb2IiOnsiY291
         bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
         YmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgx
-        LWJiYzgtNmIwZWJmZGI2NGI1L3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNl
+        LThkMWYtNmY4MDUxZjI4MjI1L3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
         YW5pZmVzdCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
         ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        NTk4ZWUwNjctZmU0ZS00ODgxLWJiYzgtNmIwZWJmZGI2NGI1L3ZlcnNpb25z
+        MjExYjE0YzctZmIzYS00ZmNlLThkMWYtNmY4MDUxZjI4MjI1L3ZlcnNpb25z
         LzEvIn0sImNvbnRhaW5lci50YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
         cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy8/cmVwb3NpdG9yeV92
         ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2Nv
-        bnRhaW5lci81OThlZTA2Ny1mZTRlLTQ4ODEtYmJjOC02YjBlYmZkYjY0YjUv
+        bnRhaW5lci8yMTFiMTRjNy1mYjNhLTRmY2UtOGQxZi02ZjgwNTFmMjgyMjUv
         dmVyc2lvbnMvMS8ifX19fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:06 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/770fc5e0-3ff9-4b47-be79-2768bdd2f1cb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/94caa7ea-6a97-4094-b152-d1b842fee231/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2NvbnRhaW5lci9jb250YWluZXIvNTk4ZWUwNjctZmU0ZS00ODgxLWJi
-        YzgtNmIwZWJmZGI2NGI1L3ZlcnNpb25zLzEvIn0=
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvMjExYjE0YzctZmIzYS00ZmNlLThk
+        MWYtNmY4MDUxZjI4MjI1L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1059,9 +1110,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:46 GMT
+      - Tue, 03 Dec 2019 14:57:06 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1077,13 +1128,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1MzM3YmIyLTg0ZmMtNDVm
-        ZS04ZTYxLTdkNjAxODlhZTFiZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwYTI4M2ZhLWMwYWEtNGYx
+        OS1iNDk3LWZhZjhhOTdkOWE2Zi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:06 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/45337bb2-84fc-45fe-8e61-7d60189ae1bf/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/50a283fa-c0aa-4f19-b497-faf8a97d9a6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1091,7 +1142,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1104,9 +1155,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:46 GMT
+      - Tue, 03 Dec 2019 14:57:06 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1118,26 +1169,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '306'
+      - '305'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDUzMzdiYjItODRm
-        Yy00NWZlLThlNjEtN2Q2MDE4OWFlMWJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NDYuMjU1ODUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBhMjgzZmEtYzBh
+        YS00ZjE5LWI0OTctZmFmOGE5N2Q5YTZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MDYuMzg2MjIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6NDYuMzQ3OTgz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjo1NTo0Ni40Mjc1NTBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6MDYuNDYxODM5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NzowNi41NTI4MTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzlhNTc4N2ZiLTM4YTUtNGZiOS1hNTFhLTRjYTQwYmI5MzRkNi8iLCJwYXJl
+        LzcxNmFiM2U5LTNjNzMtNGU2Mi1hZmRkLTdhZWVlMjhkOThhNS8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:06 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1145,7 +1196,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1158,9 +1209,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:46 GMT
+      - Tue, 03 Dec 2019 14:57:06 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1179,10 +1230,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:06 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1190,7 +1241,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1203,9 +1254,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:46 GMT
+      - Tue, 03 Dec 2019 14:57:07 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1223,27 +1274,27 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvZDk1MmI0YWUtYWFhYy00MzVjLTgyNDQtNTI2YmZm
-        OGI1MmQyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjA6MDcu
-        MDk1MjE3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84
-        N2EyMWZjMC05OWM1LTRlZTctYWEzZC1mMDk0OWJhNTc1YWUvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMmZhMmQ4M2UtNDk4Zi00NTNjLThjNWQtNmFiN2E3
+        YWI1ODgzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjZUMTg6MjQ6Mjcu
+        ODM3MjM5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        MTI4NDMxMi1jMTRmLTRlMzUtOWY0MS04MWQ0YmVjMWY4ODcvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE2ZWNiYjE1NTMzNTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVk
         MWJkNmQ5ZDg0NzQzYzdlOGU3NDY4ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvOWVkYWU1Y2MtMmM1ZS00ZjBiLTg1NzctN2RhYjQ4ZDMz
-        NWRiLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9hMjYwZGQ2Ni1jNjYzLTQ3MzUtOWRjZC05NmY1MmRhNjUxMWEv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2UwMDA4
-        OWFhLWI5NTMtNDIyOC1iNzUyLWMyNWM1Yzg4ZTg2My8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvODEzYWY4MjItMjA4ZS00ZmI3
-        LWJlMDktY2QxYTk4ZGMyZmJhLyJdfV19
+        YWluZXIvYmxvYnMvZWVlOWQ5MGItNWE0OC00NTI1LWEwZTMtNDFjNWE4NmVh
+        MmY3LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy8zY2ExOTdkYS1mNDA4LTQzZTQtOGIzMy1hYjc1N2NkMDMzNGQv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzNiNTQz
+        YjM5LWNlNDEtNGU0My05MGRiLWIyNGQ0MzM4MjVhMC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvODU1Y2IwZmMtNDQyZS00MjNk
+        LWFlMTMtNjI1NDZkMjlhNWFmLyJdfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:46 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:07 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1302,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,9 +1315,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:47 GMT
+      - Tue, 03 Dec 2019 14:57:07 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1285,10 +1336,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:07 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1296,7 +1347,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1309,9 +1360,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:47 GMT
+      - Tue, 03 Dec 2019 14:57:07 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1323,19 +1374,19 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '259'
+      - '258'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzLzQ3YTgxOGQ1LTljNGEtNDdjYy1hNmM5LTliMDQwNjBjNjQ4
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIwOjA3LjA5ODM1
-        M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODdhMjFm
-        YzAtOTljNS00ZWU3LWFhM2QtZjA5NDliYTU3NWFlLyIsIm5hbWUiOiJsYXRl
+        aW5lci90YWdzLzc5ZGNjOTRlLTcxODctNDI0MS05YzZiLTE3YmYxNmE4YmMy
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTI2VDE4OjI0OjI3Ljg0MTcy
+        NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTEyODQz
+        MTItYzE0Zi00ZTM1LTlmNDEtODFkNGJlYzFmODg3LyIsIm5hbWUiOiJsYXRl
         c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
-        b250YWluZXIvbWFuaWZlc3RzL2Q5NTJiNGFlLWFhYWMtNDM1Yy04MjQ0LTUy
-        NmJmZjhiNTJkMi8ifV19
+        b250YWluZXIvbWFuaWZlc3RzLzJmYTJkODNlLTQ5OGYtNDUzYy04YzVkLTZh
+        YjdhN2FiNTg4My8ifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:47 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_on_sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_on_sync.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -43,21 +43,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci81OThlZTA2Ny1mZTRlLTQ4ODEtYmJjOC02
-        YjBlYmZkYjY0YjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0yMlQxNjo1
-        NTo0Mi45NDYyMDlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci81OThlZTA2Ny1mZTRl
-        LTQ4ODEtYmJjOC02YjBlYmZkYjY0YjUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci8yMTFiMTRjNy1mYjNhLTRmY2UtOGQxZi02
+        ZjgwNTFmMjgyMjUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wM1QxNDo1
+        NzowMi42MzQ1NDJaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yMTFiMTRjNy1mYjNh
+        LTRmY2UtOGQxZi02ZjgwNTFmMjgyMjUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci81OThlZTA2Ny1mZTRlLTQ4ODEtYmJjOC02YjBlYmZk
-        YjY0YjUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci8yMTFiMTRjNy1mYjNhLTRmY2UtOGQxZi02ZjgwNTFm
+        MjgyMjUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
         fV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/598ee067-fe4e-4881-bbc8-6b0ebfdb64b5/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/211b14c7-fb3a-4fce-8d1f-6f8051f28225/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,7 +65,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -96,10 +96,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmNjg2MzAwLTVhMjYtNDRh
-        OS04NzY5LTU3NTU2NTlhNzVkNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1MDg5YjgzLTQ0OTAtNDA0
+        ZS1hOTljLTZkNDRmMWQ4NzFjYy8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -110,7 +110,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -143,21 +143,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMTMwZTZhYjEtYjkyMS00OGE4LTllODAtYjVmMGEz
-        NTU2NzAxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NDMu
-        MTI3MzQzWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
+        aW5lci9jb250YWluZXIvZjA1NWY1MTEtOTA4Ny00NzAyLTkxMGYtZTljNTY2
+        NDQ2MWZiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTc6MDIu
+        ODE5NjE2WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
         LXB1bHAzX0RvY2tlcl8xIiwidXJsIjoiaHR0cHM6Ly9yZWdpc3RyeS0xLmRv
         Y2tlci5pby8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwi
         Y2xpZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5
-        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTExLTIyVDE2
-        OjU1OjQzLjEyNzM1OVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
+        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTAzVDE0
+        OjU3OjAyLjgxOTYzMFoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
         bGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3No
         Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9XX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/130e6ab1-b921-48a8-9e80-b5f0a3556701/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/f055f511-9087-4702-910f-e9c5664461fb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -178,9 +178,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -196,10 +196,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjOTdiMjRhLWNlZmYtNGRl
-        Yy05YTU1LWM2YzI4YTBkY2Q5Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczOWRkZTAwLTJhNTctNGNl
+        Ni05NzQ2LTUzNTMxMThjMWY4Zi8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -210,7 +210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -237,26 +237,25 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '288'
+      - '289'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
-        cnkvcHVscDNfRG9ja2VyXzEiLCJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        ZGlzdHJpYnV0aW9ucy9jb250YWluZXIvY29udGFpbmVyLzc3MGZjNWUwLTNm
-        ZjktNGI0Ny1iZTc5LTI3NjhiZGQyZjFjYi8iLCJyZXBvc2l0b3J5X3ZlcnNp
-        b24iOm51bGwsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NDQu
-        NTA0OTUzWiIsInJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09y
-        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLmNhbm5v
-        bG8uZXhhbXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
-        dWxwM19Eb2NrZXJfMSJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnlfdmVyc2lvbiI6bnVsbCwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvY29udGFpbmVyL2NvbnRhaW5lci85NGNhYTdlYS02YTk3LTQwOTQtYjE1
+        Mi1kMWI4NDJmZWUyMzEvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRo
+        IjoiZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9jcmVhdGVk
+        IjoiMjAxOS0xMi0wM1QxNDo1NzowNC4yNzA5MjZaIiwibmFtZSI6IkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZWdp
+        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9m
+        ZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: delete
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/770fc5e0-3ff9-4b47-be79-2768bdd2f1cb/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/94caa7ea-6a97-4094-b152-d1b842fee231/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -264,7 +263,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -277,9 +276,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:08 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -295,10 +294,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3MmRlYTJjLTFjOWMtNDhh
-        OC05MjI3LWVjYzUzNzk2ZTcyOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MGNkOWIyLTI5YzEtNDg5
+        My04M2ZiLTYzN2U3NTM5N2QwNS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:08 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -309,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -322,9 +321,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -343,7 +342,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -354,7 +353,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -367,9 +366,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:48 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -388,7 +387,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:48 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -399,7 +398,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -412,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:49 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -433,7 +432,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
@@ -444,7 +443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -457,9 +456,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:49 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -478,7 +477,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: get
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
@@ -489,7 +488,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -502,9 +501,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:49 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -523,7 +522,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
@@ -536,7 +535,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -549,13 +548,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:49 GMT
+      - Tue, 03 Dec 2019 14:57:09 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/"
+      - "/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -570,17 +569,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNh
-        OGM5YmRjLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NDku
-        Njg1NDg0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAx
-        LWI1MDYtODNhMGNhOGM5YmRjL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5
+        YWZjNTQ1LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDNUMTQ6NTc6MDku
+        ODY3NjEyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00Njhj
+        LWE2MjMtNmQ0YTM5YWZjNTQ1L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNhOGM5YmRj
+        b250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5YWZjNTQ1
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
         YmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:09 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
@@ -597,7 +596,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -610,13 +609,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:49 GMT
+      - Tue, 03 Dec 2019 14:57:10 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/29644ae0-5e8d-4af7-9712-3207f1a444c6/"
+      - "/pulp/api/v3/remotes/container/container/bbf70071-7377-47a6-a5bb-22a54e5a232e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -631,21 +630,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyLzI5NjQ0YWUwLTVlOGQtNGFmNy05NzEyLTMyMDdmMWE0NDRj
-        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjU1OjQ5LjgyNTkx
-        N1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        Y29udGFpbmVyL2JiZjcwMDcxLTczNzctNDdhNi1hNWJiLTIyYTU0ZTVhMjMy
+        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTAzVDE0OjU3OjEwLjAwMzAy
+        MFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
         M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
         aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
         dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMS0yMlQxNjo1NTo0
-        OS44MjU5MzJaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wM1QxNDo1Nzox
+        MC4wMDMwMzRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
         OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIsIndo
         aXRlbGlzdF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:49 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:10 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/add/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/add/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -655,7 +654,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -668,9 +667,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:50 GMT
+      - Tue, 03 Dec 2019 14:57:10 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -686,13 +685,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzYTAyNTkyLTlhMWMtNDRm
-        Ny04NTFhLTc1YmJkNDc1MzViYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3MDY2M2YzLTA2NDktNGMz
+        Zi05NmQzLTg3YjYxNzE2MjFmMS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:10 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/remove/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/remove/
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -702,7 +701,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -715,9 +714,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:50 GMT
+      - Tue, 03 Dec 2019 14:57:10 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -733,13 +732,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwNWVmMjliLWM5NTgtNGIx
-        ZS05YzYxLTNlZDU2ZTQ5ZGNjOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwYzVhZDIzLTNlYzMtNDcx
+        NS1hOTRiLTJmOWIzZjNhOTM4OC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:10 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c05ef29b-c958-4b1e-9c61-3ed56e49dcc9/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/60c5ad23-3ec3-4715-a94b-2f9b3f3a9388/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -747,7 +746,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -760,9 +759,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:50 GMT
+      - Tue, 03 Dec 2019 14:57:10 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -774,28 +773,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '340'
+      - '339'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzA1ZWYyOWItYzk1
-        OC00YjFlLTljNjEtM2VkNTZlNDlkY2M5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NTAuMzc2MzIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjBjNWFkMjMtM2Vj
+        My00NzE1LWE5NGItMmY5YjNmM2E5Mzg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MTAuNTA2OTA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5yZWN1cnNpdmVf
         cmVtb3ZlLnJlY3Vyc2l2ZV9yZW1vdmVfY29udGVudCIsInN0YXJ0ZWRfYXQi
-        OiIyMDE5LTExLTIyVDE2OjU1OjUwLjUxNzM5M1oiLCJmaW5pc2hlZF9hdCI6
-        IjIwMTktMTEtMjJUMTY6NTU6NTAuNjExMjMxWiIsImVycm9yIjpudWxsLCJ3
-        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85YTU3ODdmYi0zOGE1LTRm
-        YjktYTUxYS00Y2E0MGJiOTM0ZDYvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
+        OiIyMDE5LTEyLTAzVDE0OjU3OjEwLjY0NDQxMloiLCJmaW5pc2hlZF9hdCI6
+        IjIwMTktMTItMDNUMTQ6NTc6MTAuNzIxMTUxWiIsImVycm9yIjpudWxsLCJ3
+        b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRl
+        NjItYWZkZC03YWVlZTI4ZDk4YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVk
         X3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
         b3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOGM2
-        M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNhOGM5YmRjLyJdfQ==
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYmYz
+        MTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5YWZjNTQ1LyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:10 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/0/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -803,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -816,9 +815,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:50 GMT
+      - Tue, 03 Dec 2019 14:57:10 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -835,30 +834,29 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNh
-        OGM5YmRjL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjo1NTo0OS42ODcwODhaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5
+        YWZjNTQ1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NzowOS44NjkyNjRaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQi
         Ont9LCJwcmVzZW50Ijp7fX19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:10 GMT
 - request:
     method: post
     uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
-        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        OGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNhOGM5YmRjL3ZlcnNpb25z
-        LzAvIn0=
+        eyJiYXNlX3BhdGgiOiJmZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9iZjMxNmJhNy04YjcwLTQ2
+        OGMtYTYyMy02ZDRhMzlhZmM1NDUvdmVyc2lvbnMvMC8ifQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -871,9 +869,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:50 GMT
+      - Tue, 03 Dec 2019 14:57:11 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -889,13 +887,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1OTQ4NmI3LWQxZGMtNDZj
-        OC04YTYzLWQ1ZTU0NjEyNzE1Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1YzBlYTU1LTQ3YjQtNDBm
+        Yi05YTE4LTM5MGQzZTMyZmY5YS8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:50 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:11 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e59486b7-d1dc-46c8-8a63-d5e546127152/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/b5c0ea55-47b4-40fb-9a18-390d3e32ff9a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -903,7 +901,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -916,9 +914,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:51 GMT
+      - Tue, 03 Dec 2019 14:57:11 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -930,28 +928,28 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '342'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU5NDg2YjctZDFk
-        Yy00NmM4LThhNjMtZDVlNTQ2MTI3MTUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NTAuOTM1MDQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjVjMGVhNTUtNDdi
+        NC00MGZiLTlhMTgtMzkwZDNlMzJmZjlhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MTEuMDkxNTI0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6NTEuMDQ0NDU4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjo1NTo1MS4yNDI2NzVa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6MTEuMjAzODgy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NzoxMS40MjI2MTda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8zMzg5MjhhNy1kZWY4LTQ0
-        Y2YtOTJkZi0xMWYwYmQzN2M4OTMvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9jMmQyNDBlOC03ODdjLTRk
+        OGItYWRlMC1iNGQ3MjU4MWUxMDMvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:11 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/338928a7-def8-44cf-92df-11f0bd37c893/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/c2d240e8-787c-4d8b-ade0-b4d72581e103/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -959,7 +957,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -972,9 +970,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:51 GMT
+      - Tue, 03 Dec 2019 14:57:11 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -986,38 +984,37 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '297'
+      - '300'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci8zMzg5MjhhNy1kZWY4LTQ0
-        Y2YtOTJkZi0xMWYwYmQzN2M4OTMvIiwicmVwb3NpdG9yeV92ZXJzaW9uIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzhjNjNjNGIwLTMzMjEtNDcwMS1iNTA2LTgzYTBjYThjOWJkYy92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6NTU6NTEuMjMx
-        MDU5WiIsInJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwiY29udGVudF9ndWFy
-        ZCI6bnVsbCwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLmNhbm5vbG8u
-        ZXhhbXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxw
-        M19Eb2NrZXJfMSJ9
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2
+        MjMtNmQ0YTM5YWZjNTQ1L3ZlcnNpb25zLzAvIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9jMmQyNDBlOC03ODdjLTRkOGItYWRlMC1i
+        NGQ3MjU4MWUxMDMvIiwicmVwb3NpdG9yeSI6bnVsbCwiYmFzZV9wYXRoIjoi
+        ZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9jcmVhdGVkIjoi
+        MjAxOS0xMi0wM1QxNDo1NzoxMS40MDI3MTJaIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZWdpc3Ry
+        eV9wYXRoIjoicHVscDMtZGV2ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9mZWRv
+        cmFfbGFiZWwtcHVscDNfZG9ja2VyXzEifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:11 GMT
 - request:
     method: post
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/sync/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyLzI5NjQ0YWUwLTVlOGQtNGFmNy05NzEyLTMyMDdmMWE0NDRjNi8i
+        dGFpbmVyL2JiZjcwMDcxLTczNzctNDdhNi1hNWJiLTIyYTU0ZTVhMjMyZS8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1030,9 +1027,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:51 GMT
+      - Tue, 03 Dec 2019 14:57:12 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1048,13 +1045,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4NzgzZjdmLWNiZjYtNGI3
-        Yi04ZjM4LWZjMzAzODE1MzBlZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M0NTlhNWYwLWZkOGMtNDc1
+        Zi1iM2E4LWM0YmViMGZhNjA1Ni8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:51 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:12 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d8783f7f-cbf6-4b7b-8f38-fc30381530ee/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c459a5f0-fd8c-475f-b3a8-c4beb0fa6056/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1062,7 +1059,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1075,9 +1072,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:52 GMT
+      - Tue, 03 Dec 2019 14:57:12 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1089,42 +1086,42 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '519'
+      - '517'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg3ODNmN2YtY2Jm
-        Ni00YjdiLThmMzgtZmMzMDM4MTUzMGVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NTEuOTI3ODgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzQ1OWE1ZjAtZmQ4
+        Yy00NzVmLWIzYTgtYzRiZWIwZmE2MDU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MTIuMDYzMjk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTExLTIyVDE2OjU1
-        OjUyLjA1NzY5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6
-        NTIuNTMzNjQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy82YWZiMmRlZC0wNjkyLTRkOWEtYjI3MS0xNzFhNzQyZGQw
-        MTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTAzVDE0OjU3
+        OjEyLjE5ODU4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6
+        MTIuNjg2MDU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83MTZhYjNlOS0zYzczLTRlNjItYWZkZC03YWVlZTI4ZDk4
+        YTUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
         c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
         IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoicHJvY2Vzc2luZy50
-        YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
-        cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9
-        LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNz
-        b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
+        c3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoiZG93bmxv
+        YWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3Nv
+        Y2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo2LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsImNv
+        ZGUiOiJwcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
         cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNhOGM5YmRj
+        b250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5YWZjNTQ1
         L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
         L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVy
-        LzhjNjNjNGIwLTMzMjEtNDcwMS1iNTA2LTgzYTBjYThjOWJkYy8iLCIvcHVs
-        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzI5NjQ0YWUw
-        LTVlOGQtNGFmNy05NzEyLTMyMDdmMWE0NDRjNi8iXX0=
+        L2JmMzE2YmE3LThiNzAtNDY4Yy1hNjIzLTZkNGEzOWFmYzU0NS8iLCIvcHVs
+        cC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2JiZjcwMDcx
+        LTczNzctNDdhNi1hNWJiLTIyYTU0ZTVhMjMyZS8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:12 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1132,7 +1129,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1145,9 +1142,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:52 GMT
+      - Tue, 03 Dec 2019 14:57:12 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1164,53 +1161,53 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNh
-        OGM5YmRjL3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMS0y
-        MlQxNjo1NTo1Mi4wNzk5NDVaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
+        aW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5
+        YWZjNTQ1L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0w
+        M1QxNDo1NzoxMi4yMzkxOTFaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24i
         Om51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJjb250YWluZXIu
         YmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
         L2NvbnRhaW5lci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci84
-        YzYzYzRiMC0zMzIxLTQ3MDEtYjUwNi04M2EwY2E4YzliZGMvdmVyc2lvbnMv
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9i
+        ZjMxNmJhNy04YjcwLTQ2OGMtYTYyMy02ZDRhMzlhZmM1NDUvdmVyc2lvbnMv
         MS8ifSwiY29udGFpbmVyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoi
         L3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvY29udGFpbmVyL2NvbnRhaW5lci84YzYzYzRiMC0zMzIxLTQ3MDEtYjUw
-        Ni04M2EwY2E4YzliZGMvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
+        ZXMvY29udGFpbmVyL2NvbnRhaW5lci9iZjMxNmJhNy04YjcwLTQ2OGMtYTYy
+        My02ZDRhMzlhZmM1NDUvdmVyc2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6
         eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
         aW5lci90YWdzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzhjNjNjNGIw
-        LTMzMjEtNDcwMS1iNTA2LTgzYTBjYThjOWJkYy92ZXJzaW9ucy8xLyJ9fSwi
+        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2JmMzE2YmE3
+        LThiNzAtNDY4Yy1hNjIzLTZkNGEzOWFmYzU0NS92ZXJzaW9ucy8xLyJ9fSwi
         cmVtb3ZlZCI6e30sInByZXNlbnQiOnsiY29udGFpbmVyLmJsb2IiOnsiY291
         bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIv
         YmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAx
-        LWI1MDYtODNhMGNhOGM5YmRjL3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00Njhj
+        LWE2MjMtNmQ0YTM5YWZjNTQ1L3ZlcnNpb25zLzEvIn0sImNvbnRhaW5lci5t
         YW5pZmVzdCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
         ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
         cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        OGM2M2M0YjAtMzMyMS00NzAxLWI1MDYtODNhMGNhOGM5YmRjL3ZlcnNpb25z
+        YmYzMTZiYTctOGI3MC00NjhjLWE2MjMtNmQ0YTM5YWZjNTQ1L3ZlcnNpb25z
         LzEvIn0sImNvbnRhaW5lci50YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
         cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvdGFncy8/cmVwb3NpdG9yeV92
         ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2Nv
-        bnRhaW5lci84YzYzYzRiMC0zMzIxLTQ3MDEtYjUwNi04M2EwY2E4YzliZGMv
+        bnRhaW5lci9iZjMxNmJhNy04YjcwLTQ2OGMtYTYyMy02ZDRhMzlhZmM1NDUv
         dmVyc2lvbnMvMS8ifX19fQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:12 GMT
 - request:
     method: patch
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/338928a7-def8-44cf-92df-11f0bd37c893/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/c2d240e8-787c-4d8b-ade0-b4d72581e103/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2NvbnRhaW5lci9jb250YWluZXIvOGM2M2M0YjAtMzMyMS00NzAxLWI1
-        MDYtODNhMGNhOGM5YmRjL3ZlcnNpb25zLzEvIn0=
+        aWVzL2NvbnRhaW5lci9jb250YWluZXIvYmYzMTZiYTctOGI3MC00NjhjLWE2
+        MjMtNmQ0YTM5YWZjNTQ1L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1223,9 +1220,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:52 GMT
+      - Tue, 03 Dec 2019 14:57:13 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1241,13 +1238,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YWEzYTkzLWM0MGEtNDA0
-        ZC1hODJlLTVjMDg1ZWY5OWIyZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2YzEwNjAyLThhZTItNDc3
+        My04ZjY0LTcyM2NlNTQ5NGQzZC8ifQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:52 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:13 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/95aa3a93-c40a-404d-a82e-5c085ef99b2e/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/26c10602-8ae2-4773-8f64-723ce5494d3d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1255,7 +1252,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0rc8/ruby
+      - OpenAPI-Generator/3.1.0.dev01574423031/ruby
       Accept:
       - application/json
       Authorization:
@@ -1268,9 +1265,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:53 GMT
+      - Tue, 03 Dec 2019 14:57:13 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1282,26 +1279,26 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '306'
+      - '305'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTVhYTNhOTMtYzQw
-        YS00MDRkLWE4MmUtNWMwODVlZjk5YjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTEtMjJUMTY6NTU6NTIuOTQ2MjMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjZjMTA2MDItOGFl
+        Mi00NzczLThmNjQtNzIzY2U1NDk0ZDNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMDNUMTQ6NTc6MTMuMDgxMDA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTEtMjJUMTY6NTU6NTMuMDQ5NjUy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMS0yMlQxNjo1NTo1My4xMzUzNzJa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDNUMTQ6NTc6MTMuMTk4OTQw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wM1QxNDo1NzoxMy4yOTkwNDBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzZhZmIyZGVkLTA2OTItNGQ5YS1iMjcxLTE3MWE3NDJkZDAxNS8iLCJwYXJl
+        L2I0NzM4ZTU5LTgzNzQtNGEyMi05ZTFhLWZlY2M0ZmY1MWQ5Ni8iLCJwYXJl
         bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
         IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:13 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1309,7 +1306,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1322,9 +1319,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:53 GMT
+      - Tue, 03 Dec 2019 14:57:13 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1343,10 +1340,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:13 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1354,7 +1351,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1367,9 +1364,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:53 GMT
+      - Tue, 03 Dec 2019 14:57:13 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1387,27 +1384,27 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvZDk1MmI0YWUtYWFhYy00MzVjLTgyNDQtNTI2YmZm
-        OGI1MmQyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjJUMTY6MjA6MDcu
-        MDk1MjE3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84
-        N2EyMWZjMC05OWM1LTRlZTctYWEzZC1mMDk0OWJhNTc1YWUvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMmZhMmQ4M2UtNDk4Zi00NTNjLThjNWQtNmFiN2E3
+        YWI1ODgzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTEtMjZUMTg6MjQ6Mjcu
+        ODM3MjM5WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        MTI4NDMxMi1jMTRmLTRlMzUtOWY0MS04MWQ0YmVjMWY4ODcvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE2ZWNiYjE1NTMzNTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVk
         MWJkNmQ5ZDg0NzQzYzdlOGU3NDY4ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvOWVkYWU1Y2MtMmM1ZS00ZjBiLTg1NzctN2RhYjQ4ZDMz
-        NWRiLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9hMjYwZGQ2Ni1jNjYzLTQ3MzUtOWRjZC05NmY1MmRhNjUxMWEv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2UwMDA4
-        OWFhLWI5NTMtNDIyOC1iNzUyLWMyNWM1Yzg4ZTg2My8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvODEzYWY4MjItMjA4ZS00ZmI3
-        LWJlMDktY2QxYTk4ZGMyZmJhLyJdfV19
+        YWluZXIvYmxvYnMvZWVlOWQ5MGItNWE0OC00NTI1LWEwZTMtNDFjNWE4NmVh
+        MmY3LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy8zY2ExOTdkYS1mNDA4LTQzZTQtOGIzMy1hYjc1N2NkMDMzNGQv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzNiNTQz
+        YjM5LWNlNDEtNGU0My05MGRiLWIyNGQ0MzM4MjVhMC8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvODU1Y2IwZmMtNDQyZS00MjNk
+        LWFlMTMtNjI1NDZkMjlhNWFmLyJdfV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:13 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1415,7 +1412,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1428,9 +1425,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:53 GMT
+      - Tue, 03 Dec 2019 14:57:13 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1449,10 +1446,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:53 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:13 GMT
 - request:
     method: get
-    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/8c63c4b0-3321-4701-b506-83a0ca8c9bdc/versions/1/
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/bf316ba7-8b70-468c-a623-6d4a39afc545/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1460,7 +1457,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.0rc1/ruby
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
       Accept:
       - application/json
       Authorization:
@@ -1473,9 +1470,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 22 Nov 2019 16:55:54 GMT
+      - Tue, 03 Dec 2019 14:57:14 GMT
       Server:
-      - gunicorn/20.0.0
+      - gunicorn/20.0.2
       Content-Type:
       - application/json
       Vary:
@@ -1487,19 +1484,19 @@ http_interactions:
       Via:
       - 1.1 pulp3-devel.cannolo.example.com
       Content-Length:
-      - '259'
+      - '258'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzLzQ3YTgxOGQ1LTljNGEtNDdjYy1hNmM5LTliMDQwNjBjNjQ4
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTIyVDE2OjIwOjA3LjA5ODM1
-        M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODdhMjFm
-        YzAtOTljNS00ZWU3LWFhM2QtZjA5NDliYTU3NWFlLyIsIm5hbWUiOiJsYXRl
+        aW5lci90YWdzLzc5ZGNjOTRlLTcxODctNDI0MS05YzZiLTE3YmYxNmE4YmMy
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTExLTI2VDE4OjI0OjI3Ljg0MTcy
+        NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTEyODQz
+        MTItYzE0Zi00ZTM1LTlmNDEtODFkNGJlYzFmODg3LyIsIm5hbWUiOiJsYXRl
         c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
-        b250YWluZXIvbWFuaWZlc3RzL2Q5NTJiNGFlLWFhYWMtNDM1Yy04MjQ0LTUy
-        NmJmZjhiNTJkMi8ifV19
+        b250YWluZXIvbWFuaWZlc3RzLzJmYTJkODNlLTQ5OGYtNDUzYy04YzVkLTZh
+        YjdhN2FiNTg4My8ifV19
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 16:55:54 GMT
+  recorded_at: Tue, 03 Dec 2019 14:57:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/index_model.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/index_model.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,308 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:45 GMT
+      - Wed, 11 Dec 2019 16:52:23 GMT
       Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel.balmora.example.com
-      Content-Length:
-      - '247'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8xODYwY2JmNy00ZDAzLTQyMmYtYmZiNy0x
-        ZmZiODMzYWRiZTcvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOToy
-        NDozNy44NDM5MTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8xODYwY2JmNy00ZDAz
-        LTQyMmYtYmZiNy0xZmZiODMzYWRiZTcvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci8xODYwY2JmNy00ZDAzLTQyMmYtYmZiNy0xZmZiODMz
-        YWRiZTcvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        fV19
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:45 GMT
-- request:
-    method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/1860cbf7-4d03-422f-bfb7-1ffb833adbe7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:45 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2MDhiNWY2LTRhM2YtNGQ0
-        OS04Y2QwLTlmY2M4OWUwZGVmOS8ifQ==
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:45 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:45 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel.balmora.example.com
-      Content-Length:
-      - '339'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvNzI4YzZiMTItZWVkYS00ZTE1LTk1NzAtZTAwNWQ2
-        ZGQxMjRhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6MjQ6Mzcu
-        OTk5MzYxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0RvY2tlcl8xIiwidXJsIjoiaHR0cHM6Ly9yZWdpc3RyeS0xLmRv
-        Y2tlci5pby8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwi
-        Y2xpZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5
-        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTA5VDE5
-        OjI0OjM3Ljk5OTM3NVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
-        bGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3No
-        Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:45 GMT
-- request:
-    method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/728c6b12-eeda-4e15-9570-e005d6dd124a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:45 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmYzA2YzQ1LTYzYzYtNDgx
-        OC1iMjM3LWVlZjcwNWQxNGZlZS8ifQ==
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:45 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:45 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel.balmora.example.com
-      Content-Length:
-      - '287'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRvcnlfdmVyc2lvbiI6
-        bnVsbCwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOToyNDozOS41NTg4
-        NjlaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9wdWxwM19Eb2NrZXJfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUi
-        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8x
-        IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29u
-        dGFpbmVyL2NvbnRhaW5lci81MDA0YjI0MC05OTVkLTQ3Y2YtOTk0Ni1iNmE0
-        NTA3ZGI2NWEvIiwicmVnaXN0cnlfcGF0aCI6ImRldmVsLmJhbG1vcmEuZXhh
-        bXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19E
-        b2NrZXJfMSJ9XX0=
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:45 GMT
-- request:
-    method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/5004b240-995d-47cf-9946-b6a4507db65a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjNmZkOTViLWFjY2QtNGVi
-        My1hMzg5LWY5ZmE3NWM1OThmNy8ifQ==
-    http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
-      Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -336,17 +37,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:23 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -367,9 +68,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
+      - Wed, 11 Dec 2019 16:52:24 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -381,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -412,9 +113,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
+      - Wed, 11 Dec 2019 16:52:24 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -426,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -457,9 +158,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
+      - Wed, 11 Dec 2019 16:52:24 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -471,17 +172,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -502,31 +203,166 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:46 GMT
+      - Wed, 11 Dec 2019 16:52:24 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Via:
-      - 1.1 devel.balmora.example.com
-      Transfer-Encoding:
-      - chunked
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:46 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Dec 2019 16:52:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Dec 2019 16:52:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.1.0.dev01574357179/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Dec 2019 16:52:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Dec 2019 16:52:24 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -549,13 +385,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:47 GMT
+      - Wed, 11 Dec 2019 16:52:25 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/"
+      - "/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -565,25 +401,25 @@ http_interactions:
       Content-Length:
       - '446'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMjZhY2JhYjktMWM0Mi00ZGM0LTk3ZGItYjg4ZWJj
-        NDU5MjllLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6NDU6NDcu
-        MjI4MzIzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjZhY2JhYjktMWM0Mi00ZGM0
-        LTk3ZGItYjg4ZWJjNDU5MjllL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvYTllZWUwYTgtY2Q4Yi00NmU0LWExNmUtMTNmOGI0
+        YWZmYWYwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMTFUMTY6NTI6MjUu
+        NDI0MTI5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvYTllZWUwYTgtY2Q4Yi00NmU0
+        LWExNmUtMTNmOGI0YWZmYWYwL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMjZhY2JhYjktMWM0Mi00ZGM0LTk3ZGItYjg4ZWJjNDU5Mjll
+        b250YWluZXIvYTllZWUwYTgtY2Q4Yi00NmU0LWExNmUtMTNmOGI0YWZmYWYw
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
         YmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:47 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:25 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -610,13 +446,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:47 GMT
+      - Wed, 11 Dec 2019 16:52:25 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/ddc3341f-b129-4da3-8e84-1cfccfd1056b/"
+      - "/pulp/api/v3/remotes/container/container/2f8403ab-4905-46af-b5e3-c807bf6caaa8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -626,31 +462,31 @@ http_interactions:
       Content-Length:
       - '469'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2RkYzMzNDFmLWIxMjktNGRhMy04ZTg0LTFjZmNjZmQxMDU2
-        Yi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTA5VDE5OjQ1OjQ3LjQ1NTc3
-        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        Y29udGFpbmVyLzJmODQwM2FiLTQ5MDUtNDZhZi1iNWUzLWM4MDdiZjZjYWFh
+        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2OjUyOjI1LjY1NjQx
+        MloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
         M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
         aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
         dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wOVQxOTo0NTo0
-        Ny40NTU3OTFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0xMVQxNjo1Mjoy
+        NS42NTY0MjZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
         OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIsIndo
         aXRlbGlzdF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:47 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:25 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/sync/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyL2RkYzMzNDFmLWIxMjktNGRhMy04ZTg0LTFjZmNjZmQxMDU2Yi8i
+        dGFpbmVyLzJmODQwM2FiLTQ5MDUtNDZhZi1iNWUzLWM4MDdiZjZjYWFhOC8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
@@ -669,9 +505,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:47 GMT
+      - Wed, 11 Dec 2019 16:52:26 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -683,17 +519,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhY2ZhMWYwLWM3OTEtNDZi
-        Yy04MWIyLTY1ODBkY2I0Y2NlYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y1OGE4M2U1LTY4MjYtNDI5
+        NS05Y2Q2LTZiYWIyODFmMDM4OS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:47 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:26 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/2acfa1f0-c791-46bc-81b2-6580dcb4ccea/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/f58a83e5-6826-4295-9cd6-6bab281f0389/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -714,9 +550,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:48 GMT
+      - Wed, 11 Dec 2019 16:52:32 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -726,53 +562,51 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '519'
+      - '499'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmFjZmExZjAtYzc5
-        MS00NmJjLTgxYjItNjU4MGRjYjRjY2VhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTItMDlUMTk6NDU6NDcuODcyMzI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjU4YTgzZTUtNjgy
+        Ni00Mjk1LTljZDYtNmJhYjI4MWYwMzg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMTFUMTY6NTI6MjYuMDQwMzI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTA5VDE5OjQ1
-        OjQ3Ljk4NTcxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDlUMTk6NDU6
-        NDguNTkxMzU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy82NmJjMmExOS1mZmVlLTQ3NDgtOTExNS03NjYyYzFiOWFl
-        MDkvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
-        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
-        IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoicHJvY2Vzc2luZy50
-        YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
-        cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9
-        LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNz
-        b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
-        cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMjZhY2JhYjktMWM0Mi00ZGM0LTk3ZGItYjg4ZWJjNDU5Mjll
-        L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
-        L3B1bHAvYXBpL3YzL3JlbW90ZXMvY29udGFpbmVyL2NvbnRhaW5lci9kZGMz
-        MzQxZi1iMTI5LTRkYTMtOGU4NC0xY2ZjY2ZkMTA1NmIvIiwiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzI2YWNiYWI5
-        LTFjNDItNGRjNC05N2RiLWI4OGViYzQ1OTI5ZS8iXX0=
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTExVDE2OjUy
+        OjI2LjE1MzY0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMTFUMTY6NTI6
+        MzIuNDUzNzA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy84MjBiYjViZi05MmRjLTQ4ZjUtYmY0Mi0wYjE2MGMyMzNj
+        NTgvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2Fk
+        aW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjo0LCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQi
+        LCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOm51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJjb2RlIjoiZG93bmxv
+        YWRpbmcudGFnX2xpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjox
+        LCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Np
+        bmcgVGFncyIsImNvZGUiOiJwcm9jZXNzaW5nLnRhZyIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2NvbnRhaW5lci9jb250YWluZXIvYTllZWUwYTgtY2Q4Yi00NmU0LWExNmUt
+        MTNmOGI0YWZmYWYwL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvY29udGFpbmVyL2Nv
+        bnRhaW5lci8yZjg0MDNhYi00OTA1LTQ2YWYtYjVlMy1jODA3YmY2Y2FhYTgv
+        IiwiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
+        bmVyL2E5ZWVlMGE4LWNkOGItNDZlNC1hMTZlLTEzZjhiNGFmZmFmMC8iXX0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:48 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:32 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
-        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        MjZhY2JhYjktMWM0Mi00ZGM0LTk3ZGItYjg4ZWJjNDU5MjllL3ZlcnNpb25z
-        LzEvIn0=
+        eyJiYXNlX3BhdGgiOiJmZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hOWVlZTBhOC1jZDhiLTQ2
+        ZTQtYTE2ZS0xM2Y4YjRhZmZhZjAvdmVyc2lvbnMvMS8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -790,9 +624,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:48 GMT
+      - Wed, 11 Dec 2019 16:52:32 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -804,17 +638,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyOGI3NjdkLThmODEtNDVj
-        ZS04YzE3LTMwYzZjZWJiNGYyYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlZWY1OTA5LTMzYTMtNGY3
+        OC05ZjQ3LTQ1YzEyZTNmMTMzZC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:48 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:32 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/728b767d-8f81-45ce-8c17-30c6cebb4f2b/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/eeef5909-33a3-4f78-9f47-45c12e3f133d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -835,9 +669,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:49 GMT
+      - Wed, 11 Dec 2019 16:52:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -847,30 +681,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '341'
+      - '324'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI4Yjc2N2QtOGY4
-        MS00NWNlLThjMTctMzBjNmNlYmI0ZjJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTItMDlUMTk6NDU6NDguOTIyMTQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWVlZjU5MDktMzNh
+        My00Zjc4LTlmNDctNDVjMTJlM2YxMzNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMTFUMTY6NTI6MzIuOTEzNzkxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDlUMTk6NDU6NDkuMDIyMjU3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wOVQxOTo0NTo0OS4yNjE5MjZa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMTFUMTY6NTI6MzMuMDM5MzAy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0xMVQxNjo1MjozMy4yNDA2NDJa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzY2YmMyYTE5LWZmZWUtNDc0OC05MTE1LTc2NjJjMWI5YWUwOS8iLCJwYXJl
-        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci80NjUxMDJmYS0zNWJkLTQ3
-        NDQtODRiMi1mMzJhOTk1NzkwMzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+        LzE2NDE3MDA3LWI3OGUtNDE3Yy1hNThlLWE1YTY4NDJjNzhmNS8iLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
+        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci84MTZh
+        NjNjMS1kMTg1LTQ0NDUtODdhZS0xZTdmZjAyYWI5NDcvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJd
+        fQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:49 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/465102fa-35bd-4744-84b2-f32a99579031/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/816a63c1-d185-4445-87ae-1e7ff02ab947/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -891,9 +725,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:49 GMT
+      - Wed, 11 Dec 2019 16:52:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -903,29 +737,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '297'
+      - '299'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMjZh
-        Y2JhYjktMWM0Mi00ZGM0LTk3ZGItYjg4ZWJjNDU5MjllL3ZlcnNpb25zLzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOTo0NTo0OS4yNDYwODBa
-        IiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
-        dWxwM19Eb2NrZXJfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFp
-        bmVyL2NvbnRhaW5lci80NjUxMDJmYS0zNWJkLTQ3NDQtODRiMi1mMzJhOTk1
-        NzkwMzEvIiwicmVnaXN0cnlfcGF0aCI6ImRldmVsLmJhbG1vcmEuZXhhbXBs
-        ZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19Eb2Nr
-        ZXJfMSJ9
+        eyJyZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImJhc2VfcGF0aCI6ImZlZG9y
+        YV9sYWJlbC1wdWxwM19kb2NrZXJfMSIsInB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9kaXN0cmlidXRpb25zL2NvbnRhaW5lci9jb250YWluZXIvODE2YTYz
+        YzEtZDE4NS00NDQ1LTg3YWUtMWU3ZmYwMmFiOTQ3LyIsInJlcG9zaXRvcnlf
+        dmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
+        L2NvbnRhaW5lci9hOWVlZTBhOC1jZDhiLTQ2ZTQtYTE2ZS0xM2Y4YjRhZmZh
+        ZjAvdmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2
+        OjUyOjMzLjIzMTU4N1oiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdpc3Ry
+        eV9wYXRoIjoicHVscDMtZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL2Zl
+        ZG9yYV9sYWJlbC1wdWxwM19kb2NrZXJfMSJ9
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:49 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -946,9 +779,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:49 GMT
+      - Wed, 11 Dec 2019 16:52:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -960,17 +793,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:49 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -991,9 +824,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:49 GMT
+      - Wed, 11 Dec 2019 16:52:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1003,7 +836,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
       - '454'
     body:
@@ -1011,27 +844,27 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvODYxMzlmZDEtNjE2Yy00OTU2LWI2ZDQtMTU3OTg5
-        NDRiZjQyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6MjQ6MzMu
-        Nzg0ODEzWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80
-        Zjg3ZTUwYi1kZmM3LTQ4N2MtYjg3ZS1mN2E3OGM5ODIwMGEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMWNkN2Q3MjgtODMwNi00ZmMyLTllNzYtMzc4MDMy
+        YWIwM2UwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMTFUMTY6NTI6MzIu
+        MzE5MDM3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8z
+        ZGE1ODdmZS1iNWQ3LTQxMzYtYTg1Mi1kNmMwZTNmYWRlOTAvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE2ZWNiYjE1NTMzNTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVk
         MWJkNmQ5ZDg0NzQzYzdlOGU3NDY4ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGY4M2JjMzItN2ZjZC00OGViLThjY2EtMmE3ZTJjNmUy
-        MWYwLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9hOTViNzZjOC0xZTY3LTQzNDQtOGFlNi0zZDA3YmMyZjJmODEv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzBjYzQx
-        Y2M4LWFhMDctNDdjNy1hYzk4LWFkMDM4YmZmMDM2Ny8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvNmY3NzllMDgtOWNlMi00OTJh
-        LTkxYTYtMTI0ZmM3MTkwYzhmLyJdfV19
+        YWluZXIvYmxvYnMvNjk1MjNhMjAtNzdiZi00MzYzLTg1YTktZDczMmNmZGI1
+        NzBmLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy9iNmE3YTY2NS0yNmY5LTRmZDAtOTI5Zi0yYWYwYWEwZDVkODgv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y4NmUw
+        ZDA5LTllYWUtNDNjOC1iYTNmLTc2ZDc4ODdmYmY5OS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvNDQwZjZkZmQtMmNlMS00NTk3
+        LTgzMjItOTdlMzUwN2IwNzBmLyJdfV19
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:49 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,9 +885,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:50 GMT
+      - Wed, 11 Dec 2019 16:52:34 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1066,17 +899,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:50 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:34 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1097,9 +930,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:50 GMT
+      - Wed, 11 Dec 2019 16:52:34 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1109,21 +942,21 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '257'
+      - '258'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2NhYmFiOWNhLWZjOWMtNDE3Ny1iMDQ3LTY0ZGRiM2VlZWVk
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTA5VDE5OjI0OjMzLjc4NjQy
-        MVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNGY4N2U1
-        MGItZGZjNy00ODdjLWI4N2UtZjdhNzhjOTgyMDBhLyIsIm5hbWUiOiJsYXRl
+        aW5lci90YWdzL2E5YWY2Nzc5LTQxNzItNGFiNC05YWY3LTdjNjY1NzUyZmYx
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2OjUyOjMyLjMyMTk0
+        NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvM2RhNTg3
+        ZmUtYjVkNy00MTM2LWE4NTItZDZjMGUzZmFkZTkwLyIsIm5hbWUiOiJsYXRl
         c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
-        b250YWluZXIvbWFuaWZlc3RzLzg2MTM5ZmQxLTYxNmMtNDk1Ni1iNmQ0LTE1
-        Nzk4OTQ0YmY0Mi8ifV19
+        b250YWluZXIvbWFuaWZlc3RzLzFjZDdkNzI4LTgzMDYtNGZjMi05ZTc2LTM3
+        ODAzMmFiMDNlMC8ifV19
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:50 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:34 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/index_on_sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/index_on_sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,9 +23,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:51 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -35,29 +35,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '247'
+      - '245'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8yNmFjYmFiOS0xYzQyLTRkYzQtOTdkYi1i
-        ODhlYmM0NTkyOWUvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOTo0
-        NTo0Ny4yMjgzMjNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8yNmFjYmFiOS0xYzQy
-        LTRkYzQtOTdkYi1iODhlYmM0NTkyOWUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        Y29udGFpbmVyL2NvbnRhaW5lci9hOWVlZTBhOC1jZDhiLTQ2ZTQtYTE2ZS0x
+        M2Y4YjRhZmZhZjAvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0xMVQxNjo1
+        MjoyNS40MjQxMjlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hOWVlZTBhOC1jZDhi
+        LTQ2ZTQtYTE2ZS0xM2Y4YjRhZmZhZjAvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci8yNmFjYmFiOS0xYzQyLTRkYzQtOTdkYi1iODhlYmM0
-        NTkyOWUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        bmVyL2NvbnRhaW5lci9hOWVlZTBhOC1jZDhiLTQ2ZTQtYTE2ZS0xM2Y4YjRh
+        ZmZhZjAvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
         fV19
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:51 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/26acbab9-1c42-4dc4-97db-b88ebc45929e/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/a9eee0a8-cd8b-46e4-a16e-13f8b4affaf0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -78,9 +78,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:51 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -92,17 +92,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0MGY1ZGJkLWY3MGItNDE4
-        NS04MmFiLWYwNDY1MmUzMzYyYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiYjQ4NTBiLTExZWQtNDI5
+        Ni1iMzExLTQyY2ZkODA0YWY3ZC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:51 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -123,9 +123,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:51 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -135,7 +135,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
       - '340'
     body:
@@ -143,21 +143,21 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
-        aW5lci9jb250YWluZXIvZGRjMzM0MWYtYjEyOS00ZGEzLThlODQtMWNmY2Nm
-        ZDEwNTZiLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6NDU6NDcu
-        NDU1Nzc2WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
+        aW5lci9jb250YWluZXIvMmY4NDAzYWItNDkwNS00NmFmLWI1ZTMtYzgwN2Jm
+        NmNhYWE4LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMTFUMTY6NTI6MjUu
+        NjU2NDEyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
         LXB1bHAzX0RvY2tlcl8xIiwidXJsIjoiaHR0cHM6Ly9yZWdpc3RyeS0xLmRv
         Y2tlci5pby8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwi
         Y2xpZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5
-        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTA5VDE5
-        OjQ1OjQ3LjQ1NTc5MVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
+        X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5LTEyLTExVDE2
+        OjUyOjI1LjY1NjQyNloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBv
         bGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3No
         Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9XX0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:51 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/ddc3341f-b129-4da3-8e84-1cfccfd1056b/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/2f8403ab-4905-46af-b5e3-c807bf6caaa8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -178,9 +178,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:51 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -192,17 +192,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3NDJiZWE3LTNlNmEtNDAw
-        My05YjEzLWFkY2U3NTFlZjNjZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkMDM4NTcyLWRiZmEtNDM5
+        MC1hOWE2LWQzMzc3Y2U3MjYwMS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:51 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -223,9 +223,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:51 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -235,28 +235,27 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '287'
+      - '291'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRvcnlfdmVyc2lvbiI6
-        bnVsbCwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOTo0NTo0OS4yNDYw
-        ODBaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9wdWxwM19Eb2NrZXJfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUi
-        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8x
-        IiwicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29u
-        dGFpbmVyL2NvbnRhaW5lci80NjUxMDJmYS0zNWJkLTQ3NDQtODRiMi1mMzJh
-        OTk1NzkwMzEvIiwicmVnaXN0cnlfcGF0aCI6ImRldmVsLmJhbG1vcmEuZXhh
-        bXBsZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19E
-        b2NrZXJfMSJ9XX0=
+        dHMiOlt7InJlcG9zaXRvcnkiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwiYmFzZV9wYXRoIjoi
+        ZmVkb3JhX2xhYmVsLXB1bHAzX2RvY2tlcl8xIiwicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci84
+        MTZhNjNjMS1kMTg1LTQ0NDUtODdhZS0xZTdmZjAyYWI5NDcvIiwicmVwb3Np
+        dG9yeV92ZXJzaW9uIjpudWxsLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTEx
+        VDE2OjUyOjMzLjIzMTU4N1oiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdp
+        c3RyeV9wYXRoIjoicHVscDMtZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        L2ZlZG9yYV9sYWJlbC1wdWxwM19kb2NrZXJfMSJ9XX0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:51 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/465102fa-35bd-4744-84b2-f32a99579031/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/816a63c1-d185-4445-87ae-1e7ff02ab947/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -277,9 +276,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -291,17 +290,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwMDUzOTI0LTZiMDktNGNh
-        Yy1iOTVjLWU0OWRiYjQ4Mjc3NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2MjFmMzdlLThmM2MtNGU4
+        Yi1iMGUwLTI0MmFhMTk4MjcxMC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -322,9 +321,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -336,17 +335,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -367,9 +366,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:35 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -381,17 +380,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:35 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -412,9 +411,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:36 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -426,17 +425,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:36 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -457,9 +456,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:36 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -471,17 +470,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:36 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/?base_path=Default_Organization/library/pulp3_Docker_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -502,9 +501,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:52 GMT
+      - Wed, 11 Dec 2019 16:52:36 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -516,17 +515,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:52 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:36 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -549,13 +548,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:53 GMT
+      - Wed, 11 Dec 2019 16:52:36 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/"
+      - "/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -565,25 +564,25 @@ http_interactions:
       Content-Length:
       - '446'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
-        aW5lci9jb250YWluZXIvMTkyM2U0ZDQtM2E1Mi00OGJjLWFkMjEtYTI5MWFm
-        NzYxZTQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6NDU6NTMu
-        MDk2Mjg4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTkyM2U0ZDQtM2E1Mi00OGJj
-        LWFkMjEtYTI5MWFmNzYxZTQxL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
+        aW5lci9jb250YWluZXIvZDA4ZTc2OWEtOTdlYy00MzIxLWI1MTctNDM2MWYw
+        NWYyMDUxLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMTFUMTY6NTI6MzYu
+        NzE3NTU1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDA4ZTc2OWEtOTdlYy00MzIx
+        LWI1MTctNDM2MWYwNWYyMDUxL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9u
         X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMTkyM2U0ZDQtM2E1Mi00OGJjLWFkMjEtYTI5MWFmNzYxZTQx
+        b250YWluZXIvZDA4ZTc2OWEtOTdlYy00MzIxLWI1MTctNDM2MWYwNWYyMDUx
         L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
         YmluZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:53 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:36 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/remotes/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/container/container/
     body:
       encoding: UTF-8
       base64_string: |
@@ -610,13 +609,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:53 GMT
+      - Wed, 11 Dec 2019 16:52:36 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/container/container/ef8a8919-c422-4dc9-a1ca-2467343dbace/"
+      - "/pulp/api/v3/remotes/container/container/6ab0e4f5-b721-406c-b8b5-465ec6a17b53/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -626,31 +625,31 @@ http_interactions:
       Content-Length:
       - '469'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
-        Y29udGFpbmVyL2VmOGE4OTE5LWM0MjItNGRjOS1hMWNhLTI0NjczNDNkYmFj
-        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTA5VDE5OjQ1OjUzLjMyNzcz
-        MFoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        Y29udGFpbmVyLzZhYjBlNGY1LWI3MjEtNDA2Yy1iOGI1LTQ2NWVjNmExN2I1
+        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2OjUyOjM2LjkxNjQ2
+        M1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
         M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
         aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
         dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0wOVQxOTo0NTo1
-        My4zMjc3NDZaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
+        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAxOS0xMi0xMVQxNjo1Mjoz
+        Ni45MTY0NzhaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3ki
         OiJpbW1lZGlhdGUiLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIsIndo
         aXRlbGlzdF90YWdzIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:53 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:36 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/sync/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29u
-        dGFpbmVyL2VmOGE4OTE5LWM0MjItNGRjOS1hMWNhLTI0NjczNDNkYmFjZS8i
+        dGFpbmVyLzZhYjBlNGY1LWI3MjEtNDA2Yy1iOGI1LTQ2NWVjNmExN2I1My8i
         LCJtaXJyb3IiOnRydWV9
     headers:
       Content-Type:
@@ -669,9 +668,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:53 GMT
+      - Wed, 11 Dec 2019 16:52:37 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -683,17 +682,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmN2ZmNzYxLTljNGEtNDNk
-        Ni1iNTUzLWJhNTRhMmVmYjcyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiYTYzNjAyLWViMDgtNDFk
+        Ni1iNDcyLTRjOGYxY2I1NGY2NC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:53 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:37 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/1f7ff761-9c4a-43d6-b553-ba54a2efb726/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/2ba63602-eb08-41d6-b472-4c8f1cb54f64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -714,9 +713,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:54 GMT
+      - Wed, 11 Dec 2019 16:52:38 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -726,53 +725,51 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '518'
+      - '500'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWY3ZmY3NjEtOWM0
-        YS00M2Q2LWI1NTMtYmE1NGEyZWZiNzI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTItMDlUMTk6NDU6NTMuNzM0NDY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmJhNjM2MDItZWIw
+        OC00MWQ2LWI0NzItNGM4ZjFjYjU0ZjY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMTFUMTY6NTI6MzcuMjY0Njk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfY29udGFpbmVyLmFwcC50YXNrcy5zeW5jaHJvbml6
-        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTA5VDE5OjQ1
-        OjUzLjgyMzA4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMDlUMTk6NDU6
-        NTQuNDU4NTIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy83NzJhZGYyMS1lYzg0LTQwYjAtODNiMi0zNDNlNDVkMzNl
-        NGUvIiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jl
-        c3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0
-        IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoicHJvY2Vzc2luZy50
-        YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
-        cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9
-        LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNz
-        b2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291
-        cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9j
-        b250YWluZXIvMTkyM2U0ZDQtM2E1Mi00OGJjLWFkMjEtYTI5MWFmNzYxZTQx
-        L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
-        L3B1bHAvYXBpL3YzL3JlbW90ZXMvY29udGFpbmVyL2NvbnRhaW5lci9lZjhh
-        ODkxOS1jNDIyLTRkYzktYTFjYS0yNDY3MzQzZGJhY2UvIiwiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzE5MjNlNGQ0
-        LTNhNTItNDhiYy1hZDIxLWEyOTFhZjc2MWU0MS8iXX0=
+        ZS5zeW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEyLTExVDE2OjUy
+        OjM3LjM5Mjg5NloiLCJmaW5pc2hlZF9hdCI6IjIwMTktMTItMTFUMTY6NTI6
+        MzcuOTI4MzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8xNjQxNzAwNy1iNzhlLTQxN2MtYTU4ZS1hNWE2ODQyYzc4
+        ZjUvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRvd25sb2Fk
+        aW5nIHRhZyBsaXN0IiwiY29kZSI6ImRvd25sb2FkaW5nLnRhZ19saXN0Iiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJjb2RlIjoi
+        cHJvY2Vzc2luZy50YWciLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjox
+        LCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2Fk
+        aW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQi
+        LCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOm51bGwsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH1dLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2NvbnRhaW5lci9jb250YWluZXIvZDA4ZTc2OWEtOTdlYy00MzIxLWI1MTct
+        NDM2MWYwNWYyMDUxL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvY29udGFpbmVyL2Nv
+        bnRhaW5lci82YWIwZTRmNS1iNzIxLTQwNmMtYjhiNS00NjVlYzZhMTdiNTMv
+        IiwiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
+        bmVyL2QwOGU3NjlhLTk3ZWMtNDMyMS1iNTE3LTQzNjFmMDVmMjA1MS8iXX0=
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:54 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:38 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
-        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
-        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIv
-        MTkyM2U0ZDQtM2E1Mi00OGJjLWFkMjEtYTI5MWFmNzYxZTQxL3ZlcnNpb25z
-        LzEvIn0=
+        eyJiYXNlX3BhdGgiOiJmZWRvcmFfbGFiZWwtcHVscDNfZG9ja2VyXzEiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kMDhlNzY5YS05N2VjLTQz
+        MjEtYjUxNy00MzYxZjA1ZjIwNTEvdmVyc2lvbnMvMS8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -790,9 +787,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:54 GMT
+      - Wed, 11 Dec 2019 16:52:38 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -804,17 +801,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmMmM0OTRlLWUwYmMtNGRj
-        NC1iOGVlLThkMmZhNWI3ZTUwNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0MjA2YzVmLTY4ZWUtNDQ3
+        NS1iYmRiLWJmZWVlNDEwZDg0NS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:54 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:38 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/3f2c494e-e0bc-4dc4-b8ee-8d2fa5b7e504/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/f4206c5f-68ee-4475-bbdb-bfeee410d845/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -835,9 +832,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:55 GMT
+      - Wed, 11 Dec 2019 16:52:38 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -847,30 +844,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '341'
+      - '324'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2YyYzQ5NGUtZTBi
-        Yy00ZGM0LWI4ZWUtOGQyZmE1YjdlNTA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MTktMTItMDlUMTk6NDU6NTQuNzk3MDUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjQyMDZjNWYtNjhl
+        ZS00NDc1LWJiZGItYmZlZWU0MTBkODQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTItMTFUMTY6NTI6MzguMjU4NTY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMDlUMTk6NDU6NTQuODk5NzA5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0wOVQxOTo0NTo1NS4xMzI4MDda
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTItMTFUMTY6NTI6MzguMzY4ODI0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMi0xMVQxNjo1MjozOC41NDc1Mzda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzY2YmMyYTE5LWZmZWUtNDc0OC05MTE1LTc2NjJjMWI5YWUwOS8iLCJwYXJl
-        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
-        aWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci83YjJkOTRmZS1hNzE1LTRi
-        NTYtOTMyMC0wNDhkOWZiYjZiZDEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+        LzE2NDE3MDA3LWI3OGUtNDE3Yy1hNThlLWE1YTY4NDJjNzhmNS8iLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
+        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRhaW5lci9hNTFh
+        YTJkYi0yNjRkLTQ1NTAtYjBmNS1jM2EwZmViZTYzYWQvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJd
+        fQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:55 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:38 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/container/container/7b2d94fe-a715-4b56-9320-048d9fbb6bd1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/a51aa2db-264d-4550-b0f5-c3a0febe63ad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -891,9 +888,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:55 GMT
+      - Wed, 11 Dec 2019 16:52:38 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -903,29 +900,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '297'
+      - '300'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvMTky
-        M2U0ZDQtM2E1Mi00OGJjLWFkMjEtYTI5MWFmNzYxZTQxL3ZlcnNpb25zLzEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMi0wOVQxOTo0NTo1NS4xMjA1MDla
-        IiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
-        dWxwM19Eb2NrZXJfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFp
-        bmVyL2NvbnRhaW5lci83YjJkOTRmZS1hNzE1LTRiNTYtOTMyMC0wNDhkOWZi
-        YjZiZDEvIiwicmVnaXN0cnlfcGF0aCI6ImRldmVsLmJhbG1vcmEuZXhhbXBs
-        ZS5jb20vRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19Eb2Nr
-        ZXJfMSJ9
+        eyJyZXBvc2l0b3J5IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImJhc2VfcGF0aCI6ImZlZG9y
+        YV9sYWJlbC1wdWxwM19kb2NrZXJfMSIsInB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9kaXN0cmlidXRpb25zL2NvbnRhaW5lci9jb250YWluZXIvYTUxYWEy
+        ZGItMjY0ZC00NTUwLWIwZjUtYzNhMGZlYmU2M2FkLyIsInJlcG9zaXRvcnlf
+        dmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVy
+        L2NvbnRhaW5lci9kMDhlNzY5YS05N2VjLTQzMjEtYjUxNy00MzYxZjA1ZjIw
+        NTEvdmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2
+        OjUyOjM4LjUzODE1M1oiLCJjb250ZW50X2d1YXJkIjpudWxsLCJyZWdpc3Ry
+        eV9wYXRoIjoicHVscDMtZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL2Zl
+        ZG9yYV9sYWJlbC1wdWxwM19kb2NrZXJfMSJ9
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:55 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:38 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -946,9 +942,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:55 GMT
+      - Wed, 11 Dec 2019 16:52:39 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -960,17 +956,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:55 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:39 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -991,9 +987,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:55 GMT
+      - Wed, 11 Dec 2019 16:52:39 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1003,7 +999,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
       - '454'
     body:
@@ -1011,27 +1007,27 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9tYW5pZmVzdHMvODYxMzlmZDEtNjE2Yy00OTU2LWI2ZDQtMTU3OTg5
-        NDRiZjQyLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMDlUMTk6MjQ6MzMu
-        Nzg0ODEzWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80
-        Zjg3ZTUwYi1kZmM3LTQ4N2MtYjg3ZS1mN2E3OGM5ODIwMGEvIiwiZGlnZXN0
+        aW5lci9tYW5pZmVzdHMvMWNkN2Q3MjgtODMwNi00ZmMyLTllNzYtMzc4MDMy
+        YWIwM2UwLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTItMTFUMTY6NTI6MzIu
+        MzE5MDM3WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8z
+        ZGE1ODdmZS1iNWQ3LTQxMzYtYTg1Mi1kNmMwZTNmYWRlOTAvIiwiZGlnZXN0
         Ijoic2hhMjU2OmE2ZWNiYjE1NTMzNTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVk
         MWJkNmQ5ZDg0NzQzYzdlOGU3NDY4ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lv
         biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
         dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
         IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250
-        YWluZXIvYmxvYnMvNGY4M2JjMzItN2ZjZC00OGViLThjY2EtMmE3ZTJjNmUy
-        MWYwLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
-        ci9ibG9icy9hOTViNzZjOC0xZTY3LTQzNDQtOGFlNi0zZDA3YmMyZjJmODEv
-        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzLzBjYzQx
-        Y2M4LWFhMDctNDdjNy1hYzk4LWFkMDM4YmZmMDM2Ny8iLCIvcHVscC9hcGkv
-        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvNmY3NzllMDgtOWNlMi00OTJh
-        LTkxYTYtMTI0ZmM3MTkwYzhmLyJdfV19
+        YWluZXIvYmxvYnMvNjk1MjNhMjAtNzdiZi00MzYzLTg1YTktZDczMmNmZGI1
+        NzBmLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5l
+        ci9ibG9icy9iNmE3YTY2NS0yNmY5LTRmZDAtOTI5Zi0yYWYwYWEwZDVkODgv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL2Jsb2JzL2Y4NmUw
+        ZDA5LTllYWUtNDNjOC1iYTNmLTc2ZDc4ODdmYmY5OS8iLCIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvYmxvYnMvNDQwZjZkZmQtMmNlMS00NTk3
+        LTgzMjItOTdlMzUwN2IwNzBmLyJdfV19
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:55 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:39 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/manifests/?limit=2000&media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,9 +1048,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:56 GMT
+      - Wed, 11 Dec 2019 16:52:39 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1066,17 +1062,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:56 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:39 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/1923e4d4-3a52-48bc-ad21-a291af761e41/versions/1/
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/content/container/tags/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/container/container/d08e769a-97ec-4321-b517-4361f05f2051/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1097,9 +1093,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Dec 2019 19:45:56 GMT
+      - Wed, 11 Dec 2019 16:52:39 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1109,21 +1105,21 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 pulp3-devel-2.cannolo.example.com
       Content-Length:
-      - '257'
+      - '258'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci90YWdzL2NhYmFiOWNhLWZjOWMtNDE3Ny1iMDQ3LTY0ZGRiM2VlZWVk
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTA5VDE5OjI0OjMzLjc4NjQy
-        MVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNGY4N2U1
-        MGItZGZjNy00ODdjLWI4N2UtZjdhNzhjOTgyMDBhLyIsIm5hbWUiOiJsYXRl
+        aW5lci90YWdzL2E5YWY2Nzc5LTQxNzItNGFiNC05YWY3LTdjNjY1NzUyZmYx
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEyLTExVDE2OjUyOjMyLjMyMTk0
+        NFoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvM2RhNTg3
+        ZmUtYjVkNy00MTM2LWE4NTItZDZjMGUzZmFkZTkwLyIsIm5hbWUiOiJsYXRl
         c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9j
-        b250YWluZXIvbWFuaWZlc3RzLzg2MTM5ZmQxLTYxNmMtNDk1Ni1iNmQ0LTE1
-        Nzk4OTQ0YmY0Mi8ifV19
+        b250YWluZXIvbWFuaWZlc3RzLzFjZDdkNzI4LTgzMDYtNGZjMi05ZTc2LTM3
+        ODAzMmFiMDNlMC8ifV19
     http_version: 
-  recorded_at: Mon, 09 Dec 2019 19:45:56 GMT
+  recorded_at: Wed, 11 Dec 2019 16:52:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/repository/docker/distribution_test.rb
+++ b/test/services/katello/pulp3/repository/docker/distribution_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class DistributionTest < ::ActiveSupport::TestCase
+        include RepositorySupport
+
+        def setup
+          @mock_pulp3_api = mock('pulp3_api')
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @mock_smart_proxy.stubs(:pulp_master?).returns(true)
+          @docker_repo = katello_repositories(:pulp3_docker_1)
+          @docker_repo.stubs(:container_repository_name).returns("a repo name")
+          @docker_repo_service = @docker_repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_distribution_options_path
+          assert_equal @docker_repo_service.distribution_options(@docker_repo_service.relative_path)[:base_path], "a repo name"
+        end
+
+        def teardown
+          mocha_teardown
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is needed to make mirror syncing work for Docker repositories that have custom naming enabled in the environment.

Note, this is a Pulp 3 bug.

To test:
1) Sync some Docker repo.
2) Make a lifecycle environment and set the "Registry Name Pattern" to something like `<%= organization.label %>-<%= repository.docker_upstream_name%>AaBbCc`.
3) Create a content view and add the Docker repo.  
4) Publish and promote the content view to your lifecycle environment.
5) Point a mirror/capsule/smart proxy with content to your lifecycle environment and sync it.

The smart proxy sync should happen without any issues.