### PR TITLE
Fixes  #28894 - load the pools from AR database instead of Candlepin

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -65,7 +65,7 @@ module Katello
       return available_for_activation_key if params[:available_for] == "activation_key"
       collection = Pool.readable
       collection = collection.where(:unmapped_guest => false)
-      collection = collection.get_for_organization(Organization.find(params[:organization_id])) if params[:organization_id]
+      collection = collection.where(organization: Organization.find(params[:organization_id])) if params[:organization_id]
       collection = collection.for_activation_key(@activation_key) if params[:activation_key_id]
       collection
     end

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -3,12 +3,6 @@ module Katello
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def get_for_organization(organization)
-        # returns objects from AR database rather than candlepin data
-        pool_ids = self.get_for_owner(organization.label).collect { |x| x['id'] }
-        self.where(:cp_id => pool_ids)
-      end
-
       def get_candlepin_ids(organization)
         self.get_for_owner(organization.label).map { |subscription| subscription["id"] }
       end

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -34,15 +34,14 @@ module Katello
     end
 
     def test_index
-      Pool.expects(:get_for_organization).returns(Pool.all)
       get :index, params: { :organization_id => @organization.id }
-
+      results = JSON.parse(@response.body)['results']
+      assert_equal results.count, Pool.all.size
       assert_response :success
       assert_template 'api/v2/subscriptions/index'
     end
 
     def test_index_csv
-      Pool.expects(:get_for_organization).returns(Pool.all)
       get :index, params: {:format => 'csv', :organization_id => @organization.id }
       assert_response :success
       assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]


### PR DESCRIPTION
In case there is a large list of pools, this will improve the speed when loading up the subscription page.