### PR TITLE
Fixes #29202 - Disallow commas in activation key name

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -34,6 +34,7 @@ module Katello
     validates_lengths_from_database
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates :name, :presence => true
+    validates :name, :format => { without: /,/, message: _('cannot contain commas') }
     validates :name, :uniqueness => {:scope => :organization_id}
     validate :environment_exists
     validates :max_hosts, :numericality => {:less_than => 2**31, :allow_nil => true}

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -11,7 +11,8 @@ module Katello
       @purpose_key = katello_activation_keys(:purpose_attributes_key)
     end
 
-    should allow_values(*valid_name_list).for(:name)
+    should allow_values(*valid_name_list.map { |name| name.gsub(',', '') }).for(:name)
+    should_not allow_values('name,with,commas').for(:name)
     should allow_values(*valid_name_list).for(:description)
     should_not allow_values(-1, 0, 'foo').for(:max_hosts)
 


### PR DESCRIPTION
With subscription-manager we can register with multiple activation keys separated by commas. This is problematic when we try to explode a string of comma-separated activation key names when one or more of them contain commas - we can't find the nonexistent keys.

Katello itself relies on the ability to register in this way on the host/hostgroup edit page through the 'Activation Key's tab => we store multiple selections separated by commas in a host parameter which ultimately gets passed directly to subscription-manager during provisioning.

Here's what the user sees now:

```
hammer activation-key update --id=1 --lifecycle-environment-id=13 --organization-id=1
Could not update the activation key:
  Validation failed: Name cannot contain commas
```