### PR TITLE
Fixes #28478 - Pulp 3 worker rename fix

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -193,10 +193,9 @@ module Katello
         end
 
         workers = json["online_workers"] || []
-        resource_manager_exists = workers.any? { |worker| worker["name"].include?("resource-manager@") }
-        reservered_resource_worker_exists = workers.any? { |worker| worker["name"] =~ /reserved-resource-worker-./ }
+        resource_manager_exists = workers.any? { |worker| worker["name"].include?("resource-manager") }
 
-        unless resource_manager_exists && reservered_resource_worker_exists
+        unless resource_manager_exists && workers.count > 1
           fail _("Not all necessary pulp workers running at %s.") % url
         end
 


### PR DESCRIPTION
To test:
1) Make a brand-new Pulp 3 dev box.
2) Check the 'About' page in Katello.  Notice Katello thinks Pulp 3 isn't running even though all of the Pulp 3 services are running.
3) Apply this PR.
4) Refresh the page.
5) See that Katello now says Pulp 3 is OK. 