### PR TITLE
Fixes #28794 - incorrect HTTP proxy id displayed

### DIFF
--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -26,9 +26,10 @@ glue(@resource.root) do
   attributes :deb_releases, :deb_components, :deb_architectures
   attributes :http_proxy_policy
   attributes :http_proxy_id
+  attributes :http_proxy_name
 
   node :http_proxy do
-    attributes :id => @resource.root&.http_proxy_id, :name => @resource.root&.http_proxy&.name
+    attributes :id => @resource.root&.http_proxy&.id, :name => @resource.root&.http_proxy&.name, :policy => @resource.root&.http_proxy_policy
   end
 
   attributes :ignorable_content


### PR DESCRIPTION
This PR correct a defect where the incorrect HTTP proxy id is supplied to the API response template for repositories, leading to confusion and delay when interacting with hammer, etc.
