### PR TITLE
Fixes #28873 - Add puppet/ostree dep warn to API

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -219,6 +219,10 @@ module Katello
         fail HttpErrors::UnprocessableEntity, msg
       end
 
+      if repo_params['content_type'] == "puppet" || repo_params['content_type'] == "ostree"
+        ::Foreman::Deprecation.api_deprecation_warning("Puppet and OSTree will no longer be supported in Katello 3.16")
+      end
+
       gpg_key = get_content_credential(repo_params, CONTENT_CREDENTIAL_GPG_KEY_TYPE)
       ssl_ca_cert = get_content_credential(repo_params, CONTENT_CREDENTIAL_SSL_CA_CERT_TYPE)
       ssl_client_cert = get_content_credential(repo_params, CONTENT_CREDENTIAL_SSL_CLIENT_CERT_TYPE)


### PR DESCRIPTION
With PR, API dep warning showing on dev box:

```ruby
17:12:33 rails.1   | 2020-01-27T17:12:33 [W|app|3bfd4025] DEPRECATION WARNING: Your API call uses deprecated behavior, Puppet and OSTree will no longer be supported Katello in 3.16 (calledfrom create at /home/vagrant/katello/app/controllers/katello/api/v2/repositories_controller.rb:224)
```