### PR TITLE
Fixes #28818 - Add aggregated sync-state

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -8,6 +8,7 @@ extends 'katello/api/v2/common/org_reference'
 attributes :provider_id
 attributes :sync_plan_id
 attributes :sync_summary
+attributes :sync_state_aggregated
 attributes :gpg_key_id
 attributes :ssl_ca_cert_id
 attributes :ssl_client_cert_id

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -12,6 +12,7 @@ module Katello
       @product = Product.find(katello_products(:fedora).id)
       @product.stubs(:redhat?).returns(false)
       Product.any_instance.stubs('sync_status').returns(PulpSyncStatus.new)
+      Product.any_instance.stubs('sync_state_aggregated').returns(:stopped)
     end
 
     def permissions


### PR DESCRIPTION
This adds a method to aggregate the last sync-status for all repositories of a product (that a sync-task exists for) and:
- uses this data for `sync_summary`-method
- adds an additional attribute to Product-API that shows the "worst" sync-status that any of the last repositories of a product has ('running' is currently defined worse/more interesting than 'error')

The latter should be added to the hammer-cli output for Katello-Products.