### PR TITLE
Fixes #28722 - Upgrade task to set modular in rpm

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -11,6 +11,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'},
     {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'},
     {:name => 'katello:upgrades:3.13:republish_deb_metadata'},
-    {:name => 'katello:upgrades:3.15:set_sub_facet_dmi_uuid'}
+    {:name => 'katello:upgrades:3.15:set_sub_facet_dmi_uuid'},
+    {:name => 'katello:upgrades:3.15:reindex_rpm_modular'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
+++ b/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
@@ -2,34 +2,21 @@ namespace :katello do
   namespace :upgrades do
     namespace '3.15' do
       desc "Reindex the is_modular attribute of an rpm"
-      def update_modular(pulp_response)
-        modular = []
-        non_modular = []
-        pulp_response.each do |rpm|
-          if rpm["is_modular"]
-            modular << rpm["_id"]
-          else
-            non_modular << rpm["_id"] unless rpm["is_modular"]
-          end
-        end
-        ::Katello::Rpm.where(pulp_id: modular).update_all(modular: true)
-        ::Katello::Rpm.where(pulp_id: non_modular).update_all(modular: false)
-      end
-
       task :reindex_rpm_modular, [:input_file] => ["environment"] do
         User.current = User.anonymous_api_admin
-        criteria = { :fields => ["is_modular"],
+        criteria = { :fields => [],
                      :limit => SETTINGS[:katello][:pulp][:bulk_load_size],
-                     :skip => 0
+                     :skip => 0,
+                     :filters => {'is_modular' => {'$eq' => true}}
                    }
         content_type = Katello.pulp_server.extensions.rpm.content_type
         batch = ::Katello::Pulp::PulpContentUnit.pulp_units_batch(criteria, criteria[:limit]) do
           Katello.pulp_server.resources.unit.search(content_type, criteria)
         end
-
-        batch.each do |pulp_response|
-          update_modular(pulp_response)
-        end
+        pulp_modular_ids = batch.map { |response| response.pluck("_id") }.flatten
+        db_modular_ids = ::Katello::Rpm.modular.pluck(:pulp_id)
+        ::Katello::Rpm.where(pulp_id: db_modular_ids - pulp_modular_ids).update_all(modular: false)
+        ::Katello::Rpm.where(pulp_id: pulp_modular_ids - db_modular_ids).update_all(modular: true)
       end
     end
   end

--- a/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
+++ b/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
@@ -2,12 +2,10 @@ namespace :katello do
   namespace :upgrades do
     namespace '3.15' do
       desc "Reindex the is_modular attribute of an rpm"
-      task :reindex_rpm_modular, [:input_file] => ["environment"] do
-        User.current = User.anonymous_api_admin
-        rpms = Katello.pulp_server.resources.unit.search(Katello.pulp_server.extensions.rpm.content_type, :fields => ["is_modular"])
+      def update_modular(pulp_response)
         modular = []
         non_modular = []
-        rpms.each do |rpm|
+        pulp_response.each do |rpm|
           if rpm["is_modular"]
             modular << rpm["_id"]
           else
@@ -16,6 +14,22 @@ namespace :katello do
         end
         ::Katello::Rpm.where(pulp_id: modular).update_all(modular: true)
         ::Katello::Rpm.where(pulp_id: non_modular).update_all(modular: false)
+      end
+
+      task :reindex_rpm_modular, [:input_file] => ["environment"] do
+        User.current = User.anonymous_api_admin
+        criteria = { :fields => ["is_modular"],
+                     :limit => SETTINGS[:katello][:pulp][:bulk_load_size],
+                     :skip => 0
+                   }
+        content_type = Katello.pulp_server.extensions.rpm.content_type
+        batch = ::Katello::Pulp::PulpContentUnit.pulp_units_batch(criteria, criteria[:limit]) do
+          Katello.pulp_server.resources.unit.search(content_type, criteria)
+        end
+
+        batch.each do |pulp_response|
+          update_modular(pulp_response)
+        end
       end
     end
   end

--- a/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
+++ b/lib/katello/tasks/upgrades/3.15/reindex_rpm_modular.rake
@@ -1,0 +1,22 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.15' do
+      desc "Reindex the is_modular attribute of an rpm"
+      task :reindex_rpm_modular, [:input_file] => ["environment"] do
+        User.current = User.anonymous_api_admin
+        rpms = Katello.pulp_server.resources.unit.search(Katello.pulp_server.extensions.rpm.content_type, :fields => ["is_modular"])
+        modular = []
+        non_modular = []
+        rpms.each do |rpm|
+          if rpm["is_modular"]
+            modular << rpm["_id"]
+          else
+            non_modular << rpm["_id"] unless rpm["is_modular"]
+          end
+        end
+        ::Katello::Rpm.where(pulp_id: modular).update_all(modular: true)
+        ::Katello::Rpm.where(pulp_id: non_modular).update_all(modular: false)
+      end
+    end
+  end
+end

--- a/test/lib/tasks/reindex_rpm_modular_test.rb
+++ b/test/lib/tasks/reindex_rpm_modular_test.rb
@@ -1,0 +1,37 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class ReindexRpmModularTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/3.15/reindex_rpm_modular'
+      Rake::Task['katello:upgrades:3.15:reindex_rpm_modular'].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_package_reindexing
+      modular = ::Katello::Rpm.modular.first
+      non_modular = ::Katello::Rpm.non_modular.first
+      #reverse the modular settings for is_modular
+      pulp_response = [
+        {"is_modular": false, "_id": modular.pulp_id},
+        {"is_modular": true, "_id": non_modular.pulp_id}
+      ].map(&:with_indifferent_access)
+      mock_pulp(pulp_response)
+      Rake.application.invoke_task('katello:upgrades:3.15:reindex_rpm_modular')
+
+      refute ::Katello::Rpm.find(modular.id).reload.modular?
+      assert ::Katello::Rpm.find(non_modular.id).reload.modular?
+    end
+
+    def mock_pulp(value = [])
+      rpm = mock(:content_type => "rpm")
+      extensions = mock(:rpm => rpm)
+
+      unit = mock(:search => value)
+      resources = stub(:unit => unit)
+      pulp_server = stub(:resources => resources, :extensions => extensions)
+      Katello.stubs(:pulp_server).returns(pulp_server)
+    end
+  end
+end

--- a/test/lib/tasks/reindex_rpm_modular_test.rb
+++ b/test/lib/tasks/reindex_rpm_modular_test.rb
@@ -28,7 +28,9 @@ module Katello
       rpm = mock(:content_type => "rpm")
       extensions = mock(:rpm => rpm)
 
-      unit = mock(:search => value)
+      unit = mock
+      unit.stubs(:search).returns(value, [])
+
       resources = stub(:unit => unit)
       pulp_server = stub(:resources => resources, :extensions => extensions)
       Katello.stubs(:pulp_server).returns(pulp_server)

--- a/test/lib/tasks/reindex_rpm_modular_test.rb
+++ b/test/lib/tasks/reindex_rpm_modular_test.rb
@@ -14,8 +14,7 @@ module Katello
       non_modular = ::Katello::Rpm.non_modular.first
       #reverse the modular settings for is_modular
       pulp_response = [
-        {"is_modular": false, "_id": modular.pulp_id},
-        {"is_modular": true, "_id": non_modular.pulp_id}
+        {"_id": non_modular.pulp_id}
       ].map(&:with_indifferent_access)
       mock_pulp(pulp_response)
       Rake.application.invoke_task('katello:upgrades:3.15:reindex_rpm_modular')


### PR DESCRIPTION
Pulp recently fixed a bug related to the the is_modular flag of a
package. https://pulp.plan.io/issues/5942

This commit adds a task to reindex the is_modular attribute of an
rpm based on the values in the pulp db store.

This upgrade script is meant to be run after
sudo -u apache /usr/bin/pulp-manage-db