### PR TITLE
Fixes #29266 -Plugin specific repository sync Url

### DIFF
--- a/app/services/katello/pulp3/api/ansible_collection.rb
+++ b/app/services/katello/pulp3/api/ansible_collection.rb
@@ -21,6 +21,10 @@ module Katello
           PulpAnsibleClient::AnsibleAnsibleDistribution
         end
 
+        def self.repository_sync_url_class
+          PulpAnsibleClient::RepositorySyncURL
+        end
+
         def api_client
           PulpAnsibleClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpAnsibleClient::Configuration))
         end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -31,6 +31,10 @@ module Katello
           fail NotImplementedError
         end
 
+        def self.repository_sync_url_class
+          fail NotImplementedError
+        end
+
         def api_client
           fail NotImplementedError
         end

--- a/app/services/katello/pulp3/api/docker.rb
+++ b/app/services/katello/pulp3/api/docker.rb
@@ -25,6 +25,10 @@ module Katello
           PulpContainerClient::ContainerPublication
         end
 
+        def self.repository_sync_url_class
+          PulpContainerClient::RepositorySyncURL
+        end
+
         def self.recursive_manage_class
           PulpContainerClient::RecursiveManage
         end

--- a/app/services/katello/pulp3/api/file.rb
+++ b/app/services/katello/pulp3/api/file.rb
@@ -25,6 +25,10 @@ module Katello
           PulpFileClient::FileFilePublication
         end
 
+        def self.repository_sync_url_class
+          PulpFileClient::RepositorySyncURL
+        end
+
         def api_client
           PulpFileClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpFileClient::Configuration))
         end

--- a/app/services/katello/pulp3/api/yum.rb
+++ b/app/services/katello/pulp3/api/yum.rb
@@ -25,6 +25,10 @@ module Katello
           PulpRpmClient::RpmRpmPublication
         end
 
+        def self.repository_sync_url_class
+          PulpRpmClient::RepositorySyncURL
+        end
+
         def api_client
           PulpRpmClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpRpmClient::Configuration))
         end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -181,7 +181,7 @@ module Katello
       end
 
       def sync
-        repository_sync_url_data = api.class.client_module::RepositorySyncURL.new(remote: repo.remote_href, mirror: repo.root.mirror_on_sync)
+        repository_sync_url_data = api.class.repository_sync_url_class.new(remote: repo.remote_href, mirror: repo.root.mirror_on_sync)
         [api.repositories_api.sync(repository_reference.repository_href, repository_sync_url_data)]
       end
 

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -103,8 +103,7 @@ module Katello
       end
 
       def sync
-        api_module = api.class.client_module
-        repository_sync_url_data = api_module::RepositorySyncURL.new(remote: remote_href, mirror: true)
+        repository_sync_url_data = api.class.repository_sync_url_class.new(remote: remote_href, mirror: true)
         [api.repositories_api.sync(repository_href, repository_sync_url_data)]
       end
 


### PR DESCRIPTION
https://github.com/pulp/pulp_rpm/blob/master/pulp_rpm/app/serializers.py#L577 changes RepositorySyncURL for RPms to RpmRepositorySyncURL . Although, the other plugins still retain the name RepositorySyncURL, these could be qualified by plugin name in the future.