### PR TITLE
Fixes #28644 - Repo Mapper prunes unused subs

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -6,7 +6,7 @@ module Katello
       def initialize(product, content, substitutions)
         @product = product
         @content = content
-        @substitutions = substitutions.try(:with_indifferent_access)
+        @substitutions = prune_substitutions(substitutions.try(:with_indifferent_access), content.content_url)
       end
 
       def find_repository
@@ -67,6 +67,10 @@ module Katello
 
       def relative_path
         ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(product.organization.library, path)
+      end
+
+      def prune_substitutions(subs, url)
+        subs.select { |key, _| url.include?("$#{key}") }
       end
 
       def feed_url

--- a/test/fixtures/models/katello_contents.yml
+++ b/test/fixtures/models/katello_contents.yml
@@ -12,3 +12,4 @@ rhel_content:
   cp_content_id: 69
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
   content_url: /content/dist/rhel/server/$releasever/$basearch/os
+  content_type: "yum"

--- a/test/models/candlepin/repository_mapper_test.rb
+++ b/test/models/candlepin/repository_mapper_test.rb
@@ -3,12 +3,29 @@ require 'katello_test_helper'
 module Katello
   class RepositoryMapperTest < ActiveSupport::TestCase
     def setup
-      @repo1 = katello_repositories(:fedora_17_x86_64)
-      @product1 = @repo1.product
+      @product_content = katello_product_contents(:rhel_content)
+    end
+
+    def test_unused_substitutions_good
+      subs = {:basearch => 'x86_64', :releasever => "greatest8"}.with_indifferent_access
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, subs)
+      assert_equal subs, mapper.substitutions
+      assert mapper.path.include?(subs[:basearch])
+      assert mapper.path.include?(subs[:releasever])
+    end
+
+    def test_unused_substitutions_bad
+      subs = {:basearch => 'x86_64', :releasever => "greatest8", :wild_card => "ddd"}.with_indifferent_access
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, subs)
+      refute_equal subs, mapper.substitutions
+      assert_equal subs.slice(:basearch, :releasever), mapper.substitutions
+      assert mapper.path.include?(subs[:basearch])
+      assert mapper.path.include?(subs[:releasever])
+      refute mapper.path.include?(subs[:wild_card])
     end
 
     def test_unprotected_suse
-      mapper = Candlepin::RepositoryMapper.new(@product1, @repo1, {})
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
       mapper.expects(:path).returns("/special/suse")
       assert mapper.unprotected?
 
@@ -17,7 +34,7 @@ module Katello
     end
 
     def test_download_policy
-      mapper = Candlepin::RepositoryMapper.new(@product1, @repo1, {})
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
 
       Setting[:default_download_policy] = 'on_demand'
       Setting[:default_redhat_download_policy] = 'immediate'


### PR DESCRIPTION
Prior to this commit any action that did something like
PUT /katello/api/v2/products/572/repository_sets/7441/enable/
-d '{"releasever":"8", "basearch":"x86_64"}'
would set the arch for a repository using the basearch value even if
basearch is an invalid/unused url substitution. This caused weird bugs
with repo enablement unacknowleged etc

This commit clears out unused subtitutions before the url path is mapped
via repo mapper. This sets the correct value for the arch in the
repository object