### PR TITLE
Fixes #24517: reduce virt required dash emphasis

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionsPage.scss
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.scss
@@ -42,3 +42,9 @@
   margin-top: 3px;
   width: 10px;
 }
+
+span.fa.fa-minus::before {
+  content: "\2014";
+  color: gray;
+  font-size: 1em;
+}


### PR DESCRIPTION
Make the dash have less emphasis in the requires virt
who column.

https://projects.theforeman.org/issues/24517

Before:
![gscreenshot_2019-11-19-121653](https://user-images.githubusercontent.com/4116405/69169628-af5afe80-0ac6-11ea-9b70-4a4f1c4baffd.png)

After:

![gscreenshot_2019-11-19-121554](https://user-images.githubusercontent.com/4116405/69169637-b1bd5880-0ac6-11ea-901e-65944c845d8f.png)
