### PR TITLE
Fixes #29358 - Upgrade foreman-js meta-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@babel/core": "^7.7.0",
     "@storybook/react": "^3.2.17",
     "@storybook/storybook-deployer": "^2.0.0",
-    "@theforeman/builder": "^4.0.2",
-    "@theforeman/vendor-dev": "^3.8.0",
+    "@theforeman/builder": "^4.2.0",
+    "@theforeman/vendor-dev": "^4.2.0",
     "axios-mock-adapter": "^1.10.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
@@ -52,8 +52,8 @@
     "react-test-renderer": "^16.0.0",
     "redux-mock-store": "^1.3.0"
   },
+  "_comment": "We don't include @theforeman/vendor because it's assumed to be present in Foreman",
   "dependencies": {
-    "@theforeman/vendor": "^1.4.0",
     "angular": "1.7.9",
     "bootstrap-select": "1.12.4",
     "downshift": "^1.28.0",
@@ -62,9 +62,6 @@
     "query-string": "^6.1.0",
     "react-bootstrap": "^0.32.1",
     "react-helmet": "^5.2.0"
-  },
-  "peerDependencies": {
-    "@theforeman/vendor": ">= 3.8.0"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
This provides patternfly 4 by way of the foreman-js metapackages. The actual production dependency comes from foreman, where it is already upgraded. This only upgrades the dev packages