### PR TITLE
Fixes #28656 - Store DMI UUID on Subscription Facet

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -41,11 +41,6 @@ module Katello
         host_facts["virt::host_type"] || host_facts["hypervisor::type"]
       end
 
-      def dmi_system_uuid
-        host_facts = self.host.facts
-        host_facts["dmi::system::uuid"]
-      end
-
       def update_from_consumer_attributes(consumer_params)
         import_database_attributes(consumer_params)
         self.facts = consumer_params['facts'] unless consumer_params['facts'].blank?
@@ -55,6 +50,10 @@ module Katello
         update_subscription_status(consumer_params[:entitlementStatus]) unless consumer_params[:entitlementStatus].blank?
         update_hypervisor(consumer_params)
         update_guests(consumer_params)
+
+        if consumer_params['facts']
+          self.dmi_uuid = consumer_params['facts']['dmi.system.uuid']
+        end
 
         self.autoheal = consumer_params['autoheal'] unless consumer_params['autoheal'].blank?
         self.service_level = consumer_params['serviceLevel'] unless consumer_params['serviceLevel'].nil?

--- a/app/views/katello/api/v2/subscription_facet/show.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/show.json.rabl
@@ -22,5 +22,5 @@ child :subscription_facet => :subscription_facet_attributes do |_facet|
     attributes :id, :name
   end
 
-  attributes :host_type, :dmi_system_uuid
+  attributes :host_type, :dmi_uuid
 end

--- a/db/migrate/20191213161248_add_dmi_uuid_to_katello_subscription_facets.rb
+++ b/db/migrate/20191213161248_add_dmi_uuid_to_katello_subscription_facets.rb
@@ -1,0 +1,6 @@
+class AddDmiUuidToKatelloSubscriptionFacets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :katello_subscription_facets, :dmi_uuid, :string
+    add_index :katello_subscription_facets, :dmi_uuid
+  end
+end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -10,6 +10,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.11:update_puppet_repos'},
     {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'},
     {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'},
-    {:name => 'katello:upgrades:3.13:republish_deb_metadata'}
+    {:name => 'katello:upgrades:3.13:republish_deb_metadata'},
+    {:name => 'katello:upgrades:3.15:set_sub_facet_dmi_uuid'}
   ]
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -19,8 +19,8 @@
         <dt translate>Subscription UUID</dt>
         <dd>{{ host.subscription_facet_attributes.uuid }}</dd>
 
-        <dt translate>Bios UUID</dt>
-        <dd>{{ host.subscription_facet_attributes.dmi_system_uuid }}</dd>
+        <dt translate>BIOS UUID</dt>
+        <dd>{{ host.subscription_facet_attributes.dmi_uuid }}</dd>
 
         <dt translate>Description</dt>
         <dd bst-edit-textarea="host.comment"

--- a/lib/katello/tasks/upgrades/3.15/set_sub_facet_dmi_uuid.rake
+++ b/lib/katello/tasks/upgrades/3.15/set_sub_facet_dmi_uuid.rake
@@ -1,0 +1,16 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.15' do
+      desc "Set the DMI UUID on Host::SubscriptionFacet from facts"
+      task :set_sub_facet_dmi_uuid, [:input_file] => ["environment"] do
+        User.current = User.anonymous_api_admin
+        dmi_uuid_fact_name = Katello::RhsmFactName.find_by_name('dmi::system::uuid') || -1
+
+        fact_values = ::FactValue.where(fact_name: dmi_uuid_fact_name).where.not(value: nil)
+        fact_values.each do |fv|
+          fv.host.subscription_facet&.update_attributes(dmi_uuid: fv.value)
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -17,6 +17,12 @@ without_content_facet:
   name: "host3.example.com"
   type: 'Host::Managed'
 
+without_subscription_facet:
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  name: "no-sub-facet.example.com"
+  type: 'Host::Managed'
+
 without_errata:
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
   location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>

--- a/test/lib/tasks/set_sub_facet_dmi_uuid_test.rb
+++ b/test/lib/tasks/set_sub_facet_dmi_uuid_test.rb
@@ -1,0 +1,37 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class SetSubFacetDmiUuidTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/3.15/set_sub_facet_dmi_uuid'
+      Rake::Task['katello:upgrades:3.15:set_sub_facet_dmi_uuid'].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_set_dmi_uuid
+      host = hosts(:one)
+      fact_name = RhsmFactName.new(name: 'dmi::system::uuid')
+      FactValue.create!(host: host, fact_name: fact_name, value: 'something')
+
+      Rake.application.invoke_task('katello:upgrades:3.15:set_sub_facet_dmi_uuid')
+
+      assert_equal 'something', host.subscription_facet.dmi_uuid
+      assert_nil hosts(:two).subscription_facet.dmi_uuid
+    end
+
+    def test_no_fact_name
+      refute RhsmFactName.find_by_name('dmi::system::uuid')
+      assert Rake.application.invoke_task('katello:upgrades:3.15:set_sub_facet_dmi_uuid')
+    end
+
+    def test_no_facet
+      host = hosts(:without_subscription_facet)
+
+      fact_name = RhsmFactName.new(name: 'dmi::system::uuid')
+      FactValue.create!(host: host, fact_name: fact_name, value: 'something')
+
+      assert Rake.application.invoke_task('katello:upgrades:3.15:set_sub_facet_dmi_uuid')
+    end
+  end
+end


### PR DESCRIPTION
Not so long ago the DMI UUID (reported by subman) of Content Hosts became critical to the registration process in order to block duplicate host registrations. The value is stored among the system facts, and looking up duplicates at registration time in a very large table can become slow as the number of hosts grow.

This PR helps alleviate the problem by making the DMI UUID a value on the SubscriptionFacet model. The below performance measures are taken from 1000 content hosts each with a distinct DMI UUID fact.

Old query performance
```
irb(main):002:0> Benchmark.bm do |x|
irb(main):003:1* x.report { 10000.times do; Katello::RegistrationManager.find_existing_hosts('flood0', SecureRandom.uuid); end }
irb(main):004:1> end
       user     system      total        real
   9.863411   0.338413  10.201824 ( 12.369747)
=> [#<Benchmark::Tms:0x000000000d5b16b8 @label="", @real=12.369746921118349, @cstime=0.0, @cutime=0.0, @stime=0.33841299999999985, @utime=9.863411000000001, @total=10.201824>]
```

New query performance:
```
irb(main):004:0> Benchmark.bm do |x|
irb(main):005:1* x.report { 10000.times do; Katello::RegistrationManager.find_existing_hosts('flood0', SecureRandom.uuid); end }
irb(main):006:1> end
       user     system      total        real
   1.884269   0.014484   1.898753 (  1.904810)
```

Looks like the duplicate lookup is 5x faster.

**To test**
- checkout PR
- migrate the DB
- run the rake task to populate subscription facet: `bundle exec rake katello:upgrades:3.15:set_sub_facet_dmi_uuid`

- Registrations should exhibit all of the same behaviors w.r.t preventing duplicate hosts by DMI UUID.
- Changing the DMI UUID from the client side via fact override should also update the subscription facet field