### PR TITLE
Fixes #28676 - Single Candlepin call to create activation key

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -49,14 +49,8 @@ module Katello
         activation_key.organization = @organization
         activation_key.user = current_user
       end
-      sync_task(::Actions::Katello::ActivationKey::Create, @activation_key)
+      sync_task(::Actions::Katello::ActivationKey::Create, @activation_key, service_level: activation_key_params['service_level'])
       @activation_key.reload
-
-      sync_task(::Actions::Katello::ActivationKey::Update, @activation_key,
-                  :service_level   => activation_key_params[:service_level],
-                  :release_version => activation_key_params[:release_version],
-                  :auto_attach     => activation_key_params[:auto_attach]
-               )
 
       respond_for_create(:resource => @activation_key)
     end

--- a/app/lib/actions/candlepin/activation_key/create.rb
+++ b/app/lib/actions/candlepin/activation_key/create.rb
@@ -4,6 +4,8 @@ module Actions
       input_format do
         param :organization_label
         param :auto_attach
+        param :service_level
+        param :release_version
         param :purpose_role
         param :purpose_usage
         param :purpse_addons
@@ -13,6 +15,8 @@ module Actions
         output[:response] = ::Katello::Resources::Candlepin::ActivationKey.create(::Katello::Util::Model.uuid,
                                                                                   input[:organization_label],
                                                                                   input[:auto_attach],
+                                                                                  input[:service_level],
+                                                                                  input[:release_version],
                                                                                   input[:purpose_role],
                                                                                   input[:purpose_usage],
                                                                                   input[:purpose_addons])

--- a/app/lib/actions/katello/activation_key/create.rb
+++ b/app/lib/actions/katello/activation_key/create.rb
@@ -2,12 +2,14 @@ module Actions
   module Katello
     module ActivationKey
       class Create < Actions::EntryAction
-        def plan(activation_key)
+        def plan(activation_key, params = {})
           activation_key.save!
           if ::SETTINGS[:katello][:use_cp]
             cp_create = plan_action(Candlepin::ActivationKey::Create,
                                     organization_label: activation_key.organization.label,
                                     auto_attach: activation_key.auto_attach,
+                                    service_level: params[:service_level],
+                                    release_version: activation_key.release_version,
                                     purpose_role: activation_key.purpose_role,
                                     purpose_usage: activation_key.purpose_usage,
                                     purpose_addons: activation_key.purpose_addons.pluck(:name))

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -10,9 +10,20 @@ module Katello
             ::Katello::Util::Data.array_with_indifferent_access akeys
           end
 
-          def create(name, owner_key, auto_attach, purpose_role, purpose_usage, purpose_addons)
+          # rubocop:disable Metrics/ParameterLists
+          def create(name, owner_key, auto_attach, service_level, release_version, purpose_role, purpose_usage, purpose_addons)
             url = "/candlepin/owners/#{owner_key}/activation_keys"
-            JSON.parse(self.post(url, {:name => name, :autoAttach => auto_attach, :role => purpose_role, :usage => purpose_usage, :addOns => purpose_addons}.to_json, self.default_headers).body).with_indifferent_access
+            params = {
+              name: name,
+              autoAttach: auto_attach,
+              serviceLevel: service_level,
+              releaseVer: release_version,
+              role: purpose_role,
+              usage: purpose_usage,
+              addOns: purpose_addons
+            }
+            response = self.post(url, params.to_json, self.default_headers)
+            JSON.parse(response.body).with_indifferent_access
           end
 
           # rubocop:disable Metrics/ParameterLists

--- a/test/actions/candlepin/activation_key_test.rb
+++ b/test/actions/candlepin/activation_key_test.rb
@@ -11,12 +11,20 @@ class Actions::Candlepin::ActivationKey::CreateTest < ActiveSupport::TestCase
   describe 'Create' do
     let(:action_class) { ::Actions::Candlepin::ActivationKey::Create }
     let(:planned_action) do
-      create_and_plan_action action_class, organization_label: nil, auto_attach: true, purpose_role: "role", purpose_usage: "usage", purpose_addons: ["Test"]
+      create_and_plan_action(action_class,
+                             organization_label: nil,
+                             auto_attach: true,
+                             service_level: 'Self-Support',
+                             release_version: '7Server',
+                             purpose_role: "role",
+                             purpose_usage: "usage",
+                             purpose_addons: ["Test"]
+                            )
     end
 
     it 'runs' do
       ::Katello::Util::Model.stubs(:uuid).returns(123)
-      ::Katello::Resources::Candlepin::ActivationKey.expects(:create).with(123, nil, true, "role", "usage", ["Test"])
+      ::Katello::Resources::Candlepin::ActivationKey.expects(:create).with(123, nil, true, "Self-Support", "7Server", "role", "usage", ["Test"])
       run_action planned_action
     end
   end

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -16,8 +16,10 @@ module ::Actions::Katello::ActivationKey
     let(:candlepin_input) do
       {  :organization_label => activation_key.organization.label,
          :auto_attach => true,
-         :purpose_usage => katello_activation_keys(:purpose_attributes_key).purpose_usage,
-         :purpose_role => katello_activation_keys(:purpose_attributes_key).purpose_role,
+         :service_level => 'Self-support',
+         :release_version => activation_key.release_version,
+         :purpose_usage => activation_key.purpose_usage,
+         :purpose_role => activation_key.purpose_role,
          :purpose_addons => [katello_purpose_addons(:addon).name]
       }
     end
@@ -25,7 +27,7 @@ module ::Actions::Katello::ActivationKey
       activation_key.expects(:save!)
       action.expects(:action_subject)
 
-      plan_action action, activation_key
+      plan_action action, activation_key, service_level: 'Self-support'
 
       assert_action_planed_with(action, ::Actions::Candlepin::ActivationKey::Create, candlepin_input)
     end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -92,15 +92,25 @@ module Katello
     def test_create
       ActivationKey.any_instance.expects(:reload)
       assert_sync_task(::Actions::Katello::ActivationKey::Create)
-      assert_sync_task(::Actions::Katello::ActivationKey::Update)
 
-      post :create, params: { organization_id: @organization.id, name: 'Typical Key', release_version: '7Server', auto_attach: true, service_level: 'Standard' }
+      post :create, params: { organization_id: @organization.id, name: 'Typical Key', release_version: '7Server', auto_attach: false, service_level: 'Standard' }
 
       assert_response :success
       response = JSON.parse(@response.body)
       assert_equal 'Standard', response['service_level']
       assert_equal '7Server', response['release_version']
       assert_equal 'Typical Key', response['name']
+      assert_equal false, response['auto_attach']
+    end
+
+    def test_create_no_auto_attach
+      ActivationKey.any_instance.expects(:reload)
+      assert_sync_task(::Actions::Katello::ActivationKey::Create)
+      post :create, params: { organization_id: @organization.id, name: 'Unset Auto-Attach' }
+
+      assert_response :success
+      response = JSON.parse(@response.body)
+
       assert_equal true, response['auto_attach']
     end
 
@@ -112,8 +122,6 @@ module Katello
         assert activation_key.unlimited_hosts
         assert_valid activation_key
       end
-
-      assert_sync_task(::Actions::Katello::ActivationKey::Update)
 
       post :create, params: { :organization_id => @organization.id, :activation_key => {:name => 'Unlimited Key', :unlimited_hosts => true} }
 
@@ -133,8 +141,6 @@ module Katello
         assert_equal max_hosts, activation_key.max_hosts
         assert_valid activation_key
       end
-
-      assert_sync_task(::Actions::Katello::ActivationKey::Update)
 
       post :create, params: {
         :organization_id => @organization.id,
@@ -159,8 +165,6 @@ module Katello
         assert_valid activation_key
       end
 
-      assert_sync_task(::Actions::Katello::ActivationKey::Update)
-
       post :create, params: { :organization_id => @organization.id, :activation_key => {:name => key_name} }
 
       assert_response :success
@@ -178,8 +182,6 @@ module Katello
         assert_equal key_description, activation_key.description
         assert_valid activation_key
       end
-
-      assert_sync_task(::Actions::Katello::ActivationKey::Update)
 
       post :create, params: {
         :organization_id => @organization.id,

--- a/test/fixtures/models/katello_activation_keys.yml
+++ b/test/fixtures/models/katello_activation_keys.yml
@@ -55,4 +55,5 @@ purpose_attributes_key:
   auto_attach: true
   purpose_role: role name
   purpose_usage: usage name
+  release_version: '7Server'
 


### PR DESCRIPTION
We can now create an activation key with service level and release version without a separate update call to Candlepin. This PR cleans up the code in order to do that! The related BZ mentions that creating a key without an `auto_attach` value will result in a null value on the resulting key even though it should be `true`. This is fixed as well.
 
To test:

Create an activation key through API via POST to `/katello/api/v2/activation_keys`:
```
{
    "organization_id": "1",
    "name": "testkey",
    "service_level": "Self-support",
    "auto_attach": false,
    "release_version": "7Server"
}
```

The important aspect is that these values reach the key in Candlepin. Verify with rails console:

```
Katello::Resources::Candlepin::ActivationKey.get(Katello::ActivationKey.last.cp_id)
```

Check the releaseVer, autoAttach, and serviceLevel keys in particular. If no auto-attach value is specified in the API call then the default should be `true`.