### PR TITLE
Fixes #28958 - disable not inited lifecycle-button

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -10,6 +10,7 @@
 
       <a class="fr btn btn-primary"
           ui-sref="environments.new({priorId: library.id})"
+          ng-disabled="!library.id"
           ng-hide="denied('create_lifecycle_environments', library)">
         <i class="pficon pficon-add-circle-o"></i>
         {{ "Create Environment Path" | translate }}


### PR DESCRIPTION
Keep 'Create Environment Path'-button disabled until it is initialized