### PR TITLE
Fixes #29197 - Remove unmigrated Docker v1 tags

### DIFF
--- a/lib/katello/tasks/pulp3_content_switchover.rake
+++ b/lib/katello/tasks/pulp3_content_switchover.rake
@@ -6,6 +6,17 @@ namespace :katello do
     migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_master)
     content_types = migration_service.content_types_for_migration
 
+    if content_types.any? { |content_type| content_type.model_class::CONTENT_TYPE == "docker_tag" }
+      unmigrated_docker_tags = Katello::DockerTag.includes(:schema1_meta_tag, :schema2_meta_tag).where(migrated_pulp3_href: nil)
+      unmigrated_docker_tags.each do |unmigrated_tag|
+        if unmigrated_tag.schema1_meta_tag && unmigrated_tag.schema1_meta_tag.schema2.try(:migrated_pulp3_href)
+          puts "\e[33mDeleting Docker tag #{unmigrated_tag.name} with pulp id: #{unmigrated_tag.pulp_id}\e[0m\n\n"
+          unmigrated_tag.destroy!
+        end
+      end
+      Katello::DockerMetaTag.cleanup_tags
+    end
+
     content_types.each do |content_type|
       if content_type.model_class.where(migrated_pulp3_href: nil).any?
         $stderr.print("ERROR: at least one #{content_type.model_class.table_name} record has migrated_pulp3_href NULL value\n")


### PR DESCRIPTION
To test:
On a pulp3 dev box:
```
cd /usr/lib/python3.6/site-packages/
sudo rm -rf pulp_2*
sudo pip3 install "git+https://github.com/sjha4/pulp-2to3-migration.git" 
sudo mv /usr/local/lib/python3.6/site-packages/pulp* /usr/lib/python3.6/site-packages/
cd ~/foreman
bundle exec rails katello:reset
```

Using pulp2 for docker, sync a couple of docker repos ex: fedora/ssh and busybox
run bundle exec rails katello:pulp3_migration
Notice  `Katello::DockerTag.where(migrated_pulp3_href: nil)`  is not nil
Run `bundle exec rails katello:pulp3_content_switchover` on this branch. It should succeed.