### PR TITLE
Fixes #28951 - implement partial repo path for yum

### DIFF
--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -45,6 +45,10 @@ module Katello
           end
         end
 
+        def partial_repo_path
+          "/pulp/repos/#{repo.relative_path}/".sub('//', '/')
+        end
+
         def copy_content_for_source
           # TODO
           fail NotImplementedError

--- a/test/services/katello/pulp3/repository/yum/repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/yum/repository_mirror_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class YumRepositoryMirrorTest < ::ActiveSupport::TestCase
+        include RepositorySupport
+
+        def setup
+          create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @mock_smart_proxy.stubs(:pulp_master?).returns(false)
+          @repo = FactoryBot.create(:katello_repository, :fedora_17_x86_64_dev, :with_product)
+          @repo_service = @repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_feed_url
+          pulp3_repo = Katello::Pulp3::Repository::Yum.new(@repo, @mock_smart_proxy)
+          repo_mirror = pulp3_repo.with_mirror_adapter
+          feed_url = URI(repo_mirror.remote_feed_url)
+
+          assert_equal '/pulp/repos' + @repo.relative_path + '/', feed_url.path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change supports synchronization of pulpcore rpm content to a pulpcore mirror. In conjunction with https://github.com/theforeman/forklift/pull/1106, which is needed for the base_url to be correctly served by the httpd process to the mirror during the synchronization.

To test this PR, create a pulpcore enabled proxy, and add it to the default environment (same as the pulpcore enabled katello server). Create a yum repo, and sync the repository. You can verify the packages for the repository in the pulp schema.

Next, select the pulpcore proxy (in this case, this is our pulp mirror), and then synchronize the proxy. Check the proxy pulp schema and verify the yum packages are listed as rpm content.