### PR TITLE
Fixes #28713 - Ensure events recover after db outage

### DIFF
--- a/app/lib/katello/util/support.rb
+++ b/app/lib/katello/util/support.rb
@@ -78,12 +78,12 @@ module Katello
         logger.error(e.message)
         logger.error("Lost database connection. Attempting reconnect.")
 
-        active_record_retry_connect
+        active_record_retry_connect(logger)
 
         retry
       end
 
-      def self.active_record_retry_connect
+      def self.active_record_retry_connect(logger)
         sleep 3
         ActiveRecord::Base.connection.reconnect!
       rescue

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -9,7 +9,9 @@ module Katello
         error = nil
         status = nil
         loop do
-          check_services(error, status)
+          Rails.application.executor.wrap do
+            check_services(error, status)
+          end
           sleep 15
         end
       end
@@ -21,7 +23,7 @@ module Katello
           rescue => error
             Rails.logger.error("Error occurred while pinging #{service_class}")
             Rails.logger.error(error.message)
-            Rails.logger.error(error.backtrace.join('\n'))
+            Rails.logger.error(error.backtrace.join("\n"))
           ensure
             if error || !status&.dig(:running)
               begin
@@ -30,7 +32,7 @@ module Katello
               rescue => error
                 Rails.logger.error("Error occurred while starting #{service_class}")
                 Rails.logger.error(error.message)
-                Rails.logger.error(error.backtrace.join('\n'))
+                Rails.logger.error(error.backtrace.join("\n"))
               ensure
                 error = nil
               end


### PR DESCRIPTION
This PR fixes the scenario when the Katello::EventDaemon::Monitor thread can not recover its database connection after postgres comes back up:
```
`sanitize_sql_for_assignment'
 | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/activerecord-5.2.1/lib/active_record/relation.rb:325:in `update_all'
 | /home/vagrant/katello/app/services/katello/event_queue.rb:42:in `reset_in_progress'
 | /home/vagrant/katello/app/services/katello/event_monitor/poller_thread.rb:24:in `run'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:31:in `block in check_services'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:20:in `each'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:20:in `check_services'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:13:in `block in start'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:11:in `loop'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:11:in `start'
 | /home/vagrant/katello/app/services/katello/event_daemon.rb:117:in `block in start_monitor_thread'
```


**Testing steps**

- start server
- curl the ping endpoint: https://centos7-katello-devel-stable.example.com/katello/api/v2/ping
- check output and see that katello_events is OK
- systemctl stop postgresql on the server
- observe logs and see that the ::PollerThread attempts to be started and fails
- systemctl start postgresql
- observe that the PollerThread recovers: `Polling Katello Event Queue` and confirm the same in the ping endpoint

repeat 3-4 times to make sure there is no variance in behavior since this would not happen each time in master
