### PR TITLE
Fixes #28474 - updates case for 'Http' and 'http'

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -50,10 +50,10 @@ module Katello
       respond_for_async :resource => task
     end
 
-    api :PUT, "/products/bulk/http_proxy", N_("Update the http proxy configuration on the repositories of one or more products.")
+    api :PUT, "/products/bulk/http_proxy", N_("Update the HTTP proxy configuration on the repositories of one or more products.")
     param :ids, Array, :desc => N_("List of product ids"), :required => true
-    param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policy for http proxy for content sync")
-    param :http_proxy_id, :number, :desc => N_("Http Proxy identifier to associated"), :required => false
+    param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policy for HTTP proxy for content sync")
+    param :http_proxy_id, :number, :desc => N_("HTTP Proxy identifier to associated"), :required => false
     def update_http_proxy
       task = async_task(::Actions::Katello::Product::UpdateHttpProxy,
                         @products.editable,

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -55,7 +55,7 @@ module Katello
       param :ignore_global_proxy, :bool, :desc => N_("if true, will ignore the globally configured proxy when syncing"), :deprecated => true
       param :ignorable_content, Array, :desc => N_("List of content units to ignore while syncing a yum repository. Must be subset of %s") % RootRepository::IGNORABLE_CONTENT_UNIT_TYPES.join(",")
       param :ansible_collection_requirements, String, :desc => N_("Contents of requirement yaml file to sync from URL")
-      param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policies for http proxy for content sync")
+      param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policies for HTTP proxy for content sync")
       param :http_proxy_id, :number, :desc => N_("ID of a HTTP Proxy")
     end
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -24,7 +24,7 @@ class Setting::Content < Setting
 
     [
       self.set('content_default_http_proxy', N_("Default HTTP Proxy for syncing content"),
-                      nil, N_('Default http proxy'),
+                      nil, N_('Default HTTP proxy'),
                       nil,
                       collection: proc { http_proxy_select }, include_blank: N_("no global default")
               ),

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-http-proxy-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-http-proxy-modal.html
@@ -1,5 +1,5 @@
 <div data-extend-template="components/views/bst-modal.html">
-  <h4 data-block="modal-header">Http Proxy Management</h4>
+  <h4 data-block="modal-header">HTTP Proxy Management</h4>
 
   <div data-block="modal-body">
     <div class="row">
@@ -21,7 +21,7 @@
     <form name="proxyForm" class="col-sm-5" novalidate role="form">
 
       <div class="form-group">
-        <label translate>Http Proxy Policy:</label>
+        <label translate>HTTP Proxy Policy:</label>
         <select required
                 id="http_proxy_policy"
                 name="http_proxy_policy"
@@ -32,7 +32,7 @@
 
       <span ng-show="proxyOptions.httpProxyPolicy === 'use_selected_http_proxy'">
         <div class="form-group">
-          <label translate>Http Proxy:</label>
+          <label translate>HTTP Proxy:</label>
           <span translate ng-show="proxies.length == 0">
             No HTTP Proxies found
           </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -151,7 +151,7 @@
       </span>
 
       <span>
-        <dt translate>Http Proxy</dt>
+        <dt translate>HTTP Proxy</dt>
         <dd bst-edit-custom="repository.http_proxy_policy"
             readonly="denied('edit_products', product)"
             on-save="save(repository)"
@@ -169,7 +169,7 @@
           </form>
 
           <span ng-show="repository.http_proxy_policy === 'use_selected_http_proxy'">
-            <div translate>Http Proxy</div>
+            <div translate>HTTP Proxy</div>
             <span translate ng-show="proxies.length == 0">
               No HTTP Proxies found
             </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -219,7 +219,7 @@
         </p>
       </div>
 
-      <div bst-form-group label="{{ 'Http Proxy Policy' | translate }}">
+      <div bst-form-group label="{{ 'HTTP Proxy Policy' | translate }}">
         <select required
                 id="http_proxy_policy"
                 name="http_proxy_policy"
@@ -228,7 +228,7 @@
         </select>
       </div>
       <span ng-show="repository.http_proxy_policy === 'use_selected_http_proxy'">
-        <div bst-form-group label="{{ 'Http Proxy' | translate }}">
+        <div bst-form-group label="{{ 'HTTP Proxy' | translate }}">
           <span translate ng-show="proxies.length == 0">
             No HTTP Proxies found
           </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -44,7 +44,7 @@
 
         <li role="menuitem" ng-show="permitted('edit_products')" ng-class="{disabled: table.numSelected === 0}">
           <a ng-click="openHttpProxyModal()" disable-link="table.numSelected === 0" translate>
-            Manage Http Proxy
+            Manage HTTP Proxy
           </a>
         </li>
 

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -1,7 +1,7 @@
 require File.expand_path("../engine", File.dirname(__FILE__))
 
 namespace :katello do
-  desc "Sets the content default http proxy to an existing http proxy based on supplied URL."
+  desc "Sets the content default HTTP proxy to an existing HTTP proxy based on supplied URL."
   task :update_default_http_proxy => :environment do
     setting = ::Setting.find_by(name: 'content_default_http_proxy')
     options = {}
@@ -52,7 +52,7 @@ namespace :katello do
       setting.update_attribute(:value, http_proxy.name)
       http_proxy.update_attributes!(url: sanitized_url,
                                    username: options[:username], password: options[:password])
-      puts "Content default http proxy set to #{http_proxy.name_and_url}."
+      puts "Content default HTTP proxy set to #{http_proxy.name_and_url}."
     else
       new_proxy = ::HttpProxy.new(name: options[:name], url: sanitized_url,
                                 username: options[:username], password: options[:password],
@@ -60,7 +60,7 @@ namespace :katello do
                                 locations: Location.all)
       if new_proxy.save!
         setting.update_attribute(:value, new_proxy.name)
-        puts "Default content http proxy set to #{new_proxy.name_and_url}."
+        puts "Default content HTTP proxy set to #{new_proxy.name_and_url}."
       end
     end
 


### PR DESCRIPTION
This updates inconsistent case with respect to HTTP proxy labels and descriptions in the UI. Previously it was established that the correct text should use "HTTP proxy" or "HTTP Proxy", not "http" or "Http" etc.