### PR TITLE
Fixes #29357: remove vendor as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "redux-mock-store": "^1.3.0"
   },
   "dependencies": {
-    "@theforeman/vendor": "^1.4.0",
     "angular": "1.7.9",
     "bootstrap-select": "1.12.4",
     "downshift": "^1.28.0",


### PR DESCRIPTION
Vendor isn't used directly as a dependency in katello but is rather
provided by foreman.  Remove vendor from the list of dependencies.

https://projects.theforeman.org/issues/29357