### PR TITLE
Fixes #28535 - fix product task results loading

### DIFF
--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -26,7 +26,7 @@ module Katello
 
             # Pulp 3 has its own registry
             if pulp_master && pulp_master.pulp3_repository_type_support?(::Katello::Repository::DOCKER_TYPE)
-              registry_url = pulp_master.setting('Pulp3', 'content_app_url')
+              registry_url = pulp_master.setting(SmartProxy::PULP3_FEATURE, 'content_app_url')
               # Assume the registry uses the same CA as the Smart Proxy
               ca_cert_file = Setting[:ssl_ca_file]
             elsif container_config

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -15,7 +15,7 @@ module Katello
         end
       end
 
-      PULP3_FEATURE = "Pulp3".freeze
+      PULP3_FEATURE = "Pulpcore".freeze
       PULP_FEATURE = "Pulp".freeze
       PULP_NODE_FEATURE = "Pulp Node".freeze
 

--- a/app/views/smart_proxies/plugins/_pulp3.html.erb
+++ b/app/views/smart_proxies/plugins/_pulp3.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
-  <h3><%= _('Pulp3') %></h3>
+  <h3><%= _('Pulpcore') %></h3>
 </div>
-<%= show_feature_version('pulp3') %>
+<%= show_feature_version('pulpcore') %>
 <div class="row">
   <div class="col-md-4">
     <strong><%= _('Supported Content Types') %></strong>

--- a/db/seeds.d/104-proxy.rb
+++ b/db/seeds.d/104-proxy.rb
@@ -16,7 +16,7 @@ User.as(::User.anonymous_api_admin.login) do
     fail "Unable to create proxy feature: #{format_errors feature}"
   end
 
-  ["Pulp", "Pulp Node", "Pulp3"].each do |input|
+  ["Pulp", "Pulp Node", "Pulpcore"].each do |input|
     f = Feature.where(:name => input).first_or_create
     fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
   end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", ">= 0.14.1"
+  gem.add_dependency "foreman-tasks", ">= 1.0.1"
   gem.add_dependency "dynflow", ">= 1.2.0"
   gem.add_dependency "activerecord-import"
 

--- a/test/factories/smart_proxy_factory.rb
+++ b/test/factories/smart_proxy_factory.rb
@@ -16,7 +16,7 @@ FactoryBot.modify do
     trait :with_pulp3 do
       after(:create) do |proxy, _evaluator|
         plugins = Katello::RepositoryTypeManager.repository_types.values.map(&:pulp3_plugin).compact
-        v3_feature = Feature.find_or_create_by(:name => 'Pulp3')
+        v3_feature = Feature.find_or_create_by(:name => ::SmartProxy::PULP3_FEATURE)
         proxy.features << v3_feature
 
         smart_proxy_feature = proxy.smart_proxy_features.find { |spf| spf.feature_id == v3_feature.id }


### PR DESCRIPTION
This PR changes the foreman-tasks version to fix an issue with NULL ids returned in the results. Currently this version is the earliest that the foreman-tasks plugin will include the fix.

The release version of foreman-tasks is not yet ready, so it's expected this PR won't pass tests until then.