### PR TITLE
Fixes #28621 - properly show repo after disabling

### DIFF
--- a/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import {
@@ -12,9 +13,23 @@ import {
 
 import { normalizeContentSetRepositories } from '../../actions/RedHatRepositories/repositorySetRepositories';
 
+const normalizeArch = (arch) => {
+  if (arch === 'noarch') {
+    return undefined;
+  }
+  return arch;
+};
+
+const substitutionMatches = (value1, value2) => {
+  if (_.isEmpty(value1) && _.isEmpty(value2)) {
+    return true;
+  }
+  return value1 === value2;
+};
+
 const reposMatch = (repoA, repoB) => (
-  repoA.arch === repoB.arch &&
-  repoA.releasever === repoB.releasever
+  substitutionMatches(normalizeArch(repoA.arch), normalizeArch(repoB.arch)) &&
+    substitutionMatches(repoA.releasever, repoB.releasever)
 );
 
 const changeRepoState = (state, repoToChange, stateDiff) => {


### PR DESCRIPTION
for a couple of reasons, a repo will not show up properly
without a page refresh:

1) the content has no release version substitution, in which
   case the repo comparison will fail when comparing undefined to null
2) the server stores 'noarch' when there is no arch substituion, and the
   comparision does not recognize this