### PR TITLE
Refs #28818 - Fix slow product list

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -8,7 +8,6 @@ extends 'katello/api/v2/common/org_reference'
 attributes :provider_id
 attributes :sync_plan_id
 attributes :sync_summary
-attributes :sync_state_aggregated
 attributes :gpg_key_id
 attributes :ssl_ca_cert_id
 attributes :ssl_client_cert_id

--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -3,6 +3,8 @@ object @resource
 
 extends "katello/api/v2/products/base"
 
+attributes :sync_state_aggregated
+
 child(:product_contents => :product_content) do
   extends "katello/api/v2/products/product_content"
 end


### PR DESCRIPTION
@chris1984 I observed an increase of loading-time for the products-index request (e.g. Products-page in Katello GUI).
Since hammer only displays this for `product info` I think it is save to only deliver this attribute in show-requests.