### PR TITLE
Fixes #28886 - App applicability associations to InstalledPackage

### DIFF
--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -8,10 +8,11 @@ module Katello
     has_many :host_installed_packages, :class_name => "Katello::HostInstalledPackage", :dependent => :destroy, :inverse_of => :installed_package
 
     scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :nvrea
     scoped_search :on => :nvra
-
-    def nvrea
-      nvra
-    end
+    scoped_search :on => :epoch
+    scoped_search :on => :version
+    scoped_search :on => :release
+    scoped_search :on => :arch
   end
 end

--- a/app/services/katello/pulp/simple_package.rb
+++ b/app/services/katello/pulp/simple_package.rb
@@ -9,11 +9,15 @@ module Katello
       end
 
       def nvra
-        nvrea
+        "#{@name}-#{@version}-#{@release}.#{@arch}"
       end
 
       def nvrea
-        "#{@name}-#{@version}-#{@release}.#{@arch}"
+        if epoch == "0"
+          @nvra
+        else
+          "#{@name}-#{@epoch}:#{@version}-#{@release}.#{@arch}"
+        end
       end
     end
   end

--- a/db/migrate/20200129172534_add_epoch_version_release_arch_to_katello_installed_packages.rb
+++ b/db/migrate/20200129172534_add_epoch_version_release_arch_to_katello_installed_packages.rb
@@ -1,0 +1,40 @@
+class AddEpochVersionReleaseArchToKatelloInstalledPackages < ActiveRecord::Migration[5.2]
+  def up
+    add_column :katello_installed_packages, :nvrea, :string
+    add_column :katello_installed_packages, :epoch, :string
+    add_column :katello_installed_packages, :version, :string
+    add_column :katello_installed_packages, :release, :string
+    add_column :katello_installed_packages, :arch, :string
+
+    epoch_non_0 = ::Katello::Rpm.where.not(epoch: [0, nil]).pluck(:nvra, :epoch).to_h
+    installed_packages = []
+
+    ::Katello::InstalledPackage.reset_column_information
+    ::Katello::InstalledPackage.find_each do |pkg|
+      epoch = epoch_non_0[pkg.nvra] || "0"
+
+      attributes_hash = ::Katello::Util::Package.parse_nvrea(pkg.nvra)
+      attributes_hash[:epoch] = epoch
+      attributes_hash[:nvra] = pkg.nvra
+      if epoch == "0"
+        attributes_hash[:nvrea] = pkg.nvra
+      else
+        attributes_hash[:nvrea] = "#{pkg.name}-#{epoch}:#{attributes_hash[:version]}-"\
+                                  "#{attributes_hash[:release]}.#{attributes_hash[:arch]}"
+      end
+
+      installed_packages << ::Katello::InstalledPackage.new(attributes_hash)
+    end
+    ::Katello::InstalledPackage.import(installed_packages, validate: false, batch_size: 50_000,
+                                       on_duplicate_key_update: {conflict_target: [:nvra],
+                                                                 columns: [:nvrea, :epoch, :version, :release, :arch]})
+  end
+
+  def down
+    remove_column :katello_installed_packages, :nvrea, :string
+    remove_column :katello_installed_packages, :epoch, :string
+    remove_column :katello_installed_packages, :version, :string
+    remove_column :katello_installed_packages, :release, :string
+    remove_column :katello_installed_packages, :arch, :string
+  end
+end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -239,7 +239,8 @@ module Katello
   class HostInstalledPackagesTest < HostManagedExtensionsTestBase
     def setup
       super
-      package_json = {:name => "foo", :version => "1", :release => "1.el7", :arch => "x86_64"}
+      package_json = {:name => "foo", :version => "1", :release => "1.el7", :arch => "x86_64", :epoch => "1",
+                      :nvra => "foo-1-1.el7.x86_64"}
       @foreman_host.import_package_profile([::Katello::Pulp::SimplePackage.new(package_json)])
       @nvra = 'foo-1-1.el7.x86_64'
       @foreman_host.reload
@@ -252,13 +253,17 @@ module Katello
     end
 
     def test_import_package_profile_adds_removes_bulk
-      packages = [::Katello::Pulp::SimplePackage.new(:name => "betterfoo", :version => "1", :release => "1.el7", :arch => "x86_64")]
+      packages = [::Katello::Pulp::SimplePackage.new(:name => "betterfoo", :version => "1", :release => "1.el7",
+                                                     :arch => "x86_64", :epoch => "1", :nvra => "betterfoo-1-1.el7.x86_64")]
       @foreman_host.import_package_profile(packages)
       assert_equal 1, @foreman_host.installed_packages.count
       assert_equal 'betterfoo', @foreman_host.installed_packages.first.name
+      assert_equal 'betterfoo-1:1-1.el7.x86_64', @foreman_host.installed_packages.first.nvrea
+      assert_equal '1', @foreman_host.installed_packages.first.epoch
 
       @foreman_host.reload
-      packages << ::Katello::Pulp::SimplePackage.new(:name => "alphabeta", :version => "1", :release => "2", :arch => "x86_64")
+      packages << ::Katello::Pulp::SimplePackage.new(:name => "alphabeta", :version => "1", :release => "2", :arch => "x86_64",
+                                                     :epoch => "1", :nvra => "alphabeta-1-2.x86_64")
       @foreman_host.import_package_profile(packages)
       assert_equal 2, @foreman_host.installed_packages.count
     end


### PR DESCRIPTION
Adds version, release, epoch, and arch to InstalledPackage to prep for the new Pulp 3 Katello applicability.  Note that there is a database migration.  The migration tries to find the correct epoch among packages that Katello has indexed.  If it cannot find any, it sets the epoch to 0.  This may be incorrect, but the next package upload should update the epoch.

To test: 
1) Register a content host
2) Makes sure the package profile was uploaded
3) Checkout this PR
4) Run the migration
5) Ensure that the new columns exist for the existing InstalledPackage(s)
6) Install something (like `sl` for example)
7) Check the installed packages again to see that new ones were uploaded
8) Play around with the package uploads and see if anything breaks
9) Another testing idea: create your own `InstalledPackage` entries with nvras that match some RPM and see if they migrate properly.  Try editing the epoch of the RPMs to ensure the migration is correctly updating the `InstalledPackage` epochs to match the RPM epochs.