### PR TITLE
Fixes #28425 - Change service name to Foreman URL

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -266,7 +266,7 @@ module Katello
     def get_parent_host(headers)
       hostnames = headers["HTTP_X_FORWARDED_SERVER"]
       host = hostnames.split(",")[0] if hostnames
-      host || SETTINGS[:fqdn]
+      host || URI.parse(Setting[:foreman_url]).host
     end
 
     private

--- a/app/models/katello/glue/candlepin/repository.rb
+++ b/app/models/katello/glue/candlepin/repository.rb
@@ -13,14 +13,6 @@ module Katello
       def content
         Katello::Content.find_by(:cp_content_id => self.content_id, :organization_id => self.product.organization_id)
       end
-
-      def yum_gpg_key_url
-        # if the repo has a gpg key return a url to access it
-        if (gpg_key && gpg_key.content.present?)
-          host = SETTINGS[:fqdn]
-          gpg_key_content_api_repository_url(self, :host => host + "/katello", :protocol => 'https')
-        end
-      end
     end
   end
 end

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -395,6 +395,7 @@ module Katello
     describe "get parent host" do
       it "can get parent host" do
         capsule = "foocapsule.example.com"
+        Setting[:foreman_url] = 'https://foreman.example.com'
 
         host_and_capsule = {"HTTP_X_FORWARDED_SERVER" => "#{capsule}, foo.example.com"}
         just_capsule = {"HTTP_X_FORWARDED_SERVER" => "#{capsule}"}
@@ -402,7 +403,7 @@ module Katello
 
         assert_equal @controller.get_parent_host(host_and_capsule), "#{capsule}"
         assert_equal @controller.get_parent_host(just_capsule), "#{capsule}"
-        assert_equal SETTINGS[:fqdn], @controller.get_parent_host(nil_host)
+        assert_equal 'foreman.example.com', @controller.get_parent_host(nil_host)
       end
     end
   end


### PR DESCRIPTION
This appears to be dead code:

https://github.com/Katello/katello/blob/d9f5d173cb8a604caae3ad20c3f237d06c0f846b/app/models/katello/glue/candlepin/repository.rb#L17-L22

Did not come up with pry and removing it all together did not impact anything and the redhat.repo file on the client is still updating correctly when cycling between two different gpg keys. Did not see any tracebacks in the rails server output and all api calls to /rhsm etc were 200.

I looked at the database and in `katello(katello_contents)` and `candlepin(cp2_content)` it looks like we store the GPG URL as such:

`../../katello/api/v2/repositories/1/gpg_key_content`

I was able to watch the database in real-time using Navicat, when doing a `rhsm refresh` on the client I could see the database GPG entries being changed so the above method is no longer in use.

Waiting on the 2nd part to hear more back from Ewoud and to see if there any test failures. 