### PR TITLE
Fixes #28350 - docker manifests not showing tags

### DIFF
--- a/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
@@ -4,7 +4,8 @@ attributes :id, :schema_version, :digest, :manifest_type
 
 child :docker_tags => :tags do
   attributes :associated_meta_tag_identifier => :id
-  attributes :repository_id, :name
+  attributes :repository => :repository_id
+  attributes :name
 end
 
 child :docker_manifests => :manifests do

--- a/app/views/katello/api/v2/docker_manifests/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifests/show.json.rabl
@@ -4,7 +4,8 @@ attributes :id, :schema_version, :digest, :manifest_type
 
 child :docker_tags => :tags do
   attributes :associated_meta_tag_identifier => :id
-  attributes :repository_id, :name
+  attributes :repository => :repository_id
+  attributes :name
 end
 
 child :docker_manifest_lists => :manifest_lists do


### PR DESCRIPTION
To test:

1) Sync a Docker repo like library/hello-world.
2) Look at the repo's manifests and manifest lists.
3) See that the tags are populated.