### PR TITLE
Fixes #29125 - Only migrate use_pulp_2_for_content_type types

### DIFF
--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -115,6 +115,8 @@ module Katello
       end
     end
 
+    class Pulp3MigrationError < StandardError; end
+
     class PulpError < StandardError
       def self.from_task(task)
         if %w(error canceled).include?(task[:state])

--- a/lib/katello/tasks/pulp3_content_switchover.rake
+++ b/lib/katello/tasks/pulp3_content_switchover.rake
@@ -3,7 +3,8 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 namespace :katello do
   desc "Runs a Pulp 3 migration of pulp3 hrefs to pulp ids for supported content types."
   task :pulp3_content_switchover => :environment do
-    content_types = Katello::Pulp3::Migration.content_types_for_migration
+    migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_master)
+    content_types = migration_service.content_types_for_migration
 
     content_types.each do |content_type|
       if content_type.model_class.where(migrated_pulp3_href: nil).any?

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/content_types_for_migration.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/content_types_for_migration.yml
@@ -1,0 +1,855 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:37 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
+        RmlsZXMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzLyIsICJodHRw
+        X3N0YXR1cyI6IDQwNCwgImVycm9yIjogeyJjb2RlIjogIlBMUDAwMDkiLCAi
+        ZGF0YSI6IHsicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifX0sICJkZXNjcmlwdGlv
+        biI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PURlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCAic3ViX2Vycm9ycyI6
+        IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9fQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:37 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
+        LCJkaXNwbGF5X25hbWUiOiJNeSBGaWxlcyIsImltcG9ydGVyX3R5cGVfaWQi
+        OiJpc29faW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZp
+        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL2ZpbGVfbWlncmF0aW9uLyIsImJh
+        c2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQi
+        Om51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiIiwi
+        c3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX2NhX2NlcnQiOm51bGx9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJpc29fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9NeV9GaWxlcyIsInNlcnZlX2h0dHAiOnRydWUsInNlcnZlX2h0
+        dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:37 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '344'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTY1MDZjNzFhNTM3N2Q2MjgwMCJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:37 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2JhMWI1OGM0LWZhNzQtNGRjMC04Y2U1LWYyMThmZGU1NTIyNS8iLCAi
+        dGFza19pZCI6ICJiYTFiNThjNC1mYTc0LTRkYzAtOGNlNS1mMjE4ZmRlNTUy
+        MjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/ba1b58c4-fa74-4dc0-8ce5-f218fde55225/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"14570ddbc08c5eb028ce4fc73d248bec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '675'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iYTFiNThjNC1mYTc0LTRkYzAtOGNlNS1mMjE4ZmRlNTUy
+        MjUvIiwgInRhc2tfaWQiOiAiYmExYjU4YzQtZmE3NC00ZGMwLThjZTUtZjIx
+        OGZkZTU1MjI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6Mzha
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMwMzBm
+        OTAxLTVhYTYtNDczNy05NmQ3LTExMzE2MGNhMWIzMi8iLCAidGFza19pZCI6
+        ICIzMDMwZjkwMS01YWE2LTQ3MzctOTZkNy0xMTMxNjBjYTFiMzIifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzgiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozOCIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjM4IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozOCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozOCIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4IiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzgiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4In19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTY2MDZjNzFhNTRhZGQwMjZlYyIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NjZjOGNjYjY3OTY4ZWQ0YzczIn0sICJpZCI6ICI1ZTYxNjk2NmM4Y2NiNjc5
+        NjhlZDRjNzMifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/ba1b58c4-fa74-4dc0-8ce5-f218fde55225/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"14570ddbc08c5eb028ce4fc73d248bec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '675'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iYTFiNThjNC1mYTc0LTRkYzAtOGNlNS1mMjE4ZmRlNTUy
+        MjUvIiwgInRhc2tfaWQiOiAiYmExYjU4YzQtZmE3NC00ZGMwLThjZTUtZjIx
+        OGZkZTU1MjI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6Mzha
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMwMzBm
+        OTAxLTVhYTYtNDczNy05NmQ3LTExMzE2MGNhMWIzMi8iLCAidGFza19pZCI6
+        ICIzMDMwZjkwMS01YWE2LTQ3MzctOTZkNy0xMTMxNjBjYTFiMzIifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzgiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozOCIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjM4IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozOCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozOCIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4IiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzgiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4In19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTY2MDZjNzFhNTRhZGQwMjZlYyIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NjZjOGNjYjY3OTY4ZWQ0YzczIn0sICJpZCI6ICI1ZTYxNjk2NmM4Y2NiNjc5
+        NjhlZDRjNzMifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/3030f901-5aa6-4737-96d7-113160ca1b32/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5d098931f07fa1af925b96af1692304f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '563'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zMDMwZjkwMS01YWE2LTQ3MzctOTZkNy0xMTMx
+        NjBjYTFiMzIvIiwgInRhc2tfaWQiOiAiMzAzMGY5MDEtNWFhNi00NzM3LTk2
+        ZDctMTEzMTYwY2ExYjMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVU
+        MjE6MDQ6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzhaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM4
+        IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzgiLCAiY29t
+        cGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozOCJ9LCAic3RhdGUiOiAiY29t
+        cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRxMiIs
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3Rh
+        YmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJzdGFydGVkIjogIjIw
+        MjAtMDMtMDVUMjE6MDQ6MzhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozOFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiaXNv
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRlIjogImNvbXBsZXRl
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIx
+        OjA0OjM4IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6Mzgi
+        LCAiY29tcGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozOCJ9fSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJpZCI6ICI1ZTYxNjk2
+        NjA2YzcxYTU0YWRkMDI2ZWYiLCAiZGV0YWlscyI6IG51bGx9LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlNjE2OTY2YzhjY2I2Nzk2OGVk
+        NGNiMyJ9LCAiaWQiOiAiNWU2MTY5NjZjOGNjYjY3OTY4ZWQ0Y2IzIn0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNf
+        RGV2IiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXNfRGV2In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '382'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTY2MDZjNzFhNTM3N2Q2MjgwMyJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0Zp
+        bGVzIiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0ZpbGVzIiwi
+        c2VydmVfaHR0cCI6dHJ1ZSwic2VydmVfaHR0cHMiOnRydWV9LCJhdXRvX3B1
+        Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '390'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTY2MDZjNzFhNTM3OGJjZjIxNyJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy8ifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1bSJd
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
+        ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
+        OTgiLCAiX2lkIjogIjU1ZDk2ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYw
+        MWE3MiIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTow
+        NDozOFoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        OFoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjU1ZDk2
+        ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYwMWE3MiIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWU2MTY5NjZjOGNjYjY3OTY4ZWQ0Yzk2In19XQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1
+        bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:38 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2IyYmVlNTI4LWVlM2UtNDRlOS04NTgwLWZlNjA3ZGVmZWZiZC8iLCAi
+        dGFza19pZCI6ICJiMmJlZTUyOC1lZTNlLTQ0ZTktODU4MC1mZTYwN2RlZmVm
+        YmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/b2bee528-ee3e-44e9-8580-fe607defefbd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:39 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d6d9ea9bae378c96fbfdfaac97dad33b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '393'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMmJlZTUyOC1lZTNlLTQ0ZTktODU4MC1mZTYwN2RlZmVm
+        YmQvIiwgInRhc2tfaWQiOiAiYjJiZWU1MjgtZWUzZS00NGU5LTg1ODAtZmU2
+        MDdkZWZlZmJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
+        MC0wMy0wNVQyMTowNDozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVlNjE2OTY2YzhjY2I2Nzk2OGVkNGQzOSJ9LCAiaWQiOiAiNWU2
+        MTY5NjZjOGNjYjY3OTY4ZWQ0ZDM5In0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:39 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk2YmQ4ZWY3LWExOTMtNDBmNC05MjI3LTNhMDE1NTQ4ZjAxMy8iLCAi
+        dGFza19pZCI6ICI5NmJkOGVmNy1hMTkzLTQwZjQtOTIyNy0zYTAxNTU0OGYw
+        MTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/96bd8ef7-a193-40f4-9227-3a015548f013/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:39 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f46badf212e38d60bd2a88d98d75367d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85NmJkOGVmNy1hMTkzLTQwZjQtOTIyNy0zYTAxNTU0OGYw
+        MTMvIiwgInRhc2tfaWQiOiAiOTZiZDhlZjctYTE5My00MGY0LTkyMjctM2Ew
+        MTU1NDhmMDEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2N2M4Y2NiNjc5NjhlZDRkN2YifSwgImlkIjog
+        IjVlNjE2OTY3YzhjY2I2Nzk2OGVkNGQ3ZiJ9
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:39 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzFkODU4MWVhLTI1M2QtNDBjZC04MmZjLTViMjgwYTBiZGM3NC8iLCAi
+        dGFza19pZCI6ICIxZDg1ODFlYS0yNTNkLTQwY2QtODJmYy01YjI4MGEwYmRj
+        NzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/1d8581ea-253d-40cd-82fc-5b280a0bdc74/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:39 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e210002ecbee13558ae2c2c5451e48a2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '396'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xZDg1ODFlYS0yNTNkLTQwY2QtODJmYy01YjI4MGEwYmRj
+        NzQvIiwgInRhc2tfaWQiOiAiMWQ4NTgxZWEtMjUzZC00MGNkLTgyZmMtNWIy
+        ODBhMGJkYzc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2N2M4Y2NiNjc5NjhlZDRkYmMifSwgImlkIjog
+        IjVlNjE2OTY3YzhjY2I2Nzk2OGVkNGRiYyJ9
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:39 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:09 GMT
+      - Thu, 05 Mar 2020 21:04:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -45,10 +45,10 @@ http_interactions:
         aXRvcnkiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
         cyJ9fQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:09 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:29 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -82,7 +82,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:10 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -98,15 +98,15 @@ http_interactions:
         LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
         bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
         b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
-        IjogeyIkb2lkIjogIjVlMzg5NTFhYjAyZTUzNTA2NjNjOTc2OSJ9LCAiaWQi
+        IjogeyIkb2lkIjogIjVlNjE2OTVlMDZjNzFhNTM3NjA5YTA0MSJ9LCAiaWQi
         OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
         aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
         YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:10 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -129,7 +129,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:10 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -140,14 +140,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZmZjQwNWE4LTdmNWYtNGMwNy1hMWE1LTcxZjAzMWQ3OGIwYS8iLCAi
-        dGFza19pZCI6ICJmZmY0MDVhOC03ZjVmLTRjMDctYTFhNS03MWYwMzFkNzhi
-        MGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzM4MmMxZWNhLTVkYjAtNDIwNC1iZGYwLWUyZmM0OWZmYWU5NC8iLCAi
+        dGFza19pZCI6ICIzODJjMWVjYS01ZGIwLTQyMDQtYmRmMC1lMmZjNDlmZmFl
+        OTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:10 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fff405a8-7f5f-4c07-a1a5-71f031d78b0a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/382c1eca-5db0-4204-bdf0-e2fc49ffae94/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -166,15 +166,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:10 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Etag:
-      - '"c15cf0077ed107e33f3075b14a242b9b-gzip"'
+      - '"9ba4e6926b5819f9af6e6a2c8aa80a47-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '663'
+      - '675'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -182,53 +182,54 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmY0MDVhOC03ZjVmLTRjMDctYTFhNS03MWYwMzFkNzhi
-        MGEvIiwgInRhc2tfaWQiOiAiZmZmNDA1YTgtN2Y1Zi00YzA3LWExYTUtNzFm
-        MDMxZDc4YjBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        aS92Mi90YXNrcy8zODJjMWVjYS01ZGIwLTQyMDQtYmRmMC1lMmZjNDlmZmFl
+        OTQvIiwgInRhc2tfaWQiOiAiMzgyYzFlY2EtNWRiMC00MjA0LWJkZjAtZTJm
+        YzQ5ZmZhZTk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
-        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDItMDNUMjE6NDg6MTBa
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzBa
         IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
-        MDItMDNUMjE6NDg6MTBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQwY2Yw
-        NGM0LTI1ZTYtNDk3Yi1hZTQwLTBiNGYxYjVjODI3Zi8iLCAidGFza19pZCI6
-        ICI0MGNmMDRjNC0yNWU2LTQ5N2ItYWU0MC0wYjRmMWI1YzgyN2YifV0sICJw
+        MDMtMDVUMjE6MDQ6MzBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2RkMTA4
+        YjhjLTdkNTMtNDNjNy04OWNlLTZhOTkzMzkyNzc3OS8iLCAidGFza19pZCI6
+        ICJkZDEwOGI4Yy03ZDUzLTQzYzctODljZS02YTk5MzM5Mjc3NzkifV0sICJw
         cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
         c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
         ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
         dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
-        IjogIjIwMjAtMDItMDNUMjE6NDg6MTAiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
-        c3MiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMCIsICJjb21wbGV0ZSI6ICIyMDIw
-        LTAyLTAzVDIxOjQ4OjEwIiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
-        Mi0wM1QyMTo0ODoxMCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozMCIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjMwIiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozMCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
         X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
-        cl9pZCI6ICJpc29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAyLTAz
-        VDIxOjQ4OjEwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
-        cGxldGVkIjogIjIwMjAtMDItMDNUMjE6NDg6MTBaIiwgImltcG9ydGVyX3R5
-        cGVfaWQiOiAiaXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
-        LCAic3VtbWFyeSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjog
-        bnVsbCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMi
-        OiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNv
-        X2Vycm9yX21lc3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAs
-        ICJzdGF0ZV90aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMi0wM1Qy
-        MTo0ODoxMCIsICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAyLTAz
-        VDIxOjQ4OjEwIiwgImNvbXBsZXRlIjogIjIwMjAtMDItMDNUMjE6NDg6MTAi
-        LCAiaXNvc19pbl9wcm9ncmVzcyI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEwIn19
-        LCAiYWRkZWRfY291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
-        dGVkX2NvdW50IjogMCwgImlkIjogIjVlMzg5NTFhYjAyZTUzMGI2ZmJjMDMy
-        NSIsICJkZXRhaWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWUzODk1MWFlNzQxY2NjMTZjNGRlNmU2In0sICJpZCI6ICI1
-        ZTM4OTUxYWU3NDFjY2MxNmM0ZGU2ZTYifQ==
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwWiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMCIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwIiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwIn19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTVlMDZjNzFhNTRhZGQwMjZkYyIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NWVjOGNjYjY3OTY4ZWQ0ODI0In0sICJpZCI6ICI1ZTYxNjk1ZWM4Y2NiNjc5
+        NjhlZDQ4MjQifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fff405a8-7f5f-4c07-a1a5-71f031d78b0a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/382c1eca-5db0-4204-bdf0-e2fc49ffae94/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -247,15 +248,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Etag:
-      - '"c15cf0077ed107e33f3075b14a242b9b-gzip"'
+      - '"9ba4e6926b5819f9af6e6a2c8aa80a47-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '663'
+      - '675'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -263,53 +264,54 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmY0MDVhOC03ZjVmLTRjMDctYTFhNS03MWYwMzFkNzhi
-        MGEvIiwgInRhc2tfaWQiOiAiZmZmNDA1YTgtN2Y1Zi00YzA3LWExYTUtNzFm
-        MDMxZDc4YjBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        aS92Mi90YXNrcy8zODJjMWVjYS01ZGIwLTQyMDQtYmRmMC1lMmZjNDlmZmFl
+        OTQvIiwgInRhc2tfaWQiOiAiMzgyYzFlY2EtNWRiMC00MjA0LWJkZjAtZTJm
+        YzQ5ZmZhZTk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
-        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDItMDNUMjE6NDg6MTBa
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzBa
         IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
-        MDItMDNUMjE6NDg6MTBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQwY2Yw
-        NGM0LTI1ZTYtNDk3Yi1hZTQwLTBiNGYxYjVjODI3Zi8iLCAidGFza19pZCI6
-        ICI0MGNmMDRjNC0yNWU2LTQ5N2ItYWU0MC0wYjRmMWI1YzgyN2YifV0sICJw
+        MDMtMDVUMjE6MDQ6MzBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2RkMTA4
+        YjhjLTdkNTMtNDNjNy04OWNlLTZhOTkzMzkyNzc3OS8iLCAidGFza19pZCI6
+        ICJkZDEwOGI4Yy03ZDUzLTQzYzctODljZS02YTk5MzM5Mjc3NzkifV0sICJw
         cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
         c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
         ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
         dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
-        IjogIjIwMjAtMDItMDNUMjE6NDg6MTAiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
-        c3MiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMCIsICJjb21wbGV0ZSI6ICIyMDIw
-        LTAyLTAzVDIxOjQ4OjEwIiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
-        Mi0wM1QyMTo0ODoxMCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozMCIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjMwIiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozMCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
         X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
-        cl9pZCI6ICJpc29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAyLTAz
-        VDIxOjQ4OjEwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
-        cGxldGVkIjogIjIwMjAtMDItMDNUMjE6NDg6MTBaIiwgImltcG9ydGVyX3R5
-        cGVfaWQiOiAiaXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
-        LCAic3VtbWFyeSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjog
-        bnVsbCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMi
-        OiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNv
-        X2Vycm9yX21lc3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAs
-        ICJzdGF0ZV90aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMi0wM1Qy
-        MTo0ODoxMCIsICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAyLTAz
-        VDIxOjQ4OjEwIiwgImNvbXBsZXRlIjogIjIwMjAtMDItMDNUMjE6NDg6MTAi
-        LCAiaXNvc19pbl9wcm9ncmVzcyI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEwIn19
-        LCAiYWRkZWRfY291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
-        dGVkX2NvdW50IjogMCwgImlkIjogIjVlMzg5NTFhYjAyZTUzMGI2ZmJjMDMy
-        NSIsICJkZXRhaWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWUzODk1MWFlNzQxY2NjMTZjNGRlNmU2In0sICJpZCI6ICI1
-        ZTM4OTUxYWU3NDFjY2MxNmM0ZGU2ZTYifQ==
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwWiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMCIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwIiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjMwIn19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTVlMDZjNzFhNTRhZGQwMjZkYyIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NWVjOGNjYjY3OTY4ZWQ0ODI0In0sICJpZCI6ICI1ZTYxNjk1ZWM4Y2NiNjc5
+        NjhlZDQ4MjQifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/40cf04c4-25e6-497b-ae40-0b4f1b5c827f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/dd108b8c-7d53-43c7-89ce-6a9933927779/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -328,15 +330,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Etag:
-      - '"5744b21d9421f336f33b31e7bf16803a-gzip"'
+      - '"bd6b43f156315b989441d5c586ad1a34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '551'
+      - '562'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -344,44 +346,44 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MGNmMDRjNC0yNWU2LTQ5N2ItYWU0MC0wYjRm
-        MWI1YzgyN2YvIiwgInRhc2tfaWQiOiAiNDBjZjA0YzQtMjVlNi00OTdiLWFl
-        NDAtMGI0ZjFiNWM4MjdmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        dWxwL2FwaS92Mi90YXNrcy9kZDEwOGI4Yy03ZDUzLTQzYzctODljZS02YTk5
+        MzM5Mjc3NzkvIiwgInRhc2tfaWQiOiAiZGQxMDhiOGMtN2Q1My00M2M3LTg5
+        Y2UtNmE5OTMzOTI3Nzc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
         ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
-        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDItMDNU
-        MjE6NDg6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMjAtMDItMDNUMjE6NDg6MTFaIiwgInRyYWNlYmFjayI6IG51bGws
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVU
+        MjE6MDQ6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzBaIiwgInRyYWNlYmFjayI6IG51bGws
         ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
-        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEx
-        IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDItMDNUMjE6NDg6MTEiLCAiY29t
-        cGxldGUiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMSJ9LCAic3RhdGUiOiAiY29t
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjMw
+        IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAiLCAiY29t
+        cGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozMCJ9LCAic3RhdGUiOiAiY29t
         cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
-        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBk
-        ZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        cmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
-        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIs
-        ICJzdGFydGVkIjogIjIwMjAtMDItMDNUMjE6NDg6MTFaIiwgIl9ucyI6ICJy
-        ZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMi0w
-        M1QyMTo0ODoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0
-        YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJh
-        Y2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6
-        ICIyMDIwLTAyLTAzVDIxOjQ4OjExIiwgImluX3Byb2dyZXNzIjogIjIwMjAt
-        MDItMDNUMjE6NDg6MTEiLCAiY29tcGxldGUiOiAiMjAyMC0wMi0wM1QyMTo0
-        ODoxMSJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIs
-        ICJpZCI6ICI1ZTM4OTUxYmIwMmU1MzBiNmZiYzAzMjgiLCAiZGV0YWlscyI6
-        IG51bGx9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlMzg5
-        NTFhZTc0MWNjYzE2YzRkZTczYyJ9LCAiaWQiOiAiNWUzODk1MWFlNzQxY2Nj
-        MTZjNGRlNzNjIn0=
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRxMiIs
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3Rh
+        YmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJzdGFydGVkIjogIjIw
+        MjAtMDMtMDVUMjE6MDQ6MzBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiaXNv
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRlIjogImNvbXBsZXRl
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIx
+        OjA0OjMwIiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzAi
+        LCAiY29tcGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozMCJ9fSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJpZCI6ICI1ZTYxNjk1
+        ZTA2YzcxYTU0YWRkMDI2ZGYiLCAiZGV0YWlscyI6IG51bGx9LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlNjE2OTVlYzhjY2I2Nzk2OGVk
+        NDg2MCJ9LCAiaWQiOiAiNWU2MTY5NWVjOGNjYjY3OTY4ZWQ0ODYwIn0=
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -411,7 +413,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -427,15 +429,15 @@ http_interactions:
         LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
         bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
         b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
-        IjogeyIkb2lkIjogIjVlMzg5NTFiYjAyZTUzNTA2NTZkMzRjOSJ9LCAiaWQi
+        IjogeyIkb2lkIjogIjVlNjE2OTVlMDZjNzFhNTM3N2Q2MjdmYiJ9LCAiaWQi
         OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:30 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -465,7 +467,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -481,15 +483,15 @@ http_interactions:
         LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
         bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
         b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
-        IjogeyIkb2lkIjogIjVlMzg5NTFiYjAyZTUzNTA2NTZkMzRjYyJ9LCAiaWQi
+        IjogeyIkb2lkIjogIjVlNjE2OTVmMDZjNzFhNTM3OGJjZjIwZCJ9LCAiaWQi
         OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
         X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy8ifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -513,7 +515,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Vary:
@@ -527,19 +529,19 @@ http_interactions:
       base64_string: |
         W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
         ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
-        OTgiLCAiX2lkIjogIjYzN2EyZjI2LWM4NjQtNDNjZC1hNjRkLWI5MjU5ZWNl
-        M2EwOCIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
-        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMC0wMi0wM1QyMTo0
-        ODoxMFoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
-        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMC0wMi0wM1QyMTo0ODox
-        MFoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjYzN2Ey
-        ZjI2LWM4NjQtNDNjZC1hNjRkLWI5MjU5ZWNlM2EwOCIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWUzODk1MWFlNzQxY2NjMTZjNGRlNzFiIn19XQ==
+        OTgiLCAiX2lkIjogIjU1ZDk2ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYw
+        MWE3MiIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTow
+        NDozMFoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MFoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjU1ZDk2
+        ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYwMWE3MiIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWU2MTY5NWVjOGNjYjY3OTY4ZWQ0ODQwIn19XQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -563,7 +565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -576,17 +578,17 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMiLCJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwi
-        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyI2
-        MzdhMmYyNi1jODY0LTQzY2QtYTY0ZC1iOTI1OWVjZTNhMDgiXX19fX0sIm92
+        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyI1
+        NWQ5NmQ4ZC1mNjYyLTRlNzAtYjIyOC05ODQ0ZjE2MDFhNzIiXX19fX0sIm92
         ZXJyaWRlX2NvbmZpZyI6e319
     headers:
       Accept:
@@ -605,7 +607,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -616,21 +618,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYyZjI0MTQ4LWFlM2UtNDI1OS1hYTFlLWYyZjAwMTBiY2YzOS8iLCAi
-        dGFza19pZCI6ICI2MmYyNDE0OC1hZTNlLTQyNTktYWExZS1mMmYwMDEwYmNm
-        MzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzUwMWUyYWY3LWNiZTUtNGUzNi04M2I5LTdmODQ1NWIwNDMzMC8iLCAi
+        dGFza19pZCI6ICI1MDFlMmFmNy1jYmU1LTRlMzYtODNiOS03Zjg0NTViMDQz
+        MzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMiLCJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwi
-        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyI2
-        MzdhMmYyNi1jODY0LTQzY2QtYTY0ZC1iOTI1OWVjZTNhMDgiXX19fX0sIm92
+        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyI1
+        NWQ5NmQ4ZC1mNjYyLTRlNzAtYjIyOC05ODQ0ZjE2MDFhNzIiXX19fX0sIm92
         ZXJyaWRlX2NvbmZpZyI6e319
     headers:
       Accept:
@@ -649,7 +651,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:11 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -660,14 +662,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MzODVjYWJhLTc2NzUtNDA4MS05MmRhLTVjMTk5NWYxZDM3OC8iLCAi
-        dGFza19pZCI6ICJjMzg1Y2FiYS03Njc1LTQwODEtOTJkYS01YzE5OTVmMWQz
-        NzgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzM3YmMwMWU3LTA1NjEtNGRmMy05MjlmLTBjYWViZTg0MTY4My8iLCAi
+        dGFza19pZCI6ICIzN2JjMDFlNy0wNTYxLTRkZjMtOTI5Zi0wY2FlYmU4NDE2
+        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:11 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -686,15 +688,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Etag:
-      - '"e9b814750cc69b913008e5c0334f4159-gzip"'
+      - '"02f3d5e38b752784e6bbef07d4cc492f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '461'
+      - '462'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -703,7 +705,7 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
         LCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVw
         b19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9G
-        aWxlcyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMVoi
+        aWxlcyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMVoi
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
         X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy9kaXN0cmlidXRv
         cnMvRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMv
@@ -711,33 +713,33 @@ http_interactions:
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJpc29fZGlzdHJpYnV0
         b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwg
         Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWUzODk1MWJiMDJlNTM1MDY1NmQzNGNlIn0sICJjb25maWciOiB7InNlcnZl
+        NWU2MTY5NWYwNmM3MWE1Mzc4YmNmMjBmIn0sICJjb25maWciOiB7InNlcnZl
         X2h0dHBzIjogdHJ1ZSwgInNlcnZlX2h0dHAiOiB0cnVlLCAicmVsYXRpdmVf
         dXJsIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0Zp
         bGVzIn0sICJpZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5l
-        dC1NeV9GaWxlcyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6ICIyMDIwLTAyLTAz
-        VDIxOjQ4OjExWiIsICJub3RlcyI6IHt9LCAibGFzdF91bml0X3JlbW92ZWQi
+        dC1NeV9GaWxlcyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6ICIyMDIwLTAzLTA1
+        VDIxOjA0OjMxWiIsICJub3RlcyI6IHt9LCAibGFzdF91bml0X3JlbW92ZWQi
         OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHsiaXNvIjogMX0sICJf
         bnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICJEZWZh
         dWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMVoiLCAiX2hyZWYiOiAi
+        X3VwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMVoiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09yZ2FuaXphdGlv
         bi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy9pbXBvcnRlcnMvaXNvX2ltcG9ydGVy
         LyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9p
         ZCI6ICJpc29faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1ZTM4OTUxYmIwMmU1MzUwNjU2ZDM0Y2QifSwgImNv
+        ZCI6IHsiJG9pZCI6ICI1ZTYxNjk1ZjA2YzcxYTUzNzhiY2YyMGUifSwgImNv
         bmZpZyI6IHt9LCAiaWQiOiAiaXNvX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
-        dG9yZWRfdW5pdHMiOiAxLCAiX2lkIjogeyIkb2lkIjogIjVlMzg5NTFiYjAy
-        ZTUzNTA2NTZkMzRjYyJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDEs
+        dG9yZWRfdW5pdHMiOiAxLCAiX2lkIjogeyIkb2lkIjogIjVlNjE2OTVmMDZj
+        NzFhNTM3OGJjZjIwZCJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDEs
         ICJpZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9G
         aWxlcyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0Rl
         ZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0ZpbGVzLyJ9
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/publish/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -760,7 +762,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -771,14 +773,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I2ZmZlNGQxLTUwMTgtNDRhNS1iOGNlLTc1MjM0MjQ2YzNmNS8iLCAi
-        dGFza19pZCI6ICJiNmZmZTRkMS01MDE4LTQ0YTUtYjhjZS03NTIzNDI0NmMz
-        ZjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2ZjZGUwMzU2LTQyYmUtNGJmZC1iYTgxLThjZjJjZDRkODhlZi8iLCAi
+        dGFza19pZCI6ICJmY2RlMDM1Ni00MmJlLTRiZmQtYmE4MS04Y2YyY2Q0ZDg4
+        ZWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b6ffe4d1-5018-44a5-b8ce-75234246c3f5/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/fcde0356-42be-4bfd-ba81-8cf2cd4d88ef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -797,15 +799,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Etag:
-      - '"c79b90931ee3493a3821fa3eb9c23c75-gzip"'
+      - '"48f8e33cd02e13ac2c14169b01780480-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '554'
+      - '565'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -813,44 +815,45 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNmZmZTRkMS01MDE4LTQ0YTUtYjhjZS03NTIz
-        NDI0NmMzZjUvIiwgInRhc2tfaWQiOiAiYjZmZmU0ZDEtNTAxOC00NGE1LWI4
-        Y2UtNzUyMzQyNDZjM2Y1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        dWxwL2FwaS92Mi90YXNrcy9mY2RlMDM1Ni00MmJlLTRiZmQtYmE4MS04Y2Yy
+        Y2Q0ZDg4ZWYvIiwgInRhc2tfaWQiOiAiZmNkZTAzNTYtNDJiZS00YmZkLWJh
+        ODEtOGNmMmNkNGQ4OGVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
         ZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJw
-        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTAy
-        LTAzVDIxOjQ4OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyWiIsICJ0cmFjZWJhY2siOiBu
+        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTAz
+        LTA1VDIxOjA0OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDIwLTAzLTA1VDIxOjA0OjMxWiIsICJ0cmFjZWJhY2siOiBu
         dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
         eyJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyI6
-        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjAtMDItMDNU
-        MjE6NDg6MTIiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMC0wMi0wM1QyMTo0ODox
-        MiIsICJjb21wbGV0ZSI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyIn0sICJzdGF0
+        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjAtMDMtMDVU
+        MjE6MDQ6MzEiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MSIsICJjb21wbGV0ZSI6ICIyMDIwLTAzLTA1VDIxOjA0OjMxIn0sICJzdGF0
         ZSI6ICJjb21wbGV0ZSIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInRyYWNl
         YmFjayI6IG51bGx9fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5l
-        dC1NeV9GaWxlcyIsICJzdGFydGVkIjogIjIwMjAtMDItMDNUMjE6NDg6MTJa
-        IiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQi
-        OiAiMjAyMC0wMi0wM1QyMTo0ODoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1
-        bW1hcnkiOiB7InN0YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2Ui
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJu
-        b3Rfc3RhcnRlZCI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyIiwgImluX3Byb2dy
-        ZXNzIjogIjIwMjAtMDItMDNUMjE6NDg6MTIiLCAiY29tcGxldGUiOiAiMjAy
-        MC0wMi0wM1QyMTo0ODoxMiJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
-        ZGlzdHJpYnV0b3JfaWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNh
-        YmluZXQtTXlfRmlsZXMiLCAiaWQiOiAiNWUzODk1MWNiMDJlNTMwYjZmYmMw
-        MzJjIiwgImRldGFpbHMiOiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZTM4OTUxY2U3NDFjY2MxNmM0ZGU4M2MifSwgImlkIjog
-        IjVlMzg5NTFjZTc0MWNjYzE2YzRkZTgzYyJ9
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJz
+        dGFydGVkIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzFaIiwgIl9ucyI6ICJyZXBv
+        X3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMy0wNVQy
+        MTowNDozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRl
+        IjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIy
+        MDIwLTAzLTA1VDIxOjA0OjMxIiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMt
+        MDVUMjE6MDQ6MzEiLCAiY29tcGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MSJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
+        LCAiaWQiOiAiNWU2MTY5NWYwNmM3MWE1NGFkZDAyNmU0IiwgImRldGFpbHMi
+        OiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZTYx
+        Njk1ZmM4Y2NiNjc5NjhlZDQ5NDEifSwgImlkIjogIjVlNjE2OTVmYzhjY2I2
+        Nzk2OGVkNDk0MSJ9
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -869,15 +872,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Etag:
-      - '"0512012178c57966c879e78946cf39cf-gzip"'
+      - '"3473c8111a6351a19a24eaa9e1884c17-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '460'
+      - '459'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -886,7 +889,7 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
         LCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVw
         b19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVz
-        X0RldiIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wMi0wM1QyMTo0ODoxMVoi
+        X0RldiIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozMFoi
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi9kaXN0cmlidXRv
         cnMvRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYv
@@ -894,33 +897,33 @@ http_interactions:
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJpc29fZGlzdHJpYnV0
         b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwg
         Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWUzODk1MWJiMDJlNTM1MDY1NmQzNGNiIn0sICJjb25maWciOiB7InNlcnZl
+        NWU2MTY5NWUwNmM3MWE1Mzc3ZDYyN2ZkIn0sICJjb25maWciOiB7InNlcnZl
         X2h0dHBzIjogdHJ1ZSwgInNlcnZlX2h0dHAiOiB0cnVlLCAicmVsYXRpdmVf
         dXJsIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyJ9LCAi
         aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19E
-        ZXYifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0wMi0wM1QyMTo0ODox
-        MloiLCAibm90ZXMiOiB7fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwg
+        ZXYifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MVoiLCAibm90ZXMiOiB7fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwg
         ImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7ImlzbyI6IDF9LCAiX25zIjogInJl
         cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRGVmYXVsdF9Pcmdh
         bml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYiLCAibGFzdF91cGRhdGVk
-        IjogIjIwMjAtMDItMDNUMjE6NDg6MTFaIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzBaIiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9yZXBvc2l0b3JpZXMvRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
         dC1NeV9GaWxlc19EZXYvaW1wb3J0ZXJzL2lzb19pbXBvcnRlci8iLCAiX25z
         IjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNv
         X2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0
         X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWUzODk1MWJiMDJlNTM1MDY1NmQzNGNhIn0sICJjb25maWciOiB7
+        aWQiOiAiNWU2MTY5NWUwNmM3MWE1Mzc3ZDYyN2ZjIn0sICJjb25maWciOiB7
         fSwgImlkIjogImlzb19pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3Vu
-        aXRzIjogMSwgIl9pZCI6IHsiJG9pZCI6ICI1ZTM4OTUxYmIwMmU1MzUwNjU2
-        ZDM0YzkifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAxLCAiaWQiOiAi
+        aXRzIjogMSwgIl9pZCI6IHsiJG9pZCI6ICI1ZTYxNjk1ZTA2YzcxYTUzNzdk
+        NjI3ZmIifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAxLCAiaWQiOiAi
         RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYiLCAi
         X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/publish/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -943,7 +946,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -954,14 +957,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg4YTMxODNhLTNhNzEtNGQ4MS1iNmExLWVkMGUxYjNmNTY1Yy8iLCAi
-        dGFza19pZCI6ICI4OGEzMTgzYS0zYTcxLTRkODEtYjZhMS1lZDBlMWIzZjU2
-        NWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2JhOTNmYWYxLWQ3MGEtNDgxYi04YWY2LWRhMzZhMmM0OTc3OS8iLCAi
+        dGFza19pZCI6ICJiYTkzZmFmMS1kNzBhLTQ4MWItOGFmNi1kYTM2YTJjNDk3
+        NzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:31 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/88a3183a-3a71-4d81-b6a1-ed0e1b3f565c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/ba93faf1-d70a-481b-8af6-da36a2c49779/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -980,15 +983,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:12 GMT
+      - Thu, 05 Mar 2020 21:04:31 GMT
       Server:
       - Apache
       Etag:
-      - '"ea3a3eaf799e6dd31b4710a85b2d5bed-gzip"'
+      - '"0a314927ba40de165eff8034186b7cdf-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '555'
+      - '567'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -996,44 +999,45 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84OGEzMTgzYS0zYTcxLTRkODEtYjZhMS1lZDBl
-        MWIzZjU2NWMvIiwgInRhc2tfaWQiOiAiODhhMzE4M2EtM2E3MS00ZDgxLWI2
-        YTEtZWQwZTFiM2Y1NjVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        dWxwL2FwaS92Mi90YXNrcy9iYTkzZmFmMS1kNzBhLTQ4MWItOGFmNi1kYTM2
+        YTJjNDk3NzkvIiwgInRhc2tfaWQiOiAiYmE5M2ZhZjEtZDcwYS00ODFiLThh
+        ZjYtZGEzNmEyYzQ5Nzc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
         ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJw
-        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTAy
-        LTAzVDIxOjQ4OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyWiIsICJ0cmFjZWJhY2siOiBu
+        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTAz
+        LTA1VDIxOjA0OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDIwLTAzLTA1VDIxOjA0OjMxWiIsICJ0cmFjZWJhY2siOiBu
         dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
         eyJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiI6
-        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjAtMDItMDNU
-        MjE6NDg6MTIiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMC0wMi0wM1QyMTo0ODox
-        MiIsICJjb21wbGV0ZSI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyIn0sICJzdGF0
+        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjAtMDMtMDVU
+        MjE6MDQ6MzEiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MSIsICJjb21wbGV0ZSI6ICIyMDIwLTAzLTA1VDIxOjA0OjMxIn0sICJzdGF0
         ZSI6ICJjb21wbGV0ZSIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInRyYWNl
         YmFjayI6IG51bGx9fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
-        X0ZpbGVzX0RldiIsICJzdGFydGVkIjogIjIwMjAtMDItMDNUMjE6NDg6MTJa
-        IiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQi
-        OiAiMjAyMC0wMi0wM1QyMTo0ODoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1
-        bW1hcnkiOiB7InN0YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2Ui
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJu
-        b3Rfc3RhcnRlZCI6ICIyMDIwLTAyLTAzVDIxOjQ4OjEyIiwgImluX3Byb2dy
-        ZXNzIjogIjIwMjAtMDItMDNUMjE6NDg6MTIiLCAiY29tcGxldGUiOiAiMjAy
-        MC0wMi0wM1QyMTo0ODoxMiJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
-        ZGlzdHJpYnV0b3JfaWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
-        dC1NeV9GaWxlc19EZXYiLCAiaWQiOiAiNWUzODk1MWNiMDJlNTMwYjZmYmMw
-        MzJmIiwgImRldGFpbHMiOiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZTM4OTUxY2U3NDFjY2MxNmM0ZGU4ODkifSwgImlkIjog
-        IjVlMzg5NTFjZTc0MWNjYzE2YzRkZTg4OSJ9
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJz
+        dGFydGVkIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzFaIiwgIl9ucyI6ICJyZXBv
+        X3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMy0wNVQy
+        MTowNDozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRl
+        IjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIy
+        MDIwLTAzLTA1VDIxOjA0OjMxIiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMt
+        MDVUMjE6MDQ6MzEiLCAiY29tcGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        MSJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
+        LCAiaWQiOiAiNWU2MTY5NWYwNmM3MWE1NGFkZDAyNmU3IiwgImRldGFpbHMi
+        OiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZTYx
+        Njk1ZmM4Y2NiNjc5NjhlZDQ5OGUifSwgImlkIjogIjVlNjE2OTVmYzhjY2I2
+        Nzk2OGVkNDk4ZSJ9
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:12 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:32 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/migration-plans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/migration-plans/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1054,7 +1058,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.0.1b2.dev01580407602/ruby
+      - OpenAPI-Generator/0.0.1rc2.dev01582827735/ruby
       Accept:
       - application/json
       Authorization:
@@ -1067,13 +1071,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:13 GMT
+      - Thu, 05 Mar 2020 21:04:32 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/migration-plans/b92ee8e5-da25-4bcd-843b-4f73420f94be/"
+      - "/pulp/api/v3/migration-plans/62dccdb7-12bd-4566-9d7a-c2a1eb30c0c7/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1083,13 +1087,13 @@ http_interactions:
       Content-Length:
       - '700'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zL2I5
-        MmVlOGU1LWRhMjUtNGJjZC04NDNiLTRmNzM0MjBmOTRiZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTAyLTAzVDIxOjQ4OjEyLjk5NTM3M1oiLCJwbGFuIjp7
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zLzYy
+        ZGNjZGI3LTEyYmQtNDU2Ni05ZDdhLWMyYTFlYjMwYzBjNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTAzLTA1VDIxOjA0OjMyLjEyNDk3NloiLCJwbGFuIjp7
         InBsdWdpbnMiOlt7InR5cGUiOiJpc28iLCJyZXBvc2l0b3JpZXMiOlt7Im5h
         bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwi
         cmVwb3NpdG9yeV92ZXJzaW9ucyI6W3sicHVscDJfcmVwb3NpdG9yeV9pZCI6
@@ -1104,10 +1108,10 @@ http_interactions:
         X3JlcG9zaXRvcnlfaWRzIjpbIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXNfRGV2Il19XX1dfV19fQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:13 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:32 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v3/migration-plans/b92ee8e5-da25-4bcd-843b-4f73420f94be/run/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/migration-plans/62dccdb7-12bd-4566-9d7a-c2a1eb30c0c7/run/
     body:
       encoding: UTF-8
       base64_string: 'eyJkcnlfcnVuIjpmYWxzZX0=
@@ -1117,7 +1121,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.0.1b2.dev01580407602/ruby
+      - OpenAPI-Generator/0.0.1rc2.dev01582827735/ruby
       Accept:
       - application/json
       Authorization:
@@ -1130,9 +1134,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:13 GMT
+      - Thu, 05 Mar 2020 21:04:32 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1144,17 +1148,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkOTcwMzZhLTcwODYtNDg5
-        MS1iZDI2LTc0YmY0NzZlY2JiNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTQzNmFiLWIxOTQtNGNm
+        Mi04NThmLTkzYTJkNTZmMjE1NS8ifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:13 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:32 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/ed97036a-7086-4891-bd26-74bf476ecbb7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/019436ab-b194-4cf2-858f-93a2d56f2155/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1175,9 +1179,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1187,59 +1191,63 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '656'
+      - '710'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQ5NzAzNmEtNzA4
-        Ni00ODkxLWJkMjYtNzRiZjQ3NmVjYmI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDItMDNUMjE6NDg6MTMuMTEwNTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NDM2YWItYjE5
+        NC00Y2YyLTg1OGYtOTNhMmQ1NmYyMTU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDMtMDVUMjE6MDQ6MzIuMTg0NTQzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
-        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwic3RhcnRlZF9hdCI6IjIwMjAtMDIt
-        MDNUMjE6NDg6MTMuMjUxMDk0WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wMi0w
-        M1QyMTo0ODoxMy45NjI2MjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9w
-        dWxwL2FwaS92My93b3JrZXJzLzI3YTg1YjY5LTEyY2MtNDE1ZC04Yzc4LWM3
-        Mzk3NDcwZDk1My8iLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoi
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwic3RhcnRlZF9hdCI6IjIwMjAtMDMt
+        MDVUMjE6MDQ6MzIuMzA1MjcwWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wMy0w
+        NVQyMTowNDozMi43NTQwNjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9w
+        dWxwL2FwaS92My93b3JrZXJzL2JjNTJiMWFkLWViMGEtNDAzYy05NzI3LWRk
+        M2NjMGU5N2M3My8iLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoi
         UHJvY2Vzc2luZyBQdWxwIDIgcmVwb3NpdG9yaWVzLCBpbXBvcnRlcnMsIGRp
         c3RyaWJ1dG9ycyIsImNvZGUiOiJwcm9jZXNzaW5nLnJlcG9zaXRvcmllcyIs
         InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiQ3JlYXRpbmcgcmVwb3NpdG9yaWVzIGlu
         IFB1bHAgMyIsImNvZGUiOiJjcmVhdGluZy5yZXBvc2l0b3JpZXMiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51
         bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBpbXBvcnRlcnMgdG8gUHVscCAz
         IiwiY29kZSI6Im1pZ3JhdGluZy5pbXBvcnRlcnMiLCJzdGF0ZSI6ImNvbXBs
         ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
-        c2FnZSI6Ik1pZ3JhdGluZyBpc28gY29udGVudCB0byBQdWxwIDMgaXNvIiwi
-        Y29kZSI6Im1pZ3JhdGluZy5pc28uY29udGVudCIsInN0YXRlIjoiY29tcGxl
-        dGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNz
-        YWdlIjoiTWlncmF0aW5nIGNvbnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1p
-        Z3JhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWln
-        cmF0aW5nIFB1bHAgMiBJU08gY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNv
-        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJj
-        b21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7
-        Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBJU08gY29udGVudCAo
-        ZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRl
-        dGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAs
+        c2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIElTTyBjb250ZW50IChnZW5l
+        cmFsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVy
+        YWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAy
+        IElTTyBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0
+        aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdy
+        YXRpbmcgY29udGVudCB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5nLmNv
+        bnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjox
+        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBpc28gY29u
+        dGVudCB0byBQdWxwIDMgaXNvIiwiY29kZSI6Im1pZ3JhdGluZy5pc28uY29u
+        dGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
         InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGRpc3RyaWJ1
         dG9ycyB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5nLmRpc3RyaWJ1dG9y
         cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1
         ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkv
-        djMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9mYmY0YzYyMi00MjkwLTRhMDMt
-        YTdiOC1iNWZhNDRiYTJiZDQvIiwiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlv
-        bnMvZmlsZS9maWxlLzVjMGE0NWI3LTAyNDYtNGM0MS04YWFlLTFlMGIxYWM2
-        NjZlMS8iLCIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS82
-        ZDk4MzA1Mi1kODM2LTQ1NDMtYjBiZS1mMGE4OWVmZjIyZGIvIiwiL3B1bHAv
-        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2ExNjI5YjkwLTU3Mjct
-        NDE5Yi05YjA1LTNmNzJmMWU1YWYzZC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
-        X3JlY29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xMzNjYTY1NC0zMTc5LTQ3MmQt
+        YjY4My0xOWVhZGJjNDYyMGIvdmVyc2lvbnMvMS8iLCIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84ODY3NTViMS1lYTc1LTQwMjktYWUy
+        YS1hMGU1MGFmNWQ3Y2MvdmVyc2lvbnMvMS8iLCIvcHVscC9hcGkvdjMvcHVi
+        bGljYXRpb25zL2ZpbGUvZmlsZS8zZDQyNzk1OC05YmQ2LTQwNjAtOWUwNi1j
+        YjQ3MWNmM2M3M2IvIiwiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzUwMTIyYWNiLTc1MzctNDU4My1hZjRiLTY1MWZmZGE1ODc1OS8i
+        LCIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8zODBlZGUz
+        NC1mNWFhLTQxNTAtYjI3ZC0zOGQ3NWMzMDM0OWMvIiwiL3B1bHAvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzFiYzQyMjViLTA1Y2ItNDMwOS1h
+        MGZjLWMxODc3NjRjMDBmNi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=fjd89-ad8d8-sdkas-adjja,123983-123812-123812-2131,637a2f26-c864-43cd-a64d-b9259ece3a08
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=fjd89-ad8d8-sdkas-adjja,123983-123812-123812-2131,55d96d8d-f662-4e70-b228-9844f1601a72
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1247,7 +1255,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.0.1b2.dev01580407602/ruby
+      - OpenAPI-Generator/0.0.1rc2.dev01582827735/ruby
       Accept:
       - application/json
       Authorization:
@@ -1260,9 +1268,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1272,29 +1280,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '360'
+      - '356'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9taWdyYXRpb24tcGxh
-        bnMvMGFiMTVjYjMtNTIzOS00ZjEyLWEyYzEtMDAyMTkwMWE5MjI0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDEtMzBUMjE6NDg6MTkuMzQxMzA3WiIsInB1
-        bHAyX2lkIjoiNjM3YTJmMjYtYzg2NC00M2NkLWE2NGQtYjkyNTllY2UzYTA4
+        bnMvNWEwYzE2OGQtOGY5Mi00M2JlLWJjZmItNDNkNzA1NTYzMGMyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDMtMDVUMjE6MDQ6MzIuNTAxOTcwWiIsInB1
+        bHAyX2lkIjoiNTVkOTZkOGQtZjY2Mi00ZTcwLWIyMjgtOTg0NGYxNjAxYTcy
         IiwicHVscDJfY29udGVudF90eXBlX2lkIjoiaXNvIiwicHVscDJfbGFzdF91
-        cGRhdGVkIjoxNTgwNDA2NTIwLCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFy
+        cGRhdGVkIjoxNTgzNDQxODUxLCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFy
         L2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvaXNvLzcyLzNlNzFiYjM3OWY5Mzhh
         ZDFkZmJhMmYyZDZiZDBjN2Q3NDAyNzY2MTViODYzN2RkNWI3OWUwMjBjZGIw
         OWMyL21pZ3JhdGVfdGVzdC5iaW4iLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxw
-        M19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy82
-        Zjg5YjBlYS1lZmU4LTRkN2ItYjhkZS1lY2QwNjE2YjllOGYvIn1dfQ==
+        M19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy81
+        MDVmZjE4Ny1iYjE3LTQyY2MtOTZlZS0wOTg0NjQ0N2VhOWYvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/pulp2repositories/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/pulp2repositories/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1302,7 +1310,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.0.1b2.dev01580407602/ruby
+      - OpenAPI-Generator/0.0.1rc2.dev01582827735/ruby
       Accept:
       - application/json
       Authorization:
@@ -1315,9 +1323,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1327,148 +1335,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '886'
+      - '586'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6OCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRv
-        cmllcy9lNzkwZWRhOC0wYTczLTRmZWUtODM4Zi1jNTI2ZTJlOTg2ZjAvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wMS0zMFQyMTo0ODoxOS4yMzEzMzNaIiwi
-        cHVscDJfb2JqZWN0X2lkIjoiNWUzMzRmMWZiMDJlNTM3NTgwMDk2YTYzIiwi
-        cHVscDJfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJp
-        bmV0LU15X0ZpbGVzIiwiaXNfbWlncmF0ZWQiOnRydWUsIm5vdF9pbl9wbGFu
-        Ijp0cnVlLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82YzdmZDQ1YS1jOGI0LTQyMGYt
-        YmQ3ZC1iZWFlN2IzNTRhYTkvdmVyc2lvbnMvMS8iLCJwdWxwM19yZW1vdGVf
-        aHJlZiI6bnVsbCwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzZkOTgzMDUyLWQ4MzYtNDU0
-        My1iMGJlLWYwYTg5ZWZmMjJkYi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJl
-        ZnMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2Ex
-        NjI5YjkwLTU3MjctNDE5Yi05YjA1LTNmNzJmMWU1YWYzZC8iXSwicHVscDNf
-        cmVwb3NpdG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvNmM3ZmQ0NWEtYzhiNC00MjBmLWJkN2QtYmVhZTdiMzU0YWE5
-        LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9y
-        aWVzLzhjZTRlOWUyLTczNDUtNDI2Yy04M2VlLTc4ZTY2MTY5NTAwYS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTAxLTMwVDIxOjQ4OjE5LjIwOTkzNVoiLCJw
-        dWxwMl9vYmplY3RfaWQiOiI1ZTMzNGYxZWIwMmU1Mzc1ODAwOTZhNWQiLCJw
-        dWxwMl9yZXBvX2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1N
-        eV9GaWxlcyIsImlzX21pZ3JhdGVkIjp0cnVlLCJub3RfaW5fcGxhbiI6dHJ1
-        ZSwicHVscDNfcmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9maWxlL2ZpbGUvNjM3MmQzMzItNjJjZC00MmVlLTk2Njgt
-        NmJiNmM1ZmYyYjY4L3ZlcnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYi
-        Om51bGwsInB1bHAzX3B1YmxpY2F0aW9uX2hyZWYiOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL2ZpbGUvZmlsZS9mYmY0YzYyMi00MjkwLTRhMDMtYTdi
-        OC1iNWZhNDRiYTJiZDQvIiwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZzIjpb
-        Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmlsZS81YzBhNDVi
-        Ny0wMjQ2LTRjNDEtOGFhZS0xZTBiMWFjNjY2ZTEvIl0sInB1bHAzX3JlcG9z
-        aXRvcnlfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
-        aWxlLzYzNzJkMzMyLTYyY2QtNDJlZS05NjY4LTZiYjZjNWZmMmI2OC8ifSx7
-        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRvcmllcy82
-        YjY0MjczNS0wZGE3LTRhMjMtOTk2Yi0yM2E3Y2NkZWExYmMvIiwicHVscF9j
-        cmVhdGVkIjoiMjAyMC0wMS0zMFQyMTo0OTo1OS44OTY4MTVaIiwicHVscDJf
-        b2JqZWN0X2lkIjoiNWUzMzRmODNiMDJlNTM3NTgxODg1ZTc5IiwicHVscDJf
-        cmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15
-        X0ZpbGVzIiwiaXNfbWlncmF0ZWQiOnRydWUsIm5vdF9pbl9wbGFuIjp0cnVl
-        LCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS82YzdmZDQ1YS1jOGI0LTQyMGYtYmQ3ZC1i
-        ZWFlN2IzNTRhYTkvdmVyc2lvbnMvMS8iLCJwdWxwM19yZW1vdGVfaHJlZiI6
-        bnVsbCwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2FwaS92My9w
-        dWJsaWNhdGlvbnMvZmlsZS9maWxlLzZkOTgzMDUyLWQ4MzYtNDU0My1iMGJl
-        LWYwYTg5ZWZmMjJkYi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMiOlsi
-        L3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2ExNjI5Yjkw
-        LTU3MjctNDE5Yi05YjA1LTNmNzJmMWU1YWYzZC8iXSwicHVscDNfcmVwb3Np
-        dG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvNmM3ZmQ0NWEtYzhiNC00MjBmLWJkN2QtYmVhZTdiMzU0YWE5LyJ9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9yaWVzLzE4
-        ZWJiOWNmLWVjMTUtNDk5Yy05YjJiLTU0N2ExNGQ0YjVjZC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTAxLTMwVDIxOjQ5OjU5Ljg4MDk1MFoiLCJwdWxwMl9v
-        YmplY3RfaWQiOiI1ZTMzNGY4MmIwMmU1Mzc1ODE4ODVlNzMiLCJwdWxwMl9y
-        ZXBvX2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsImlzX21pZ3JhdGVkIjp0cnVlLCJub3RfaW5fcGxhbiI6dHJ1ZSwicHVs
-        cDNfcmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvNjM3MmQzMzItNjJjZC00MmVlLTk2NjgtNmJiNmM1
-        ZmYyYjY4L3ZlcnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYiOm51bGws
-        InB1bHAzX3B1YmxpY2F0aW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGlj
-        YXRpb25zL2ZpbGUvZmlsZS9mYmY0YzYyMi00MjkwLTRhMDMtYTdiOC1iNWZh
-        NDRiYTJiZDQvIiwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZzIjpbIi9wdWxw
-        L2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmlsZS81YzBhNDViNy0wMjQ2
-        LTRjNDEtOGFhZS0xZTBiMWFjNjY2ZTEvIl0sInB1bHAzX3JlcG9zaXRvcnlf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzYz
-        NzJkMzMyLTYyY2QtNDJlZS05NjY4LTZiYjZjNWZmMmI2OC8ifSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRvcmllcy9mOTE1YWM5
-        OC0zY2ViLTQyYjAtYjkyYy01ZWY0OTUwNjI3N2UvIiwicHVscF9jcmVhdGVk
-        IjoiMjAyMC0wMS0zMFQyMTo1MDo1Mi45ODE1NzFaIiwicHVscDJfb2JqZWN0
-        X2lkIjoiNWUzMzRmYmJiMDJlNTM3NTgwMDk2YTZjIiwicHVscDJfcmVwb19p
-        ZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0ZpbGVz
-        IiwiaXNfbWlncmF0ZWQiOnRydWUsIm5vdF9pbl9wbGFuIjp0cnVlLCJwdWxw
-        M19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS82YzdmZDQ1YS1jOGI0LTQyMGYtYmQ3ZC1iZWFlN2Iz
-        NTRhYTkvdmVyc2lvbnMvMS8iLCJwdWxwM19yZW1vdGVfaHJlZiI6bnVsbCwi
-        cHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2FwaS92My9wdWJsaWNh
-        dGlvbnMvZmlsZS9maWxlLzZkOTgzMDUyLWQ4MzYtNDU0My1iMGJlLWYwYTg5
-        ZWZmMjJkYi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMiOlsiL3B1bHAv
-        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2ExNjI5YjkwLTU3Mjct
-        NDE5Yi05YjA1LTNmNzJmMWU1YWYzZC8iXSwicHVscDNfcmVwb3NpdG9yeV9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNmM3
-        ZmQ0NWEtYzhiNC00MjBmLWJkN2QtYmVhZTdiMzU0YWE5LyJ9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9yaWVzLzg0MzcxNTVm
-        LTBlNjYtNDE5Zi04MWYyLTI1NjkwY2I5Nzc0Ni8iLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDIwLTAxLTMwVDIxOjUwOjUyLjk2NDY0M1oiLCJwdWxwMl9vYmplY3Rf
-        aWQiOiI1ZTMzNGZiYmIwMmU1Mzc1N2ZhYjNhMGMiLCJwdWxwMl9yZXBvX2lk
-        IjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsImlz
-        X21pZ3JhdGVkIjp0cnVlLCJub3RfaW5fcGxhbiI6dHJ1ZSwicHVscDNfcmVw
-        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvNjM3MmQzMzItNjJjZC00MmVlLTk2NjgtNmJiNmM1ZmYyYjY4
-        L3ZlcnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYiOm51bGwsInB1bHAz
-        X3B1YmxpY2F0aW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25z
-        L2ZpbGUvZmlsZS9mYmY0YzYyMi00MjkwLTRhMDMtYTdiOC1iNWZhNDRiYTJi
-        ZDQvIiwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZzIjpbIi9wdWxwL2FwaS92
-        My9kaXN0cmlidXRpb25zL2ZpbGUvZmlsZS81YzBhNDViNy0wMjQ2LTRjNDEt
-        OGFhZS0xZTBiMWFjNjY2ZTEvIl0sInB1bHAzX3JlcG9zaXRvcnlfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzYzNzJkMzMy
-        LTYyY2QtNDJlZS05NjY4LTZiYjZjNWZmMmI2OC8ifSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRvcmllcy9mMTZjODExOS01NGJj
-        LTQxODUtYTUwMi1iZGE1YjI4YjgzOTQvIiwicHVscF9jcmVhdGVkIjoiMjAy
-        MC0wMi0wM1QyMTo0ODoxMy40NzA5NDVaIiwicHVscDJfb2JqZWN0X2lkIjoi
-        NWUzODk1MWFiMDJlNTM1MDY2M2M5NzY5IiwicHVscDJfcmVwb19pZCI6IkRl
-        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJpc19taWdy
-        YXRlZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBvc2l0
-        b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS82MzcyZDMzMi02MmNkLTQyZWUtOTY2OC02YmI2YzVmZjJiNjgvdmVy
-        c2lvbnMvMS8iLCJwdWxwM19yZW1vdGVfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZW1vdGVzL2ZpbGUvZmlsZS82MTI5M2I5My00ZjA5LTQ2MTMtODIxNi1iM2U3
-        MWMyMTJmMjUvIiwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlL2ZiZjRjNjIyLTQyOTAtNGEw
-        My1hN2I4LWI1ZmE0NGJhMmJkNC8iLCJwdWxwM19kaXN0cmlidXRpb25faHJl
-        ZnMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzVj
-        MGE0NWI3LTAyNDYtNGM0MS04YWFlLTFlMGIxYWM2NjZlMS8iXSwicHVscDNf
-        cmVwb3NpdG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvNjM3MmQzMzItNjJjZC00MmVlLTk2NjgtNmJiNmM1ZmYyYjY4
-        LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9y
-        aWVzLzUxNTU1YmYyLTA4MzctNGUxOS1iNDM1LWYwZTYzYWI1Mjc1OC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTAyLTAzVDIxOjQ4OjEzLjQ5NzEzOVoiLCJw
-        dWxwMl9vYmplY3RfaWQiOiI1ZTM4OTUxYmIwMmU1MzUwNjU2ZDM0Y2MiLCJw
-        dWxwMl9yZXBvX2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmlu
-        ZXQtTXlfRmlsZXMiLCJpc19taWdyYXRlZCI6dHJ1ZSwibm90X2luX3BsYW4i
-        OmZhbHNlLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82YzdmZDQ1YS1jOGI0LTQyMGYt
-        YmQ3ZC1iZWFlN2IzNTRhYTkvdmVyc2lvbnMvMS8iLCJwdWxwM19yZW1vdGVf
-        aHJlZiI6bnVsbCwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzZkOTgzMDUyLWQ4MzYtNDU0
-        My1iMGJlLWYwYTg5ZWZmMjJkYi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJl
-        ZnMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2Ex
-        NjI5YjkwLTU3MjctNDE5Yi05YjA1LTNmNzJmMWU1YWYzZC8iXSwicHVscDNf
-        cmVwb3NpdG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvNmM3ZmQ0NWEtYzhiNC00MjBmLWJkN2QtYmVhZTdiMzU0YWE5
-        LyJ9XX0=
+        cmllcy9lMzE5OGJiMC0yMmEyLTRhNWUtYjcyMS1jZTJhODlhODRiMzQvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wMy0wNVQyMTowNDozMi4zOTIxOTZaIiwi
+        cHVscDJfb2JqZWN0X2lkIjoiNWU2MTY5NWUwNmM3MWE1Mzc2MDlhMDQxIiwi
+        cHVscDJfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
+        TXlfRmlsZXMiLCJwdWxwMl9yZXBvX3R5cGUiOiJpc28iLCJpc19taWdyYXRl
+        ZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBvc2l0b3J5
+        X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS8xMzNjYTY1NC0zMTc5LTQ3MmQtYjY4My0xOWVhZGJjNDYyMGIvdmVyc2lv
+        bnMvMS8iLCJwdWxwM19yZW1vdGVfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1v
+        dGVzL2ZpbGUvZmlsZS9lZjEyMTA0Ny0zMjFhLTQ2Y2ItOWQwOC1hNDkwNTAw
+        Y2Y5N2QvIiwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2FwaS92
+        My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzNkNDI3OTU4LTliZDYtNDA2MC05
+        ZTA2LWNiNDcxY2YzYzczYi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzUwMTIy
+        YWNiLTc1MzctNDU4My1hZjRiLTY1MWZmZGE1ODc1OS8iXSwicHVscDNfcmVw
+        b3NpdG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
+        L2ZpbGUvMTMzY2E2NTQtMzE3OS00NzJkLWI2ODMtMTllYWRiYzQ2MjBiLyJ9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9yaWVz
+        L2Q1MzJiOTVhLTRlYjEtNDE3Yy05N2U5LTM3ZGJkZWFjMjBhMy8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIwLTAzLTA1VDIxOjA0OjMyLjQxODg5MVoiLCJwdWxw
+        Ml9vYmplY3RfaWQiOiI1ZTYxNjk1ZjA2YzcxYTUzNzhiY2YyMGQiLCJwdWxw
+        Ml9yZXBvX2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQt
+        TXlfRmlsZXMiLCJwdWxwMl9yZXBvX3R5cGUiOiJpc28iLCJpc19taWdyYXRl
+        ZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBvc2l0b3J5
+        X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS84ODY3NTViMS1lYTc1LTQwMjktYWUyYS1hMGU1MGFmNWQ3Y2MvdmVyc2lv
+        bnMvMS8iLCJwdWxwM19yZW1vdGVfaHJlZiI6bnVsbCwicHVscDNfcHVibGlj
+        YXRpb25faHJlZiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9m
+        aWxlLzM4MGVkZTM0LWY1YWEtNDE1MC1iMjdkLTM4ZDc1YzMwMzQ5Yy8iLCJw
+        dWxwM19kaXN0cmlidXRpb25faHJlZnMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
+        aWJ1dGlvbnMvZmlsZS9maWxlLzFiYzQyMjViLTA1Y2ItNDMwOS1hMGZjLWMx
+        ODc3NjRjMDBmNi8iXSwicHVscDNfcmVwb3NpdG9yeV9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvODg2NzU1YjEtZWE3NS00
+        MDI5LWFlMmEtYTBlNTBhZjVkN2NjLyJ9XX0=
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/file/file/5c0a45b7-0246-4c41-8aae-1e0b1ac666e1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/50122acb-7537-4583-af4b-651ffda58759/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1476,7 +1389,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.1.0/ruby
+      - OpenAPI-Generator/0.1.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1489,9 +1402,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1501,28 +1414,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '292'
+      - '308'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvNWMwYTQ1YjctMDI0Ni00YzQxLThhYWUtMWUwYjFhYzY2NmUxLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDItMDNUMjE6NDg6MTMuODg1NTIwWiIs
+        L2ZpbGUvNTAxMjJhY2ItNzUzNy00NTgzLWFmNGItNjUxZmZkYTU4NzU5LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDMtMDVUMjE6MDQ6MzIuNzEzNDcyWiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
-        RmlsZXMiLCJiYXNlX3VybCI6ImRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20v
-        cHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
-        RmlsZXMiLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiNWUzODk1MWFi
-        MDJlNTM1MDY2M2M5NzZiLURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
-        TXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNh
-        dGlvbnMvZmlsZS9maWxlL2ZiZjRjNjIyLTQyOTAtNGEwMy1hN2I4LWI1ZmE0
-        NGJhMmJkNC8ifQ==
+        RmlsZXMiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09y
+        Z2FuaXphdGlvbi9saWJyYXJ5L015X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IjVlNjE2OTVlMDZjNzFhNTM3NjA5YTA0My1EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwicHVibGljYXRpb24i
+        OiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8zZDQyNzk1
+        OC05YmQ2LTQwNjAtOWUwNi1jYjQ3MWNmM2M3M2IvIn0=
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v3/distributions/file/file/a1629b90-5727-419b-9b05-3f72f1e5af3d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/1bc4225b-05cb-4309-a0fc-c187764c00f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,7 +1443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.1.0/ruby
+      - OpenAPI-Generator/0.1.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1543,9 +1456,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
-      - gunicorn/19.9.0
+      - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
@@ -1555,28 +1468,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel.balmora.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '295'
+      - '310'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvYTE2MjliOTAtNTcyNy00MTliLTliMDUtM2Y3MmYxZTVhZjNkLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDItMDNUMjE6NDg6MTMuOTM4NzkxWiIs
+        L2ZpbGUvMWJjNDIyNWItMDVjYi00MzA5LWEwZmMtYzE4Nzc2NGMwMGY2LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDMtMDVUMjE6MDQ6MzIuNzQ1Mzg3WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxl
-        cyIsImJhc2VfdXJsIjoiZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS9wdWxw
-        L2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRpb24vZGV2L015X0ZpbGVzIiwi
-        Y29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IjVlMzg5NTFiYjAyZTUzNTA2
-        NTZkMzRjYi1EZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVz
-        X0RldiIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
-        cy9maWxlL2ZpbGUvNmQ5ODMwNTItZDgzNi00NTQzLWIwYmUtZjBhODllZmYy
-        MmRiLyJ9
+        cyIsImJhc2VfdXJsIjoiaHR0cDovL2NlbnRvczcta2F0ZWxsby1kZXZlbC1z
+        dGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2Rldi9NeV9GaWxlcyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5h
+        bWUiOiI1ZTYxNjk1ZTA2YzcxYTUzNzdkNjI3ZmQtRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYiLCJwdWJsaWNhdGlvbiI6Ii9w
+        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzM4MGVkZTM0LWY1
+        YWEtNDE1MC1iMjdkLTM4ZDc1YzMwMzQ5Yy8ifQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1595,7 +1508,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
       - Apache
       Content-Length:
@@ -1606,14 +1519,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I3MDJmYjNmLTE3NmQtNDU1ZS1iMGJjLTVkY2MwN2QyMDkyNy8iLCAi
-        dGFza19pZCI6ICJiNzAyZmIzZi0xNzZkLTQ1NWUtYjBiYy01ZGNjMDdkMjA5
-        MjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2EyY2IwYTVjLTgzNGItNDQ4Yy1iODEyLWI1MGQ0ZGM3YTI2YS8iLCAi
+        dGFza19pZCI6ICJhMmNiMGE1Yy04MzRiLTQ0OGMtYjgxMi1iNTBkNGRjN2Ey
+        NmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b702fb3f-176d-455e-b0bc-5dcc07d20927/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a2cb0a5c-834b-448c-b812-b50d4dc7a26a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1632,15 +1545,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
       - Apache
       Etag:
-      - '"d74ead5d7df45cdb9b57b8cb1b5cf448-gzip"'
+      - '"77279f41ad9bc312617fd101ab997363-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '382'
+      - '395'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1648,25 +1561,26 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNzAyZmIzZi0xNzZkLTQ1NWUtYjBiYy01ZGNjMDdkMjA5
-        MjcvIiwgInRhc2tfaWQiOiAiYjcwMmZiM2YtMTc2ZC00NTVlLWIwYmMtNWRj
-        YzA3ZDIwOTI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        aS92Mi90YXNrcy9hMmNiMGE1Yy04MzRiLTQ0OGMtYjgxMi1iNTBkNGRjN2Ey
+        NmEvIiwgInRhc2tfaWQiOiAiYTJjYjBhNWMtODM0Yi00NDhjLWI4MTItYjUw
+        ZDRkYzdhMjZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
-        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0wMi0wM1QyMTo0ODox
-        NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
-        MC0wMi0wM1QyMTo0ODoxNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
+        MC0wMy0wNVQyMTowNDozM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
         ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
-        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVlMzg5NTFlZTc0MWNjYzE2YzRkZTkw
-        MCJ9LCAiaWQiOiAiNWUzODk1MWVlNzQxY2NjMTZjNGRlOTAwIn0=
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVlNjE2OTYxYzhjY2I2Nzk2OGVkNDlmYiJ9LCAiaWQiOiAiNWU2
+        MTY5NjFjOGNjYjY3OTY4ZWQ0OWZiIn0=
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1685,7 +1599,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:14 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
       - Apache
       Content-Length:
@@ -1696,14 +1610,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2YyZTcwNTU2LWQzZWEtNGY5Mi04ZDZjLWZhNDU2MzkzYmFjYS8iLCAi
-        dGFza19pZCI6ICJmMmU3MDU1Ni1kM2VhLTRmOTItOGQ2Yy1mYTQ1NjM5M2Jh
-        Y2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJhOWQzMTI1LTQzZTEtNDBjOS05YzU5LTVmMzA0OTE1OTc4Ny8iLCAi
+        dGFza19pZCI6ICIyYTlkMzEyNS00M2UxLTQwYzktOWM1OS01ZjMwNDkxNTk3
+        ODcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:14 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f2e70556-d3ea-4f92-8d6c-fa456393baca/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/2a9d3125-43e1-40c9-9c59-5f3049159787/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1722,15 +1636,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:15 GMT
+      - Thu, 05 Mar 2020 21:04:33 GMT
       Server:
       - Apache
       Etag:
-      - '"ce270366cf3938922a61a995e2f92c7d-gzip"'
+      - '"671c1d00e54d117174753a1885dbf1de-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '387'
+      - '397'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1738,25 +1652,26 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMmU3MDU1Ni1kM2VhLTRmOTItOGQ2Yy1mYTQ1NjM5M2Jh
-        Y2EvIiwgInRhc2tfaWQiOiAiZjJlNzA1NTYtZDNlYS00ZjkyLThkNmMtZmE0
-        NTYzOTNiYWNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        aS92Mi90YXNrcy8yYTlkMzEyNS00M2UxLTQwYzktOWM1OS01ZjMwNDkxNTk3
+        ODcvIiwgInRhc2tfaWQiOiAiMmE5ZDMxMjUtNDNlMS00MGM5LTljNTktNWYz
+        MDQ5MTU5Nzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
         X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJwdWxwOmFj
-        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDItMDNUMjE6
-        NDg6MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
-        IjIwMjAtMDItMDNUMjE6NDg6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzNaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
         cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
-        cmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
-        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZTM4OTUxZWU3NDFjY2MxNmM0
-        ZGU5NGIifSwgImlkIjogIjVlMzg5NTFlZTc0MWNjYzE2YzRkZTk0YiJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2MWM4Y2NiNjc5NjhlZDRhM2IifSwgImlkIjog
+        IjVlNjE2OTYxYzhjY2I2Nzk2OGVkNGEzYiJ9
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:15 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:33 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1775,7 +1690,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:15 GMT
+      - Thu, 05 Mar 2020 21:04:34 GMT
       Server:
       - Apache
       Content-Length:
@@ -1786,14 +1701,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2YzYzU1NTM3LWRmNDUtNDkwOC05ZTRiLWZjZTIzYTQyOTAwMi8iLCAi
-        dGFza19pZCI6ICJmM2M1NTUzNy1kZjQ1LTQ5MDgtOWU0Yi1mY2UyM2E0Mjkw
-        MDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I3M2QwOTk2LTc5M2YtNDE1YS04MzNhLWI3NDg1ZDU5ZTRmNC8iLCAi
+        dGFza19pZCI6ICJiNzNkMDk5Ni03OTNmLTQxNWEtODMzYS1iNzQ4NWQ1OWU0
+        ZjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:15 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:34 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f3c55537-df45-4908-9e4b-fce23a429002/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/b73d0996-793f-415a-833a-b7485d59e4f4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1812,15 +1727,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Feb 2020 21:48:15 GMT
+      - Thu, 05 Mar 2020 21:04:34 GMT
       Server:
       - Apache
       Etag:
-      - '"919e912577878fe5e40ace5d8870ef43-gzip"'
+      - '"2e9ec508c64c2e3e3a6ead4a783d1f40-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '384'
+      - '399'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1828,20 +1743,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mM2M1NTUzNy1kZjQ1LTQ5MDgtOWU0Yi1mY2UyM2E0Mjkw
-        MDIvIiwgInRhc2tfaWQiOiAiZjNjNTU1MzctZGY0NS00OTA4LTllNGItZmNl
-        MjNhNDI5MDAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        aS92Mi90YXNrcy9iNzNkMDk5Ni03OTNmLTQxNWEtODMzYS1iNzQ4NWQ1OWU0
+        ZjQvIiwgInRhc2tfaWQiOiAiYjczZDA5OTYtNzkzZi00MTVhLTgzM2EtYjc0
+        ODVkNTllNGY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJwdWxwOmFj
-        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDItMDNUMjE6
-        NDg6MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
-        IjIwMjAtMDItMDNUMjE6NDg6MTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
         cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
-        cmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
-        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZTM4OTUxZmU3NDFjY2MxNmM0
-        ZGU5OGMifSwgImlkIjogIjVlMzg5NTFmZTc0MWNjYzE2YzRkZTk4YyJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2MmM4Y2NiNjc5NjhlZDRhN2IifSwgImlkIjog
+        IjVlNjE2OTYyYzhjY2I2Nzk2OGVkNGE3YiJ9
     http_version: 
-  recorded_at: Mon, 03 Feb 2020 21:48:15 GMT
+  recorded_at: Thu, 05 Mar 2020 21:04:34 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/migration_service_type_already_migrated.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/migration_service_type_already_migrated.yml
@@ -1,0 +1,855 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
+        RmlsZXMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzLyIsICJodHRw
+        X3N0YXR1cyI6IDQwNCwgImVycm9yIjogeyJjb2RlIjogIlBMUDAwMDkiLCAi
+        ZGF0YSI6IHsicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifX0sICJkZXNjcmlwdGlv
+        biI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PURlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCAic3ViX2Vycm9ycyI6
+        IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9fQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
+        LCJkaXNwbGF5X25hbWUiOiJNeSBGaWxlcyIsImltcG9ydGVyX3R5cGVfaWQi
+        OiJpc29faW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZp
+        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL2ZpbGVfbWlncmF0aW9uLyIsImJh
+        c2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQi
+        Om51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiIiwi
+        c3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX2NhX2NlcnQiOm51bGx9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJpc29fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9NeV9GaWxlcyIsInNlcnZlX2h0dHAiOnRydWUsInNlcnZlX2h0
+        dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '344'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTYzMDZjNzFhNTM3OGJjZjIxMSJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzQ1MTZiYjIyLWYyYjAtNGZmOS05NTgwLWJjNDMzYjZlN2NhNy8iLCAi
+        dGFza19pZCI6ICI0NTE2YmIyMi1mMmIwLTRmZjktOTU4MC1iYzQzM2I2ZTdj
+        YTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4516bb22-f2b0-4ff9-9580-bc433b6e7ca7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"24ee0590e685e3ce6518098cdfc3ce18-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '674'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NTE2YmIyMi1mMmIwLTRmZjktOTU4MC1iYzQzM2I2ZTdj
+        YTcvIiwgInRhc2tfaWQiOiAiNDUxNmJiMjItZjJiMC00ZmY5LTk1ODAtYmM0
+        MzNiNmU3Y2E3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzVa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2NlYzM5
+        ODAxLWQ5MDEtNDgwOC05MTViLWU4M2I2MTU1MDhkNC8iLCAidGFza19pZCI6
+        ICJjZWMzOTgwMS1kOTAxLTQ4MDgtOTE1Yi1lODNiNjE1NTA4ZDQifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozNSIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjM1IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozNSJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozNSIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1IiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1In19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTYzMDZjNzFhNTRhZGQwMjZlOCIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NjNjOGNjYjY3OTY4ZWQ0YWQyIn0sICJpZCI6ICI1ZTYxNjk2M2M4Y2NiNjc5
+        NjhlZDRhZDIifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4516bb22-f2b0-4ff9-9580-bc433b6e7ca7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"24ee0590e685e3ce6518098cdfc3ce18-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '674'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NTE2YmIyMi1mMmIwLTRmZjktOTU4MC1iYzQzM2I2ZTdj
+        YTcvIiwgInRhc2tfaWQiOiAiNDUxNmJiMjItZjJiMC00ZmY5LTk1ODAtYmM0
+        MzNiNmU3Y2E3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzVa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2NlYzM5
+        ODAxLWQ5MDEtNDgwOC05MTViLWU4M2I2MTU1MDhkNC8iLCAidGFza19pZCI6
+        ICJjZWMzOTgwMS1kOTAxLTQ4MDgtOTE1Yi1lODNiNjE1NTA4ZDQifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMC0wMy0wNVQyMTowNDozNSIsICJjb21wbGV0ZSI6ICIyMDIw
+        LTAzLTA1VDIxOjA0OjM1IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMC0w
+        My0wNVQyMTowNDozNSJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJpc29faW1w
+        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
+        MDMtMDVUMjE6MDQ6MzVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNvX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVtX2lzb3Mi
+        OiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21lc3NhZ2Vz
+        IjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90aW1lcyI6
+        IHsibm90X3N0YXJ0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozNSIsICJtYW5p
+        ZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1IiwgImNv
+        bXBsZXRlIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUiLCAiaXNvc19pbl9wcm9n
+        cmVzcyI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1In19LCAiYWRkZWRfY291bnQi
+        OiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjVlNjE2OTYzMDZjNzFhNTRhZGQwMjZlOCIsICJkZXRhaWxzIjog
+        bnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWU2MTY5
+        NjNjOGNjYjY3OTY4ZWQ0YWQyIn0sICJpZCI6ICI1ZTYxNjk2M2M4Y2NiNjc5
+        NjhlZDRhZDIifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/cec39801-d901-4808-915b-e83b615508d4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fbd3580a24cdda37667d819d679f449f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '563'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jZWMzOTgwMS1kOTAxLTQ4MDgtOTE1Yi1lODNi
+        NjE1NTA4ZDQvIiwgInRhc2tfaWQiOiAiY2VjMzk4MDEtZDkwMS00ODA4LTkx
+        NWItZTgzYjYxNTUwOGQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVU
+        MjE6MDQ6MzVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMjAtMDMtMDVUMjE6MDQ6MzVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIxOjA0OjM1
+        IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUiLCAiY29t
+        cGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozNSJ9LCAic3RhdGUiOiAiY29t
+        cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRxMiIs
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3Rh
+        YmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJzdGFydGVkIjogIjIw
+        MjAtMDMtMDVUMjE6MDQ6MzVaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDozNVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiaXNv
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRlIjogImNvbXBsZXRl
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIwLTAzLTA1VDIx
+        OjA0OjM1IiwgImluX3Byb2dyZXNzIjogIjIwMjAtMDMtMDVUMjE6MDQ6MzUi
+        LCAiY29tcGxldGUiOiAiMjAyMC0wMy0wNVQyMTowNDozNSJ9fSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJpZCI6ICI1ZTYxNjk2
+        MzA2YzcxYTU0YWRkMDI2ZWIiLCAiZGV0YWlscyI6IG51bGx9LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlNjE2OTYzYzhjY2I2Nzk2OGVk
+        NGIwZSJ9LCAiaWQiOiAiNWU2MTY5NjNjOGNjYjY3OTY4ZWQ0YjBlIn0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNf
+        RGV2IiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXNfRGV2In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '382'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:35 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTYzMDZjNzFhNTM3OGJjZjIxNCJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:35 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0Zp
+        bGVzIiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0ZpbGVzIiwi
+        c2VydmVfaHR0cCI6dHJ1ZSwic2VydmVfaHR0cHMiOnRydWV9LCJhdXRvX3B1
+        Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '390'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVlNjE2OTY0MDZjNzFhNTM3NjA5YTA0NiJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy8ifQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1bSJd
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
+        ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
+        OTgiLCAiX2lkIjogIjU1ZDk2ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYw
+        MWE3MiIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMC0wMy0wNVQyMTow
+        NDozNVoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        NVoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjU1ZDk2
+        ZDhkLWY2NjItNGU3MC1iMjI4LTk4NDRmMTYwMWE3MiIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWU2MTY5NjNjOGNjYjY3OTY4ZWQ0YWYwIn19XQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1
+        bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzQ3MDMwNTFhLTZjMjItNDhmYS1hYzVjLTgyYWNjNjljNzViOC8iLCAi
+        dGFza19pZCI6ICI0NzAzMDUxYS02YzIyLTQ4ZmEtYWM1Yy04MmFjYzY5Yzc1
+        YjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4703051a-6c22-48fa-ac5c-82acc69c75b8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e1e19781bbeb6a7fb630dc3b2a646d6c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '396'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NzAzMDUxYS02YzIyLTQ4ZmEtYWM1Yy04MmFjYzY5Yzc1
+        YjgvIiwgInRhc2tfaWQiOiAiNDcwMzA1MWEtNmMyMi00OGZhLWFjNWMtODJh
+        Y2M2OWM3NWI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0wMy0wNVQyMTowNDoz
+        NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
+        MC0wMy0wNVQyMTowNDozNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVlNjE2OTY0YzhjY2I2Nzk2OGVkNGI5MSJ9LCAiaWQiOiAiNWU2
+        MTY5NjRjOGNjYjY3OTY4ZWQ0YjkxIn0=
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzViMjQ3MjNhLTI0MTQtNGRlZS1iMmM0LWE5MDQ5ZTU1MzRhYi8iLCAi
+        dGFza19pZCI6ICI1YjI0NzIzYS0yNDE0LTRkZWUtYjJjNC1hOTA0OWU1NTM0
+        YWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/5b24723a-2414-4dee-b2c4-a9049e5534ab/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fcd0e1eaf279211c0ecc3e5c9fc85321-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '396'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YjI0NzIzYS0yNDE0LTRkZWUtYjJjNC1hOTA0OWU1NTM0
+        YWIvIiwgInRhc2tfaWQiOiAiNWIyNDcyM2EtMjQxNC00ZGVlLWIyYzQtYTkw
+        NDllNTUzNGFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2NGM4Y2NiNjc5NjhlZDRiZDEifSwgImlkIjog
+        IjVlNjE2OTY0YzhjY2I2Nzk2OGVkNGJkMSJ9
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAyMmI2ZTAyLTRjNDctNGQwOS05MDJlLTA3OWFmMDBjM2NlOC8iLCAi
+        dGFza19pZCI6ICIwMjJiNmUwMi00YzQ3LTRkMDktOTAyZS0wNzlhZjAwYzNj
+        ZTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/022b6e02-4c47-4d09-902e-079af00c3ce8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Mar 2020 21:04:36 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fcdc03ee345626363c805c62e6c19ce0-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '395'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMjJiNmUwMi00YzQ3LTRkMDktOTAyZS0wNzlhZjAwYzNj
+        ZTgvIiwgInRhc2tfaWQiOiAiMDIyYjZlMDItNGM0Ny00ZDA5LTkwMmUtMDc5
+        YWYwMGMzY2U4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDMtMDVUMjE6
+        MDQ6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjAtMDMtMDVUMjE6MDQ6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZTYxNjk2NGM4Y2NiNjc5NjhlZDRjMTEifSwgImlkIjog
+        IjVlNjE2OTY0YzhjY2I2Nzk2OGVkNGMxMSJ9
+    http_version: 
+  recorded_at: Thu, 05 Mar 2020 21:04:36 GMT
+recorded_with: VCR 3.0.3

--- a/test/lib/tasks/pulp3_content_switchover_test.rb
+++ b/test/lib/tasks/pulp3_content_switchover_test.rb
@@ -9,7 +9,10 @@ module Katello
       @fake_pulp3_href = 'fake_pulp3_href'
       @another_fake_pulp3_href = 'another_fake_pulp3_href'
 
-      Katello::Pulp3::Migration.content_types_for_migration.each do |content_type|
+      SETTINGS[:katello][:use_pulp_2_for_content_type] = {:file => true, :docker => true}
+
+      migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_master, ['file', 'docker'])
+      migration_service.content_types_for_migration.each do |content_type|
         content_type.model_class.all.each do |record|
           record.update(:migrated_pulp3_href => @fake_pulp3_href + record.id.to_s)
         end
@@ -20,6 +23,10 @@ module Katello
 
       Rake::Task[@task_name].reenable
       Rake::Task.define_task(:environment)
+    end
+
+    def teardown
+      SETTINGS[:katello][:use_pulp_2_for_content_type] = nil
     end
 
     def test_file_unit_pulp_ids_updated


### PR DESCRIPTION
This PR ensures that `katello:pulp3_migration` and `katello:pulp3_content_switchover` only migrate repository types that have `:use_pulp_2_for_content_type:` as `true`.

To test:
1) Make a Pulp 3 development box
2) Apply this PR
3) Add some repo types (file and docker perhaps) under `:use_pulp_2_for_content_type:` in `foreman/config/settings.plugins.d/katello.yaml` and make their values `true`
4) Stick a `binding.pry` after line 8 of `lib/katello/tasks/pulp3_content_switchover.rake`
5) Run `bundle exec rake katello:pulp3_content_switchover`
6) Check that `content_types` matches what you put in `katello.yaml`
7) Stick a `binding.pry` on the first line of `def create_migrations`
8) Ensure that `@repository_types` returns the types under `:use_pulp_2_for_content_type:`