### PR TITLE
Fixes #28657 - adds a rake task to copy migrated pulp3 href to pulp ids

### DIFF
--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -6,6 +6,11 @@ module Katello
       attr_accessor :smart_proxy
       GET_QUERY_ID_LENGTH = 90
 
+      REPOSITORY_TYPES = [
+        Katello::Repository::FILE_TYPE,
+        Katello::Repository::DOCKER_TYPE
+      ].freeze
+
       def initialize(smart_proxy, repository_type_labels)
         @smart_proxy = smart_proxy
         @repository_type_labels = repository_type_labels
@@ -25,6 +30,14 @@ module Katello
 
       def create_and_run_migration
         start_migration(create_migration)
+      end
+
+      def self.content_types_for_migration
+        content_types = REPOSITORY_TYPES.collect do |repository_type_label|
+          Katello::RepositoryTypeManager.repository_types[repository_type_label].content_types_to_index
+        end
+
+        content_types.flatten
       end
 
       def import_pulp3_content

--- a/lib/katello/tasks/pulp3_content_switchover.rake
+++ b/lib/katello/tasks/pulp3_content_switchover.rake
@@ -1,0 +1,21 @@
+require File.expand_path("../engine", File.dirname(__FILE__))
+
+namespace :katello do
+  desc "Runs a Pulp 3 migration of pulp3 hrefs to pulp ids for supported content types."
+  task :pulp3_content_switchover => :environment do
+    content_types = Katello::Pulp3::Migration.content_types_for_migration
+
+    content_types.each do |content_type|
+      if content_type.model_class.where(migrated_pulp3_href: nil).any?
+        $stderr.print("ERROR: at least one #{content_type.model_class.table_name} record has migrated_pulp3_href NULL value\n")
+        exit 1
+      end
+    end
+
+    content_types.each do |content_type|
+      content_type.model_class
+        .where.not("pulp_id=migrated_pulp3_href")
+        .update_all("pulp_id = migrated_pulp3_href")
+    end
+  end
+end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -4,7 +4,7 @@ require 'simplecov-rcov'
 require 'test_helper'
 require 'factory_bot_rails'
 require "webmock/minitest"
-require "mocha/setup"
+require 'mocha/minitest'
 require 'set'
 require 'robottelo/reporter/attributes'
 require 'minitest/reporters'

--- a/test/lib/tasks/pulp3_content_switchover_test.rb
+++ b/test/lib/tasks/pulp3_content_switchover_test.rb
@@ -1,0 +1,125 @@
+require 'katello_test_helper'
+require 'rake_test_helper'
+require 'rake'
+
+module Katello
+  class Pulp3ContentSwitchoverTest < ActiveSupport::TestCase
+    def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @fake_pulp3_href = 'fake_pulp3_href'
+      @another_fake_pulp3_href = 'another_fake_pulp3_href'
+
+      Katello::Pulp3::Migration.content_types_for_migration.each do |content_type|
+        content_type.model_class.all.each do |record|
+          record.update(:migrated_pulp3_href => @fake_pulp3_href + record.id.to_s)
+        end
+      end
+
+      Rake.application.rake_require 'katello/tasks/pulp3_content_switchover'
+      @task_name = 'katello:pulp3_content_switchover'
+
+      Rake::Task[@task_name].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_file_unit_pulp_ids_updated
+      file_unit = katello_files(:one)
+
+      file_unit.update(:migrated_pulp3_href => @another_fake_pulp3_href)
+
+      refute_equal @another_fake_pulp3_href, file_unit.reload.pulp_id
+
+      capture_out do
+        Rake::Task[@task_name].invoke
+      end
+
+      assert_equal @another_fake_pulp3_href, file_unit.reload.pulp_id
+    end
+
+    def test_file_unit_with_null_migrated_pulp3_href_throws_an_error
+      file_unit = katello_files(:two)
+      file_unit.update(:migrated_pulp3_href => nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_docker_manifest_pulp_ids_updated
+      manifest = FactoryBot.create(:docker_manifest)
+      manifest.update(:migrated_pulp3_href => @another_fake_pulp3_href)
+
+      refute_equal @another_fake_pulp3_href, manifest.reload.pulp_id
+
+      capture_out do
+        Rake::Task[@task_name].invoke
+      end
+
+      assert_equal @another_fake_pulp3_href, manifest.reload.pulp_id
+    end
+
+    def test_docker_manifest_with_null_migrated_pulp3_href_throws_an_error
+      Katello::DockerManifest.first.update(:migrated_pulp3_href => nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_docker_manifest_list_pulp_ids_updated
+      manifest_list = FactoryBot.create(:docker_manifest_list)
+      manifest_list.update(:migrated_pulp3_href => @another_fake_pulp3_href)
+      docker_manifest = manifest_list.docker_manifests.first
+      docker_manifest.update(:migrated_pulp3_href => @another_fake_pulp3_href + docker_manifest.id.to_s)
+
+      refute_equal @another_fake_pulp3_href, manifest_list.reload.pulp_id
+
+      capture_out do
+        Rake::Task[@task_name].invoke
+      end
+
+      assert_equal @another_fake_pulp3_href, manifest_list.reload.pulp_id
+    end
+
+    def test_docker_manifest_list_with_null_migrated_pulp3_href_throws_an_error
+      manifest_list = FactoryBot.create(:docker_manifest_list)
+      manifest_list.update(:migrated_pulp3_href => nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_docker_tag_pulp_ids_updated
+      repo = Repository.find(katello_repositories(:busybox).id)
+      tag = create(:docker_tag, :repositories => [repo])
+      tag.update(:migrated_pulp3_href => @another_fake_pulp3_href)
+      tag.update(:pulp_id => "areallyfakepulpid")
+      docker_manifest = tag.docker_taggable
+      docker_manifest.update(:migrated_pulp3_href => @another_fake_pulp3_href + docker_manifest.id.to_s)
+
+      refute_equal @another_fake_pulp3_href, tag.reload.pulp_id
+
+      capture_out do
+        Rake::Task[@task_name].invoke
+      end
+
+      assert_equal @another_fake_pulp3_href, tag.reload.pulp_id
+    end
+
+    def test_docker_manifest_tag_with_null_migrated_pulp3_href_throws_an_error
+      repo = Repository.find(katello_repositories(:busybox).id)
+      tag = create(:docker_tag, :repositories => [repo])
+      tag.update(:migrated_pulp3_href => nil)
+      docker_manifest = tag.docker_taggable
+      docker_manifest.update(:migrated_pulp3_href => @another_fake_pulp3_href + docker_manifest.id.to_s)
+
+      assert_error(@task_name)
+    end
+
+    def test_rpm_pulp_ids_not_updated
+      rpm = katello_rpms(:one)
+      pulp_id = rpm.pulp_id
+
+      capture_out do
+        Rake::Task[@task_name].invoke
+      end
+
+      assert_equal pulp_id, rpm.reload.pulp_id
+    end
+  end
+end

--- a/test/rake_test_helper.rb
+++ b/test/rake_test_helper.rb
@@ -1,0 +1,24 @@
+def capture_out(&_block)
+  original_stdout = $stdout
+  original_stderr = $stderr
+  $stdout = fakeout = StringIO.new
+  $stderr = fakeerr = StringIO.new
+
+  begin
+    yield
+  ensure
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+
+  [fakeout.string, fakeerr.string]
+end
+
+def assert_error(task_name, exit_code = 1)
+  result = assert_raises SystemExit do
+    capture_out do
+      Rake::Task[task_name].invoke
+    end
+  end
+  assert_equal exit_code, result.status
+end


### PR DESCRIPTION
This PR introduces a rake task that copies the `migrated_pulp3_href` values into the `pulp_id` column for supported content types (file, docker).