### PR TITLE
Fixes #27366 - handles missing puppet content type in CVV removal

### DIFF
--- a/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/destroy.rb
@@ -4,7 +4,9 @@ module Actions
       class Destroy < Actions::EntryAction
         def plan(puppet_env)
           action_subject(puppet_env)
-          plan_action(Pulp::Repository::Destroy, content_view_puppet_environment_id: puppet_env.id)
+          if ::Katello::RepositoryTypeManager.enabled?('puppet')
+            plan_action(Pulp::Repository::Destroy, content_view_puppet_environment_id: puppet_env.id)
+          end
           plan_self
         end
 

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -148,5 +148,15 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
 
       assert_action_planed_with action, ::Actions::Pulp::Repository::Destroy, content_view_puppet_environment_id: puppet_env.id
     end
+
+    it 'does not plan action if puppet content type is missing' do
+      action.expects(:action_subject).with(puppet_env)
+      action.expects(:plan_self)
+
+      Katello::RepositoryTypeManager.stubs(:enabled?).with('puppet').returns(false)
+
+      plan_action action, puppet_env
+      refute_action_planned action, ::Actions::Pulp::Repository::Destroy
+    end
   end
 end


### PR DESCRIPTION
This PR address the issues discovered in https://projects.theforeman.org/issues/27366 - when katello is installed without puppet CVV removal triggers an error, which blocks completion of the CVV removal task.

To reproduce the original error, set the puppet content in `config/settings.plugin.d/katello.yml` to false. Restart spring and the foreman web app. Create a product and a new repository, then sync that repo. Finally, create a Content View with that repository. Create 2 new CV versions, and then promote the oldest one. 

Delete the older CV version, opting to delete all environments. 

You will encounter an error, which on master manifests as:
`"RuntimeError: Cannot find repository type puppet, is it enabled?"` and the task will be blocked.

After applying this PR you should no longer have any errors when trying to remove e CV version when puppet is not a known content type.