### PR TITLE
Refs #28842 - Add messaging to Subscriptions page

### DIFF
--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -7,6 +7,9 @@ attributes :task_id, :label, :owner_details, :redhat_repository_url
 if ::SETTINGS[:katello][:use_cp]
   attributes :system_purposes, :system_purposes
   attributes :service_levels, :service_level
+  node :simple_content_access do |org|
+    org.simple_content_access?
+  end
 end
 
 node :default_content_view_id do |org|

--- a/webpack/scenes/Organizations/OrganizationSelectors.js
+++ b/webpack/scenes/Organizations/OrganizationSelectors.js
@@ -1,0 +1,4 @@
+export const selectOrganizationState = state => state.katello.organization;
+
+export const selectSimpleContentAccessEnabled = state =>
+  selectOrganizationState(state).simple_content_access;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.scss
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.scss
@@ -1,0 +1,12 @@
+.form-horizontal {
+  padding-left: 40px;
+  padding-right: 20px;
+}
+
+form .row {
+  margin-left: -15px;
+}
+
+span.pficon.pficon-info {
+  margin: 0 5px 0 5px;
+}

--- a/webpack/scenes/Subscriptions/Manifest/index.js
+++ b/webpack/scenes/Subscriptions/Manifest/index.js
@@ -9,6 +9,7 @@ import * as manifestActions from './ManifestActions';
 import * as organizationActions from '../../Organizations/OrganizationActions';
 import * as tasksActions from '../../Tasks/TaskActions';
 import history from './ManifestHistoryReducer';
+import { selectSimpleContentAccessEnabled } from '../../Organizations/OrganizationSelectors';
 
 import ManifestModal from './ManageManifestModal';
 
@@ -19,6 +20,7 @@ const mapStateToProps = state => ({
   organization: state.katello.organization,
   manifestHistory: state.katello.manifestHistory,
   taskDetails: state.katello.manifestHistory.taskDetails,
+  simpleContentAccess: selectSimpleContentAccessEnabled(state),
   modalOpenState: state.foremanModals.ManageManifestModal,
   deleteManifestModalIsOpen: selectIsModalOpen(state, DELETE_MANIFEST_MODAL_ID),
 });

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -4,7 +4,7 @@ import Immutable from 'seamless-immutable';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import { isEmpty, isEqual } from 'lodash';
-import { Grid, Row, Col } from 'patternfly-react';
+import { Grid, Row, Col, Alert } from 'patternfly-react';
 import ModalProgressBar from 'foremanReact/components/common/ModalProgressBar';
 import PermissionDenied from 'foremanReact/components/PermissionDenied';
 import { renderTaskFinishedToast, renderTaskStartedToast } from '../Tasks/helpers';
@@ -162,7 +162,7 @@ class SubscriptionsPage extends Component {
       deleteModalOpened, openDeleteModal, closeDeleteModal,
       deleteButtonDisabled, disableDeleteButton, enableDeleteButton,
       searchQuery, updateSearchQuery,
-      taskModalOpened,
+      taskModalOpened, simpleContentAccess,
       tasks = [], activePermissions, subscriptions, organization, subscriptionTableSettings,
     } = this.props;
     // Basic permissions - should we even show this page?
@@ -285,6 +285,13 @@ class SubscriptionsPage extends Component {
             />
 
             <div id="subscriptions-table" className="modal-container">
+              {simpleContentAccess && (
+                <Alert type="info">
+                This organization has Simple Content Access enabled. <br />
+                Hosts can consume from all repositories in their Content View regardless of
+                subscription status.
+                </Alert>
+              )}
               <SubscriptionsTable
                 canManageSubscriptionAllocations={canManageSubscriptionAllocations}
                 loadSubscriptions={this.props.loadSubscriptions}
@@ -321,6 +328,7 @@ SubscriptionsPage.propTypes = {
   updateQuantity: PropTypes.func.isRequired,
   loadTableColumns: PropTypes.func.isRequired,
   taskDetails: PropTypes.shape({}),
+  simpleContentAccess: PropTypes.bool,
   subscriptions: PropTypes.shape({
     disconnected: PropTypes.bool,
     tableColumns: PropTypes.array,
@@ -372,6 +380,7 @@ SubscriptionsPage.defaultProps = {
   taskModalOpened: false,
   deleteButtonDisabled: true,
   subscriptionTableSettings: {},
+  simpleContentAccess: false,
   activePermissions: {
     can_import_manifest: false,
     can_manage_subscription_allocations: false,

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -17,6 +17,7 @@ import {
   selectActivePermissions,
   selectTableSettings,
 } from './SubscriptionsSelectors';
+import { selectSimpleContentAccessEnabled } from '../Organizations/OrganizationSelectors';
 
 import reducer from './SubscriptionReducer';
 import { SUBSCRIPTION_TABLE_NAME } from './SubscriptionConstants';
@@ -31,6 +32,7 @@ const mapStateToProps = (state) => {
     subscriptions,
     subscriptionTableSettings,
     activePermissions: selectActivePermissions(state),
+    simpleContentAccess: selectSimpleContentAccessEnabled(state),
     tasks: selectSubscriptionsTasks(state),
     searchQuery: selectSearchQuery(state),
     deleteModalOpened: selectDeleteModalOpened(state),


### PR DESCRIPTION
Add messaging to Subscriptions page when Simple Content Access is enabled.

~(Will require changes if #8529 is merged first)~

- Add simple_content_access key to org API endpoint
- Add organization selector to consume in Redux
- Add info bar to Subscriptions table
- Add info to ManageManifestModal
- Improve styling of ManageManifestModal

![mmm](https://user-images.githubusercontent.com/22042343/73031239-9560d380-3e09-11ea-9fff-1ca35668ca8e.png)
![subs_page](https://user-images.githubusercontent.com/22042343/73031240-9560d380-3e09-11ea-872d-11153d024812.png)
