### PR TITLE
Fixes #29094 - Prevent setting auto-attach on Activation Key when in Simple Content Access

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -36,6 +36,19 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
             $scope.panel.loading = false;
         }
 
+        $scope.autoAttachOptions = function () {
+            return [
+                {
+                    id: true,
+                    name: translate("Yes")
+                },
+                {
+                    id: false,
+                    name: translate("No")
+                }
+            ];
+        };
+
         $scope.activationKey = ActivationKey.get({id: $scope.$stateParams.activationKeyId}, function (activationKey) {
             $scope.$broadcast('activationKey.loaded', activationKey);
             $scope.panel.loading = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
@@ -9,13 +9,14 @@
  * @requires ActivationKey
  * @requires SubscriptionsHelper
  * @requires Notification
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the activation key subscriptions details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptionsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'Subscription', 'SubscriptionsHelper', 'Notification',
-    function ($scope, $location, translate, Nutupane, ActivationKey, Subscription, SubscriptionsHelper, Notification) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'Subscription', 'SubscriptionsHelper', 'Notification', 'simpleContentAccessEnabled',
+    function ($scope, $location, translate, Nutupane, ActivationKey, Subscription, SubscriptionsHelper, Notification, simpleContentAccessEnabled) {
         var params;
 
         params = {
@@ -32,6 +33,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptions
         $scope.contentNutupane.setSearchKey('subscriptionSearch');
         $scope.isRemoving = false;
         $scope.contextAdd = false;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions.html
@@ -1,21 +1,24 @@
 <span page-title ng-model="activationKey">{{ 'Subscriptions for Activation Key:' | translate }} {{ activationKey.name }}</span>
 
 <section>
-  <h4 translate>Activation Key Type:</h4>
-
+  <h4 translate>Subscription Details</h4>
   <div class="details">
     <span class="info-label" translate>Auto-Attach</span>
+    <span class="info-value" ng-if="simpleContentAccessEnabled" translate>Not Applicable</span>
     <span class="info-value"
-          bst-edit-checkbox="activationKey.auto_attach"
-          formatter="booleanToYesNo"
-          readonly="denied('edit_activation_keys', activationKey)"
-          on-save="save(activationKey)">
+      ng-if="!simpleContentAccessEnabled"
+      bst-edit-select="activationKey.auto_attach"
+      selector="activationKey.auto_attach"
+      options="autoAttachOptions()"
+      formatter="booleanToYesNo"
+      readonly="denied('edit_activation_keys', activationKey)"
+      on-save="save(activationKey)">
     </span>
   </div>
-  <p bst-alert="info" ng-hide="!activationKey.auto_attach">
+  <p bst-alert="info" ng-hide="simpleContentAccessEnabled || !activationKey.auto_attach">
     <span>When Auto Attach is enabled, registering systems will be attached to all associated custom products and only associated Red Hat subscriptions required to satisfy the system's installed products.</span>
   </p>
-  <p bst-alert="info" ng-hide="activationKey.auto_attach">
+  <p bst-alert="info" ng-hide="simpleContentAccessEnabled || activationKey.auto_attach">
     <span translate>When Auto Attach is disabled, registering systems will be attached to all associated subscriptions.</span>
   </p>
 </section>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -142,7 +142,16 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         };
 
         $scope.autoHealOptions = function () {
-            return [{value: true, name: translate("Yes")}, {value: true, name: translate("No")}];
+            return [
+                {
+                    id: true,
+                    name: translate("Yes")
+                },
+                {
+                    id: false,
+                    name: translate("No")
+                }
+            ];
         };
 
         $scope.serviceLevels = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -81,9 +81,12 @@
           </ul>
         </dd>
 
-        <dt translate>Auto-Attach</dt>
-        <dd ng-if= "simpleContentAccessEnabled" translate> Not Applicable </dd>
-        <dd ng-if= "!simpleContentAccessEnabled" bst-edit-select="host.subscription_facet_attributes.autoheal"
+        <dt translate>Auto-Attach Details</dt>
+        <dd ng-if="simpleContentAccessEnabled" translate>Not Applicable</dd>
+        <dd ng-if="!simpleContentAccessEnabled"
+            bst-edit-select="host.subscription_facet_attributes.autoheal"
+            selector="host.subscription_facet_attributes.autoheal"
+            options="autoHealOptions()"
             readonly="denied('edit_hosts', host)"
             formatter="booleanToYesNo"
             on-save="saveSubscriptionFacet(host)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -29,11 +29,13 @@
             Not Applicable
           </span>
           <div ng-if="!simpleContentAccessEnabled">
-          <div bst-edit-checkbox="host.subscription_facet_attributes.autoheal"
+            <div bst-edit-select="host.subscription_facet_attributes.autoheal"
+               options="autoHealOptions()"
+               selector="host.subscription_facet_attributes.autoheal"
                formatter="booleanToYesNo"
                readonly="denied('edit_hosts', host)"
                on-save="saveSubscriptionFacet(host)">
-          </div>
+            </div>
             <a ng-hide="denied('edit_hosts', host)"
                ng-click="autoAttachSubscriptions()"
                class="btn btn-default"


### PR DESCRIPTION
This change prevents setting the auto-attach preference on an activation key when in simple content access and shows 'Not Applicable' in place of the selection. Per discussion with UX it also changes the preference checkbox to a select dropdown when not in SCA.

This does not affect the behavior of the UI since setting auto-attach to true or false has no positive or negative effect.

This also fixes the changes introduced by #8529 in the scenario when not in SCA. The checkbox was only changed to a dropdown in one place, and the one that was changed did not work at all.

Ask me for a manifest that can be used to test :)