### PR TITLE
Fixes #16333 - sort CCV version based on IDs

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
@@ -52,7 +52,7 @@
                   ng-if="componentContentView.versions.length > 0"
                   ng-model="componentContentView.versionId"
                   ng-selected="latest"
-                  ng-options="cvv.id as cvv.version for cvv in availableVersions | orderBy: '-version'">
+                  ng-options="cvv.id as cvv.version for cvv in availableVersions | orderBy: '-id'">
           </select>
           <span ng-if="componentContentView.versions.length === 0" ng-model="componentContentView.version" translate>Always Use Latest (Currently no versions)</span>
         </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
@@ -44,7 +44,7 @@
                   readonly="denied('edit_content_views', contentView)"
                   selector="contentViewComponent.versionId"
                   options="getAvailableVersions(contentViewComponent.content_view)"
-                  options-format="option.id as option.version for option in options | orderBy: '-version'"
+                  options-format="option.id as option.version for option in options | orderBy: '-id'"
                   on-save="saveContentViewComponent(contentViewComponent)"
                   ng-if="contentViewComponent.content_view.version_count > 0">
             </span>


### PR DESCRIPTION
Sorting order doesn't work based on `version`, switching it to be sorted based on `id`. Tested this on katello 3.14 and works as expected. 