### PR TITLE
Fixes #29007 - fixes uploads api regression

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -25,7 +25,7 @@ module Actions
             else
               repo = ::Katello::Repository.find(input[:repository_id])
               repo_backend_service = repo.backend_service(smart_proxy)
-              uploads_api = repo_backend_service.uploads_api
+              uploads_api = repo_backend_service.core_api.uploads_api
               output[:pulp_tasks] = [uploads_api.commit(input[:upload_href], sha256: input[:sha256])]
             end
           end


### PR DESCRIPTION
At some point in the last 4-5 months, the uploads api changed and this caused a regression for uploads via hammer. 
It's troubling that none of our tests detected this regression.