### PR TITLE
Fixes #28751 - Allow admin users to access subscriptions from all organizations

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -75,10 +75,9 @@ module Katello
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :id, :number, :desc => N_("Subscription identifier"), :required => true
     def show
-      org_id = Organization.current&.id
       @resource = Katello::Pool.with_identifier(params[:id])
       fail ActiveRecord::RecordNotFound, N_('Subscription not found') unless @resource
-      if @resource.organization_id != org_id && !User.current.organizations&.pluck(:id)&.include?(@resource.organization_id)
+      unless @resource.readable?
         fail ActiveRecord::RecordNotFound, N_('This subscription is not relevant to the current user and organization.')
       end
       respond(:resource => @resource)

--- a/app/models/katello/authorization/pool.rb
+++ b/app/models/katello/authorization/pool.rb
@@ -2,9 +2,13 @@ module Katello
   module Authorization::Pool
     extend ActiveSupport::Concern
 
+    def readable?
+      self.class.readable.where(id: self.id).any?
+    end
+
     module ClassMethods
       def readable
-        where(:subscription_id => Katello::Subscription.authorized(:view_subscriptions))
+        where(:subscription_id => Katello::Subscription.readable)
       end
     end
   end

--- a/app/models/katello/authorization/subscription.rb
+++ b/app/models/katello/authorization/subscription.rb
@@ -10,7 +10,9 @@ module Katello
 
     module ClassMethods
       def readable
-        authorized(:view_subscriptions)
+        return all if User.current.admin?
+
+        authorized(:view_subscriptions).where(organization_id: User.current.organization_ids)
       end
     end
   end


### PR DESCRIPTION
If the current user is an admin, don't check if the requested subscription matches the current user & organization.