### PR TITLE
Fixes #29122 - Correct CV deletion behavior for pulp3

### DIFF
--- a/app/lib/actions/katello/content_view/destroy.rb
+++ b/app/lib/actions/katello/content_view/destroy.rb
@@ -17,6 +17,7 @@ module Actions
               end
             end
 
+            plan_action(Actions::Pulp3::ContentView::DeleteRepositoryReferences, content_view, SmartProxy.pulp_master)
             plan_self
           end
         end

--- a/app/lib/actions/pulp3/content_view/delete_repository_references.rb
+++ b/app/lib/actions/pulp3/content_view/delete_repository_references.rb
@@ -1,0 +1,26 @@
+module Actions
+  module Pulp3
+    module ContentView
+      class DeleteRepositoryReferences < Pulp3::AbstractAsyncTask
+        def plan(content_view, smart_proxy)
+          if content_view.repository_references.any?
+            plan_self(:content_view_id => content_view.id, :smart_proxy_id => smart_proxy.id)
+          end
+        end
+
+        def invoke_external_task
+          tasks = []
+          content_view = ::Katello::ContentView.find(input[:content_view_id])
+          content_view.repository_references.each do |repository_reference|
+            repo = repository_reference.root_repository.library_instance
+            #force pulp3 in case we've done migrations, but haven't switched over yet
+            tasks << repo.backend_service(smart_proxy, true).delete(repository_reference.repository_href)
+          end
+          content_view.repository_references.destroy_all
+
+          output[:pulp_tasks] = tasks
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/repository/delete.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/delete.rb
@@ -7,7 +7,14 @@ module Actions
             sequence do
               plan_action(Actions::Pulp3::Repository::DeleteRemote, repository.id, smart_proxy) if repository.remote_href
               plan_action(Actions::Pulp3::Repository::DeleteDistributions, repository.id, smart_proxy)
-              plan_action(Actions::Pulp3::Repository::Delete, repository.id, smart_proxy)
+
+              if repository.content_view.default?
+                #we're deleting the library instance, so just delete the whole pulp3 repo
+                plan_action(Actions::Pulp3::Repository::Delete, repository.id, smart_proxy)
+              elsif repository.environment.nil?
+                #we're deleting the archived instance, so delete the version
+                plan_action(Actions::Pulp3::Repository::DeleteVersion, repository, smart_proxy)
+              end
             end
           end
         end

--- a/app/lib/actions/pulp3/repository/delete_version.rb
+++ b/app/lib/actions/pulp3/repository/delete_version.rb
@@ -1,0 +1,20 @@
+module Actions
+  module Pulp3
+    module Repository
+      class DeleteVersion < Pulp3::AbstractAsyncTask
+        def plan(repository, smart_proxy)
+          #A version from library might be reused in a composite, or could have been copied
+          # from a library repository, so only delete the version if its the last
+          if ::Katello::Repository.where(:version_href => repository.version_href).count == 1
+            plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id)
+          end
+        end
+
+        def invoke_external_task
+          repo = ::Katello::Repository.find(input[:repository_id])
+          output[:response] = repo.backend_service(smart_proxy).delete_version
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -172,8 +172,8 @@ module Katello
       joins(:root).where("#{RootRepository.table_name}.content_type" => content_type)
     end
 
-    def backend_service(smart_proxy)
-      if smart_proxy.pulp3_support?(self)
+    def backend_service(smart_proxy, force_pulp3 = false)
+      if force_pulp3 || smart_proxy.pulp3_support?(self)
         @service ||= Katello::Pulp3::Repository.instance_for_type(self, smart_proxy)
       else
         @service ||= Katello::Pulp::Repository.instance_for_type(self, smart_proxy)

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -230,6 +230,10 @@ module Katello
         create_version(:base_version => from_repository.version_href)
       end
 
+      def delete_version
+        api.repository_versions_api.delete(repo.version_href)
+      end
+
       def create_version(options = {})
         api.repositories_api.modify(repository_reference.repository_href, options)
       end

--- a/test/actions/pulp3/content_view/delete_repository_references.rb
+++ b/test/actions/pulp3/content_view/delete_repository_references.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::ContentView
+  class DeleteRepositoryReferenceTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:generic_file_archive)
+      @content_view = @repo.content_view
+      ensure_creatable(@repo, @master)
+    end
+
+    def test_create
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Create, @repo, @master)
+      repo_reference = Katello::Pulp3::RepositoryReference.find_by(:content_view => @content_view, :root_repository_id => @repo.root_id)
+      assert repo_reference
+      assert Katello::Pulp3::Api::File.new(@master).repositories_api.read(repo_reference.repository_href)
+
+      ForemanTasks.sync_task(::Actions::Pulp3::ContentView::DeleteRepositoryReferences, @content_view, @master)
+      refute Katello::Pulp3::RepositoryReference.find_by(:id => repo_reference.id)
+
+      assert_raises(PulpFileClient::ApiError) do
+        Katello::Pulp3::Api::File.new(@master).repositories_api.read(repo_reference.repository_href)
+      end
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/delete_repository_reference/create.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/delete_repository_reference/create.yml
@@ -1,0 +1,438 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-1_0-Cabinet-My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-1_0-Cabinet-My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-1_0-Cabinet-My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/1.0/library/My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: post
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlf
+        RmlsZXMifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/file/file/2686dfbd-57f7-4d8b-ba67-2182de540db8/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '414'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8yNjg2ZGZiZC01N2Y3LTRkOGItYmE2Ny0yMTgyZGU1NDBkYjgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wMy0xMFQxNzo1MDozOC42NDc2NjBaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzI2ODZkZmJkLTU3ZjctNGQ4Yi1iYTY3LTIxODJkZTU0MGRiOC92
+        ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMjY4NmRmYmQtNTdmNy00ZDhiLWJh
+        NjctMjE4MmRlNTQwZGI4L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0ZpbGVzIiwiZGVzY3JpcHRp
+        b24iOm51bGx9
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/2686dfbd-57f7-4d8b-ba67-2182de540db8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '213'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8yNjg2ZGZiZC01N2Y3LTRkOGItYmE2Ny0yMTgyZGU1NDBkYjgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wMy0xMFQxNzo1MDozOC42NDc2NjBaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzI2ODZkZmJkLTU3ZjctNGQ4Yi1iYTY3LTIxODJkZTU0MGRiOC92
+        ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMjY4NmRmYmQtNTdmNy00ZDhiLWJh
+        NjctMjE4MmRlNTQwZGI4L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0ZpbGVzIiwiZGVzY3JpcHRp
+        b24iOm51bGx9
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: delete
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/2686dfbd-57f7-4d8b-ba67-2182de540db8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjNjM2ZDU3LTMzNGQtNDFi
+        MS1hYzcyLTM2ODI3ZmIyNDNlMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:38 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3c636d57-334d-41b1-ac72-36827fb243e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M2MzZkNTctMzM0
+        ZC00MWIxLWFjNzItMzY4MjdmYjI0M2UwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDMtMTBUMTc6NTA6MzguOTAxMDc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTAzLTEwVDE3OjUwOjM5LjAzMjkyM1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDMtMTBUMTc6NTA6MzkuMDkyOTAwWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80
+        YjY2ODAxOC1jZWZkLTRjZmUtOTIxNC1iN2RmNmUzZjE4NjcvIiwicHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2
+        ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS8yNjg2ZGZiZC01N2Y3LTRkOGItYmE2Ny0yMTgyZGU1
+        NDBkYjgvIl19
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:39 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/2686dfbd-57f7-4d8b-ba67-2182de540db8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 10 Mar 2020 17:50:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 10 Mar 2020 17:50:39 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This fixes four situations:

* Deleting a CVV would delete the pulp3 repository, deleting repo
  versions across all CVVs in that content view
* Deleting a CV would NOT delete the pulp3 repository, when it should
* Removing a CVV from a Lifecycle Env would not properly delete the
  distribution
* If you deleted a CVV, that had re-used the version_href and
  publication_href from a Library repo, it would delete the library
  repo's pulp3 repo version (and thus its publication too).