### PR TITLE
Fixes #28327 - Allow users in org to access subs

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -77,8 +77,9 @@ module Katello
     def show
       org_id = Organization.current&.id
       @resource = Katello::Pool.with_identifier(params[:id])
-      if @resource.organization_id != org_id
-        fail ActiveRecord::RecordNotFound, N_('This subscription is not relevant to the current organization.')
+      fail ActiveRecord::RecordNotFound, N_('Subscription not found') unless @resource
+      if @resource.organization_id != org_id && !User.current.organizations&.pluck(:id)&.include?(@resource.organization_id)
+        fail ActiveRecord::RecordNotFound, N_('This subscription is not relevant to the current user and organization.')
       end
       respond(:resource => @resource)
     end

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -86,6 +86,35 @@ module Katello
       assert_template 'api/v2/subscriptions/index'
     end
 
+    def test_show_with_org_id
+      @subscription = katello_pools(:pool_one)
+      @org = get_organization(:empty_organization)
+      get :show, params: { :id => @subscription.id, :organization_id => @org.id }
+
+      assert_response :success
+      assert_template 'api/v2/subscriptions/show'
+    end
+
+    def test_show_without_user_org_id
+      @subscription = katello_pools(:pool_one)
+      @org = get_organization(:empty_organization)
+      response = get :show, params: { :id => @subscription.id }
+      body = JSON.parse(response.body)
+
+      assert_response 404
+      assert_equal('This subscription is not relevant to the current user and organization.', body['errors'][0])
+    end
+
+    def test_show_with_user_org_id
+      @subscription = katello_pools(:pool_one)
+      @org = get_organization(:empty_organization)
+      User.current.organizations << @org
+      get :show, params: { :id => @subscription.id }
+
+      assert_response :success
+      assert_template 'api/v2/subscriptions/show'
+    end
+
     def test_blank_upload
       post :upload, params: { :organization_id => @organization.id }
       assert_response 400


### PR DESCRIPTION
**Current flow:**
Cannot access katello/api/v2/subscriptions/:id without specifying org id

**Updated flow:**
Allow access to katello/api/v2/subscriptions/:id  if the current user belongs to the org of the subscription and deny permission if not.

**To Test:**
Create an organization
Create a user and add the new org to the user.
Try to access a subscription in a different org. Should see the error.
Add user to the subscription.organization. Should see the subscription without error.