### PR TITLE
Fixes #28781 - Disable Auto attach on Host

### DIFF
--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -35,7 +35,7 @@ module Katello
         self.owner_details['contentAccessMode']
       end
 
-      def golden_ticket?
+      def simple_content_access?
         content_access_mode == "org_environment"
       end
 

--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -4,7 +4,7 @@
 
 <% if Organization.current.blank? %>
   <p class="ca"><%= _("Please select an organization to view subscription status.") %></p>
-<% elsif Organization.current.golden_ticket?%>
+<% elsif Organization.current.simple_content_access?%>
   <div class="bastion alert alert-info">
     <span translate>This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.
     </span>

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -18,7 +18,7 @@
     angular.module('Bastion.features').value('FeatureSettings', angular.fromJson(<%= SETTINGS[:features].nil? ? {} : SETTINGS[:features].to_json.html_safe %>));
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
-    angular.module('Bastion').value('contentAccessMode', "<%= Organization.current.try(:content_access_mode) if Organization.current %>");
+    angular.module('Bastion').value('simpleContentAccessEnabled',  "<%= Organization.current.simple_content_access? if Organization.current %>")
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -18,7 +18,7 @@
     angular.module('Bastion.features').value('FeatureSettings', angular.fromJson(<%= SETTINGS[:features].nil? ? {} : SETTINGS[:features].to_json.html_safe %>));
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
-    angular.module('Bastion').value('simpleContentAccessEnabled',  <%= Organization.current.simple_content_access? if Organization.current %>)
+    angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>)
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -18,7 +18,7 @@
     angular.module('Bastion.features').value('FeatureSettings', angular.fromJson(<%= SETTINGS[:features].nil? ? {} : SETTINGS[:features].to_json.html_safe %>));
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
-    angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>)
+    angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>);
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -18,7 +18,7 @@
     angular.module('Bastion.features').value('FeatureSettings', angular.fromJson(<%= SETTINGS[:features].nil? ? {} : SETTINGS[:features].to_json.html_safe %>));
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
-    angular.module('Bastion').value('simpleContentAccessEnabled',  "<%= Organization.current.simple_content_access? if Organization.current %>")
+    angular.module('Bastion').value('simpleContentAccessEnabled',  <%= Organization.current.simple_content_access? if Organization.current %>)
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
@@ -12,13 +12,14 @@
  * @requires SubscriptionsHelper
  * @requires Notification
  * @requires hostIds
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   A controller for providing bulk action functionality to the content hosts page.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscriptionsModalController',
-    ['$scope', '$location', '$uibModalInstance', 'Nutupane', 'CurrentOrganization', 'HostBulkAction', 'Subscription', 'SubscriptionsHelper', 'Notification', 'hostIds', 'contentAccessMode',
-        function ($scope, $location, $uibModalInstance, Nutupane, CurrentOrganization, HostBulkAction, Subscription, SubscriptionsHelper, Notification, hostIds, contentAccessMode) {
+    ['$scope', '$location', '$uibModalInstance', 'Nutupane', 'CurrentOrganization', 'HostBulkAction', 'Subscription', 'SubscriptionsHelper', 'Notification', 'hostIds', 'simpleContentAccessEnabled',
+        function ($scope, $location, $uibModalInstance, Nutupane, CurrentOrganization, HostBulkAction, Subscription, SubscriptionsHelper, Notification, hostIds, simpleContentAccessEnabled) {
             var success, error, params = {
                 'organization_id': CurrentOrganization,
                 'sort_order': 'ASC',
@@ -44,7 +45,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
                 });
             };
 
-
             $scope.contentNutupane = new Nutupane(Subscription, params,
               'queryPaged', {disableAutoLoad: true});
             $scope.controllerName = 'katello_subscriptions';
@@ -53,7 +53,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
             $scope.contentNutupane.masterOnly = true;
             $scope.contentNutupane.load();
             $scope.groupedSubscriptions = {};
-            $scope.contentAccessMode = contentAccessMode;
+            $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
             $scope.$watch('table.rows', function (rows) {
                 $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
@@ -11,7 +11,7 @@
           <span translate>Auto-Attach</span>
         </button>
 
-        <p class="help-text" ng-show="table.numSelected === 0 && !simpleContentAccessEnabled'">
+        <p class="help-text" ng-show="table.numSelected === 0 && !simpleContentAccessEnabled">
           Auto-attach available subscriptions to all selected hosts.
         </p>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
@@ -7,11 +7,11 @@
 
     <div class="row">
       <div class="col-sm-12">
-        <button type="button" class="btn btn-default" ng-click="autoAttach()" ng-disabled="table.numSelected > 0 || contentAccessMode === 'org_environment'">
+        <button type="button" class="btn btn-default" ng-click="autoAttach()" ng-disabled="table.numSelected > 0 || simpleContentAccessEnabled">
           <span translate>Auto-Attach</span>
         </button>
 
-        <p class="help-text" ng-show="table.numSelected === 0 && contentAccessMode != 'org_environment'">
+        <p class="help-text" ng-show="table.numSelected === 0 && !simpleContentAccessEnabled'">
           Auto-attach available subscriptions to all selected hosts.
         </p>
 
@@ -19,7 +19,7 @@
         <div content-access-mode-banner/>
         </p>
 
-        <p class="help-text" ng-show="table.numSelected > 0 && contentAccessMode != 'org_environment'">
+        <p class="help-text" ng-show="table.numSelected > 0 && !simpleContentAccessEnabled">
           Auto-attach uses all available subscriptions, not a selected subset.
         </p>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -141,6 +141,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
             return false;
         };
 
+        $scope.autoHealOptions = function () {
+            return [{value: true, name: translate("Yes")}, {value: true, name: translate("No")}];
+        };
+
         $scope.serviceLevels = function () {
             return $scope.organization.$promise.then(function(org) {
                 return _.union(org.service_levels, $scope.defaultServiceLevels);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
@@ -8,13 +8,14 @@
  * @requires Subscription
  * @requires SubscriptionsHelper
  * @requires Notification
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Subscription', 'Host', 'HostSubscription', 'SubscriptionsHelper', 'Notification',
-    function ($scope, $location, translate, Nutupane, CurrentOrganization, Subscription, Host, HostSubscription, SubscriptionsHelper, Notification) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Subscription', 'Host', 'HostSubscription', 'SubscriptionsHelper', 'Notification', 'simpleContentAccessEnabled',
+    function ($scope, $location, translate, Nutupane, CurrentOrganization, Subscription, Host, HostSubscription, SubscriptionsHelper, Notification, simpleContentAccessEnabled) {
 
         var params = {
             'organization_id': CurrentOrganization,
@@ -30,6 +31,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsCont
         $scope.nutupane.masterOnly = true;
         $scope.isRemoving = false;
         $scope.contextAdd = false;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {
             $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -82,12 +82,12 @@
         </dd>
 
         <dt translate>Auto-Attach</dt>
-        <dd bst-edit-checkbox="host.subscription_facet_attributes.autoheal"
+        <dd ng-if= "simpleContentAccessEnabled" translate> Not Applicable </dd>
+        <dd ng-if= "!simpleContentAccessEnabled" bst-edit-select="host.subscription_facet_attributes.autoheal"
             readonly="denied('edit_hosts', host)"
             formatter="booleanToYesNo"
             on-save="saveSubscriptionFacet(host)">
         </dd>
-
       </dl>
 
       <div class="divider"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -25,22 +25,27 @@
 
         <dt translate>Auto-Attach</dt>
         <dd>
+          <span ng-if="simpleContentAccessEnabled" translate>
+            Not Applicable
+          </span>
+          <div ng-if="!simpleContentAccessEnabled">
           <div bst-edit-checkbox="host.subscription_facet_attributes.autoheal"
                formatter="booleanToYesNo"
                readonly="denied('edit_hosts', host)"
                on-save="saveSubscriptionFacet(host)">
           </div>
+            <a ng-hide="denied('edit_hosts', host)"
+               ng-click="autoAttachSubscriptions()"
+               class="btn btn-default"
+               ng-disabled="subscription.workingMode">
+              <span translate>Run Auto-Attach</span>
+            </a>
 
-          <a ng-hide="denied('edit_hosts', host)"
-             ng-click="autoAttachSubscriptions()"
-             ng-disabled="subscription.workingMode">
-            <span translate>Run Auto-Attach</span>
-          </a>
-
-          <span ng-show="subscription.workingMode">
-            <i class="fa fa-spinner inline-icon fa-spin"></i>
-            <span translate>Working</span>
-          </span>
+            <span ng-show="subscription.workingMode">
+              <i class="fa fa-spinner inline-icon fa-spin"></i>
+              <span translate>Working</span>
+            </span>
+          </div>
         </dd>
 
         <dt translate>Service Level</dt>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/content-access-mode-banner.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/content-access-mode-banner.directive.js
@@ -2,19 +2,19 @@
  * @ngdoc directive
  * @name Bastion.subscriptions:contentAccessModeBanner
  *
- * @requires contentAccessMode
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Component for showing information about content access mode (whether content is
  *   allowed with or without a subscription)
  */
 angular.module('Bastion.subscriptions').directive('contentAccessModeBanner',
-    ['contentAccessMode',
-    function (contentAccessMode) {
+    ['simpleContentAccessEnabled',
+    function (simpleContentAccessEnabled) {
         return {
             restrict: 'AE',
             controller: ['$scope', function ($scope) {
-                $scope.contentAccessMode = contentAccessMode;
+                $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
             }],
             templateUrl: 'subscriptions/views/content-access-mode-banner.html'
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -1,4 +1,4 @@
-<div bst-alert="info" ng-show="contentAccessMode === 'org_environment'">
+<div bst-alert="info" ng-show="simpleContentAccessEnabled">
   <span translate>
 This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.
   </span>

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ContentHostsBulkSubscriptionsModalController', function() {
-    var $scope, $uibModalInstance, Nutupane, hostIds, CurrentOrganization, HostBulkAction, HostCollection, SubscriptionsHelper, contentAccessMode;
+    var $scope, $uibModalInstance, Nutupane, hostIds, CurrentOrganization, HostBulkAction, HostCollection, SubscriptionsHelper, simpleContentAccessEnabled;
 
     beforeEach(module('Bastion.content-hosts', 'Bastion.test-mocks'));
 
@@ -60,7 +60,7 @@ describe('Controller: ContentHostsBulkSubscriptionsModalController', function() 
             HostBulkAction: HostBulkAction,
             HostCollection: HostCollection,
             SubscriptionsHelper: SubscriptionsHelper,
-            contentAccessMode: contentAccessMode
+            simpleContentAccessEnabled: simpleContentAccessEnabled
         });
     }));
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-subscriptions.controller.test.js
@@ -74,7 +74,8 @@ describe('Controller: ContentHostSubscriptionsController', function() {
             Subscription: Subscription,
             Nutupane: Nutupane,
             HostSubscription: HostSubscription,
-            SubscriptionsHelper: SubscriptionsHelper
+            SubscriptionsHelper: SubscriptionsHelper,
+            simpleContentAccessEnabled: false
         });
     }));
 

--- a/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
+++ b/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
@@ -7,7 +7,7 @@ describe('Directive: contentAccessModeBanner', function() {
     ));
 
     beforeEach(module(function($provide) {
-        $provide.value('contentAccessMode', 'org_environment');
+        $provide.value('simContentAccessEnabled', true);
     }));
 
     beforeEach(inject(function($compile, $rootScope, $httpBackend) {
@@ -21,6 +21,6 @@ describe('Directive: contentAccessModeBanner', function() {
     }));
 
     it("set content access mode on the scope", function() {
-        expect($scope.contentAccessMode).toEqual("org_environment");
+        expect($scope.simpleContentAccessEnabled).toEqual(true);
     });
 });

--- a/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
+++ b/engines/bastion_katello/test/subscriptions/content-access-mode-banner.directive.test.js
@@ -7,7 +7,7 @@ describe('Directive: contentAccessModeBanner', function() {
     ));
 
     beforeEach(module(function($provide) {
-        $provide.value('simContentAccessEnabled', true);
+        $provide.value('simpleContentAccessEnabled', true);
     }));
 
     beforeEach(inject(function($compile, $rootScope, $httpBackend) {


### PR DESCRIPTION
This commit does a couple of things
1) It disables auto attach setup in Simple Content Access enabled orgs.
2) It sets it auto attach status to 'Not Applicable'
3) Changed contentAccessMode=== 'org_enviroment' to
   'simpleContentAccessEnabled' when Simple Content Access is enabled.