### PR TITLE
Fixes #28811 - checks root repository for null url

### DIFF
--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -11,7 +11,7 @@ namespace :katello do
   task :publish_unpublished_repositories => ["environment", "disable_dynflow", "check_ping"] do
     needing_publish = []
     Organization.find_each do |org|
-      if org.default_content_view and not org.default_content_view.versions.empty?
+      if org.default_content_view && !org.default_content_view.versions.empty?
         org.default_content_view.versions.first.repositories.joins(:root)
           .where.not(katello_root_repositories: { url: nil }).find_each do |repo|
           begin

--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -11,14 +11,17 @@ namespace :katello do
   task :publish_unpublished_repositories => ["environment", "disable_dynflow", "check_ping"] do
     needing_publish = []
     Organization.find_each do |org|
-      org.default_content_view.versions.first.repositories.where.not(:url => nil).find_each do |repo|
-        begin
-          if repo.needs_metadata_publish?
-            Rails.logger.error("Repository metadata for #{repo.name} (#{repo.id}) is out of date, regenerating.")
-            needing_publish << repo.id
+      if org.default_content_view and not org.default_content_view.versions.empty?
+        org.default_content_view.versions.first.repositories.joins(:root)
+          .where.not(katello_root_repositories: { url: nil }).find_each do |repo|
+          begin
+            if repo.needs_metadata_publish?
+              Rails.logger.error("Repository metadata for #{repo.name} (#{repo.id}) is out of date, regenerating.")
+              needing_publish << repo.id
+            end
+          rescue => e
+            puts "Failed to check repository #{repo.id}: #{e}"
           end
-        rescue => e
-          puts "Failed to check repository #{repo.id}: #{e}"
         end
       end
     end

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -30,6 +30,12 @@ module Katello
       ENV['LIFECYCLE_ENVIRONMENT'] = nil
     end
 
+    def test_publish_unpublished_repositories
+      Katello::Repository.any_instance.stubs(:needs_metadata_publish?).returns(true)
+
+      Rake.application.invoke_task('katello:publish_unpublished_repositories')
+    end
+
     def test_regenerate_repo_metadata
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
                                              Katello::Repository.all.order_by_root(:name)).returns(ForemanTasks::Task::DynflowTask::DynflowTask.new)


### PR DESCRIPTION
This PR checks for empty urls on root repositories, which used to be a column in the katello repository table. Otherwise the rake task `publish_unpublished_repositories` fails when invoked.