### PR TITLE
Fixes #28349 - refactors importer comparison

### DIFF
--- a/app/services/katello/pulp/importer_comparison.rb
+++ b/app/services/katello/pulp/importer_comparison.rb
@@ -6,21 +6,25 @@ module Katello
           return false
         end
 
-        if generated_importer.config['proxy_host'] == ""
-          generated_importer.config.delete('proxy_host')
-          generated_importer.config.delete('proxy_username')
-          generated_importer.config.delete('proxy_password')
-          generated_importer.config.delete('proxy_port')
-          capsule_importer['config'].delete('proxy_host')
-          capsule_importer['config'].delete('proxy_username')
-          capsule_importer['config'].delete('proxy_port')
-          capsule_importer['config'].delete('proxy_password')
+        generated_config = generated_importer.config
+        capsule_config = capsule_importer['config']
+        if generated_config['proxy_host'] == ""
+          generated_config.delete('proxy_host')
+          generated_config.delete('proxy_username')
+          generated_config.delete('proxy_password')
+          generated_config.delete('proxy_port')
+          capsule_config.delete('proxy_host')
+          capsule_config.delete('proxy_username')
+          capsule_config.delete('proxy_password')
+          capsule_config.delete('proxy_port')
         end
-        if generated_importer.config['proxy_password'] == "" && capsule_importer['config']['proxy_password'] == "*****"
-          generated_importer.config.delete('proxy_password')
-          capsule_importer['config'].delete('proxy_password')
+
+        if generated_config['proxy_password'] == "" && capsule_config['proxy_password'] == "*****"
+          generated_config.delete('proxy_password')
+          capsule_config.delete('proxy_password')
         end
-        generated_importer.config.compact == capsule_importer['config'].compact
+
+        generated_config.compact == capsule_config.compact
       end
     end
   end

--- a/app/services/katello/pulp/importer_comparison.rb
+++ b/app/services/katello/pulp/importer_comparison.rb
@@ -9,14 +9,11 @@ module Katello
         generated_config = generated_importer.config
         capsule_config = capsule_importer['config']
         if generated_config['proxy_host'] == ""
-          generated_config.delete('proxy_host')
-          generated_config.delete('proxy_username')
-          generated_config.delete('proxy_password')
-          generated_config.delete('proxy_port')
-          capsule_config.delete('proxy_host')
-          capsule_config.delete('proxy_username')
-          capsule_config.delete('proxy_password')
-          capsule_config.delete('proxy_port')
+          proxy_keys = %w(proxy_host proxy_username proxy_password)
+          proxy_keys.each do |key|
+            generated_config.delete(key)
+            capsule_config.delete(key)
+          end
         end
 
         if generated_config['proxy_password'] == "" && capsule_config['proxy_password'] == "*****"

--- a/app/services/katello/pulp/importer_comparison.rb
+++ b/app/services/katello/pulp/importer_comparison.rb
@@ -1,0 +1,27 @@
+module Katello
+  module Pulp
+    module ImporterComparison
+      def importer_matches?(generated_importer, capsule_importer)
+        if capsule_importer.try(:[], 'importer_type_id') != generated_importer.id
+          return false
+        end
+
+        if generated_importer.config['proxy_host'] == ""
+          generated_importer.config.delete('proxy_host')
+          generated_importer.config.delete('proxy_username')
+          generated_importer.config.delete('proxy_password')
+          generated_importer.config.delete('proxy_port')
+          capsule_importer['config'].delete('proxy_host')
+          capsule_importer['config'].delete('proxy_username')
+          capsule_importer['config'].delete('proxy_port')
+          capsule_importer['config'].delete('proxy_password')
+        end
+        if generated_importer.config['proxy_password'] == "" && capsule_importer['config']['proxy_password'] == "*****"
+          generated_importer.config.delete('proxy_password')
+          capsule_importer['config'].delete('proxy_password')
+        end
+        generated_importer.config.compact == capsule_importer['config'].compact
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -1,6 +1,7 @@
 module Katello
   module Pulp
     class Repository < ::Actions::Pulp::Abstract
+      include ImporterComparison
       attr_accessor :repo, :input
       attr_accessor :smart_proxy
       delegate :root, to: :repo
@@ -139,7 +140,8 @@ module Katello
         repo_details = backend_data
         return unless repo_details
         capsule_importer = repo_details["importers"][0]
-        !importer_matches?(capsule_importer)
+        generated_importer = generate_importer
+        !importer_matches?(generated_importer, capsule_importer)
       end
 
       def needs_distributor_updates?
@@ -317,12 +319,6 @@ module Katello
           actual.delete('checksum_type')
         end
         generated.compact == actual.compact
-      end
-
-      def importer_matches?(capsule_importer)
-        generated_importer = generate_importer
-        capsule_importer.try(:[], 'importer_type_id') == generated_importer.id &&
-            generated_importer.config.compact == capsule_importer['config'].compact
       end
 
       def distributors_match?(capsule_distributors)

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -140,8 +140,7 @@ module Katello
         repo_details = backend_data
         return unless repo_details
         capsule_importer = repo_details["importers"][0]
-        generated_importer = generate_importer
-        !importer_matches?(generated_importer, capsule_importer)
+        !importer_matches?(generate_importer, capsule_importer)
       end
 
       def needs_distributor_updates?

--- a/test/services/katello/pulp/importer_comparison_test.rb
+++ b/test/services/katello/pulp/importer_comparison_test.rb
@@ -1,0 +1,55 @@
+require 'katello_test_helper'
+require 'support/pulp/repository_support'
+
+module Katello
+  module Pulp
+    class TestImporterClass
+      attr_accessor :id
+      attr_accessor :config
+    end
+
+    class ImporterComparisonTest < ActiveSupport::TestCase
+      include ImporterComparison
+      def setup
+        yum_config = {
+          'relative_url' => '/foo/bar',
+          'checksum_type' => nil,
+          'http' => true,
+          'https' => true,
+          'proxy_host' => 'http://someurl.org',
+          'proxy_username' => 'admin',
+          'proxy_password' => 'redhat',
+          'proxy_port' => 8888
+        }
+        @generated_importer = TestImporterClass.new
+        @generated_importer.id = 6
+        @generated_importer.config = yum_config.clone
+        @capsule_importer = {
+          'config' => yum_config.clone,
+          'importer_type_id' => 6
+        }
+      end
+
+      def test_importer_matches_rejects_inqeual_ids
+        @generated_importer.id = 12
+        @capsule_importer['imported_type_id'] = 2
+        refute importer_matches?(@generated_importer, @capsule_importer)
+      end
+
+      def test_importer_matches_ignores_proxy_values_if_host_is_blank
+        @generated_importer.config['proxy_host'] = ""
+        assert importer_matches?(@generated_importer, @capsule_importer)
+      end
+
+      def test_importer_matches_ignores_proxy_password_if_generated_is_blank
+        @generated_importer.config['proxy_password'] = ""
+        @capsule_importer['config']['proxy_password'] = "*****"
+        assert importer_matches?(@generated_importer, @capsule_importer)
+      end
+
+      def test_importer_matches_accepts_equivalent_configs
+        assert importer_matches?(@generated_importer, @capsule_importer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses a pulp2 bug where the proxy password is returned as a masked string.

```
>> in the pulp2 db

> db.repo_importers.find({})
{ "_id" : ObjectId("5dd6ce3506c71a7bd3d7623f"), "repo_id" : "5bc050e0-88d7-4f8d-8a75-ab2516b53b74", "importer_type_id" : "yum_importer", "config" : { "feed" : "https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-unsigned/", "remove_missing" : true, "proxy_host" : "", "ssl_validation" : true, "proxy_password" : "", "download_policy" : "immediate", "proxy_username" : "" }, "last_updated" : ISODate("2019-11-22T14:52:10.174Z"), "last_override_config" : { "num_threads" : 4, "validate" : true }, "_ns" : "repo_importers", "scratchpad" : { "repomd_revision" : 1573300917, "repomd_checksum" : "734ef2769824aeb357165a7959b0c942fad7ce0ba5d8bde12c145d7f4fa0c231" }, "last_sync" : "2019-11-21T17:50:14Z" }

>> Check repos details using pulp-admin

[vagrant@centos7-katello-devel-stable foreman]$ pulp-admin -u admin -p admin repo list --details --repo-id 5bc050e0-88d7-4f8d-8a75-ab2516b53b74
+----------------------------------------------------------------------+
                              Repositories
+----------------------------------------------------------------------+

Id:                   5bc050e0-88d7-4f8d-8a75-ab2516b53b74
Display Name:         test
Description:          None
Content Unit Counts:  
  Erratum:           4
  Package Category:  1
  Package Group:     2
  Package Langpacks: 1
  Rpm:               35
Notes:                
Scratchpad:           
  Checksum Type: sha256
Importers:            
  Config:               
    Download Policy: immediate
    Feed:            https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-unsig
                     ned/
    Proxy Host:      
    Proxy Password:  *****
    Proxy Username:  
   [...]
```

This condition triggers repo refreshes unnecessarily.