### PR TITLE
Fixes #28677 - Use correct distributor on publish

### DIFF
--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -53,11 +53,13 @@ module Katello
           distributors
         end
 
-        def distributors_to_publish(_options)
-          if repo.clone && !repo.master? && smart_proxy.pulp_master?
-            source_service = repo.target_repository.backend_service(smart_proxy)
+        def distributors_to_publish(options)
+          source_repo_id = options[:source_repository]&.fetch(:id)
+          if (source_repo_id || !repo.master?) && smart_proxy.pulp_master?
+            source_repository = source_repo_id ? ::Katello::Repository.find(source_repo_id) : repo.target_repository
+            source_service = source_repository.backend_service(smart_proxy)
             source_distributor_id = source_service.lookup_distributor_id(Runcible::Models::YumDistributor.type_id)
-            {Runcible::Models::YumCloneDistributor => {source_repo_id: repo.target_repository.pulp_id,
+            {Runcible::Models::YumCloneDistributor => {source_repo_id: source_repository.pulp_id,
                                                        source_distributor_id: source_distributor_id}}
           else
             {Runcible::Models::YumDistributor => {}}


### PR DESCRIPTION
Prior to this commit the yum clone distributor associated to the
metadata generation did not take cognizance of the source_repository
option during the distributor publish operation.
This commit fixes that by correctly making use of the source_repository
option and chooses the correct values for the distributor publish.