### PR TITLE
Fixes #28250 - refactor pulp3 service classes

### DIFF
--- a/app/lib/actions/katello/repository/refresh_repository.rb
+++ b/app/lib/actions/katello/repository/refresh_repository.rb
@@ -2,10 +2,13 @@ module Actions
   module Katello
     module Repository
       class RefreshRepository < Actions::Base
+        include Actions::Katello::PulpSelector
+
         def plan(repo, options = {})
           User.as_anonymous_admin do
             repo = ::Katello::Repository.find(repo.id)
-            plan_action(Pulp::Repository::Refresh, repo, :capsule_id => SmartProxy.default_capsule!.id, :dependency => options[:dependency])
+            plan_pulp_action([Actions::Pulp::Orchestration::Repository::RefreshIfNeeded],
+                             repo, SmartProxy.default_capsule!, :dependency => options[:dependency])
             plan_self(:name => repo.name, :dependency => options[:dependency])
           end
         end

--- a/app/lib/actions/pulp/orchestration/repository/refresh_if_needed.rb
+++ b/app/lib/actions/pulp/orchestration/repository/refresh_if_needed.rb
@@ -3,7 +3,7 @@ module Actions
     module Orchestration
       module Repository
         class RefreshIfNeeded < Pulp::Abstract
-          def plan(repository, smart_proxy)
+          def plan(repository, smart_proxy, _options = {})
             plan_action(Actions::Pulp::Repository::Refresh, repository, smart_proxy_id: smart_proxy.id)
           end
         end

--- a/app/lib/actions/pulp3/abstract_async_task.rb
+++ b/app/lib/actions/pulp3/abstract_async_task.rb
@@ -121,8 +121,7 @@ module Actions
       end
 
       def tasks_api
-        api_client = PulpcoreClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpcoreClient::Configuration))
-        PulpcoreClient::TasksApi.new(api_client)
+        ::Katello::Pulp3::Api::Core.new(smart_proxy).tasks_api
       end
 
       def poll_external_task

--- a/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
+++ b/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
@@ -24,7 +24,7 @@ module Actions
         def invoke_external_task
           repository = ::Katello::Repository.find(input[:repository_id])
           smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
-          output[:response] = repository.backend_service(smart_proxy).create_mirror_publication
+          output[:response] = repository.backend_service(smart_proxy).with_mirror_adapter.create_publication
         end
       end
     end

--- a/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
+++ b/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
@@ -17,11 +17,11 @@ module Actions
           tasks = options[:tasks]
           repo = ::Katello::Repository.find(input[:repository_id])
           if options[:use_repository_version]
-            output[:response] = repo.backend_service(smart_proxy).refresh_mirror_distributions(:use_repository_version => true)
+            output[:response] = repo.backend_service(smart_proxy).with_mirror_adapter.refresh_distributions(:use_repository_version => true)
           elsif tasks && tasks[:pulp_tasks] && tasks[:pulp_tasks].first
             publication_href = tasks[:pulp_tasks].first[:created_resources].first
             if publication_href
-              output[:response] = repo.backend_service(smart_proxy).refresh_mirror_distributions(:publication => publication_href)
+              output[:response] = repo.backend_service(smart_proxy).with_mirror_adapter.refresh_distributions(:publication => publication_href)
             end
           end
         end

--- a/app/lib/actions/pulp3/capsule_content/sync.rb
+++ b/app/lib/actions/pulp3/capsule_content/sync.rb
@@ -11,7 +11,7 @@ module Actions
 
         def invoke_external_task
           repo = ::Katello::Repository.find(input[:repository_id])
-          output[:pulp_tasks] = repo.backend_service(::SmartProxy.unscoped.find(input[:smart_proxy_id])).sync_mirror
+          output[:pulp_tasks] = repo.backend_service(smart_proxy).with_mirror_adapter.sync
         end
 
         def rescue_strategy_for_self

--- a/app/lib/actions/pulp3/orchestration/repository/refresh_repos.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/refresh_repos.rb
@@ -11,7 +11,7 @@ module Actions
             param :repository_id
           end
           def fetch_proxy_service(smart_proxy)
-            ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
+            ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy)
           end
 
           def act_on_repo?(repo, smart_proxy)

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_distributions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_distributions.rb
@@ -7,8 +7,8 @@ module Actions
         end
 
         def invoke_external_task
-          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
-          smart_proxy_service.delete_orphaned_distributions_for_mirror_proxies
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy)
+          smart_proxy_service.delete_orphan_distributions
         end
       end
     end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_remotes.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_remotes.rb
@@ -7,8 +7,8 @@ module Actions
         end
 
         def invoke_external_task
-          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
-          smart_proxy_service.delete_orphaned_remotes_for_mirror_proxies
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy)
+          smart_proxy_service.delete_orphan_remotes
         end
       end
     end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
@@ -7,12 +7,7 @@ module Actions
         end
 
         def run
-          smart_proxy = SmartProxy.find(input[:smart_proxy_id])
-          if smart_proxy.pulp_mirror?
-            output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions_for_mirror(smart_proxy)
-          else
-            output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions(smart_proxy)
-          end
+          output[:pulp_tasks] = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy).delete_orphan_repository_versions
         end
       end
     end

--- a/app/lib/actions/pulp3/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/remove_orphans.rb
@@ -7,8 +7,7 @@ module Actions
         end
 
         def invoke_external_task
-          smart_proxy = SmartProxy.find(input[:smart_proxy_id])
-          output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphans(smart_proxy)
+          output[:pulp_tasks] = ::Katello::Pulp3::Api::Core.new(smart_proxy).delete_orphans
         end
       end
     end

--- a/app/lib/actions/pulp3/orphan_cleanup/remove_unneeded_repos.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/remove_unneeded_repos.rb
@@ -7,8 +7,8 @@ module Actions
         end
 
         def invoke_external_task
-          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
-          smart_proxy_service.delete_orphaned_repositories_for_mirror_proxies
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy)
+          smart_proxy_service.delete_orphan_repositories
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/create.rb
+++ b/app/lib/actions/pulp3/repository/create.rb
@@ -8,7 +8,7 @@ module Actions
 
         def run
           repo = ::Katello::Repository.find(input[:repository_id])
-          output[:response] = repo.backend_service(smart_proxy).create
+          output[:response] = repo.backend_service(smart_proxy).with_mirror_adapter.create
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/create_publication.rb
+++ b/app/lib/actions/pulp3/repository/create_publication.rb
@@ -12,7 +12,7 @@ module Actions
 
         def invoke_external_task
           repository = ::Katello::Repository.find(input[:repository_id])
-          output[:response] = repository.backend_service(smart_proxy).create_publication
+          output[:response] = repository.backend_service(smart_proxy).with_mirror_adapter.create_publication
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/create_version.rb
+++ b/app/lib/actions/pulp3/repository/create_version.rb
@@ -11,7 +11,7 @@ module Actions
 
         def invoke_external_task
           repo = ::Katello::Repository.find(input[:repository_id])
-          output[:response] = repo.backend_service(smart_proxy).create_version
+          output[:response] = repo.backend_service(smart_proxy).with_mirror_adapter.create_version
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/refresh_distribution.rb
+++ b/app/lib/actions/pulp3/repository/refresh_distribution.rb
@@ -15,7 +15,7 @@ module Actions
 
         def invoke_external_task
           repo = ::Katello::Repository.find(input[:repository_id])
-          output[:response] = repo.backend_service(smart_proxy).refresh_distributions
+          output[:response] = repo.backend_service(smart_proxy).with_mirror_adapter.refresh_distributions
         end
       end
     end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -217,7 +217,7 @@ module Katello
       end
 
       def refresh_mirror_entities
-        refresh
+        refresh_if_needed
       end
 
       def update_or_associate_importer

--- a/app/services/katello/pulp3/ansible_collection.rb
+++ b/app/services/katello/pulp3/ansible_collection.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       def self.content_api
-        PulpAnsibleClient::ContentCollectionVersionsApi.new(Katello::Pulp3::Repository::AnsibleCollection.api_client(SmartProxy.pulp_master!))
+        PulpAnsibleClient::ContentCollectionVersionsApi.new(Katello::Pulp3::Api::AnsibleCollection.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.ids_for_repository(repo_id)

--- a/app/services/katello/pulp3/api/ansible_collection.rb
+++ b/app/services/katello/pulp3/api/ansible_collection.rb
@@ -1,0 +1,38 @@
+require "pulpcore_client"
+# rubocop:disable ClassLength
+
+module Katello
+  module Pulp3
+    module Api
+      class AnsibleCollection < Core
+        def self.api_exception_class
+          PulpAnsibleClient::ApiError
+        end
+
+        def self.client_module
+          PulpAnsibleClient
+        end
+
+        def self.remote_class
+          PulpAnsibleClient::AnsibleCollectionRemote
+        end
+
+        def self.distribution_class
+          PulpAnsibleClient::AnsibleAnsibleDistribution
+        end
+
+        def api_client
+          PulpAnsibleClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpAnsibleClient::Configuration))
+        end
+
+        def remotes_api
+          PulpAnsibleClient::RemotesCollectionApi.new(api_client)
+        end
+
+        def distributions_api
+          PulpAnsibleClient::DistributionsAnsibleApi.new(api_client)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -1,0 +1,159 @@
+require "pulpcore_client"
+# rubocop:disable ClassLength
+
+module Katello
+  module Pulp3
+    module Api
+      class Core
+        attr_accessor :smart_proxy
+
+        def initialize(smart_proxy)
+          @smart_proxy = smart_proxy
+        end
+
+        def self.api_exception_class
+          fail NotImplementedError
+        end
+
+        def self.client_module
+          fail NotImplementedError
+        end
+
+        def self.remote_class
+          fail NotImplementedError
+        end
+
+        def self.distribution_class
+          fail NotImplementedError
+        end
+
+        def self.publication_class
+          fail NotImplementedError
+        end
+
+        def api_client
+          fail NotImplementedError
+        end
+
+        def remotes_api
+          fail NotImplementedError
+        end
+
+        def publications_api
+          fail NotImplementedError #Optional
+        end
+
+        def distributions_api
+          fail NotImplementedError
+        end
+
+        def orphans_api
+          PulpcoreClient::OrphansApi.new(core_api_client)
+        end
+
+        def core_api_client
+          PulpcoreClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpcoreClient::Configuration))
+        end
+
+        def repositories_api
+          PulpcoreClient::RepositoriesApi.new(core_api_client)
+        end
+
+        def repository_versions_api
+          PulpcoreClient::RepositoriesVersionsApi.new(core_api_client)
+        end
+
+        def uploads_api
+          PulpcoreClient::UploadsApi.new(core_api_client)
+        end
+
+        def tasks_api
+          PulpcoreClient::TasksApi.new(core_api_client)
+        end
+
+        def upload_class
+          PulpcoreClient::Upload
+        end
+
+        def delete_orphans
+          [orphans_api.delete]
+        end
+
+        def delete_remote(remote_href)
+          remotes_api.delete(remote_href)
+        end
+
+        def repository_versions(options = {})
+          current_pulp_repositories = self.list_all(options)
+          repo_hrefs = current_pulp_repositories.collect { |repo| repo.pulp_href }.uniq
+
+          version_hrefs = repo_hrefs.collect do |href|
+            versions_list_for_repository(href, options).map(&:pulp_href)
+          end
+
+          version_hrefs.flatten.uniq
+        end
+
+        def versions_list_for_repository(repository_href, options)
+          self.class.fetch_from_list { |page_opts| repository_versions_api.list(repository_href, page_opts.merge(options)) }
+        end
+
+        def distributions_list_all(args = {})
+          self.class.fetch_from_list do |page_opts|
+            distributions_api.list(page_opts.merge(args))
+          end
+        end
+
+        def get_distribution(href)
+          distributions_api.read(href)
+        rescue self.class.api_exception_class => e
+          raise e if e.code != 404
+          nil
+        end
+
+        def delete_distribution(href)
+          distributions_api.delete(href)
+        rescue self.class.api_exception_class => e
+          raise e if e.code != 404
+          nil
+        end
+
+        def list_all(options = {})
+          self.class.fetch_from_list do |page_opts|
+            repositories_api.list(page_opts.merge(options))
+          end
+        end
+
+        def remotes_list(args = {})
+          remotes_api.list(args).results
+        end
+
+        def remotes_list_all(_smart_proxy, options)
+          self.class.fetch_from_list do |page_opts|
+            remotes_api.list(page_opts.merge(options))
+          end
+        end
+
+        def self.fetch_from_list
+          page_size = SETTINGS[:katello][:pulp][:bulk_load_size]
+          page_opts = { "offset" => 0, limit: page_size }
+          response = {}
+
+          results = []
+
+          loop do
+            page_opts = page_opts.with_indifferent_access
+            break unless (
+            (response.count && (page_opts['offset'] < response.count)) ||
+                page_opts["offset"] == 0)
+            response = yield page_opts
+            results = results.concat(response.results)
+            page_opts[:offset] += page_size
+          end
+
+          results
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/docker.rb
+++ b/app/services/katello/pulp3/api/docker.rb
@@ -1,0 +1,54 @@
+require "pulpcore_client"
+# rubocop:disable ClassLength
+
+module Katello
+  module Pulp3
+    module Api
+      class Docker < Core
+        def self.api_exception_class
+          PulpDockerClient::ApiError
+        end
+
+        def self.client_module
+          PulpDockerClient
+        end
+
+        def self.remote_class
+          PulpDockerClient::DockerDockerRemote
+        end
+
+        def self.distribution_class
+          PulpDockerClient::DockerDockerDistribution
+        end
+
+        def self.publication_class
+          PulpDockerClient::DockerPublication
+        end
+
+        def self.recursive_manage_class
+          PulpDockerClient::RecursiveManage
+        end
+
+        def api_client
+          PulpDockerClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpDockerClient::Configuration))
+        end
+
+        def remotes_api
+          PulpDockerClient::RemotesDockerApi.new(api_client)
+        end
+
+        def publications_api
+          PulpDockerClient::PublicationsDockerApi.new(api_client)
+        end
+
+        def distributions_api
+          PulpDockerClient::DistributionsDockerApi.new(api_client)
+        end
+
+        def recursive_add_api
+          PulpDockerClient::DockerRecursiveAddApi.new(api_client)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/file.rb
+++ b/app/services/katello/pulp3/api/file.rb
@@ -1,0 +1,46 @@
+require "pulpcore_client"
+# rubocop:disable ClassLength
+
+module Katello
+  module Pulp3
+    module Api
+      class File < Core
+        def self.api_exception_class
+          PulpFileClient::ApiError
+        end
+
+        def self.client_module
+          PulpFileClient
+        end
+
+        def self.remote_class
+          PulpFileClient::FileFileRemote
+        end
+
+        def self.distribution_class
+          PulpFileClient::FileFileDistribution
+        end
+
+        def self.publication_class
+          PulpFileClient::FileFilePublication
+        end
+
+        def api_client
+          PulpFileClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpFileClient::Configuration))
+        end
+
+        def remotes_api
+          PulpFileClient::RemotesFileApi.new(api_client)
+        end
+
+        def publications_api
+          PulpFileClient::PublicationsFileApi.new(api_client)
+        end
+
+        def distributions_api
+          PulpFileClient::DistributionsFileApi.new(api_client)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/yum.rb
+++ b/app/services/katello/pulp3/api/yum.rb
@@ -1,0 +1,46 @@
+require "pulpcore_client"
+# rubocop:disable ClassLength
+
+module Katello
+  module Pulp3
+    module Api
+      class Yum < Core
+        def self.api_exception_class
+          PulpRpmClient::ApiError
+        end
+
+        def self.client_module
+          PulpRpmClient
+        end
+
+        def self.remote_class
+          PulpRpmClient::RpmRpmRemote
+        end
+
+        def self.distribution_class
+          PulpRpmClient::RpmRpmDistribution
+        end
+
+        def self.publication_class
+          PulpRpmClient::RpmRpmPublication
+        end
+
+        def api_client
+          PulpRpmClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpRpmClient::Configuration))
+        end
+
+        def remotes_api
+          PulpRpmClient::RemotesRpmApi.new(api_client)
+        end
+
+        def publications_api
+          PulpRpmClient::PublicationsRpmApi.new(api_client)
+        end
+
+        def distributions_api
+          PulpRpmClient::DistributionsRpmApi.new(api_client)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/docker_blob.rb
+++ b/app/services/katello/pulp3/docker_blob.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       def self.content_api
-        PulpDockerClient::ContentBlobsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+        PulpDockerClient::ContentBlobsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.ids_for_repository(repo_id)

--- a/app/services/katello/pulp3/docker_manifest.rb
+++ b/app/services/katello/pulp3/docker_manifest.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       def self.content_api
-        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.ids_for_repository(repo_id)

--- a/app/services/katello/pulp3/docker_manifest_list.rb
+++ b/app/services/katello/pulp3/docker_manifest_list.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       def self.content_api
-        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.ids_for_repository(repo_id)

--- a/app/services/katello/pulp3/docker_tag.rb
+++ b/app/services/katello/pulp3/docker_tag.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       def self.content_api
-        PulpDockerClient::ContentTagsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+        PulpDockerClient::ContentTagsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.ids_for_repository(repo_id)

--- a/app/services/katello/pulp3/file_unit.rb
+++ b/app/services/katello/pulp3/file_unit.rb
@@ -5,7 +5,7 @@ module Katello
       CONTENT_TYPE = "file".freeze
 
       def self.content_api
-        PulpFileClient::ContentFilesApi.new(Katello::Pulp3::Repository::File.api_client(SmartProxy.pulp_master!))
+        PulpFileClient::ContentFilesApi.new(Katello::Pulp3::Api::File.new(SmartProxy.pulp_master!).api_client)
       end
 
       def self.create_content(options)

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -6,7 +6,7 @@ module Katello
     class Repository
       include Katello::Util::HttpProxy
 
-      attr_accessor :repo, :input
+      attr_accessor :repo
       attr_accessor :smart_proxy
       delegate :root, to: :repo
       delegate :pulp3_api, to: :smart_proxy
@@ -18,80 +18,38 @@ module Katello
         @smart_proxy = smart_proxy
       end
 
-      def api_exception_class
-        self.class.api_exception_class
-      end
-
-      def remote_class
+      def partial_repo_path
         fail NotImplementedError
       end
 
-      def publications_api
-        fail NotImplementedError
+      def with_mirror_adapter
+        if smart_proxy.pulp_master?
+          return self
+        else
+          return RepositoryMirror.new(self)
+        end
       end
 
-      def publication_class
-        fail NotImplementedError
+      def self.api(smart_proxy)
+        api_class = RepositoryTypeManager.find_by(:pulp3_service_class, self).pulp3_api_class
+        api_class ? api_class.new(smart_proxy) : Katello::Pulp3::Api::Core.new(smart_proxy)
       end
 
-      def distribution_class
-        fail NotImplementedError
+      def core_api
+        Katello::Pulp3::Api::Core.new(smart_proxy)
       end
 
-      def distributions_api_class
-        fail NotImplementedError
-      end
-
-      def distribution_options
-        fail NotImplementedError
-      end
-
-      def remote_options
-        fail NotImplementedError
+      def api
+        @api ||= self.class.api(smart_proxy)
       end
 
       def content_service
         Katello::Pulp3::Content
       end
 
-      def self.api_client(_smart_proxy)
-        fail NotImplementedError
-      end
-
-      def api_client
-        self.class.api_client(smart_proxy)
-      end
-
-      def self.orphans_api(smart_proxy)
-        PulpcoreClient::OrphansApi.new(core_api_client(smart_proxy))
-      end
-
-      def self.delete_orphans(smart_proxy)
-        [orphans_api(smart_proxy).delete]
-      end
-
-      def distribution_mirror_options(path, options = {})
-        ret = {
-          base_path: path,
-          name: "#{backend_object_name}"
-        }
-        ret[:publication] = options[:publication] if options.key? :publication
-        ret[:repository_version] = options[:repository_version] if options.key? :repository_version
-        ret
-      end
-
-      def mirror_remote_options
-        common_mirror_remote_options.merge(url: mirror_remote_feed_url)
-      end
-
-      def create_mirror_remote
-        remote_file_data = remote_class.new(mirror_remote_options)
-        remotes_api.create(remote_file_data)
-      end
-
       def create_remote
-        remote_file_data = remote_class.new(remote_options)
-        response = remotes_api.create(remote_file_data)
+        remote_file_data = api.class.remote_class.new(remote_options)
+        response = api.remotes_api.create(remote_file_data)
         repo.update_attributes!(:remote_href => response.pulp_href)
       end
 
@@ -111,72 +69,12 @@ module Katello
         end
       end
 
-      def self.remotes_list(smart_proxy, options)
-        fetch_from_list do |page_opts|
-          remotes_api(smart_proxy).list(page_opts.merge(options))
-        end
-      end
-
       def remote_partial_update
-        remotes_api.partial_update(repo.remote_href, remote_options)
+        api.remotes_api.partial_update(repo.remote_href, remote_options)
       end
 
       def delete_remote(href = repo.remote_href)
-        remotes_api.delete(href) if href
-      end
-
-      def self.delete_remote(smart_proxy, href)
-        remotes_api(smart_proxy).delete(href) if href
-      end
-
-      def remotes_list(args)
-        remotes_api.list(args).results
-      end
-
-      def self.delete_orphan_remotes(smart_proxy, repo_types = pulp3_enabled_repo_types(smart_proxy))
-        tasks = []
-        repo_types.each do |repo_type|
-          pulp3_class = repo_type.pulp3_service_class
-          remotes = pulp3_class.remotes_list(smart_proxy, {})
-          repos_on_capsule = ::Katello::Pulp3::Repository.list(smart_proxy)
-          capsule_repo_names = repos_on_capsule.collect { |repo| repo['name'] }
-          remotes.each do |remote|
-            tasks << pulp3_class.delete_remote(smart_proxy, remote['pulp_href']) unless capsule_repo_names.include?(remote['name'])
-          end
-        end
-        tasks
-      end
-
-      def self.core_api_client(smart_proxy)
-        PulpcoreClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpcoreClient::Configuration))
-      end
-
-      def core_api_client
-        self.class.core_api_client(smart_proxy)
-      end
-
-      def repositories_api
-        PulpcoreClient::RepositoriesApi.new(core_api_client)
-      end
-
-      def repository_versions_api
-        PulpcoreClient::RepositoriesVersionsApi.new(core_api_client)
-      end
-
-      def uploads_api
-        PulpcoreClient::UploadsApi.new(core_api_client)
-      end
-
-      def upload_class
-        PulpcoreClient::Upload
-      end
-
-      def distributions_api
-        self.class.distributions_api(smart_proxy)
-      end
-
-      def remotes_api
-        self.class.remotes_api(smart_proxy)
+        api.remotes_api.delete(href) if href
       end
 
       def self.instance_for_type(repo, smart_proxy)
@@ -187,13 +85,8 @@ module Katello
         false
       end
 
-      def backend_object_name
-        if @smart_proxy.pulp_master?
-          "#{root.label}-#{repo.id}#{rand(9999)}"
-        else
-          # this is a capsule. Create repos in pulp3 instance with the name as this repo's pulp_id
-          repo.pulp_id
-        end
+      def generate_backend_object_name
+        "#{root.label}-#{repo.id}#{rand(9999)}"
       end
 
       def repository_reference
@@ -204,44 +97,22 @@ module Katello
         DistributionReference.find_by(:path => path)
       end
 
+      def create_mirror_entities
+        RepositoryMirror.new(self).create_entities
+      end
+
       def refresh_mirror_entities
-        href = mirror_remote_href
-        if href
-          [remotes_api.partial_update(href, mirror_remote_options)]
-        else
-          create_mirror_remote
-          []
-        end
+        RepositoryMirror.new(self).refresh_entities
       end
 
       def mirror_needs_updates?
-        remote = fetch_remote
-        return true if remote.blank?
-        options = compute_mirror_remote_options
-        options.keys.any? { |key| remote.send(key) != options[key] }
-      end
-
-      def compute_mirror_remote_options
-        computed_options = mirror_remote_options
-        [:ssl_client_certificate, :ssl_client_key, :ssl_ca_certificate].each do |key|
-          computed_options[key] = Digest::SHA256.hexdigest(computed_options[key].chomp)
-        end
-        computed_options
-      end
-
-      def create_mirror_entities
-        create_mirror
-        create_mirror_remote unless mirror_remote_href
-      end
-
-      def create_mirror
-        repositories_api.create(name: backend_object_name)
+        RepositoryMirror.new(self).needs_updates?
       end
 
       def create
         unless repository_reference
-          response = repositories_api.create(
-            name: backend_object_name)
+          response = core_api.repositories_api.create(
+            name: generate_backend_object_name)
           RepositoryReference.create!(
            root_repository_id: repo.root_id,
            content_view_id: repo.content_view.id,
@@ -250,153 +121,31 @@ module Katello
         end
       end
 
-      def update_mirror
-        repositories_api.update(mirror_repository_href, name: backend_object_name)
-      end
-
       def update
-        repositories_api.update(repository_reference.try(:repository_href), name: backend_object_name)
+        api.repositories_api.update(repository_reference.try(:repository_href), name: generate_backend_object_name)
       end
 
       def list(options)
-        repositories_api.list(options).results
-      end
-
-      def self.versions_list(smart_proxy, href, options)
-        repository_versions_api = ::Katello::Pulp3::Repository.new(nil, smart_proxy).repository_versions_api
-        fetch_from_list { |page_opts| repository_versions_api.list(href, page_opts.merge(options)) }
-      end
-
-      def self.list(smart_proxy, options = {})
-        repositories_api = ::Katello::Pulp3::Repository.new(nil, smart_proxy).repositories_api
-        fetch_from_list do |page_opts|
-          repositories_api.list(page_opts.merge(options))
-        end
-      end
-
-      def self.fetch_from_list
-        page_size = SETTINGS[:katello][:pulp][:bulk_load_size]
-        page_opts = { "offset" => 0, limit: page_size }
-        response = {}
-
-        results = []
-
-        loop do
-          page_opts = page_opts.with_indifferent_access
-          break unless (
-            (response["count"] && (page_opts["offset"] < response["count"])) ||
-            page_opts["offset"] == 0)
-          response = yield page_opts
-          response = response.as_json.with_indifferent_access
-          results = results.concat(response[:results])
-          page_opts[:offset] += page_size
-        end
-
-        results
-      end
-
-      def self.repository_versions(smart_proxy, options)
-        current_pulp_repositories = ::Katello::Pulp3::Repository.list(smart_proxy, options)
-        repo_hrefs = current_pulp_repositories.collect { |repo| repo[:pulp_href] }.uniq
-
-        version_hrefs = repo_hrefs.collect do |href|
-          ::Katello::Pulp3::Repository.versions_list(smart_proxy, href, options).pluck(:pulp_href)
-        end
-
-        version_hrefs.flatten.uniq
-      end
-
-      def self.orphan_repository_versions(smart_proxy)
-        version_hrefs = repository_versions(smart_proxy, {})
-
-        version_hrefs - ::Katello::Repository.where(version_href: version_hrefs).pluck(:version_href)
-      end
-
-      def self.delete_orphan_repository_versions(smart_proxy)
-        orphans = orphan_repository_versions(smart_proxy)
-        orphans.collect do |href|
-          ::Katello::Pulp3::Repository.new(nil, smart_proxy).
-            repository_versions_api.delete(href)
-        end
-      end
-
-      def self.orphan_repository_versions_for_mirror(smart_proxy)
-        current_pulp_repositories = ::Katello::Pulp3::Repository.list(smart_proxy, {})
-
-        orphan_version_hrefs = current_pulp_repositories.collect do |pulp_repo|
-          mirror_repo_versions = ::Katello::Pulp3::Repository.versions_list(
-            smart_proxy, pulp_repo['pulp_href'], ordering: :_created).pluck(:pulp_href)
-
-          mirror_repo_versions - [pulp_repo['latest_version_href']]
-        end
-
-        orphan_version_hrefs.flatten
-      end
-
-      def self.delete_orphan_repository_versions_for_mirror(smart_proxy)
-        orphans = orphan_repository_versions_for_mirror(smart_proxy)
-        orphans.collect do |href|
-          ::Katello::Pulp3::Repository.new(nil, smart_proxy).
-            repository_versions_api.delete(href)
-        end
-      end
-
-      def delete_mirror(href = mirror_repository_href)
-        repositories_api.delete(href) if href
+        api.repositories_api.list(options).results
       end
 
       def delete(href = repository_reference.try(:repository_href))
         repository_reference.try(:destroy)
-        repositories_api.delete(href) if href
-      end
-
-      def sync_mirror
-        repository_sync_url_data = client_class::RepositorySyncURL.new(repository: mirror_repository_href, mirror: true)
-        [remotes_api.sync(mirror_remote_href, repository_sync_url_data)]
+        api.repositories_api.delete(href) if href
       end
 
       def sync
-        repository_sync_url_data = client_class::RepositorySyncURL.new(repository: repository_reference.repository_href, mirror: repo.root.mirror_on_sync)
-        [remotes_api.sync(repo.remote_href, repository_sync_url_data)]
-      end
-
-      def mirror_version_href
-        repository = fetch_repository
-        repository.latest_version_href
+        repository_sync_url_data = api.class.client_module::RepositorySyncURL.new(repository: repository_reference.repository_href, mirror: repo.root.mirror_on_sync)
+        [api.remotes_api.sync(repo.remote_href, repository_sync_url_data)]
       end
 
       def create_publication
-        publication_data = publication_class.new(repository_version: repo.version_href)
-        publications_api.create(publication_data)
-      end
-
-      def create_mirror_publication
-        href = mirror_version_href
-        if href
-          publication_data = publication_class.new(repository_version: href)
-          publications_api.create(publication_data)
-        end
+        publication_data = api.class.publication_class.new(repository_version: repo.version_href)
+        api.publications_api.create(publication_data)
       end
 
       def relative_path
         repo.relative_path.sub(/^\//, '')
-      end
-
-      def refresh_mirror_distributions(options = {})
-        path = relative_path
-        dist_params = {}
-        dist_params[:publication] = options[:publication] if options[:publication]
-        dist_params[:repository_version] = mirror_version_href if options[:use_repository_version]
-        dist_options = distribution_mirror_options(path, dist_params)
-        if (distro = lookup_distributions(base_path: path).first)
-          # update dist
-          dist_options = dist_options.except(:name, :base_path)
-          distributions_api.partial_update(distro.pulp_href, dist_options)
-        else
-          # create dist
-          distribution_data = distribution_class.new(dist_options)
-          distributions_api.create(distribution_data)
-        end
       end
 
       def refresh_distributions
@@ -409,97 +158,21 @@ module Katello
         end
       end
 
-      def create_mirror_distribution(path)
-        distribution_data = distribution_class.new(distribution_mirror_options(path))
-        distributions_api.create(distribution_data)
-      end
-
       def create_distribution(path)
-        distribution_data = distribution_class.new(distribution_options(path))
-        distributions_api.create(distribution_data)
-      end
-
-      def self.delete_distribution(smart_proxy, href)
-        distributions_api(smart_proxy).delete(href)
-      rescue api_exception_class => e
-        raise e if e.code != 404
-        nil
-      end
-
-      def delete_distribution(href)
-        self.class.delete_distribution(smart_proxy, href)
+        distribution_data = api.class.distribution_class.new(distribution_options(path))
+        api.distributions_api.create(distribution_data)
       end
 
       def lookup_distributions(args)
-        distributions_api.list(args).results
-      end
-
-      def self.distributions_list(smart_proxy, args = {})
-        fetch_from_list do |page_opts|
-          distributions_api(smart_proxy).list(page_opts.merge(args))
-        end
-      end
-
-      def distributions_list(args = {})
-        self.class.distributions_list(smart_proxy, args)
-      end
-
-      def self.pulp3_enabled_repo_types(smart_proxy, content_types = SETTINGS[:katello][:content_types].keys)
-        repository_types = content_types.collect do |content_type|
-          Katello::RepositoryTypeManager.find(content_type)
-        end
-
-        repository_types.select do |repository_type|
-          smart_proxy.pulp3_repository_type_support?(repository_type)
-        end
-      end
-
-      def self.delete_orphan_distributions(smart_proxy, repo_types = pulp3_enabled_repo_types(smart_proxy))
-        tasks = []
-        repo_types.each do |repo_type|
-          pulp3_class = repo_type.pulp3_service_class
-          orphan_distribution_hrefs = pulp3_class.orphan_distributions(smart_proxy)
-          orphan_distribution_hrefs.each do |distribution_href|
-            tasks << pulp3_class.delete_distribution(smart_proxy, distribution_href)
-          end
-        end
-        tasks
-      end
-
-      def self.orphan_distributions(smart_proxy)
-        distributions = distributions_list(smart_proxy, {})
-
-        distribution_hrefs = distributions.pluck(:pulp_href)
-
-        distribution_hrefs.select do |distribution_href|
-          dist = get_distribution(smart_proxy, distribution_href)
-          orphan_distribution?(dist)
-        end
-      end
-
-      def self.orphan_distribution?(distribution)
-        distribution.try(:publication).nil? &&
-        distribution.try(:repository).nil? &&
-        distribution.try(:repository_version).nil?
+        api.distributions_api.list(args).results
       end
 
       def update_distribution(path)
         distribution_reference = distribution_reference(path)
         if distribution_reference
           options = distribution_options(path).except(:name, :base_path)
-          distributions_api.partial_update(distribution_reference.href, options)
+          api.distributions_api.partial_update(distribution_reference.href, options)
         end
-      end
-
-      def self.get_distribution(smart_proxy, href)
-        distributions_api(smart_proxy).read(href)
-      rescue api_exception_class => e
-        raise e if e.code != 404
-        nil
-      end
-
-      def get_distribution(href)
-        self.class.get_distribution(smart_proxy, href)
       end
 
       def copy_units_by_href(unit_hrefs)
@@ -514,26 +187,13 @@ module Katello
         create_version(:base_version => from_repository.version_href)
       end
 
-      def mirror_repository_href
-        fetch_repository.try(:pulp_href)
-      end
-
-      def mirror_remote_href
-        fetch_remote.try(:pulp_href)
-      end
-
-      def create_mirror_version(options = {})
-        href = mirror_repository_href
-        repository_versions_api.create(href, options) if href
-      end
-
       def create_version(options = {})
-        repository_versions_api.create(repository_reference.repository_href, options)
+        api.repository_versions_api.create(repository_reference.repository_href, options)
       end
 
       def save_distribution_references(hrefs)
         hrefs.each do |href|
-          path = get_distribution(href)&.base_path
+          path = api.get_distribution(href)&.base_path
           unless distribution_reference(path)
             DistributionReference.create!(path: path, href: href, root_repository_id: repo.root.id)
           end
@@ -543,7 +203,7 @@ module Katello
       def delete_distributions
         path = repo.relative_path.sub(/^\//, '')
         dists = lookup_distributions(base_path: path)
-        delete_distribution(dists.first.pulp_href) if dists.first
+        api.delete_distribution(dists.first.pulp_href) if dists.first
         dist_ref = distribution_reference(path)
         dist_ref.destroy! if dist_ref
       end
@@ -551,7 +211,7 @@ module Katello
       def common_remote_options
         remote_options = {
           ssl_validation: root.verify_ssl_on_sync,
-          name: backend_object_name,
+          name: generate_backend_object_name,
           url: root.url,
           proxy_url: root.http_proxy&.full_url
         }
@@ -581,74 +241,31 @@ module Katello
         end
       end
 
-      def common_mirror_remote_options
-        remote_options = {
-          name: backend_object_name
-        }
-        remote_options.merge!(ssl_mirror_remote_options)
-      end
-
-      def ssl_mirror_remote_options
-        ueber_cert = ::Cert::Certs.ueber_cert(root.organization)
-        {
-          ssl_client_certificate: ueber_cert[:cert],
-          ssl_client_key: ueber_cert[:key],
-          ssl_ca_certificate: ::Cert::Certs.ca_cert,
-          ssl_validation: true
-        }
-      end
-
-      def mirror_remote_feed_url
-        uri = ::SmartProxy.pulp_master.pulp3_uri!
-        uri.path = partial_repo_path
-        uri.to_s
-      end
-
-      def partial_repo_path
-        fail NotImplementedError
-      end
-
-      def needs_importer_updates?
-        false
-      end
-
-      def needs_distributor_updates?
-        false
-      end
-
       def lookup_version(href)
-        repository_versions_api.read(href) if href
+        api.repository_versions_api.read(href) if href
       rescue PulpcoreClient::ApiError => e
         Rails.logger.error "Exception when calling repository_versions_api->read: #{e}"
         nil
       end
 
       def lookup_publication(href)
-        publications_api.read(href) if href
+        api.publications_api.read(href) if href
       rescue PulpcoreClient::ApiError => e
         Rails.logger.error "Exception when calling publications_api->read: #{e}"
         nil
       end
 
-      def fetch_repository
-        list(name: backend_object_name).first
-      end
-
-      def fetch_remote
-        remotes_list(name: backend_object_name).first
-      end
-
       def remove_content(content_units)
         data = PulpcoreClient::RepositoryVersionCreate.new(
           remove_content_units: content_units.map(&:pulp_id))
-        repository_versions_api.create(repository_reference.repository_href, data)
+        api.repository_versions_api.create(repository_reference.repository_href, data)
       end
 
       def add_content(content_unit_href)
         content_unit_href = [content_unit_href] unless content_unit_href.is_a?(Array)
         data = PulpcoreClient::RepositoryVersionCreate.new(
             add_content_units: content_unit_href)
-        repository_versions_api.create(repository_reference.repository_href, data)
+        api.repository_versions_api.create(repository_reference.repository_href, data)
       end
 
       def unit_keys(uploads)

--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -4,34 +4,6 @@ module Katello
   module Pulp3
     class Repository
       class AnsibleCollection < ::Katello::Pulp3::Repository
-        def self.api_client(smart_proxy)
-          PulpAnsibleClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpAnsibleClient::Configuration))
-        end
-
-        def client_class
-          PulpAnsibleClient
-        end
-
-        def self.api_exception_class
-          PulpAnsibleClient::ApiError
-        end
-
-        def remote_class
-          PulpAnsibleClient::AnsibleCollectionRemote
-        end
-
-        def self.remotes_api(smart_proxy)
-          PulpAnsibleClient::RemotesCollectionApi.new(api_client(smart_proxy))
-        end
-
-        def distribution_class
-          PulpAnsibleClient::AnsibleAnsibleDistribution
-        end
-
-        def self.distributions_api(smart_proxy)
-          PulpAnsibleClient::DistributionsAnsibleApi.new(api_client(smart_proxy))
-        end
-
         def remote_options
           if root.url.blank?
             super
@@ -44,7 +16,7 @@ module Katello
           {
             base_path: path,
             repository_version: repo.version_href,
-            name: "#{backend_object_name}"
+            name: "#{generate_backend_object_name}"
           }
         end
       end

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -4,42 +4,6 @@ module Katello
   module Pulp3
     class Repository
       class Docker < ::Katello::Pulp3::Repository
-        def self.api_client(smart_proxy)
-          PulpDockerClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpDockerClient::Configuration))
-        end
-
-        def self.api_exception_class
-          PulpDockerClient::ApiError
-        end
-
-        def client_class
-          PulpDockerClient
-        end
-
-        def remote_class
-          PulpDockerClient::DockerDockerRemote
-        end
-
-        def self.remotes_api(smart_proxy)
-          PulpDockerClient::RemotesDockerApi.new(api_client(smart_proxy))
-        end
-
-        def distribution_class
-          PulpDockerClient::DockerDockerDistribution
-        end
-
-        def self.distributions_api(smart_proxy)
-          PulpDockerClient::DistributionsDockerApi.new(api_client(smart_proxy))
-        end
-
-        def recursive_manage_class
-          PulpDockerClient::RecursiveManage
-        end
-
-        def recursive_add_api
-          PulpDockerClient::DockerRecursiveAddApi.new(api_client)
-        end
-
         def remote_options
           options = {url: root.url, upstream_name: root.docker_upstream_name}
           if root.docker_tags_whitelist && root.docker_tags_whitelist.any?
@@ -51,18 +15,17 @@ module Katello
         end
 
         def mirror_remote_options
-          docker_options = {
+          {
             url: "https://#{SmartProxy.pulp_master.pulp3_host!.downcase}",
             upstream_name: repo.container_repository_name
           }
-          common_mirror_remote_options.merge(docker_options)
         end
 
         def distribution_options(path)
           {
             base_path: path,
             repository_version: repo.version_href,
-            name: "#{backend_object_name}"
+            name: "#{generate_backend_object_name}"
           }
         end
 
@@ -71,7 +34,7 @@ module Katello
           if clear_repo
             tasks << create_version(:remove_content_units => ["*"])
           end
-          tasks << recursive_add_api.create(recursive_manage_class.new(repository: repository_reference.repository_href,
+          tasks << api.recursive_add_api.create(api.class.recursive_manage_class.new(repository: repository_reference.repository_href,
                                                                        content_units: unit_hrefs))
           tasks
         end

--- a/app/services/katello/pulp3/repository/file.rb
+++ b/app/services/katello/pulp3/repository/file.rb
@@ -4,42 +4,6 @@ module Katello
   module Pulp3
     class Repository
       class File < ::Katello::Pulp3::Repository
-        def self.api_exception_class
-          PulpFileClient::ApiError
-        end
-
-        def client_class
-          PulpFileClient
-        end
-
-        def remote_class
-          PulpFileClient::FileFileRemote
-        end
-
-        def self.api_client(smart_proxy)
-          PulpFileClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpFileClient::Configuration))
-        end
-
-        def self.remotes_api(smart_proxy)
-          PulpFileClient::RemotesFileApi.new(api_client(smart_proxy))
-        end
-
-        def publication_class
-          PulpFileClient::FileFilePublication
-        end
-
-        def publications_api
-          PulpFileClient::PublicationsFileApi.new(api_client)
-        end
-
-        def distribution_class
-          PulpFileClient::FileFileDistribution
-        end
-
-        def self.distributions_api(smart_proxy)
-          PulpFileClient::DistributionsFileApi.new(api_client(smart_proxy))
-        end
-
         def copy_content_for_source(source_repository, _options = {})
           copy_units_by_href(source_repository.files.pluck(:pulp_id))
         end
@@ -48,7 +12,7 @@ module Katello
           {
             base_path: path,
             publication: repo.publication_href,
-            name: "#{backend_object_name}"
+            name: "#{generate_backend_object_name}"
           }
         end
 

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -4,42 +4,6 @@ module Katello
   module Pulp3
     class Repository
       class Yum < ::Katello::Pulp3::Repository
-        def self.api_client(smart_proxy)
-          PulpRpmClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpRpmClient::Configuration))
-        end
-
-        def self.api_exception_class
-          PulpRpmClient::ApiError
-        end
-
-        def client_class
-          PulpRpmClient
-        end
-
-        def remote_class
-          PulpRpmClient::RpmRpmRemote
-        end
-
-        def self.remotes_api(smart_proxy)
-          PulpRpmClient::RemotesRpmApi.new(api_client(smart_proxy))
-        end
-
-        def publication_class
-          PulpRpmClient::RpmRpmPublication
-        end
-
-        def publications_api
-          PulpRpmClient::PublicationsRpmApi.new(api_client)
-        end
-
-        def distribution_class
-          PulpRpmClient::RpmRpmDistribution
-        end
-
-        def self.distributions_api(smart_proxy)
-          PulpRpmClient::DistributionsRpmApi.new(api_client(smart_proxy))
-        end
-
         def remote_options
           if root.url.blank?
             common_remote_options.merge(url: nil, policy: root.download_policy)
@@ -52,7 +16,7 @@ module Katello
           {
             base_path: path,
             publication: repo.publication_href,
-            name: "#{backend_object_name}"
+            name: "#{generate_backend_object_name}"
           }
         end
       end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -1,0 +1,183 @@
+module Katello
+  module Pulp3
+    class RepositoryMirror
+      attr_accessor :repo_service
+      delegate :repo, to: :repo_service
+      delegate :smart_proxy, to: :repo_service
+
+      delegate :api, to: :repo_service
+
+      def initialize(repository_service)
+        @repo_service = repository_service
+      end
+
+      def backend_object_name
+        #Create repos in pulp3 instance with the name as this repo's pulp_id
+        repo.pulp_id
+      end
+
+      def refresh_entities
+        href = remote_href
+        if href
+          [api.remotes_api.partial_update(href, remote_options)]
+        else
+          create_remote
+          []
+        end
+      end
+
+      def needs_updates?
+        remote = fetch_remote
+        return true if remote.blank?
+        options = compute_remote_options
+        options.keys.any? { |key| remote.send(key) != options[key] }
+      end
+
+      def remote_href
+        fetch_remote.try(:pulp_href)
+      end
+
+      def create_entities
+        create
+        create_remote unless fetch_remote
+      end
+
+      def create
+        api.repositories_api.create(name: backend_object_name)
+      end
+
+      def update
+        api.repositories_api.update(repository_href, name: backend_object_name)
+      end
+
+      def delete(href = repository_href)
+        api.repositories_api.delete(href) if href
+      end
+
+      def repository_href
+        fetch_repository.try(:pulp_href)
+      end
+
+      def fetch_repository
+        repo_service.api.list_all(name: backend_object_name).first
+      end
+
+      def version_href
+        fetch_repository.latest_version_href
+      end
+
+      def create_version(options = {})
+        api.repository_versions_api.create(repository_href, options)
+      end
+
+      def distribution_options(path, options = {})
+        ret = {
+          base_path: path,
+          name: "#{backend_object_name}"
+        }
+        ret[:publication] = options[:publication] if options.key? :publication
+        ret[:repository_version] = options[:repository_version] if options.key? :repository_version
+        ret
+      end
+
+      def remote_options
+        base_options = common_remote_options.merge(url: remote_feed_url)
+        type_options = api.try(:mirror_remote_options) || {}
+        type_options.merge(base_options)
+      end
+
+      def create_remote
+        remote_file_data = @repo_service.api.class.remote_class.new(remote_options)
+        api.remotes_api.create(remote_file_data)
+      end
+
+      def compute_remote_options
+        computed_options = remote_options
+        [:ssl_client_certificate, :ssl_client_key, :ssl_ca_certificate].each do |key|
+          computed_options[key] = Digest::SHA256.hexdigest(computed_options[key].chomp)
+        end
+        computed_options
+      end
+
+      def fetch_remote
+        api.remotes_list(name: backend_object_name).first
+      end
+
+      def sync
+        api_module = api.class.client_module
+        repository_sync_url_data = api_module::RepositorySyncURL.new(repository: repository_href, mirror: true)
+        [api.remotes_api.sync(remote_href, repository_sync_url_data)]
+      end
+
+      def common_remote_options
+        remote_options = {
+          name: backend_object_name
+        }
+        remote_options.merge!(ssl_remote_options)
+      end
+
+      def ssl_remote_options
+        ueber_cert = ::Cert::Certs.ueber_cert(repo.root.organization)
+        {
+          ssl_client_certificate: ueber_cert[:cert],
+          ssl_client_key: ueber_cert[:key],
+          ssl_ca_certificate: ::Cert::Certs.ca_cert,
+          ssl_validation: true
+        }
+      end
+
+      def remote_feed_url
+        uri = ::SmartProxy.pulp_master.pulp3_uri!
+        uri.path = repo_service.partial_repo_path
+        uri.to_s
+      end
+
+      def create_publication
+        if (href = version_href)
+          publication_data = api.class.publication_class.new(repository_version: href)
+          api.publications_api.create(publication_data)
+        end
+      end
+
+      def refresh_distributions(options = {})
+        path = repo_service.relative_path
+        dist_params = {}
+        dist_params[:publication] = options[:publication] if options[:publication]
+        dist_params[:repository_version] = version_href if options[:use_repository_version]
+        dist_options = distribution_options(path, dist_params)
+        if (distro = repo_service.lookup_distributions(base_path: path).first)
+          # update dist
+          dist_options = dist_options.except(:name, :base_path)
+          api.distributions_api.partial_update(distro.pulp_href, dist_options)
+        else
+          # create dist
+          distribution_data = api.class.distribution_class.new(dist_options)
+          api.distributions_api.create(distribution_data)
+        end
+      end
+
+      def create_distribution(path)
+        distribution_data = api.class.distribution_class.new(distribution_options(path))
+        repo_service.distributions_api.create(distribution_data)
+      end
+
+      def orphan_repository_versions
+        current_pulp_repositories = self.list
+
+        orphan_version_hrefs = current_pulp_repositories.collect do |pulp_repo|
+          mirror_repo_versions = api.versions_list(pulp_repo['pulp_href'], ordering: :_created).pluck(:pulp_href)
+
+          mirror_repo_versions - [pulp_repo['latest_version_href']]
+        end
+
+        orphan_version_hrefs.flatten
+      end
+
+      def delete_orphan_repository_versions
+        orphan_repository_versions.collect do |href|
+          repo_service.api.repositories_api.delete(href)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -1,0 +1,67 @@
+module Katello
+  module Pulp3
+    class SmartProxyMirrorRepository < SmartProxyRepository
+      def initialize(smart_proxy)
+        fail "Cannot use a central pulp smart proxy" if smart_proxy.pulp_master?
+        @smart_proxy = smart_proxy
+      end
+
+      def orphaned_repositories
+        smart_proxy_helper = ::Katello::SmartProxyHelper.new(smart_proxy)
+        katello_pulp_ids = smart_proxy_helper.repos_available_to_capsule.map(&:pulp_id)
+        repos_on_capsule = ::Katello::Pulp3::Api::Core.new(smart_proxy).list_all
+        repos_on_capsule.reject { |capsule_repo| katello_pulp_ids.include? capsule_repo.name }
+      end
+
+      def orphan_repository_versions
+        version_hrefs = core_api.repository_versions
+        version_hrefs - ::Katello::Repository.where(version_href: version_hrefs).pluck(:version_href)
+      end
+
+      def delete_orphan_repositories
+        orphaned_repositories.map do |repo|
+          ::Katello::Pulp3::Api::Core.new(smart_proxy).repositories_api.delete(repo.pulp_href)
+        end
+      end
+
+      def delete_orphan_distributions
+        tasks = []
+        pulp3_enabled_repo_types.each do |repo_type|
+          pulp3_class = repo_type.pulp3_service_class
+          orphan_distributions(pulp3_class).each do |distribution|
+            tasks << pulp3_class.api(smart_proxy).delete_distribution(distribution.pulp_href)
+          end
+        end
+        tasks
+      end
+
+      def orphan_distributions(pulp3_service_class)
+        api = pulp3_service_class.api(smart_proxy)
+        api.distributions_list_all.select do |distribution|
+          dist = api.get_distribution(distribution.pulp_href)
+          self.class.orphan_distribution?(dist)
+        end
+      end
+
+      def self.orphan_distribution?(distribution)
+        distribution.try(:publication).nil? &&
+            distribution.try(:repository).nil? &&
+            distribution.try(:repository_version).nil?
+      end
+
+      def delete_orphan_remotes
+        tasks = []
+        repo_names = Katello::Repository.pluck(:pulp_id)
+        pulp3_enabled_repo_types.each do |repo_type|
+          api = repo_type.pulp3_service_class.api(smart_proxy)
+          remotes = api.remotes_list
+
+          remotes.each do |remote|
+            tasks << api.delete_remote(remote.pulp_href) unless repo_names.include?(remote.name)
+          end
+        end
+        tasks
+      end
+    end
+  end
+end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -12,7 +12,9 @@ module Katello
       end
     end
 
-    def_field :allow_creation_by_user, :service_class, :pulp3_service_class, :pulp3_plugin, :pulp3_skip_publication
+    def_field :allow_creation_by_user, :service_class, :pulp3_service_class, :pulp3_plugin,
+              :pulp3_skip_publication, :pulp3_api_class
+
     attr_accessor :metadata_publish_matching_check, :index_additional_data_proc
     attr_reader :id, :unique_content_per_repo
 

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -51,6 +51,10 @@ module Katello
         repository_types[repository_type.to_s]
       end
 
+      def find_by(attribute, value)
+        repository_types.values.find { |type| type.try(attribute) == value }
+      end
+
       def find_repository_type(katello_label)
         repository_types.values.each do |repo_type|
           repo_type.content_types.each do |content_type|

--- a/lib/katello/repository_types/ansible_collection.rb
+++ b/lib/katello/repository_types/ansible_collection.rb
@@ -2,6 +2,7 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::ANSIBLE_COLLECTIO
   allow_creation_by_user true
   pulp3_skip_publication true
   pulp3_service_class Katello::Pulp3::Repository::AnsibleCollection
+  pulp3_api_class Katello::Pulp3::Api::AnsibleCollection
   pulp3_plugin 'pulp_ansible'
 
   content_type Katello::AnsibleCollection, :pulp3_service_class => ::Katello::Pulp3::AnsibleCollection, :user_removable => true

--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -2,6 +2,7 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE) do
   service_class Katello::Pulp::Repository::Docker
   default_managed_content_type Katello::DockerManifest
   pulp3_service_class Katello::Pulp3::Repository::Docker
+  pulp3_api_class Katello::Pulp3::Api::Docker
   pulp3_skip_publication true
   pulp3_plugin 'pulp_docker'
 

--- a/lib/katello/repository_types/file.rb
+++ b/lib/katello/repository_types/file.rb
@@ -1,8 +1,8 @@
 Katello::RepositoryTypeManager.register(::Katello::Repository::FILE_TYPE) do
   allow_creation_by_user true
   service_class Katello::Pulp::Repository::File
-
   pulp3_service_class Katello::Pulp3::Repository::File
+  pulp3_api_class Katello::Pulp3::Api::File
   pulp3_plugin 'pulp_file'
 
   content_type Katello::FileUnit,

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -1,6 +1,7 @@
 Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
   service_class Katello::Pulp::Repository::Yum
   pulp3_service_class Katello::Pulp3::Repository::Yum
+  pulp3_api_class Katello::Pulp3::Api::Yum
   pulp3_plugin 'pulp_rpm'
   prevent_unneeded_metadata_publish
 

--- a/test/actions/pulp3/orchestration/remove_orphans_test.rb
+++ b/test/actions/pulp3/orchestration/remove_orphans_test.rb
@@ -50,7 +50,7 @@ module ::Actions::Pulp3
 
     def test_orphans_are_removed
       repository_reference = repo_reference(@repo)
-      versions = ::Katello::Pulp3::Repository.new(@repo, @master).repository_versions_api.list(repository_reference.repository_href, {}).results.collect(&:pulp_href)
+      versions = ::Katello::Pulp3::Api::Core.new(@master).repository_versions_api.list(repository_reference.repository_href, {}).results.collect(&:pulp_href)
       refute_includes versions, repository_reference.repository_href + "versions/1/"
       assert_includes versions, repository_reference.repository_href + "versions/2/"
     end

--- a/test/actions/pulp3/orchestration/yum_update_test.rb
+++ b/test/actions/pulp3/orchestration/yum_update_test.rb
@@ -53,7 +53,7 @@ module ::Actions::Pulp3
         @repo,
         @master)
 
-      yum_remote = ::Katello::Pulp3::Repository::Yum.new(Organization.first, @master).remotes_api
+      yum_remote = ::Katello::Pulp3::Api::Yum.new(@master).remotes_api
       assert_equal yum_remote.list.results.select { |remote| remote.name == "2_duplicate" }[0].policy, "on_demand"
     end
 

--- a/test/services/katello/pulp3/orphan_test.rb
+++ b/test/services/katello/pulp3/orphan_test.rb
@@ -38,6 +38,8 @@ module Katello
         ensure_creatable(@repo, @master)
         create_repo(@repo, @master)
 
+        @smart_proxy_service = Katello::Pulp3::SmartProxyRepository.new(@master)
+
         ForemanTasks.sync_task(
           ::Actions::Katello::Repository::MetadataGenerate, @repo,
           repository_creation: true)
@@ -59,7 +61,7 @@ module Katello
       end
 
       def test_orphan_repository_versions
-        orphans = ::Katello::Pulp3::Repository.orphan_repository_versions(@master)
+        orphans = @smart_proxy_service.orphan_repository_versions
 
         repo_reference = Katello::Pulp3::RepositoryReference.find_by(
             :root_repository_id => @repo.root.id,
@@ -69,8 +71,8 @@ module Katello
       end
 
       def test_delete_orphan_repository_versions
-        ::Katello::Pulp3::Repository.delete_orphan_repository_versions(@master)
-        orphans = ::Katello::Pulp3::Repository.orphan_repository_versions(@master)
+        @smart_proxy_service.delete_orphan_repository_versions
+        orphans = @smart_proxy_service.orphan_repository_versions
         assert_empty orphans
       end
     end

--- a/test/services/katello/pulp3/repository/file/update_remote_test.rb
+++ b/test/services/katello/pulp3/repository/file/update_remote_test.rb
@@ -9,6 +9,7 @@ module Katello
         def setup
           mock_remotes_create_response = mock('response')
           mock_remotes_create_response.stubs(:pulp_href).returns('http://someurl')
+          @mock_api_wrapper = mock("api_wrapper")
           @mock_pulp3_api = mock('pulp3_api')
           @mock_pulp3_api.stubs(:create).returns(mock_remotes_create_response)
           @mock_smart_proxy = mock('smart_proxy')
@@ -18,7 +19,8 @@ module Katello
           @file_repo = katello_repositories(:generic_file)
           @file_repo_service = @file_repo.backend_service(@mock_smart_proxy)
           @file_repo.root.update_attributes(url: 'my-files.org')
-          @file_repo_service.stubs(:remotes_api).returns(@mock_pulp3_api)
+          @file_repo_service.stubs(:api).returns(@mock_api_wrapper)
+          @mock_api_wrapper.stubs(:remotes_api).returns(@mock_pulp3_api)
 
           @file_repo.remote_href = '193874298udsfsdf'
           refute_empty @file_repo.remote_href

--- a/test/services/katello/pulp3/repository/orphan_distributions_test.rb
+++ b/test/services/katello/pulp3/repository/orphan_distributions_test.rb
@@ -9,27 +9,27 @@ module Katello
       def test_distribution_with_publication_is_not_an_orphan
         dist = PulpFileClient::FileFileDistribution.new(
           publication: 'http://some.href')
-        refute Katello::Pulp3::Repository.orphan_distribution?(dist)
+        refute Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
 
       def test_distribution_without_a_publication_is_an_orphan
         dist = PulpFileClient::FileFileDistribution.new(
           publication: nil)
-        assert Katello::Pulp3::Repository.orphan_distribution?(dist)
+        assert Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
 
       def test_distribution_with_repository_and_repository_version_is_not_an_orphan
         dist = PulpAnsibleClient::AnsibleAnsibleDistribution.new(
           repository: 'http://some.href',
           repository_version: 'http://some.href/version/')
-        refute Katello::Pulp3::Repository.orphan_distribution?(dist)
+        refute Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
 
       def test_distribution_without_repository_and_repository_version_is_an_orphan
         dist = PulpAnsibleClient::AnsibleAnsibleDistribution.new(
           repository: nil,
           repository_version: nil)
-        assert Katello::Pulp3::Repository.orphan_distribution?(dist)
+        assert Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
     end
   end

--- a/test/services/katello/pulp3/repository_list_test.rb
+++ b/test/services/katello/pulp3/repository_list_test.rb
@@ -34,10 +34,10 @@ module Katello
         create_repo(repo2, @master)
         sync_and_reload_repo(repo2, @master)
 
-        repository_list = ::Katello::Pulp3::Repository.list(@master)
+        repository_list = ::Katello::Pulp3::Api::Core.new(@master).list_all
 
         Katello::Pulp3::RepositoryReference.all.each do |repo_reference|
-          assert_includes repository_list.pluck(:pulp_href), repo_reference.repository_href
+          assert_includes repository_list.map(&:pulp_href), repo_reference.repository_href
         end
       end
     end


### PR DESCRIPTION
The goal of this was to fix a couple of issues with the
current pulp3 service classes.  They mixed api definitions
with katello<->pulp translations around repositories which
made it difficult to work with the api outside the content of
a repository.  To remedy this, the api references and instantiation
is moved to a sepearate set of classes.

The second issue was that logic related to mirror repositories
complicated the Repository class considerably, and made it somewhat
confusing in places.  To fix this, the mirror logic is moved to a
RepositoryMirror class.