### PR TITLE
Fixes #28792 - fix product update proxy test

### DIFF
--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -116,7 +116,7 @@ module Katello
       prod = @products.first
       assert_async_task(::Actions::Katello::Product::UpdateHttpProxy, [prod], 'use_selected_http_proxy', proxy)
 
-      put :update_http_proxy, params: { :ids => [prod.id], :organization_id => @organization.id,
+      put :update_http_proxy, params: { :ids => [prod.id],
                                         :http_proxy_policy => 'use_selected_http_proxy',
                                         :http_proxy_id => proxy.id}
 


### PR DESCRIPTION
A change is being introduced in foreman to provide scoping
on http_proxy objects by organization, similar to how other
resources are handled.  With that change, a small change
is required to the katello test.

The foreman PR is : https://github.com/theforeman/foreman/pull/7279