### PR TITLE
Fixes #28326 - Improve event daemon resilience

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -2,7 +2,6 @@ module Katello
   class Ping
     OK_RETURN_CODE = 'ok'.freeze
     FAIL_RETURN_CODE = 'FAIL'.freeze
-    WARN_RETURN_CODE = 'WARN'.freeze
     PACKAGES = %w(katello candlepin pulp qpid foreman tfm hammer).freeze
 
     class << self
@@ -33,7 +32,7 @@ module Katello
         # set overall status result code
         result = {:services => result}
         result[:services].each_value do |v|
-          result[:status] = [OK_RETURN_CODE, WARN_RETURN_CODE].include?(v[:status]) ? OK_RETURN_CODE : FAIL_RETURN_CODE
+          result[:status] = v[:status] == OK_RETURN_CODE ? OK_RETURN_CODE : FAIL_RETURN_CODE
         end
         result
       end
@@ -45,31 +44,28 @@ module Katello
         }
       end
 
-      def daemon_status_message(status)
-        "#{status[:processed_count]} Processed, #{status[:failed_count]} Failed, #{status[:queue_depth]} in queue"
+      def event_daemon_status(status, result)
+        running = status&.dig(:running)
+
+        if running
+          result[:message] = "#{status[:processed_count]} Processed, #{status[:failed_count]} Failed"
+        else
+          result[:status] = FAIL_RETURN_CODE
+          result[:message] = _("Not running")
+        end
       end
 
       def ping_katello_events(result)
         exception_watch(result) do
-          status = Katello::EventMonitor::PollerThread.status
-
-          if status[:queue_depth] && status[:queue_depth] > 1000
-            result[:status] = WARN_RETURN_CODE
-          end
-
-          result[:message] = daemon_status_message(status)
+          status = Katello::EventMonitor::PollerThread.status(refresh: false)
+          event_daemon_status(status, result)
         end
       end
 
       def ping_candlepin_events(result)
         exception_watch(result) do
-          status = Katello::CandlepinEventListener.status
-
-          if status[:queue_depth] && status[:queue_depth] > 1000
-            result[:status] = WARN_RETURN_CODE
-          end
-
-          result[:message] = daemon_status_message(status)
+          status = Katello::CandlepinEventListener.status(refresh: false)
+          event_daemon_status(status, result)
         end
       end
 

--- a/app/services/katello/candlepin_listening_service.rb
+++ b/app/services/katello/candlepin_listening_service.rb
@@ -64,10 +64,13 @@ module Katello
         @receiver = @session.create_receiver(@address)
         @logger.info("Candlepin Event Listener started")
       end
-
       :connected
     rescue => e
-      raise e unless e.class.name.include? "TransportFailure"
+      @logger.error("Unable to establish candlepin events connection: #{e.message}")
+    end
+
+    def running?
+      @connection.open? && @thread&.status || false
     end
 
     def fetch_message
@@ -83,7 +86,7 @@ module Katello
           message = fetch_message
           yield(message) if block_given?
 
-          sleep SLEEP_INTERVAL if message[:result].nil? && message[:error].nil?
+          sleep SLEEP_INTERVAL if message[:result].nil?
         end
       end
     end

--- a/test/models/ping_test.rb
+++ b/test/models/ping_test.rb
@@ -82,40 +82,39 @@ module Katello
     end
 
     def test_ping_candlepin_events
-      Katello::CandlepinEventListener.reset_status
-      Katello::Resources::Candlepin::Admin.expects(:queue_depth).returns(0)
+      Katello::CandlepinEventListener.stubs(:status).returns(processed_count: 0, failed_count: 0, running: true)
 
       result = Katello::Ping.ping_candlepin_events({})
 
       assert_equal 'ok', result[:status]
-      assert_equal '0 Processed, 0 Failed, 0 in queue', result[:message]
+      assert_equal '0 Processed, 0 Failed', result[:message]
     end
 
-    def test_ping_candlepin_deep_queue
-      Katello::CandlepinEventListener.expects(:status).returns(processed_count: 10, failed_count: 5, queue_depth: 1001)
+    def test_ping_candlepin_not_running
+      Katello::CandlepinEventListener.expects(:status).returns(processed_count: 10, failed_count: 5, running: false)
 
       result = Katello::Ping.ping_candlepin_events({})
 
-      assert_equal 'WARN', result[:status]
-      assert_equal '10 Processed, 5 Failed, 1001 in queue', result[:message]
+      assert_equal 'FAIL', result[:status]
+      assert_equal 'Not running', result[:message]
     end
 
     def test_ping_katello_events
-      Katello::EventMonitor::PollerThread.reset_status
+      Katello::EventMonitor::PollerThread.stubs(:status).returns(processed_count: 0, failed_count: 0, running: true)
 
       result = Katello::Ping.ping_katello_events({})
 
       assert_equal 'ok', result[:status]
-      assert_equal '0 Processed, 0 Failed, 0 in queue', result[:message]
+      assert_equal '0 Processed, 0 Failed', result[:message]
     end
 
-    def test_ping_katello_events_deep_queue
+    def test_ping_katello_events_not_running
       Katello::EventMonitor::PollerThread.expects(:status).returns(processed_count: 10, failed_count: 5, queue_depth: 1001)
 
       result = Katello::Ping.ping_katello_events({})
 
-      assert_equal 'WARN', result[:status]
-      assert_equal '10 Processed, 5 Failed, 1001 in queue', result[:message]
+      assert_equal 'FAIL', result[:status]
+      assert_equal 'Not running', result[:message]
     end
   end
 

--- a/test/services/katello/candlepin_event_listener_test.rb
+++ b/test/services/katello/candlepin_event_listener_test.rb
@@ -2,22 +2,15 @@ require 'katello_test_helper'
 
 module Katello
   class CandlepinEventListenerTest < ActiveSupport::TestCase
-    def test_start_service
-      service = mock(start: :connected)
-      Katello::CandlepinListeningService.expects(:instance).returns(service)
-
-      Katello::CandlepinEventListener.start_service
-    end
-
     def test_status
       status = {
         processed_count: 0,
         failed_count: 0,
-        queue_depth: nil
+        running: false
       }
       Katello::CandlepinEventListener.reset_status
 
-      assert_equal status, Katello::CandlepinEventListener.status
+      assert_equal status, Katello::CandlepinEventListener.status(refresh: true)
     end
 
     def test_act_on_event

--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -8,6 +8,12 @@ module Katello
 
       def self.close
       end
+
+      def self.status(*)
+        {
+          running: true
+        }
+      end
     end
 
     def setup
@@ -18,9 +24,7 @@ module Katello
       refute Katello::EventDaemon.started?
     end
 
-    def test_start_runs_services
-      MockService.expects(:run)
-
+    def test_start
       Katello::EventDaemon.start
 
       assert Katello::EventDaemon.started?
@@ -33,6 +37,32 @@ module Katello
       MockService.expects(:close)
 
       Katello::EventDaemon.stop
+    end
+
+    def test_monitor_running
+      monitor = Katello::EventDaemon::Monitor.new([MockService])
+
+      MockService.expects(:run).never
+
+      monitor.check_services(nil, nil)
+    end
+
+    def test_monitor_not_running
+      monitor = Katello::EventDaemon::Monitor.new([MockService])
+      MockService.stubs(:status).returns(running: false)
+
+      MockService.expects(:run)
+
+      monitor.check_services(nil, nil)
+    end
+
+    def test_monitor_no_status
+      monitor = Katello::EventDaemon::Monitor.new([MockService])
+      MockService.stubs(:status).returns(nil)
+
+      MockService.expects(:run)
+
+      monitor.check_services(nil, nil)
     end
   end
 end

--- a/test/services/katello/event_monitor/poller_thread_test.rb
+++ b/test/services/katello/event_monitor/poller_thread_test.rb
@@ -26,11 +26,11 @@ module Katello
         status = {
           processed_count: 0,
           failed_count: 0,
-          queue_depth: 0
+          running: false
         }
-        Katello::EventMonitor::PollerThread.reset_status
+        Katello::EventMonitor::PollerThread.initialize
 
-        assert_equal status, Katello::EventMonitor::PollerThread.status
+        assert_equal status, Katello::EventMonitor::PollerThread.status(refresh: true)
       end
     end
   end


### PR DESCRIPTION

If the polling thread for either of the event listeners dies we would be left in an unrecoverable state ie. events would not be handled until the daemon process is recycled by passenger or puma, or the server is altogether restarted. That is hopefully a never-happens scenario but now we are guarded from it by having a special monitor thread on the EventDaemon class itself. It will periodically ping the services and attempt to revive them if they aren't running. This design will continue to work well for us when we switch to Artemis.

**Notable changes in this PR:**

- `EventDaemon::Monitor` is now responsible for starting the services the first time (replacing old startup code) so that it's regularly tested at runtime.
- The Monitor updates the cached status of each of the services. Previously it was updated on every incoming event in the poller threads. The disadvantage there is that our app is using the file cache so it's 'slow', and if the cache expired or were cleared we would not correctly know the status. The Monitor ensures the cache is always updated even when no events are coming in.
- The health of each service is determined by the `:running` key of its status. It reports whether the thread is still running and any relevant connections are still established. With this in mind I've changed how we report service status in the Ping API. I removed the WARN state that was added in #8366 and replaced it with the FAIL state since we can truly know if it's running or not.
- Since we accurately know if the pollers are running I removed reporting of the queue depth on the Ping API as there is no specific action to take based on that number.

**To test:**

This is how to create a candlepin and katello event from the console respectively:

```
Katello::Resources::Candlepin::Consumer.update(::Host.last.subscription_facet.uuid, {'role' => SecureRandom.uuid})
```
```
Katello::Event.create!(event_type: 'import_host_applicability', object_id: 16)
```

With that in mind, exiting behavior can be verified by looking for the following events after making a request to the server for the first time:

```
2019-11-22T15:07:02 [I|app|94fd8786] Katello event daemon started process=7705
2019-11-22T15:07:02 [I|kat|94fd8786] Candlepin Event Listener started
2019-11-22T15:07:03 [I|kat|94fd8786] Polling Katello Event Queue
```

It's easiest to test the restart functionality of the monitor by starting and stopping qpidd:
```
systemctl stop qpidd
```
I found it useful to see the behavior by stopping qpidd before I started my rails server and once again after startup (with event daemon already running) to see that it was graceful in both cases. That should look something like this:

```
2019-11-22T15:12:19 [I|kat|94fd8786] Stopping Candlepin Listening Service
2019-11-22 15:12:19 [Security] warning Connect failed: Connection refused
2019-11-22T15:12:19 [E|kat|94fd8786] Unable to establish candlepin events connection: Failed to connect (reconnect disabled)

<qpidd is started again>

2019-11-22T15:12:49 [I|kat|94fd8786] Stopping Candlepin Listening Service
2019-11-22T15:12:49 [I|kat|94fd8786] Candlepin Event Listener started
``` 

Similar can be performed for the Katello events side by stopping postgresql and seeing that it also recovers when postgres is back

**About page looks like this:**
![about_page](https://user-images.githubusercontent.com/1979598/69439031-2802ca80-0d14-11ea-9edb-1f1b2b023b2f.png)

