### PR TITLE
Fixes #28489 - properly handle no-arch repos

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -19,12 +19,11 @@ class RepositorySetRepository extends Component {
 
   repoForAction = () => {
     const {
-      productId, contentId, arch, displayArch, releasever, label,
+      productId, contentId, arch, releasever, label,
     } = this.props;
 
-    const derivedArch = arch || displayArch;
     return {
-      arch: derivedArch,
+      arch,
       productId,
       contentId,
       releasever,


### PR DESCRIPTION
the rhel8 tools repo does not have an arch variable
within its content url, and the UI seemed to confuse
the displayArch with what is actually needed to enable
or disable a repo