### PR TITLE
Fixes #28238: pass result of await into reload.

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -55,8 +55,8 @@ class EnabledRepository extends Component {
   };
 
   disableRepository = async () => {
-    await this.props.disableRepository(this.repoForAction());
-    this.reloadAndNotify();
+    const result = await this.props.disableRepository(this.repoForAction());
+    this.reloadAndNotify(result);
   };
 
   render() {

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -48,7 +48,7 @@ class RepositorySetRepository extends Component {
   };
 
   reloadAndNotify = async (result) => {
-    if (result.success) {
+    if (result && result.success) {
       await this.reloadEnabledRepos();
       await this.setEnabled();
       await this.notifyEnabled(result.data);
@@ -56,8 +56,8 @@ class RepositorySetRepository extends Component {
   };
 
   enableRepository = async () => {
-    await this.props.enableRepository(this.repoForAction());
-    this.reloadAndNotify();
+    const result = await this.props.enableRepository(this.repoForAction());
+    this.reloadAndNotify(result);
   };
 
   render() {


### PR DESCRIPTION
Pass the result of async-await into the reload
handler so that it works correctly.

https://projects.theforeman.org/issues/28238