### PR TITLE
Fixes #28310 - Restore content access mode banner

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/content-access-mode-banner.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/content-access-mode-banner.directive.js
@@ -1,0 +1,22 @@
+/**
+ * @ngdoc directive
+ * @name Bastion.subscriptions:contentAccessModeBanner
+ *
+ * @requires contentAccessMode
+ *
+ * @description
+ *   Component for showing information about content access mode (whether content is
+ *   allowed with or without a subscription)
+ */
+angular.module('Bastion.subscriptions').directive('contentAccessModeBanner',
+    ['contentAccessMode',
+    function (contentAccessMode) {
+        return {
+            restrict: 'AE',
+            controller: ['$scope', function ($scope) {
+                $scope.contentAccessMode = contentAccessMode;
+            }],
+            templateUrl: 'subscriptions/views/content-access-mode-banner.html'
+        };
+    }
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -1,0 +1,5 @@
+<div bst-alert="info" ng-show="contentAccessMode === 'org_environment'">
+  <span translate>
+    Access to repositories is unrestricted in this organization. Hosts can consume all repositories available in the Content View they are registered to, regardless of subscription status.
+  </span>
+</div>

--- a/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
+++ b/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
@@ -1,0 +1,26 @@
+describe('Directive: contentAccessModeBanner', function() {
+    var $scope, element;
+
+    beforeEach(module(
+        'Bastion.subscriptions',
+        'subscriptions/views/content-access-mode-banner.html'
+    ));
+
+    beforeEach(module(function($provide) {
+        $provide.value('contentAccessMode', 'org_environment');
+    }));
+
+    beforeEach(inject(function($compile, $rootScope, $httpBackend) {
+        //TODO: necessary because of https://github.com/theforeman/rfcs/pull/13
+        $httpBackend.expectGET('/components/views/bst-alert.html').respond("");
+
+        $scope = $rootScope.$new();
+        element = angular.element('<div content-access-mode-banner></div>');
+        $compile(element)($scope);
+        $scope.$digest();
+    }));
+
+    it("set content access mode on the scope", function() {
+        expect($scope.contentAccessMode).toEqual("org_environment");
+    });
+});


### PR DESCRIPTION
This was accidentally removed during removal of the legacy subs pages. Ping me for a golden ticket manifest so this can be tested.

The banner is expected to be shown on content host and activation key details pages.