### PR TITLE
Fixes #26878 - commit deprecations

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -52,7 +52,6 @@ module Katello
     api :POST, "/content_view_versions/:id/promote", N_("Promote a content view version")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
     param :force, :bool, :desc => N_("force content view promotion and bypass lifecycle environment restriction")
-    param :environment_id, :number, :deprecated => true, :desc => N_("LifeCycle Environment identifier")
     param :environment_ids, Array, :desc => N_("Identifiers for Lifecycle Environment")
     param :description, String, :desc => N_("The description for the content view version promotion")
     def promote
@@ -287,12 +286,7 @@ module Katello
     end
 
     def find_environments
-      @environments = if params[:environment_id]
-                        ::Foreman::Deprecation.api_deprecation_warning("The parameter environment_id will be removed in Katello 3.4. Please update to use the environment_ids parameter.")
-                        KTEnvironment.where(:id => params[:environment_id])
-                      else
-                        KTEnvironment.where(:id => params[:environment_ids])
-                      end
+      @environments = KTEnvironment.where(:id => params[:environment_ids])
     end
 
     def validate_promotable

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -147,7 +147,6 @@ module Katello
 
     api :PUT, "/hosts/:host_id/subscriptions/content_override", N_("Set content overrides for the host")
     param :host_id, String, :desc => N_("Id of the content host"), :required => true
-    param :content_label, String, :desc => N_("Label of the content"), :required => false
     param :value, String, :desc => N_("Override to a boolean value or 'default'"), :required => false
     param :content_overrides, Array, :desc => N_("Array of Content override parameters") do
       param :content_label, String, :desc => N_("Label of the content"), :required => true
@@ -156,20 +155,7 @@ module Katello
       param :remove, :bool, :desc => N_("Set true to remove an override and reset it to 'default'"), :required => false
     end
     def content_override
-      content_overrides = []
-      if params[:content_label]
-        ::Foreman::Deprecation.api_deprecation_warning("The parameter content_label will be removed in Katello 3.5. Please update to use the content_overrides parameter.")
-        content_override_params = {:content_label => params[:content_label]}
-        value = params[:value]
-        if value == "default"
-          content_override_params[:remove] = true
-        elsif value
-          content_override_params[:value] = ::Foreman::Cast.to_bool(value)
-        end
-        content_overrides << content_override_params
-      elsif params[:content_overrides]
-        content_overrides = params[:content_overrides]
-      end
+      content_overrides = params[:content_overrides] || []
 
       content_override_values = content_overrides.map do |override_params|
         validate_content_overrides_enabled(override_params)

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -245,19 +245,19 @@ module Katello
                       [@env_promote_permission, diff_view_promote_permission]
                      ]
       assert_protected_action(:promote, allowed_perms, denied_perms) do
-        post :promote, params: { :id => @library_dev_staging_view.versions.first.id, :environment_id => @dev.id }
+        post :promote, params: { :id => @library_dev_staging_view.versions.first.id, :environment_ids => [@dev.id] }
       end
     end
 
     def test_promote_default
       view = ContentView.find(katello_content_views(:acme_default).id)
-      post :promote, params: { :id => view.versions.first.id, :environment_id => @dev.id }
+      post :promote, params: { :id => view.versions.first.id, :environment_ids => [@dev.id] }
       assert_response 400
     end
 
     def test_promote_out_of_sequence
       view = ContentView.find(katello_content_views(:acme_default).id)
-      post :promote, params: { :id => view.versions.first.id, :environment_id => @dev.id }
+      post :promote, params: { :id => view.versions.first.id, :environment_ids => [@dev.id] }
       assert_response 400
     end
 
@@ -269,7 +269,7 @@ module Katello
 
     def test_promote_outside_org
       version = @library_dev_staging_view.versions.first
-      post :promote, params: { :id => version.id, :environment_id => [@candlepin_dev.id], :force => 1, :description => 'test with param environment_id outside org' }
+      post :promote, params: { :id => version.id, :environment_ids => [@candlepin_dev.id], :force => 1, :description => 'test with param environment_id outside org' }
       assert_response 422
     end
 

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -221,17 +221,17 @@ module Katello
     end
 
     def test_content_override
-      content_label = "some-content"
+      content_overrides = [{:content_label => 'some-content', :value => 1}]
       value = "1"
       assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides, prune_invalid|
         assert_equal @host, host
         assert_equal 1, overrides.count
-        assert_equal content_label, overrides.first.content_label
+        assert_equal 'some-content', overrides.first.content_label
         assert_equal value, overrides.first.value
         assert_equal false, prune_invalid
       end
 
-      put :content_override, params: { :host_id => @host.id, :content_label => content_label, :value => value }
+      put :content_override, params: { :host_id => @host.id, :content_overrides => content_overrides }
 
       assert_response :success
       assert_template 'api/v2/host_subscriptions/content_override'
@@ -239,7 +239,7 @@ module Katello
 
     def test_content_override_bulk
       content_overrides = [{:content_label => 'some-content', :value => 1}]
-      expected_content_labels = content_overrides.map { |override| override[:content_label] }
+      expected_content_labels = content_overrides.map { |co| co[:content_label] }
       assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides, prune_invalid|
         assert_equal @host, host
         assert_equal content_overrides.count, overrides.count
@@ -254,33 +254,33 @@ module Katello
     end
 
     def test_content_override_accepts_string_values
-      content_label = "some-content"
+      content_overrides = [{:content_label => 'some-content', :value => 1}]
       value = "1"
       assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides, _|
         assert_equal @host, host
         assert_equal 1, overrides.count
-        assert_equal content_label, overrides.first.content_label
+        assert_equal 'some-content', overrides.first.content_label
         assert_equal value, overrides.first.value
       end
 
-      put :content_override, params: { :host_id => @host.id, :content_label => 'some-content', :value => 'yes' }
+      put :content_override, params: { :host_id => @host.id, :content_overrides => content_overrides, :value => 'yes' }
 
       assert_response :success
     end
 
     # content overrides may be added before the host has access to the content
     def test_invalid_content_succeeds
-      content_label = "wrong-content"
+      content_overrides = [{:content_label => 'wrong-content', :value => 1}]
       value = "1"
       assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides, prune_invalid|
         assert_equal @host, host
         assert_equal 1, overrides.count
-        assert_equal content_label, overrides.first.content_label
+        assert_equal 'wrong-content', overrides.first.content_label
         assert_equal value, overrides.first.value
         assert_equal false, prune_invalid
       end
 
-      put :content_override, params: { :host_id => @host.id, :content_label => content_label, :value => value }
+      put :content_override, params: { :host_id => @host.id, :content_overrides => content_overrides, :value => value }
 
       assert_response :success
       assert_template 'api/v2/host_subscriptions/content_override'

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -827,30 +827,6 @@ module Katello
       end
     end
 
-    def test_import_upload_ids
-      uploads = [{'id' => '1'}]
-      @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-              generate_metadata: false, content_type: nil, sync_capsule: false)
-        .returns(build_task_stub)
-
-      put(:import_uploads, params: { :id => @repository.id, :upload_ids => uploads.map { |u| u['id'] }, :publish_repository => 'false', sync_capsule: 'false' })
-
-      assert_response :success
-    end
-
-    def test_two_import_upload_ids
-      uploads = [{'id' => '1'}, {'id' => '2'}]
-      @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-              generate_metadata: false, content_type: nil, sync_capsule: false)
-        .returns(build_task_stub)
-
-      put(:import_uploads, params: { :id => @repository.id, :upload_ids => uploads.map { |u| u['id'] }, :publish_repository => 'false', sync_capsule: 'false' })
-
-      assert_response :success
-    end
-
     def test_import_uploads
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
       # make sure name gets ignored for non-file repos
@@ -927,7 +903,7 @@ module Katello
       denied_perms = [@read_permission, @create_permission, @destroy_permission]
 
       assert_protected_action(:import_uploads, allowed_perms, denied_perms) do
-        put :import_uploads, params: { :id => @repository.id, :upload_ids => [1] }
+        put :import_uploads, params: { :id => @repository.id, :uploads => [{'id' => '1'}] }
       end
     end
 


### PR DESCRIPTION
This PR completes actual removal of features associated with the following deprecation warnings:

```
[vagrant@centos7-katello-devel tool_belt]$ ./tools.rb check-deprecation-warnings configs/katello/3.14.yaml
warning: parser/current is loading parser/ruby25, which recognizes
warning: 2.5.7-compliant syntax, but you are running 2.5.5.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

Scanning for deprecation warnings in /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/**/*.rb, /home/vagrant/tool_belt/repos/katello/3.14.1/katello/lib/**/*.rb

Deprecation warnings were found with versions that are outdated, please check below and ensure both the deprecated functionality and the deprecation warning are removed if the deprecation is outdated in this release

Deprecation warning at /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/controllers/katello/api/v2/host_subscriptions_controller.rb line 161 is marked for removal in version 3.5, which is less than or equal to the specified version of 3.14.1.

Deprecation warning at /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/controllers/katello/api/v2/content_view_versions_controller.rb line 291 is marked for removal in version 3.4, which is less than or equal to the specified version of 3.14.1.

Deprecation warning at /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/controllers/katello/api/v2/repositories_controller.rb line 409 is marked for removal in version 3.3, which is less than or equal to the specified version of 3.14.1.

Deprecation warning at /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/controllers/katello/api/v2/subscriptions_controller.rb line 204 is marked for removal in version 2.6, which is less than or equal to the specified version of 3.14.1.
```

Does not address the following future deprecation:

```
Deprecation warnings were found marked for removal for the *next* release version 3.15. Please check below and file issues aligned to 3.15 to remove the functionality and the deprecation warning. This will ensure the functionality is removed in time for the next release 3.15. The deprecation warning should stay in this release, only file issues for its removal at this time.

Deprecation warning at /home/vagrant/tool_belt/repos/katello/3.14.1/katello/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb line 70 is marked for removal in version 3.15, which is the *next* release version.
```