### PR TITLE
Refs #29322 - Add custom scoped_search parameter

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -61,6 +61,14 @@ module Katello
         scoped_search :relation => :host_traces, :on => :application, :complete_value => true, :rename => :trace_app, :only_explicit => true
         scoped_search :relation => :host_traces, :on => :app_type, :complete_value => true, :rename => :trace_app_type, :only_explicit => true
         scoped_search :relation => :host_traces, :on => :helper, :complete_value => true, :rename => :trace_helper, :only_explicit => true
+
+        scoped_search relation: :pools, on: :end_date, ext_method: :find_with_pools
+
+        def self.find_with_pools(key, operator, value)
+          conditions = sanitize_sql_for_conditions(["katello_pools.#{key} #{operator} ?", value_to_sql(operator, value)])
+          host_ids = ::Host.joins(:pools).where(conditions).ids
+          { :conditions => "hosts.id IN(#{host_ids.join(',')})" }
+        end
       end
 
       def correct_kickstart_repository

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -51,12 +51,6 @@ module Katello
         before_save :correct_puppet_environment
         before_validation :correct_kickstart_repository
 
-        # show all hosts which have expiring pools
-        scope :with_pools_expiring_in_days, ->(days_from_now) do
-          minimum_pool_date = (Date.today + days_from_now.to_i.days).strftime('%Y-%m-%d')
-          joins(:pools).where(["katello_pools.end_date < ?", minimum_pool_date])
-        end
-
         scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
         scoped_search :relation => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
         scoped_search :relation => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package, :only_explicit => true
@@ -71,8 +65,12 @@ module Katello
         scoped_search relation: :pools, on: :pools_expiring_in_days, ext_method: :find_with_expiring_pools, only_explicit: true
 
         def self.find_with_expiring_pools(_key, _operator, days_from_now)
-          host_ids = self.with_pools_expiring_in_days(days_from_now).ids
-          { :conditions => "hosts.id IN(#{host_ids.join(',')})" }
+          minimum_pool_date = (Date.today + days_from_now.to_i.days).strftime('%Y-%m-%d')
+          {
+            :joins => :pools,
+            :conditions => "katello_pools.end_date < ?",
+            :parameter => [minimum_pool_date]
+          }
         end
       end
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -69,9 +69,7 @@ module Katello
         def self.find_with_expiring_pools(_key, _operator, days_from_now)
           host_ids = with_pools_expiring_in_days(days_from_now).ids
           scoped_search_params = {
-            :conditions => "katello_pools.end_date < ?",
-            :parameter => [days_from_now.to_i.days.from_now.end_of_day],
-            :joins => :pools
+            :conditions => "1=0"
           }
           if host_ids.present?
             scoped_search_params = { :conditions => "hosts.id IN (#{host_ids.join(', ')})" }

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -68,13 +68,11 @@ module Katello
 
         def self.find_with_expiring_pools(_key, _operator, days_from_now)
           host_ids = with_pools_expiring_in_days(days_from_now).ids
-          scoped_search_params = {
-            :conditions => "1=0"
-          }
-          if host_ids.present?
-            scoped_search_params = { :conditions => "hosts.id IN (#{host_ids.join(', ')})" }
+          if host_ids.any?
+            { :conditions => "hosts.id IN (#{host_ids.join(', ')})" }
+          else
+            { :conditions => "1=0" }
           end
-          scoped_search_params
         end
       end
 

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -17,7 +17,10 @@ module Katello
 
     scope :in_organization, ->(org_id) { where(:organization_id => org_id) }
     scope :for_activation_key, ->(ak) { joins(:activation_keys).where("#{Katello::ActivationKey.table_name}.id" => ak.id) }
-
+    scope :expiring_in_days, ->(days) do
+      return self if days.blank?
+      where(["end_date < ?", days.to_i.days.from_now.end_of_day])
+    end
     include Glue::Candlepin::Pool
     include Glue::Candlepin::CandlepinObject
 
@@ -52,12 +55,12 @@ module Katello
 
     # used for notification bell
     def expiring_soon?
-      expiring_in_days >= 0 &&
-        expiring_in_days <= Setting[:expire_soon_days].to_i
+      days_until_expiration >= 0 &&
+        days_until_expiration <= Setting[:expire_soon_days].to_i
     end
 
     # used for entitlements report template
-    def expiring_in_days
+    def days_until_expiration
       (end_date.to_date - Date.today).to_i
     end
 
@@ -107,8 +110,12 @@ module Katello
       Pool.joins(:subscription).order("subscription.name")
     end
 
-    class Jail < ::Safemode::Jail
-      allow :id, :name, :available, :quantity, :product_id, :contract_number, :type, :account_number, :start_date, :end_date, :organization, :consumed, :expiring_in_days
+    class Pool::Jail < ::Safemode::Jail
+      allow :id, :name, :available, :quantity, :product_id, :contract_number, :type, :account_number, :start_date, :end_date, :organization, :consumed, :days_until_expiration
     end
   end
+end
+
+class ActiveRecord::AssociationRelation::Jail < Safemode::Jail
+  allow :sort
 end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -51,7 +51,12 @@ module Katello
     end
 
     def expiring_soon?
-      (end_date.to_date - Date.today) <= Setting[:expire_soon_days]
+      expiring_in_days >= 0 &&
+        expiring_in_days <= Setting[:expire_soon_days].to_i
+    end
+
+    def expiring_in_days
+      (end_date.to_date - Date.today).to_i
     end
 
     def recently_expired?
@@ -101,7 +106,7 @@ module Katello
     end
 
     class Jail < ::Safemode::Jail
-      allow :id, :name, :available, :quantity, :product_id, :contract_number, :type, :account_number, :start_date, :end_date, :organization, :consumed
+      allow :id, :name, :available, :quantity, :product_id, :contract_number, :type, :account_number, :start_date, :end_date, :organization, :consumed, :expiring_in_days
     end
   end
 end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -50,11 +50,13 @@ module Katello
       active
     end
 
+    # used for notification bell
     def expiring_soon?
       expiring_in_days >= 0 &&
         expiring_in_days <= Setting[:expire_soon_days].to_i
     end
 
+    # used for entitlements report template
     def expiring_in_days
       (end_date.to_date - Date.today).to_i
     end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -117,5 +117,5 @@ module Katello
 end
 
 class ActiveRecord::AssociationRelation::Jail < Safemode::Jail
-  allow :sort
+  allow :sort_by
 end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -110,7 +110,7 @@ module Katello
       Pool.joins(:subscription).order("subscription.name")
     end
 
-    class Pool::Jail < ::Safemode::Jail
+    class Jail < ::Safemode::Jail
       allow :id, :name, :available, :quantity, :product_id, :contract_number, :type, :account_number, :start_date, :end_date, :organization, :consumed, :days_until_expiration
     end
   end

--- a/test/factories/pool_factory.rb
+++ b/test/factories/pool_factory.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       end_date { Date.today + (Setting[:expire_soon_days] || 120) }
     end
 
+    trait :expiring_in_12_days do
+      end_date { Date.today + 12 }
+    end
+
     trait :not_expiring_soon do
       end_date { Date.today + (Setting[:expire_soon_days] || 120) + 1 }
     end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -43,6 +43,12 @@ module Katello
       refute_includes found, other_host
     end
 
+    def test_pools_expiring_in_days
+      host_with_pool = FactoryBot.create(:host, :with_subscription)
+      host_with_pool.subscription_facet.pools << FactoryBot.build(:katello_pool, :expiring_in_12_days, cp_id: 1)
+      assert_includes ::Host.search_for('pools_expiring_in_days = 30'), host_with_pool
+    end
+
     def test_smart_proxy_ids_with_katello
       content_source = FactoryBot.create(:smart_proxy,
                                           :features => [Feature.where(:name => "Pulp Node").first_or_create])

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -37,9 +37,9 @@ module Katello
       assert_equal expiring_soon_subscriptions, all_subscriptions - [not_expiring_soon]
     end
 
-    def test_expiring_in_days
+    def test_days_until_expiration
       expiring_pool = FactoryBot.build(:katello_pool, :expiring_in_12_days)
-      assert_equal expiring_pool.expiring_in_days, 12
+      assert_equal expiring_pool.days_until_expiration, 12
     end
 
     def test_stacking_id

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -37,6 +37,11 @@ module Katello
       assert_equal expiring_soon_subscriptions, all_subscriptions - [not_expiring_soon]
     end
 
+    def test_expiring_in_days
+      expiring_pool = FactoryBot.build(:katello_pool, :expiring_in_12_days)
+      assert_equal expiring_pool.expiring_in_days, 12
+    end
+
     def test_stacking_id
       assert_equal @pool_one.subscription, Pool.stacking_subscription(@pool_one.organization.label, @pool_one.subscription.cp_id)
     end


### PR DESCRIPTION
[SAT-E-459]  Updated with [testing instructions](https://github.com/Katello/katello/pull/8606#issuecomment-600827102) 3/18

This PR contains updates to enable improvements to the Entitlements report template.

* Add `days_until_expiration` method to `Pool` - Allows the addition of a new column to the Entitlements report, _Subscription Expires In_
* Allow access via Jail so that you can use it in a report template
* Add a scoped_search parameter, `with_pools_expiring_in_days`, with a custom external method that joins Hosts and Pools and fetches the required data.

Inside a report template, this allows you to do 
```
load_hosts(search: 'pools_expiring_in_days = 30')
```

Or anywhere else,
```
Host.search_for('pools_expiring_in_days = 30')
```
/
and get all hosts with pools expiring in the next 30 days.
