### PR TITLE
Fixes #29145 - Add custom evr type column to katello_rpms and katello_installed_packages

### DIFF
--- a/config/initializers/monkeys.rb
+++ b/config/initializers/monkeys.rb
@@ -1,3 +1,5 @@
 #place where monkey patches are required
 require 'monkeys/passenger_tee_input'
 require 'monkeys/anemone'
+require 'monkeys/ar_postgres_evr_t'
+require 'monkeys/fx_sqlite_skip'

--- a/db/functions/empty_v01.sql
+++ b/db/functions/empty_v01.sql
@@ -1,0 +1,7 @@
+create or replace FUNCTION empty(t TEXT)
+	RETURNS BOOLEAN as $$
+	BEGIN
+		return t ~ '^[[:space:]]*$';
+	END;
+$$ language 'plpgsql';
+

--- a/db/functions/evr_trigger_v01.sql
+++ b/db/functions/evr_trigger_v01.sql
@@ -1,0 +1,9 @@
+CREATE FUNCTION evr_trigger() RETURNS trigger AS $$
+  BEGIN
+    NEW.evr = (select ROW(coalesce(NEW.epoch::numeric,0),
+                          rpmver_array(coalesce(NEW.version,'empty'))::evr_array_item[],
+                          rpmver_array(coalesce(NEW.release,'empty'))::evr_array_item[])::evr_t);
+    RETURN NEW;
+  END;
+$$ language 'plpgsql';
+

--- a/db/functions/isalpha_v01.sql
+++ b/db/functions/isalpha_v01.sql
@@ -1,0 +1,11 @@
+create or replace FUNCTION isalpha(ch CHAR)
+  RETURNS BOOLEAN as $$
+  BEGIN
+    if ascii(ch) between ascii('a') and ascii('z') or
+        ascii(ch) between ascii('A') and ascii('Z')
+    then
+      return TRUE;
+    end if;
+    return FALSE;
+  END;
+$$ language 'plpgsql';

--- a/db/functions/isalphanum_v01.sql
+++ b/db/functions/isalphanum_v01.sql
@@ -1,0 +1,12 @@
+create or replace FUNCTION isalphanum(ch CHAR)
+	RETURNS BOOLEAN as $$
+	BEGIN
+		if ascii(ch) between ascii('a') and ascii('z') or
+			ascii(ch) between ascii('A') and ascii('Z') or
+			ascii(ch) between ascii('0') and ascii('9')
+		then
+			return TRUE;
+		end if;
+		return FALSE;
+	END;
+$$ language 'plpgsql';

--- a/db/functions/isdigit_v01.sql
+++ b/db/functions/isdigit_v01.sql
@@ -1,0 +1,10 @@
+create or replace function isdigit(ch CHAR)
+	RETURNS BOOLEAN as $$
+	BEGIN
+	  if ascii(ch) between ascii('0') and ascii('9')
+	  then
+		return TRUE;
+	  end if;
+	  return FALSE;
+	END ;
+$$ language 'plpgsql';

--- a/db/functions/rpmver_array_v01.sql
+++ b/db/functions/rpmver_array_v01.sql
@@ -1,0 +1,60 @@
+create or replace FUNCTION rpmver_array (string1 IN VARCHAR)
+	RETURNS evr_array_item[] as $$
+	declare
+		str1 VARCHAR := string1;
+		digits VARCHAR(10) := '0123456789';
+		lc_alpha VARCHAR(27) := 'abcdefghijklmnopqrstuvwxyz';
+		uc_alpha VARCHAR(27) := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		alpha VARCHAR(54) := lc_alpha || uc_alpha;
+		one VARCHAR;
+		isnum BOOLEAN;
+		ver_array evr_array_item[] := ARRAY[]::evr_array_item[];
+	BEGIN
+		if str1 is NULL
+		then
+			RAISE EXCEPTION 'VALUE_ERROR.';
+		end if;
+
+		one := str1;
+		<<segment_loop>>
+		while one <> ''
+		loop
+			declare
+				segm1 VARCHAR;
+				segm1_n NUMERIC := 0;
+			begin
+				-- Throw out all non-alphanum characters
+				while one <> '' and not isalphanum(one)
+				loop
+					one := substr(one, 2);
+				end loop;
+				str1 := one;
+				if str1 <> '' and isdigit(str1)
+				then
+					str1 := ltrim(str1, digits);
+					isnum := true;
+				else
+					str1 := ltrim(str1, alpha);
+					isnum := false;
+				end if;
+				if str1 <> ''
+				then segm1 := substr(one, 1, length(one) - length(str1));
+				else segm1 := one;
+				end if;
+
+				if segm1 = '' then return ver_array; end if; /* arbitrary */
+				if isnum
+				then
+					segm1 := ltrim(segm1, '0');
+					if segm1 <> '' then segm1_n := segm1::numeric; end if;
+					segm1 := NULL;
+				else
+				end if;
+				ver_array := array_append(ver_array, (segm1_n, segm1)::evr_array_item);
+				one := str1;
+			end;
+		end loop segment_loop;
+
+		return ver_array;
+	END ;
+$$ language 'plpgsql';

--- a/db/migrate/20200213184848_create_evr_type.rb
+++ b/db/migrate/20200213184848_create_evr_type.rb
@@ -1,0 +1,49 @@
+require 'fx'
+
+class CreateEvrType < ActiveRecord::Migration[5.2]
+  def up
+    unless connection.adapter_name.downcase.include?('sqlite')
+
+      enable_extension "evr"
+
+      add_column :katello_rpms, :evr, :evr_t
+      add_column :katello_installed_packages, :evr, :evr_t
+
+      create_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
+      create_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
+      create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
+      create_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
+
+      execute <<-SQL
+        update katello_rpms SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+
+        update katello_installed_packages SET evr = (ROW(coalesce(epoch::numeric,0),
+                                                         rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                                         rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+
+      add_index :katello_rpms, [:name, :arch, :evr]
+      add_index :katello_erratum_packages, [:erratum_id, :nvrea]
+    end
+  end
+
+  def down
+    # fx doesn't seem to have support for dropping functions with parameters
+    unless connection.adapter_name.downcase.include?('sqlite')
+      remove_index :katello_rpms, column: [:name, :arch, :evr]
+      remove_index :katello_erratum_packages, column: [:erratum_id, :nvrea]
+
+      drop_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
+      drop_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
+      drop_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
+      drop_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
+
+      remove_column :katello_rpms, :evr
+      remove_column :katello_installed_packages, :evr
+
+      disable_extension "evr"
+    end
+  end
+end

--- a/db/triggers/evr_insert_trigger_katello_installed_packages_v01.sql
+++ b/db/triggers/evr_insert_trigger_katello_installed_packages_v01.sql
@@ -1,0 +1,5 @@
+CREATE TRIGGER evr_insert_trigger_katello_installed_packages
+  BEFORE INSERT
+  ON katello_installed_packages
+  FOR EACH ROW
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_insert_trigger_katello_rpms_v01.sql
+++ b/db/triggers/evr_insert_trigger_katello_rpms_v01.sql
@@ -1,0 +1,5 @@
+CREATE TRIGGER evr_insert_trigger_katello_rpms
+  BEFORE INSERT
+  ON katello_rpms
+  FOR EACH ROW
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_update_trigger_katello_installed_packages_v01.sql
+++ b/db/triggers/evr_update_trigger_katello_installed_packages_v01.sql
@@ -1,0 +1,10 @@
+CREATE TRIGGER evr_update_trigger_katello_installed_packages
+  BEFORE UPDATE OF epoch, version, release
+  ON katello_installed_packages
+  FOR EACH ROW
+  WHEN (
+    OLD.epoch IS DISTINCT FROM NEW.epoch OR
+    OLD.version IS DISTINCT FROM NEW.version OR
+    OLD.release IS DISTINCT FROM NEW.release
+  )
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_update_trigger_katello_rpms_v01.sql
+++ b/db/triggers/evr_update_trigger_katello_rpms_v01.sql
@@ -1,0 +1,10 @@
+CREATE TRIGGER evr_update_trigger_katello_rpms
+  BEFORE UPDATE OF epoch, version, release
+  ON katello_rpms
+  FOR EACH ROW
+  WHEN (
+    OLD.epoch IS DISTINCT FROM NEW.epoch OR
+    OLD.version IS DISTINCT FROM NEW.version OR
+    OLD.release IS DISTINCT FROM NEW.release
+  )
+  EXECUTE PROCEDURE evr_trigger();

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gettext_i18n_rails"
   gem.add_dependency "apipie-rails", ">= 0.5.14"
 
+  gem.add_dependency "fx", "< 1.0"
+
   # Pulp
   gem.add_dependency "runcible", ">= 2.13.0", "< 3.0.0"
   gem.add_dependency "anemone"

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -1,3 +1,5 @@
+require 'fx'
+
 module Katello
   HOST_TASKS_QUEUE = :hosts_queue
 

--- a/lib/monkeys/ar_postgres_evr_t.rb
+++ b/lib/monkeys/ar_postgres_evr_t.rb
@@ -1,0 +1,24 @@
+if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  module PostgreSQLAdapterExtensions
+    private
+
+    def get_oid_type(oid, fmod, column_name, sql_type = "".freeze)
+      if type_map.instance_variable_get(:@mapping)["evr_t"].nil?
+        type_map.register_type "evr_t", ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::EvrT.new
+      end
+      super
+    end
+  end
+  module ActiveRecord
+    module ConnectionAdapters
+      module PostgreSQL
+        module OID # :nodoc:
+          class EvrT < Type::String; end # :nodoc:
+        end
+      end
+      class PostgreSQLAdapter < AbstractAdapter
+        prepend PostgreSQLAdapterExtensions
+      end
+    end
+  end
+end

--- a/lib/monkeys/fx_sqlite_skip.rb
+++ b/lib/monkeys/fx_sqlite_skip.rb
@@ -1,0 +1,13 @@
+module Fx
+  module SchemaDumper
+    # @api private
+    module Trigger
+      def tables(stream)
+        unless ActiveRecord::Migration[5.2].connection.adapter_name.downcase.include?('sqlite')
+          super
+          triggers(stream)
+        end
+      end
+    end
+  end
+end

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -1,4 +1,5 @@
 require 'katello_test_helper'
+require 'support/evr_extension_support'
 
 module Katello
   class RpmTestBase < ActiveSupport::TestCase
@@ -116,6 +117,13 @@ module Katello
       @host_two = katello_content_facets(:content_facet_two).host
     end
 
+    def teardown
+      rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
+      rpm.update(epoch: '0')
+      rpm.update(version: '1.0')
+      rpm.update(release: '2.el7')
+    end
+
     def test_applicable_to_hosts
       rpms = Rpm.applicable_to_hosts([@host_one])
 
@@ -146,6 +154,48 @@ module Katello
       @host_one.content_facet.bound_repositories += @rpm_one.repositories
       facet = @rpm_one.hosts_available(@host_one.organization_id).first
       assert_equal @host_one, facet.host
+    end
+
+    def test_epoch_updates_evr_string
+      rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      rpm.update(epoch: '99')
+      installed_package.update(epoch: '99')
+      EvrExtensionSupport.set_rpm_evrs
+      EvrExtensionSupport.set_installed_package_evrs
+      rpm.reload
+      installed_package.reload
+
+      assert_equal "(99,\"{\"\"(1,)\"\",\"\"(0,)\"\"}\",\"{\"\"(2,)\"\",\"\"(0,el)\"\",\"\"(7,)\"\"}\")", rpm.evr
+      assert_equal "(99,\"{\"\"(1,)\"\",\"\"(0,)\"\"}\",\"{\"\"(2,)\"\",\"\"(0,el)\"\",\"\"(7,)\"\"}\")", installed_package.evr
+    end
+
+    def test_version_updates_evr_string
+      rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      rpm.update(version: '2.0')
+      installed_package.update(version: '2.0')
+      EvrExtensionSupport.set_rpm_evrs
+      EvrExtensionSupport.set_installed_package_evrs
+      rpm.reload
+      installed_package.reload
+
+      assert_equal "(0,\"{\"\"(2,)\"\",\"\"(0,)\"\"}\",\"{\"\"(2,)\"\",\"\"(0,el)\"\",\"\"(7,)\"\"}\")", rpm.evr
+      assert_equal "(0,\"{\"\"(2,)\"\",\"\"(0,)\"\"}\",\"{\"\"(2,)\"\",\"\"(0,el)\"\",\"\"(7,)\"\"}\")", installed_package.evr
+    end
+
+    def test_release_updates_evr_string
+      rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      rpm.update(release: '3.el8')
+      installed_package.update(release: '3.el8')
+      EvrExtensionSupport.set_rpm_evrs
+      EvrExtensionSupport.set_installed_package_evrs
+      rpm.reload
+      installed_package.reload
+
+      assert_equal "(0,\"{\"\"(1,)\"\",\"\"(0,)\"\"}\",\"{\"\"(3,)\"\",\"\"(0,el)\"\",\"\"(8,)\"\"}\")", rpm.evr
+      assert_equal "(0,\"{\"\"(1,)\"\",\"\"(0,)\"\"}\",\"{\"\"(3,)\"\",\"\"(0,el)\"\",\"\"(8,)\"\"}\")", installed_package.evr
     end
   end
 

--- a/test/support/evr_extension_support.rb
+++ b/test/support/evr_extension_support.rb
@@ -1,0 +1,21 @@
+module Katello
+  module EvrExtensionSupport
+    extend ActiveSupport::Concern
+
+    def self.set_rpm_evrs
+      ::ActiveRecord::Migration[5.2].execute <<-SQL
+        update katello_rpms SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+    end
+
+    def self.set_installed_package_evrs
+      ::ActiveRecord::Migration[5.2].execute <<-SQL
+        update katello_installed_packages SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
Includes custom sql types, functions, and triggers that automatically generate items in the new "evr" column for katello_rpms and katello_installed_packages. The migrations that add these types are all reversible. The logic for creating the evr type is mostly pulled from here: https://github.com/ggainey/pulp_startup/blob/master/applicability/evr_t.sql. The evr type is treated as a string by ActiveRecord, but this shouldn't be an issue since the EVR type shouldn't be used directly in Ruby code.

To test: 
1) Ensure there are some RPMs and InstalledPackages in your database.  
2) Install this RPM: https://fedorapeople.org/groups/katello/releases/yum/nightly/pulpcore/el7/x86_64/rh-postgresql12-postgresql-evr-0.0.1-2.el7.x86_64.rpm
2) Checkout my branch and run the migration (ignore the new warning about the evr_t type). 
3) Check that the existing RPMs and InstalledPackages have something other than `nil` for evr.  
4) Sync in or create some RPMs and see that the evr column for katello_rpms is updated. 
5) Create some InstalledPackages and see that evr is updated too.  The evr column will show up as a weird string, but that's okay since it'll be used in the background. 
6) Check that the evr columns are updated if the epochs, versions, or releases are updated.
7) Try rolling back the migration.

TODO:

- [x] Get postgresql-evr package into foreman-packaging (https://github.com/theforeman/foreman-packaging/pull/4795)
- [x] Get postgresql-evr installed on the Jenkins slaves