### PR TITLE
Fixes #28777 - sync_summary no result in API

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -97,7 +97,7 @@ module Katello
       def last_repo_sync_task_group
         if last_repo_sync_task
           started_after = last_repo_sync_task.started_at - 30.seconds
-          last_repo_sync_tasks.where("#{ForemanTasks::Task::DynflowTask.table_name}.started_at > '%s'", started_after).uniq
+          last_repo_sync_tasks.where("#{ForemanTasks::Task::DynflowTask.table_name}.started_at > '%s'", started_after.utc).uniq
         else
           []
         end


### PR DESCRIPTION
From within the API-Controller `started_at` returns timezoned-format that does not work with the following `where`-statement.