### PR TITLE
Fixes #28550 - allow foreman-tasks 1.0.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", "~> 0.13", ">= 0.14.1"
+  gem.add_dependency "foreman-tasks", ">= 0.14.1"
   gem.add_dependency "dynflow", ">= 1.2.0"
   gem.add_dependency "activerecord-import"
 


### PR DESCRIPTION
foreman-tasks 1.0.0 is not any revolution and only updated vendor to v3, meaning it requires Foreman 1.25, that's the reason for major bump. We may see that more often, so I suggest we drop the major version up limitation.