### PR TITLE
Fixes #26229 - show name of repository for CV audit record on page

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -172,6 +172,10 @@ module Katello
       joins(:root).where("#{RootRepository.table_name}.content_type" => content_type)
     end
 
+    def to_label
+      name
+    end
+
     def backend_service(smart_proxy, force_pulp3 = false)
       if force_pulp3 || smart_proxy.pulp3_support?(self)
         @service ||= Katello::Pulp3::Repository.instance_for_type(self, smart_proxy)


### PR DESCRIPTION
Before change:
![Screenshot from 2020-02-07 17-24-48](https://user-images.githubusercontent.com/6470528/74030012-fd034b00-49d3-11ea-915a-6646f0e59d1a.png)

After change:
![Screenshot from 2020-02-07 17-25-24](https://user-images.githubusercontent.com/6470528/74030018-01c7ff00-49d4-11ea-803e-721aac767014.png)


Note that - This change fixes the display name for repository changes in content-view audit record.
It will show comma separated repositories names instead of ids. 
But I am not sure overriding this method will cause any issue in other scenarios.