### PR TITLE
Fixes #28756 - unwrap IPv6 address in proxy

### DIFF
--- a/app/lib/actions/katello/repository/discover.rb
+++ b/app/lib/actions/katello/repository/discover.rb
@@ -54,7 +54,7 @@ module Actions
           proxy_details = {}
           if (proxy = ::HttpProxy.default_global_content_proxy)
             uri = URI(proxy.url)
-            proxy_details[:proxy_host] = "#{uri.host}#{uri.path}"
+            proxy_details[:proxy_host] = uri.hostname
             proxy_details[:proxy_port] = uri.port
             proxy_details[:proxy_user] = proxy.username
             proxy_details[:proxy_password] = proxy.password

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -50,7 +50,7 @@ module Katello
         end
 
         def http_downloader
-          net = net_http_class.new(@uri.host, @uri.port)
+          net = net_http_class.new(@uri.hostname, @uri.port)
           net.use_ssl = @uri.is_a?(URI::HTTPS)
 
           if CdnResource.redhat_cdn?(@uri.to_s)
@@ -136,8 +136,8 @@ module Katello
 
         def net_http_class
           if (proxy = ::HttpProxy.default_global_content_proxy)
-            uri = URI(proxy.url) #Net::HTTP::Proxy ignores port as part of the url
-            Net::HTTP::Proxy("#{uri.host}#{uri.path}", uri.port, proxy.username, proxy.password)
+            uri = URI(proxy.url)
+            Net::HTTP::Proxy(uri.hostname, uri.port, proxy.username, proxy.password)
           else
             Net::HTTP
           end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -118,7 +118,7 @@ module Katello
       def pulp3_configuration(config_class)
         config_class.new do |config|
           uri = pulp3_uri!
-          config.host = uri.host
+          config.host = uri.hostname
           config.scheme = uri.scheme
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert
           config.ssl_client_key = ::Cert::Certs.ssl_client_key

--- a/test/services/katello/pulp/repository/yum_test.rb
+++ b/test/services/katello/pulp/repository/yum_test.rb
@@ -210,6 +210,17 @@ module Katello
           assert_equal "http://" + uri.host, config['proxy_host']
         end
 
+        def test_create_with_global_http_proxy_ipv6
+          @default_proxy = FactoryBot.create(:http_proxy, name: 'best proxy 6', url: "http://[2001:db8:abcd::1]")
+          @repo.root.update(http_proxy_policy: RootRepository::GLOBAL_DEFAULT_HTTP_PROXY)
+          RepositorySupport.create_repo(@repo)
+          backend_data = @repo.backend_service(@master).backend_data
+          importers = backend_data['importers']
+          config = importers.first['config']
+          uri = URI(@default_proxy.url)
+          assert_equal "http://" + uri.hostname, config['proxy_host']
+        end
+
         def test_sync_with_global_http_proxy
           @repo.root.update(http_proxy_policy: RootRepository::GLOBAL_DEFAULT_HTTP_PROXY)
           RepositorySupport.create_repo(@repo)


### PR DESCRIPTION
When URI is parsed and host part extracted, two methods must be used in order not to break `http://[2001::db8::1]` IPv6 address notation in URLs:

* uri.host - when brackets should be preserved (e.g. the variable goes back into URI/URL)
* uri.hostname - when brackets should be unwrapped