### PR TITLE
Fixes #29355 - allow CVE id in safe mode

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -76,7 +76,7 @@ module Katello
       end
 
       def host_applicable_errata_filtered(host, filter = '')
-        host.applicable_errata.search_for(filter)
+        host.applicable_errata.includes(:cves).search_for(filter)
       end
 
       def host_latest_applicable_rpm_version(host, package)

--- a/app/models/katello/erratum_cve.rb
+++ b/app/models/katello/erratum_cve.rb
@@ -1,5 +1,9 @@
 module Katello
   class ErratumCve < Katello::Model
     belongs_to :erratum, :inverse_of => :cves, :class_name => 'Katello::Erratum'
+
+    class Jail < ::Safemode::Jail
+      allow :erratum, :cve_id, :href
+    end
   end
 end


### PR DESCRIPTION
to test, apply [this](https://github.com/theforeman/community-templates/pull/709) to your report template and generate, cves column will contain CVE identifiers instead of internal AR object id