### PR TITLE
Fixes #28291 - Error in sync status after upgrade

### DIFF
--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -66,7 +66,9 @@ module Actions
         end
 
         def presenter
-          repo = ::Katello::Repository.find(input['repo_id'])
+          repo = ::Katello::Repository.find(input['repo_id']) if input['repo_id']
+          # For repo sync tasks older than katello 3.14, we only have pulp_id available in input.
+          repo ||= ::Katello::Repository.where(:pulp_id => input['pulp_id']).first if input['pulp_id']
 
           if repo.try(:puppet?)
             Presenters::PuppetPresenter.new(self)


### PR DESCRIPTION
This action was changed in 3.14 and so was the presenter. For new syncs, the task has the input as repo_id. However, prior to 3.14, the task has input of pulp_id. Therefore, the presenter for old actions needs to look at pulp_id since repo_id wasn't available before that.

To reproduce: 

1. Sync a repo on 3.13.
2. Upgrade to 3.14.
3. Go to content>sync status page.