### PR TITLE
Fixes #29320 - use the proxy policy when setting remote download policy for a mirror remote 

### DIFF
--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -20,6 +20,16 @@ module Katello
           }
         end
 
+        def mirror_remote_options
+          policy = smart_proxy.download_policy
+
+          if smart_proxy.download_policy == SmartProxy::DOWNLOAD_INHERIT
+            policy = repo.root.download_policy
+          end
+
+          { policy: policy }
+        end
+
         def import_distribution_data
           distribution = ::Katello::Pulp3::Distribution.fetch_content_list(repository_version: repo.version_href)
           if distribution.results.present?


### PR DESCRIPTION
This PR fixes an oversight where the download policy set on sync'd repositories don't correctly set the download policy on repository remotes.

The download policy should match the mirror proxy.

To test this, add a pulpcore proxy as a mirror node to katello. Then sync a an rpm repository on the pulpcore master node. Set the download policy on the repository to "immediate". We'll want to compare this value to the download policy of the pulpcore mirror, which you should set to another, conflicting value - "on demand". 

Be sure to add the pulpcore proxy to a lifecycle environment then sync the capsule.

Check that the pulpcore schema on the pulpcore mirror shows the right download policy.

For example, on the proxy:
```
pulp=# select pulp_created, url, policy from core_remote;
         pulp_created          |                                                                url                                                                 |  policy   
-------------------------------+------------------------------------------------------------------------------------------------------------------------------------+-----------
 2020-03-10 15:54:41.528278+00 | https://centos7-katello-devel-stable.example.com/pulp/repos/Default_Organization/Library/custom/test/test-yum/                     | on_demand
```

If the mirror proxy was set to a download policy of "immediate", and then re-sync'd, then the policy should change to "immediate". Note that we did *not* change the download policy of the repository on the pulpcore master node.

```
pulp=# select pulp_created, url, policy from core_remote;
         pulp_created          |                                                                url                                                                 |  policy   
-------------------------------+------------------------------------------------------------------------------------------------------------------------------------+-----------
2020-03-10 15:54:41.528278+00 | https://centos7-katello-devel-stable.example.com/pulp/repos/Default_Organization/Library/custom/test/test-yum/                     | immediate
```

