### PR TITLE
Fixes #28446 - reverting snap update

### DIFF
--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -7,7 +7,7 @@ exports[`Content Details Info should render and contain appropriate components 1
     loadingText="Loading"
     timeout={300}
   >
-    <Uncontrolled(TabContainer)
+    <ForwardRef
       defaultActiveKey={1}
       id="content-tabs-container"
     >
@@ -131,7 +131,7 @@ exports[`Content Details Info should render and contain appropriate components 1
           </TabPane>
         </TabContent>
       </Grid>
-    </Uncontrolled(TabContainer)>
+    </ForwardRef>
   </LoadingState>
 </div>
 `;

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -24,7 +24,7 @@ exports[`subscriptions details page should render and contain appropiate compone
     }
     onSwitcherItemClick={[Function]}
   />
-  <Uncontrolled(TabContainer)
+  <ForwardRef
     defaultActiveKey={1}
     id="subscription-tabs-container"
   >
@@ -531,6 +531,6 @@ exports[`subscriptions details page should render and contain appropiate compone
         </Grid>
       </LoadingState>
     </div>
-  </Uncontrolled(TabContainer)>
+  </ForwardRef>
 </div>
 `;


### PR DESCRIPTION
This change reverts (via `npm test -- -u`) changes made that originally were needed to address an upgrade to a dependency in npm land. Now that update was reverted, and so we need to revert our tests.