### PR TITLE
Fixes #26878 - Adds Deprecation Warning testing

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -158,7 +158,7 @@ module Katello
     def content_override
       content_overrides = []
       if params[:content_label]
-        ::Foreman::Deprecation.api_deprecation_warning("The parameter content_label will be removed in Katello 3.5. Please update to use the content_overrides parameter.")
+        ::Katello::Deprecation.api_deprecation_warning("host_subs_content_label", caller(0))
         content_override_params = {:content_label => params[:content_label]}
         value = params[:value]
         if value == "default"

--- a/app/services/katello/deprecation.rb
+++ b/app/services/katello/deprecation.rb
@@ -1,0 +1,28 @@
+module Katello
+  class Deprecation
+    class << self; attr_accessor :deprecations end
+
+    # Structure of Deprecation warning object:
+    # reference_key : {
+    #   removal_version: Katello version that the deprecated behavior will be removed by. This value is used in
+    #                    testing to compare to the current Katello version, failing if it is less than the current version.
+    #   item:            The part of the application being removed or modified.
+    #   action_message:  A follow up message giving an actionable instruction to the user. e.g. "Please use foo instead."
+    # }
+    @deprecations = {
+      host_subs_content_label: {
+        removal_version: 3.5,
+        item: "The parameter content_label",
+        action_message: "Please update to use the content_overrides parameter."
+      }
+    }.with_indifferent_access
+
+    # Pass in caller(0) to ensure the correct line of source code is referenced
+    def self.api_deprecation_warning(deprecation_key, my_caller = caller)
+      dep_info = deprecations[deprecation_key]
+      warning = "#{dep_info[:item]} will be removed in Katello #{dep_info[:removal_version]} or " \
+                "the equivalent version. #{dep_info[:action_message]}"
+      ::Foreman::Deprecation.api_deprecation_warning(warning, my_caller)
+    end
+  end
+end

--- a/test/services/katello/deprecation_test.rb
+++ b/test/services/katello/deprecation_test.rb
@@ -1,0 +1,32 @@
+require 'katello_test_helper'
+
+module Katello
+  class DeprecationTest < ActiveSupport::TestCase
+    # Ensures that we actually remove deprecated behavior when we say we will. If this fails on a version bump,
+    # please remove the code associated with the deprecation and the deprecation warning itself.
+    def test_deprecations_have_been_removed
+      katello_version = Katello::VERSION
+      Katello::Deprecation.deprecations.each do |dep_key, dep|
+        assert_not_nil dep[:removal_version]
+        msg = "Deprecation warning #{dep_key} is marked for removal in #{dep[:removal_version]}, which "\
+              "is less than or equal to the current Katello version of #{katello_version}."
+        assert(Gem::Version.new(katello_version) <= Gem::Version.new(dep[:removal_version]) , msg)
+      end
+    end
+
+    def test_api_deprecation_warning
+      test_warning = {
+        removal_version: 100.0,
+        item: "Hamburger",
+        action_message: "Please use Cheeseburger instead"
+      }
+      Katello::Deprecation.expects(:deprecations).returns({this_is_a_test: test_warning })
+      dep_warning = Katello::Deprecation.api_deprecation_warning(:this_is_a_test)
+
+      assert_includes dep_warning, test_warning[:removal_version].to_s
+      assert_includes dep_warning, test_warning[:item]
+      assert_includes dep_warning, test_warning[:action_message]
+      assert_includes dep_warning, "will be removed"
+    end
+  end
+end


### PR DESCRIPTION
This adds a central way to handle deprecation warnings and tests them against the Katello version to ensure they are removed.