### PR TITLE
Fixes #28427 - Caches counts in a CVV

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -92,6 +92,8 @@ module Actions
         end
 
         def finalize
+          version = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+          version.update_content_counts!
           # update errata applicability counts for all hosts in the CV & Library
           ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
                                               :lifecycle_environment_id => input[:environment_id]).each do |facet|

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -167,6 +167,7 @@ module Actions
 
         def finalize
           version = ::Katello::ContentViewVersion.find(input[:new_content_view_version_id])
+          version.update_content_counts!
           generate_description(version, output[:added_units]) if version.description.blank?
 
           history = ::Katello::ContentViewHistory.find(input[:history_id])

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -28,6 +28,13 @@ module Katello
         list.flatten
       end
 
+      def indexable_content_types
+        repository_types.
+                  values.
+                  map(&:content_types_to_index).
+                  flatten
+      end
+
       def creatable_by_user?(repository_type)
         return false unless (type = find(repository_type))
         type.allow_creation_by_user

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -8,17 +8,10 @@ attributes :published_in_composite_content_view_ids
 attributes :content_view_id
 attributes :default
 attributes :description
-attributes :package_count
-attributes :module_stream_count
-attributes :srpm_count
-attributes :file_count
-attributes :package_group_count
-attributes :puppet_module_count
-attributes :docker_manifest_count
-attributes :docker_manifest_list_count
-attributes :docker_tag_count
-attributes :ostree_branch_count
-attributes :deb_count
+
+node do |version|
+  version.content_counts_map
+end
 
 node :errata_counts do |version|
   partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(version.errata))

--- a/db/migrate/20191204214919_add_content_view_version_counts.rb
+++ b/db/migrate/20191204214919_add_content_view_version_counts.rb
@@ -1,0 +1,7 @@
+class AddContentViewVersionCounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :katello_content_view_versions, :content_counts, :text
+    Katello::ContentViewVersion.reset_column_information
+    Katello::ContentViewVersion.all.each(&:update_content_counts!)
+  end
+end

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -258,9 +258,8 @@ module Katello
     end
 
     def test_available_incremental_updates
-      ContentViewVersion.any_instance.stubs(:package_count).returns(0)
-      ContentViewVersion.any_instance.stubs(:errata_count).returns(0)
-      ContentViewVersion.any_instance.stubs(:puppet_module_count).returns(0)
+      ContentViewVersion.any_instance.stubs(:content_counts).returns(
+                     :package_count => 0, :errata_count => 0, :puppet_module_count => 0)
 
       @view_repo = Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)
 


### PR DESCRIPTION
Content view versions list api ran a count query for every content type
belonging to a content view. This means atleast 10 queries for each
content type and can get out of hand when one is returning over 40
versions in a list api call

This commit addresses the above issue by storing the counts in a
serializable hash for each content view version on every publish and
that cached result is returned when content_counts is called.
This should result in a speed up in the api response