### PR TITLE
Fixes #28660 - post pulp3 migration rake task

### DIFF
--- a/lib/katello/tasks/pulp3_post_migration_check.rake
+++ b/lib/katello/tasks/pulp3_post_migration_check.rake
@@ -1,0 +1,32 @@
+require File.expand_path("../engine", File.dirname(__FILE__))
+
+namespace :katello do
+  desc "Runs a post Pulp3 migration check for supported content types."
+  task :pulp3_post_migration_check => :environment do
+    repository_types = Katello::Pulp3::Migration::REPOSITORY_TYPES
+
+    repository_types.each do |type|
+      filter = 'version_href is NULL OR remote_href is NULL'
+
+      unless type == Katello::Repository::DOCKER_TYPE
+        filter += ' OR publication_href is NULL'
+      end
+      repositories = Katello::Repository.with_type(type).where(filter)
+
+      if repositories.any?
+        $stderr.print("ERROR: #{type} repository #{repositories.first.id} has a NULL value for remote_href, version_href, publication_href\n")
+        exit 1
+      end
+
+      non_archived_repositories = Katello::Repository.with_type(type).non_archived
+      with_no_distribution_references = non_archived_repositories
+        .left_outer_joins(:distribution_references)
+        .where(katello_distribution_references: { id: nil })
+
+      if with_no_distribution_references.any?
+        $stderr.print("ERROR: A non-archive #{type} repository #{with_no_distribution_references.first.id} did not have a distribution reference\n")
+        exit 1
+      end
+    end
+  end
+end

--- a/test/lib/tasks/pulp3_post_migration_check_test.rb
+++ b/test/lib/tasks/pulp3_post_migration_check_test.rb
@@ -1,0 +1,153 @@
+require 'katello_test_helper'
+require 'rake_test_helper'
+require 'rake'
+
+module Katello
+  class PostPulp3MigrationCheckTest < ActiveSupport::TestCase
+    def setup
+      @fake_pulp3_href = 'fake_pulp3_href'
+      @another_fake_pulp3_href = 'another_fake_pulp3_href'
+
+      Katello::Pulp3::Migration::REPOSITORY_TYPES.each do |type|
+        Katello::Repository.with_type(type).each do |repo|
+          repo.update(:version_href => @fake_pulp3_href + repo.id.to_s,
+                        :remote_href => @fake_pulp3_href + repo.id.to_s,
+                        :publication_href => @fake_pulp3_href + repo.id.to_s)
+        end
+      end
+
+      Rake.application.rake_require 'katello/tasks/pulp3_post_migration_check'
+      @task_name = 'katello:pulp3_post_migration_check'
+      Rake::Task[@task_name].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_fails_if_file_repository_has_nil_version_href
+      file = katello_repositories(:pulp3_file_1)
+      file.update(version_href: nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_fails_if_file_repository_has_nil_remote_href
+      file = katello_repositories(:pulp3_file_1)
+      file.update(remote_href: nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_fails_if_file_repository_has_nil_publication_href
+      file = katello_repositories(:pulp3_file_1)
+      file.update(publication_href: nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_fails_if_non_archive_file_repository_lacks_a_distribution_reference
+      file = katello_repositories(:pulp3_file_1)
+      file.update(:remote_href => 'someurl', :version_href => 'someotherurl')
+
+      refute Katello::Pulp3::DistributionReference.exists?(repository_id: file.id)
+
+      assert_error(@task_name)
+    end
+
+    def test_passes_if_archive_file_repository_lacks_a_distribution_reference
+      Katello::Repository.all.each do |repo|
+        Katello::Pulp3::DistributionReference.create!(
+          repository_id: repo.id, href: 'somedisthref', path: '/')
+      end
+
+      file = katello_repositories(:pulp3_file_1)
+      file.update(:remote_href => 'someurl', :version_href => 'someotherurl')
+      file.update(:environment => nil)
+      Katello::Pulp3::DistributionReference.find_by(repository_id: file.id).delete
+
+      assert file.reload.archive?, "Repository was not an archive repository as expected"
+      refute Katello::Pulp3::DistributionReference.exists?(repository_id: file.id)
+
+      Rake::Task[@task_name].invoke
+    end
+
+    def test_check_passes_with_non_archive_file_repo_with_distribution_reference
+      Katello::Repository.update_all(environment_id: nil)
+
+      file = katello_repositories(:pulp3_file_1)
+      file.update(:remote_href => 'someurl', :version_href => 'someotherurl',
+                    :environment_id => Katello::KTEnvironment.first.id)
+
+      Katello::Pulp3::DistributionReference.create!(repository_id: file.id, href: 'somedisthref', path: '/')
+
+      refute file.reload.archive?
+      assert Katello::Pulp3::DistributionReference.exists?(repository_id: file.id)
+
+      Rake::Task[@task_name].invoke
+    end
+
+    def test_fails_if_docker_repository_has_nil_version_href
+      docker = katello_repositories(:busybox)
+      docker.update(version_href: nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_fails_if_docker_repository_has_nil_remote_href
+      docker = katello_repositories(:busybox)
+      docker.update(remote_href: nil)
+
+      assert_error(@task_name)
+    end
+
+    def test_ok_if_docker_repository_has_nil_publication_href
+      Katello::Repository.all.each do |repo|
+        Katello::Pulp3::DistributionReference.create!(
+          repository_id: repo.id, href: 'somedisthref', path: '/')
+      end
+      docker = katello_repositories(:busybox)
+      docker.update(publication_href: nil)
+
+      Rake::Task[@task_name].invoke
+    end
+
+    def test_fails_if_non_archive_docker_repository_lacks_a_distribution_reference
+      docker = katello_repositories(:busybox)
+      docker.update(:remote_href => 'someurl', :version_href => 'someotherurl')
+
+      refute Katello::Pulp3::DistributionReference.exists?(repository_id: docker.id)
+
+      assert_error(@task_name)
+    end
+
+    def test_passes_if_archive_docker_repository_lacks_a_distribution_reference
+      Katello::Repository.all.each do |repo|
+        Katello::Pulp3::DistributionReference.create!(
+          repository_id: repo.id, href: 'somedisthref', path: '/')
+      end
+
+      docker = katello_repositories(:busybox)
+      docker.update(:remote_href => 'someurl', :version_href => 'someotherurl')
+      docker.update(:environment => nil)
+      Katello::Pulp3::DistributionReference.find_by(repository_id: docker.id).delete
+
+      assert docker.reload.archive?, "Repository was not an archive repository as expected"
+      refute Katello::Pulp3::DistributionReference.exists?(repository_id: docker.id)
+
+      Rake::Task[@task_name].invoke
+    end
+
+    def test_check_passes_with_non_archive_docker_repo_with_distribution_reference
+      Katello::Repository.update_all(environment_id: nil)
+
+      docker = katello_repositories(:busybox)
+      docker.update(:remote_href => 'someurl', :version_href => 'someotherurl',
+                    :environment_id => Katello::KTEnvironment.first.id)
+
+      Katello::Pulp3::DistributionReference.create!(repository_id: docker.id, href: 'somedisthref', path: '/')
+
+      refute docker.reload.archive?
+      assert Katello::Pulp3::DistributionReference.exists?(repository_id: docker.id)
+
+      Rake::Task[@task_name].invoke
+    end
+  end
+end

--- a/test/rake_test_helper.rb
+++ b/test/rake_test_helper.rb
@@ -14,6 +14,12 @@ def capture_out(&_block)
   [fakeout.string, fakeerr.string]
 end
 
+def assert_ok(task_name)
+  capture_out do
+    Rake::Task[task_name].invoke
+  end
+end
+
 def assert_error(task_name, exit_code = 1)
   result = assert_raises SystemExit do
     capture_out do


### PR DESCRIPTION
This PR introduces a post-migration check for pulp3 content. The task checks that pulp3 repositories have `version_href` and `remote_href` values. For non-archived repositories, the task also checks that a distribution reference exists.