### PR TITLE
Fixes #29035 - Add @taxonomy when creating organization from API

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -73,6 +73,9 @@ module Katello
       @organization = Organization.new(resource_params)
       sync_task(::Actions::Katello::Organization::Create, @organization)
       @organization.reload
+      # @taxonomy instance variable is necessary for foreman side
+      # app/views/api/v2/taxonomies/show.json.rabl is using it.
+      @taxonomy = @organization
       respond_for_create :resource => @organization
     rescue => e
       ::Foreman::Logging.exception('Could not create organization', e)


### PR DESCRIPTION
This PR should fix the failing tests of https://github.com/theforeman/foreman/pull/7434
Failures example :
Error Message
Expected {"message"=>"resource have no errors"} to be nil.
Stacktrace
Expected {"message"=>"resource have no errors"} to be nil. (Minitest::Assertion)
/home/jenkins/workspace/test_develop_pr_katello@2/database/postgresql/ruby/2.5/slave/fast/plugin/test/controllers/api/v2/organizations_controller_test.rb:198

the failures are related to the fact I used `ancestors = @taxonomy.ancestors` In my PR, but @taxonomy is not an instance variable

the fix for it will be to set @taxonomy instance variable when creating an organization