### PR TITLE
Fixes #28709 - supplies only uniq root repo ids

### DIFF
--- a/app/lib/actions/katello/product/update_http_proxy.rb
+++ b/app/lib/actions/katello/product/update_http_proxy.rb
@@ -4,7 +4,7 @@ module Actions
       class UpdateHttpProxy < Actions::EntryAction
         def plan(products, http_proxy_policy, http_proxy)
           products.each do |product|
-            roots = product.repositories.map(&:root)
+            roots = product.root_repositories
             next if roots.empty?
             plan_action(::Actions::BulkAction,
                         ::Actions::Katello::Repository::Update,

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -154,7 +154,7 @@ module ::Actions::Katello::Product
       assert_action_planned_with(action,
                                 ::Actions::BulkAction,
                                 ::Actions::Katello::Repository::Update,
-                                product.repositories.map(&:root),
+                                product.root_repositories,
                                 http_proxy_policy: 'use_selected_http_proxy',
                                 http_proxy_id: http_proxy.id)
     end
@@ -169,7 +169,7 @@ module ::Actions::Katello::Product
       assert_action_planned_with(action,
                                 ::Actions::BulkAction,
                                 ::Actions::Katello::Repository::Update,
-                                product.repositories.map(&:root),
+                                product.root_repositories,
                                 http_proxy_policy: 'global_default_http_proxy',
                                 http_proxy_id: nil)
     end


### PR DESCRIPTION
This PR corrects a problem where multiple repositories with the same root repository would supply a non-unique list of root repository ids to a bulk update. This causes issues with lock contention during an update, causing one or more sub-tasks to fail.

To test, before the PR:
1. create a product with at least 1 yum repository
2. create a content view, include that repository
3. publish that content view
4. create an HTTP proxy
5. navigate to products page, select that product
6. use the "Manage HTTP Proxy" action
7. Set the HTTP Proxy policy to "Use selected proxy"
8. Select the HTTP proxy you created
9. Apply the change

Observe that one of the tasks may error with a message similar to:
```
2019-12-17T02:21:47 [I|bac|] Task {label: Actions::Katello::Repository::Update, id: f28b5bfa-9a6f-46e9-b619-3293eca805ae, execution_plan_id: 7b2eefe4-51b8-43d5-b2fa-8da36a43f0a0} state changed: planning 
2019-12-17T02:21:47 [I|bac|] Task {label: Actions::Katello::Repository::Update, id: f28b5bfa-9a6f-46e9-b619-3293eca805ae, execution_plan_id: 7b2eefe4-51b8-43d5-b2fa-8da36a43f0a0} state changed: planned 
2019-12-17T02:21:47 [I|bac|] Task {label: Actions::Katello::Repository::Update, id: f28b5bfa-9a6f-46e9-b619-3293eca805ae, execution_plan_id: 7b2eefe4-51b8-43d5-b2fa-8da36a43f0a0} state changed: running 
2019-12-17T02:21:47 [I|bac|] Task {label: Actions::Katello::Repository::Update, id: 8540c10f-ccc6-44e6-9c84-7590831a5b82, execution_plan_id: 35b2882d-20c8-4c11-b5a9-48df1cf387a5} state changed: planning 
2019-12-17T02:21:47 [E|bac|] Required lock is already taken by other running tasks.
Please inspect their state, fix their errors and resume them.

Required lock: read
Conflicts with tasks:
- https://hostname.example.com/foreman_tasks/tasks/f28b5bfa-9a6f-46e9-b619-3293eca805ae (ForemanTasks::Lock::LockConflict)
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman-tasks-0.17.4/app/models/foreman_tasks/lock.rb:44:in `block in <class:Lock>'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:426:in `instance_exec'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:426:in `block in make_lambda'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:606:in `block (2 levels) in default_terminator'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:605:in `catch'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:605:in `block in default_terminator'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:199:in `block in halting'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:513:in `block in invoke_before'
[...]
```

After applying the PR:
Follow the same steps as above, but there should be a reduction in the number of repositories the updates are applied to (only once per root repository). There should be no lock conflicts and no tasks should error.