### PR TITLE
Fixes #28714 - Limit the certificate end date to late 2049

### DIFF
--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -72,8 +72,13 @@ module Katello
 
           def create_unlimited_subscription(owner_key, product_id, start_date)
             start_date ||= Time.now
-            # End it 100 years from now
-            end_date ||= start_date + 10_950.days
+
+            # Subscription-manager (python-rhsm) can't read the certificate with end date deyond
+            # 2049 year correctly. Refer the links below for more details:
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1789654
+            # https://github.com/candlepin/candlepin/blob/5b87865f304555c112982af4fbc83a1c463d37b2
+            # /server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java#L247
+            end_date = Time.parse('2049-12-01 00:00:00 +0000')
 
             pool = {
               'startDate' => start_date,

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -39,6 +39,30 @@ module Katello
           assert_equal 'proxy://admin:password@foo.com:1000', UpstreamCandlepinResource.proxy_uri
         end
       end
+
+      class ProductTest < ActiveSupport::TestCase
+        def setup
+        end
+
+        def test_create_unlimited_subsciption
+          product_id = 3
+          owner = Organization.first
+          start_date = Time.parse('2020-01-10 07:07:47 +0000')
+          end_date = Time.parse('2049-12-01 00:00:00 +0000')
+          expected_pool = {
+            'startDate' => start_date,
+            'endDate' => end_date,
+            'quantity' => -1,
+            'accountNumber' => '',
+            'productId' => product_id,
+            'providedProducts' => [],
+            'contractNumber' => ''
+          }
+
+          ::Katello::Resources::Candlepin::Pool.expects(:create).with(owner.label, expected_pool).returns('{}')
+          ::Katello::Resources::Candlepin::Product.create_unlimited_subscription(owner.label, product_id, start_date)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Subscription-manager (python-rhsm) can't read the certificate
with end date deyond 2049 year correctly. It will read the date
as 1949 year which causing the pool of the custom products not
accessible.