### PR TITLE
Refs #26878 - send environment_ids parameter on CV promotion

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
@@ -97,7 +97,7 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
         $scope.promote = function () {
             $scope.promoting = true;
             ContentViewVersion.promote({id: $scope.version.id,
-                                        'environment_id': $scope.selectedEnvironment.id,
+                                        'environment_ids': [$scope.selectedEnvironment.id],
                                         'description': $scope.description,
                                         force: true},
                 success, failure);


### PR DESCRIPTION
This makes the UI compatible with the recent removal of the deprecated `environment_id` param for CV promotion