### PR TITLE
Fixes #29013 - Can view record in different organization

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -198,9 +198,9 @@ module Katello
     end
 
     def check_resource_organization(resource, organization_id)
-      return unless resource && resource&.organization_id && organization_id
+      return unless resource && resource.try(:organization_id) && organization_id
       if resource.organization_id != organization_id.to_i
-        fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified organization")
+        fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified Organization")
       end
     end
 

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -192,6 +192,18 @@ module Katello
       end
     end
 
+    def respond_for_show(options = {})
+      check_resource_organization(options[:resource], params[:organization_id])
+      super
+    end
+
+    def check_resource_organization(resource, organization_id)
+      return unless resource && resource&.organization_id && organization_id
+      if resource.organization_id != organization_id.to_i
+        fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified organization")
+      end
+    end
+
     def find_host_with_subscriptions(id, permission)
       @host = resource_finder(::Host::Managed.authorized(permission, ::Host::Managed), id)
       fail HttpErrors::BadRequest, _("Host has not been registered with subscription-manager") if @host.subscription_facet.nil?

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -198,7 +198,7 @@ module Katello
     end
 
     def check_resource_organization(resource, organization_id)
-      return unless resource && resource.try(:organization_id) && organization_id
+      return unless resource.try(:organization_id) && organization_id
       if resource.organization_id != organization_id.to_i
         fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified Organization")
       end

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -67,7 +67,7 @@ module Katello
     param :id, :number, :desc => N_("ID of the environment"), :required => true
     param :organization_id, :number, :desc => N_("ID of the organization")
     def show
-      respond
+      respond(resource: @environment)
     end
 
     api :POST, "/environments", N_("Create an environment")

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -19,8 +19,9 @@ module Katello
 
     api :GET, "/host_collections/:id", N_("Show a host collection")
     param :id, :number, :desc => N_("Id of the host collection"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => false
     def show
-      respond
+      respond(:resource => @host_collection)
     end
 
     api :GET, "/host_collections", N_("List host collections")

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -86,7 +86,6 @@ module Katello
       respond_for_create(:resource => product)
     end
 
-    api :GET, "/organizations/:organization_id/products/:id", N_("Show a products")
     api :GET, "/products/:id", N_("Show a product")
     param :organization_id, :number, :desc => N_("Organization ID")
     param :id, :number, :desc => N_("product numeric identifier"), :required => true

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -86,7 +86,9 @@ module Katello
       respond_for_create(:resource => product)
     end
 
+    api :GET, "/organizations/:organization_id/products/:id", N_("Show a products")
     api :GET, "/products/:id", N_("Show a product")
+    param :organization_id, :number, :desc => N_("Organization ID")
     param :id, :number, :desc => N_("product numeric identifier"), :required => true
     def show
       find_product(:includes => [{:root_repositories => {:repositories => :environment}}])

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -260,6 +260,7 @@ module Katello
 
     api :GET, "/repositories/:id", N_("Show a repository")
     param :id, :number, :required => true, :desc => N_("repository ID")
+    param :organization_id, :number, :desc => N_("Organization ID")
     def show
       respond_for_show(:resource => @repository)
     end

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -7,7 +7,7 @@ module Katello
         include Katello::Concerns::FilteredAutoCompleteSearch
 
         before_action :find_repository
-        before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+        before_action :find_optional_organization, :only => [:index, :show, :auto_complete_search]
         before_action :find_environment, :only => [:index, :auto_complete_search]
         before_action :find_content_view_version, :only => [:index, :auto_complete_search]
         before_action :find_filter, :find_filter_rule, :only => [:index, :auto_complete_search]
@@ -36,6 +36,7 @@ module Katello
       api :GET, "/:resource_id/:id", N_("Show :a_resource")
       api :GET, "/repositories/:repository_id/:resource_id/:id", N_("Show :a_resource")
       param :repository_id, :number, :desc => N_("repository identifier")
+      param :organization_id, :number, :desc => N_("organization identifier")
       param :id, String, :desc => N_(":a_resource identifier"), :required => true
       def show
         respond :resource => @resource
@@ -159,6 +160,10 @@ module Katello
         if params[:repository_id] && !@resource.repositories.include?(@repo)
           fail HttpErrors::NotFound, _("Could not find %{content} with id '%{id}' in repository.") %
             {content: resource_name, id: params[:id]}
+        end
+
+        if params[:organization_id] && !@resource.repositories.any? {|repo| repo.organization_id == params[:organization_id].to_i}
+          fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified organization")
         end
       end
 

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -162,7 +162,7 @@ module Katello
             {content: resource_name, id: params[:id]}
         end
 
-        if params[:organization_id] && !@resource.repositories.any? {|repo| repo.organization_id == params[:organization_id].to_i}
+        if params[:organization_id] && !@resource.repositories.any? { |repo| repo.organization_id == params[:organization_id].to_i }
           fail HttpErrors::BadRequest, _("The requested resource does not belong to the specified organization")
         end
       end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -200,6 +200,10 @@ module Katello
       end
     end
 
+    def organization_id
+      organization&.id
+    end
+
     def audit_sync
       write_audit(action: AUDIT_SYNC_ACTION, comment: _('Successfully synchronized.'), audited_changes: {})
     end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -220,22 +220,7 @@ Katello::Engine.routes.draw do
             get :redhat_provider
             get :releases
           end
-          api_resources :products, :only => [:index, :show, :create, :update, :destroy] do
-            member do
-              post :sync
-            end
-            collection do
-              get :auto_complete_search
-            end
-            api_resources :repository_sets, :only => [:index, :show] do
-              get :auto_complete_search, :on => :collection
-              member do
-                get :available_repositories
-                put :enable
-                put :disable
-              end
-            end
-          end
+          api_resources :products, :only => [:index]
           api_resources :repositories, :only => [:index]
           api_resources :subscriptions, :only => [:index] do
             collection do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -220,7 +220,22 @@ Katello::Engine.routes.draw do
             get :redhat_provider
             get :releases
           end
-          api_resources :products, :only => [:index]
+          api_resources :products, :only => [:index, :show, :create, :update, :destroy] do
+            member do
+              post :sync
+            end
+            collection do
+              get :auto_complete_search
+            end
+            api_resources :repository_sets, :only => [:index, :show] do
+              get :auto_complete_search, :on => :collection
+              member do
+                get :available_repositories
+                put :enable
+                put :disable
+              end
+            end
+          end
           api_resources :repositories, :only => [:index]
           api_resources :subscriptions, :only => [:index] do
             collection do

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
@@ -8,9 +8,9 @@
  *   Provides a BastionResource for activation keys.
  */
 angular.module('Bastion.activation-keys').factory('ActivationKey',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('katello/api/v2/activation_keys/:id/:action/:action2', {id: '@id'}, {
+        return BastionResource('katello/api/v2/activation_keys/:id/:action/:action2', {id: '@id', 'organization_id': CurrentOrganization}, {
             get: {method: 'GET', params: {fields: 'full'}},
             update: {method: 'PUT'},
             copy: {method: 'POST', params: {action: 'copy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ansible-collections/ansible-collections.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ansible-collections/ansible-collections.factory.js
@@ -8,10 +8,10 @@
      * @description
      *   Provides a BastionResource for interacting with Ansible Collections
      */
-    function AnsibleCollection(BastionResource) {
+    function AnsibleCollection(BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/ansible_collections/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -23,6 +23,6 @@
         .module('Bastion.ansible-collections')
         .factory('AnsibleCollection', AnsibleCollection);
 
-    AnsibleCollection.$inject = ['BastionResource'];
+    AnsibleCollection.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/api-error-handler.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/api-error-handler.service.js
@@ -14,6 +14,8 @@
                 angular.forEach(response.data.errors, function (error) {
                     Notification.setErrorMessage(error);
                 });
+            } else if (response.hasOwnProperty('data') && response.data.hasOwnProperty('error') && response.data.error.hasOwnProperty('message')) {
+                Notification.setErrorMessage(response.data.error.message);
             } else {
                 Notification.setErrorMessage(defaultErrorMessage);
             }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/deb.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/deb.factory.js
@@ -8,10 +8,10 @@
      * @description
      *   Provides a BastionResource for interacting with deb Packages
      */
-    function Deb(BastionResource) {
+    function Deb(BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/debs/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -23,6 +23,6 @@
         .module('Bastion.debs')
         .factory('Deb', Deb);
 
-    Deb.$inject = ['BastionResource'];
+    Deb.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-list.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-list.factory.js
@@ -8,9 +8,9 @@
      * @description
      *   Provides a BastionResource for interacting with Docker Manifest Lists
      */
-    function DockerManifestList(BastionResource) {
+    function DockerManifestList(BastionResource, CurrentOrganization) {
         return BastionResource('katello/api/v2/docker_manifest_lists/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -21,6 +21,6 @@
         .module('Bastion.docker-manifest-lists')
         .factory('DockerManifestList', DockerManifestList);
 
-    DockerManifestList.$inject = ['BastionResource'];
+    DockerManifestList.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
@@ -8,9 +8,9 @@
      * @description
      *   Provides a BastionResource for interacting with Docker Manifests
      */
-    function DockerManifest(BastionResource) {
+    function DockerManifest(BastionResource, CurrentOrganization) {
         return BastionResource('katello/api/v2/docker_manifests/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -21,6 +21,6 @@
         .module('Bastion.docker-manifests')
         .factory('DockerManifest', DockerManifest);
 
-    DockerManifest.$inject = ['BastionResource'];
+    DockerManifest.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
@@ -8,10 +8,10 @@
  *   Provides a BastionResource for Docker Tags
  */
 angular.module('Bastion.docker-tags').factory('DockerTag',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/docker_tags/:id/',
-            {id: '@id'},
+            {id: '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 'autocompleteName': {method: 'GET', isArray: false, params: {id: 'auto_complete_name'},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
@@ -8,10 +8,10 @@
  *   Provides a BastionResource for Errata
  */
 angular.module('Bastion.errata').factory('Erratum',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/errata/:id/',
-            {id: '@id', 'sort_by': 'issued', 'sort_order': 'DESC'},
+            {id: '@id', 'organization_id': CurrentOrganization, 'sort_by': 'issued', 'sort_order': 'DESC'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 applicableContentHosts: {method: 'GET', transformResponse: function (data) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/file.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/file.factory.js
@@ -8,10 +8,10 @@
      * @description
      *   Provides a BastionResource for interacting with Files
      */
-    function File(BastionResource) {
+    function File(BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/files/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -23,6 +23,6 @@
         .module('Bastion.files')
         .factory('File', File);
 
-    File.$inject = ['BastionResource'];
+    File.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
@@ -8,9 +8,9 @@
  *   Provides a BastionResource for host collections.
  */
 angular.module('Bastion.host-collections').factory('HostCollection',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('katello/api/v2/host_collections/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/v2/host_collections/:id/:action', {id: '@id', 'organization_id': CurrentOrganization}, {
             get: {method: 'GET', params: {fields: 'full'}},
             update: {method: 'PUT'},
             copy: {method: 'POST', params: {action: 'copy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/module-streams/module-stream.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/module-streams/module-stream.factory.js
@@ -8,9 +8,9 @@
      * @description
      *   Provides a BastionResource for interacting with Ostree Branches
      */
-    function ModuleStream(BastionResource) {
+    function ModuleStream(BastionResource, CurrentOrganization) {
         return BastionResource('katello/api/v2/module_streams/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -22,6 +22,6 @@
         .module('Bastion.module-streams')
         .factory('ModuleStream', ModuleStream);
 
-    ModuleStream.$inject = ['BastionResource'];
+    ModuleStream.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
@@ -8,9 +8,9 @@
      * @description
      *   Provides a BastionResource for interacting with Package Groups
      */
-    function PackageGroup(BastionResource) {
+    function PackageGroup(BastionResource, CurrentOrganization) {
         return BastionResource('katello/api/v2/package_groups/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
               autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
             }
@@ -21,6 +21,6 @@
         .module('Bastion.package-groups')
         .factory('PackageGroup', PackageGroup);
 
-    PackageGroup.$inject = ['BastionResource'];
+    PackageGroup.$inject = ['BastionResource', 'CurrentOrganization'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
@@ -8,10 +8,10 @@
  *   Provides a BastionResource for product or list of providers.
  */
 angular.module('Bastion.packages').factory('Package',
-    ['BastionResource', 'CurrentOrganization', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/packages/:id',
-            {'id': '@id'},
+            {'id': '@id', 'organization_id': CurrentOrganization},
             {
                 'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 'autocompleteName': {method: 'GET', isArray: false, params: {id: 'auto_complete_name'},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.products').factory('Product',
     ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('katello/api/v2/organizations/:organizationId/products/:id/:action', {id: '@id', organizationId: CurrentOrganization}, {
+        return BastionResource('katello/api/v2/products/:id/:action', {id: '@id', 'organization_id': CurrentOrganization}, {
             update: { method: 'PUT'},
             sync: { method: 'POST', params: { action: 'sync' }},
             updateSyncPlan: { method: 'POST', params: { action: 'sync_plan' }},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
@@ -8,9 +8,9 @@
  *   Provides a BastionResource for product or list of products.
  */
 angular.module('Bastion.products').factory('Product',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('katello/api/v2/products/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/v2/organizations/:organizationId/products/:id/:action', {id: '@id', organizationId: CurrentOrganization}, {
             update: { method: 'PUT'},
             sync: { method: 'POST', params: { action: 'sync' }},
             updateSyncPlan: { method: 'POST', params: { action: 'sync_plan' }},

--- a/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
+++ b/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
@@ -35,16 +35,16 @@ describe('Factory: ActivationKey', function() {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('ActivationKey.get GET /api/v2/activation_keys/1?fields=full', function() {
-        $httpBackend.expectGET('katello/api/v2/activation_keys/1?fields=full').respond(activationKeys.results[0]);
+    it('ActivationKey.get GET /api/v2/activation_keys/1?fields=full&organization_id=ACME', function() {
+        $httpBackend.expectGET('katello/api/v2/activation_keys/1?fields=full&organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.get({id: 1}, function(response) {
             expect(response.id).toBe(activationKeys.results[0].id);
         });
     });
 
-    it('ActivationKey.query GET /api/v2/activation_keys', function() {
-        $httpBackend.expectGET('katello/api/v2/activation_keys').respond(activationKeys);
+    it('ActivationKey.query GET /api/v2/activation_keys?organization_id=ACME', function() {
+        $httpBackend.expectGET('katello/api/v2/activation_keys?organization_id=ACME').respond(activationKeys);
 
         ActivationKey.queryPaged(function(response) {
             expect(response.results.length).toBe(activationKeys.results.length);
@@ -55,64 +55,64 @@ describe('Factory: ActivationKey', function() {
         });
     });
 
-    it('ActivationKey.update PUT /api/v2/activation_keys/1', function() {
-        $httpBackend.expectPUT('katello/api/v2/activation_keys/1').respond(activationKeys.results[0]);
+    it('ActivationKey.update PUT /api/v2/activation_keys/1?organization_id=ACME', function() {
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.update({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.copy POST /api/v2/activation_keys/1/copy', function() {
-        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/copy').respond(activationKeys.results[0]);
+    it('ActivationKey.copy POST /api/v2/activation_keys/1/copy?organization_id=ACME', function() {
+        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/copy?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.copy({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.removeSubscriptions PUT /api/v2/activation_keys/1/remove_subscriptions', function() {
-        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/remove_subscriptions').respond(activationKeys.results[0]);
+    it('ActivationKey.removeSubscriptions PUT /api/v2/activation_keys/1/remove_subscriptions?organization_id=ACME', function() {
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/remove_subscriptions?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.removeSubscriptions({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.addSubscriptions PUT /api/v2/activation_keys/1/add_subscriptions', function() {
-        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/add_subscriptions').respond(activationKeys.results[0]);
+    it('ActivationKey.addSubscriptions PUT /api/v2/activation_keys/1/add_subscriptions?organization_id=ACME', function() {
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/add_subscriptions?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.addSubscriptions({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.availableHostCollections GET /api/v2/activation_keys/1/host_collections/available', function() {
-        $httpBackend.expectGET('katello/api/v2/activation_keys/1/host_collections/available').respond(activationKeys.results[0]);
+    it('ActivationKey.availableHostCollections GET /api/v2/activation_keys/1/host_collections/available?organization_id=ACME', function() {
+        $httpBackend.expectGET('katello/api/v2/activation_keys/1/host_collections/available?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.availableHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.removeHostCollections PUT /api/v2/activation_keys/1/host_collections', function() {
-        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
+    it('ActivationKey.removeHostCollections PUT /api/v2/activation_keys/1/host_collections?organization_id=ACME', function() {
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/host_collections?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.removeHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.addHostCollections POST /api/v2/activation_keys/1/host_collections', function() {
-        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
+    it('ActivationKey.addHostCollections POST /api/v2/activation_keys/1/host_collections?organization_id=ACME', function() {
+        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/host_collections?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.addHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
         });
     });
 
-    it('ActivationKey.contentOverride PUT /api/v2/activation_keys/1/content_override', function() {
-        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/content_override').respond(activationKeys.results[0]);
+    it('ActivationKey.contentOverride PUT /api/v2/activation_keys/1/content_override?organization_id=ACME', function() {
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/content_override?organization_id=ACME').respond(activationKeys.results[0]);
 
         ActivationKey.contentOverride({id: 1},
                         {'content_override': { 'content_label': 'my-repository-label',

--- a/engines/bastion_katello/test/docker-manifest-lists/docker-manifest-list.factory.test.js
+++ b/engines/bastion_katello/test/docker-manifest-lists/docker-manifest-list.factory.test.js
@@ -25,8 +25,8 @@ describe('Factory: DockerManifestList', function () {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('katello/api/v2/docker_manifest_lists').respond(dockerManifestLists);
+    it('provides a way to get a list of docker manifest lists', function () {
+        $httpBackend.expectGET('katello/api/v2/docker_manifest_lists?organization_id=ACME').respond(dockerManifestLists);
 
         DockerManifestList.queryPaged(function (dockerManifestLists) {
             expect(dockerManifestLists.records.length).toBe(1);

--- a/engines/bastion_katello/test/docker-manifests/docker-manifest.factory.test.js
+++ b/engines/bastion_katello/test/docker-manifests/docker-manifest.factory.test.js
@@ -25,8 +25,8 @@ describe('Factory: DockerManifest', function () {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('katello/api/v2/docker_manifests').respond(dockerManifests);
+    it('provides a way to get a list of docker manifests', function () {
+        $httpBackend.expectGET('katello/api/v2/docker_manifests?organization_id=ACME').respond(dockerManifests);
 
         DockerManifest.queryPaged(function (dockerManifests) {
             expect(dockerManifests.records.length).toBe(1);

--- a/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
+++ b/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: DockerTag', function () {
     });
 
     it('provides a way to get a list of tags', function () {
-        $httpBackend.expectGET('katello/api/v2/docker_tags').respond(dockerTags);
+        $httpBackend.expectGET('katello/api/v2/docker_tags?organization_id=ACME').respond(dockerTags);
 
         DockerTag.queryPaged(function (dockerTags) {
             expect(dockerTags.records.length).toBe(1);

--- a/engines/bastion_katello/test/files/files.factory.test.js
+++ b/engines/bastion_katello/test/files/files.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: Files', function () {
     });
 
     it('provides a way to get a list of files', function () {
-        $httpBackend.expectGET('katello/api/v2/files').respond(files);
+        $httpBackend.expectGET('katello/api/v2/files?organization_id=ACME').respond(files);
 
         File.queryPaged(function (files) {
             expect(files.records.length).toBe(1);
@@ -34,7 +34,7 @@ describe('Factory: Files', function () {
     });
 
     it('provides a way to get autocompleted search terms for files', function () {
-        $httpBackend.expectGET('katello/api/v2/files/auto_complete_search').respond(files.records);
+        $httpBackend.expectGET('katello/api/v2/files/auto_complete_search?organization_id=ACME').respond(files.records);
 
         File.autocomplete(function (files) {
             expect(files.length).toBe(1);

--- a/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
+++ b/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
@@ -21,7 +21,7 @@ describe('Factory: HostCollection', function() {
     });
 
     it('makes a request to get the host collection list from the API.', function() {
-        $httpBackend.expectGET('katello/api/v2/host_collections').respond(hostCollections);
+        $httpBackend.expectGET('katello/api/v2/host_collections?organization_id=ACME').respond(hostCollections);
 
         HostCollection.queryPaged(function(response) {
             expect(response.results.length).toBe(hostCollections.results.length);
@@ -36,7 +36,7 @@ describe('Factory: HostCollection', function() {
         var hostCollection = hostCollections.results[0];
 
         hostCollection.name = 'NewName';
-        $httpBackend.expectPUT('katello/api/v2/host_collections/0').respond(hostCollection);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0?organization_id=ACME').respond(hostCollection);
 
         HostCollection.update({name: hostCollection.name, id: 0}, function(response) {
             expect(response).toBeDefined();
@@ -46,7 +46,7 @@ describe('Factory: HostCollection', function() {
 
     it('provides a way to add hosts', function() {
         var hosts = {test: 'this'};
-        $httpBackend.expectPUT('katello/api/v2/host_collections/0/add_hosts').respond(hosts);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0/add_hosts?organization_id=ACME').respond(hosts);
         HostCollection.addHosts({'host_collection': {'host_ids': [1,2]} , id: 0}, function(response) {
             expect(response.test).toBe('this');
         });
@@ -54,7 +54,7 @@ describe('Factory: HostCollection', function() {
 
     it('provides a way to remove hosts', function() {
         var hosts = {test: 'this'};
-        $httpBackend.expectPUT('katello/api/v2/host_collections/0/remove_hosts').respond(hosts);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0/remove_hosts?organization_id=ACME').respond(hosts);
         HostCollection.removeHosts({'host_collection': {'host_ids': [1,2]} , id: 0}, function(response) {
             expect(response.test).toBe('this');
         });

--- a/engines/bastion_katello/test/module-streams/module-stream.factory.test.js
+++ b/engines/bastion_katello/test/module-streams/module-stream.factory.test.js
@@ -25,8 +25,8 @@ describe('Factory: ModuleStream', function () {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('katello/api/v2/module_streams').respond(moduleStreams);
+    it('provides a way to get a list of module streams', function () {
+        $httpBackend.expectGET('katello/api/v2/module_streams?organization_id=ACME').respond(moduleStreams);
 
         ModuleStream.queryPaged(function (moduleStreams) {
             expect(moduleStreams.records.length).toBe(1);

--- a/engines/bastion_katello/test/package-groups/package-group.factory.test.js
+++ b/engines/bastion_katello/test/package-groups/package-group.factory.test.js
@@ -25,8 +25,8 @@ describe('Factory: PackageGroup', function () {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-    it('provides a way to get a list of repositorys', function () {
-        $httpBackend.expectGET('katello/api/v2/package_groups').respond(packageGroups);
+    it('provides a way to get a list of package groups', function () {
+        $httpBackend.expectGET('katello/api/v2/package_groups?organization_id=ACME').respond(packageGroups);
 
         PackageGroup.queryPaged(function (packageGroups) {
             expect(packageGroups.records.length).toBe(1);

--- a/engines/bastion_katello/test/products/product.factory.test.js
+++ b/engines/bastion_katello/test/products/product.factory.test.js
@@ -29,7 +29,7 @@ describe('Factory: Product', function() {
     });
 
     it('provides a way to get a list of products', function() {
-        $httpBackend.expectGET('katello/api/v2/products').respond(products);
+        $httpBackend.expectGET('katello/api/v2/products?organization_id=ACME').respond(products);
 
         Product.queryPaged(function(products) {
             expect(products.records.length).toBe(2);
@@ -40,7 +40,7 @@ describe('Factory: Product', function() {
         var updatedProduct = products.records[0];
 
         updatedProduct.name = 'NewProductName';
-        $httpBackend.expectPUT('katello/api/v2/products/1').respond(updatedProduct);
+        $httpBackend.expectPUT('katello/api/v2/products/1?organization_id=ACME').respond(updatedProduct);
 
         Product.update({ id: 1 }, function(product) {
             expect(product).toBeDefined();
@@ -49,7 +49,7 @@ describe('Factory: Product', function() {
     });
 
     it('provides a way to sync a product', function() {
-        $httpBackend.expectPOST('katello/api/v2/products/1/sync').respond(products[0]);
+        $httpBackend.expectPOST('katello/api/v2/products/1/sync?organization_id=ACME').respond(products[0]);
 
         Product.sync({ id: 1 });
     });
@@ -58,7 +58,7 @@ describe('Factory: Product', function() {
         var updatedProduct = products.records[0];
 
         updatedProduct.sync_plan_id = 2;
-        $httpBackend.expectPOST('katello/api/v2/products/1/sync_plan').respond(updatedProduct);
+        $httpBackend.expectPOST('katello/api/v2/products/1/sync_plan?organization_id=ACME').respond(updatedProduct);
 
         Product.updateSyncPlan({ id: 1, plan_id: 2 }, function(product) {
             expect(product).toBeDefined();

--- a/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
+++ b/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
@@ -1,4 +1,4 @@
-import api from '../../../services/api';
+import api, {orgId} from '../../../services/api';
 import {
   ANSIBLE_COLLECTION_DETAILS_ERROR,
   ANSIBLE_COLLECTION_DETAILS_REQUEST,
@@ -10,7 +10,7 @@ export const getAnsibleCollectionDetails = ansibleCollectionId => async (dispatc
   dispatch({ type: ANSIBLE_COLLECTION_DETAILS_REQUEST });
 
   try {
-    const { data } = await api.get(`/ansible_collections/${ansibleCollectionId}`);
+    const { data } = await api.get(`/ansible_collections/${ansibleCollectionId}`, {}, {organization_id: orgId()});
     return dispatch({
       type: ANSIBLE_COLLECTION_DETAILS_SUCCESS,
       response: data,

--- a/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
+++ b/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
@@ -1,4 +1,4 @@
-import api, {orgId} from '../../../services/api';
+import api, { orgId } from '../../../services/api';
 import {
   ANSIBLE_COLLECTION_DETAILS_ERROR,
   ANSIBLE_COLLECTION_DETAILS_REQUEST,
@@ -10,7 +10,7 @@ export const getAnsibleCollectionDetails = ansibleCollectionId => async (dispatc
   dispatch({ type: ANSIBLE_COLLECTION_DETAILS_REQUEST });
 
   try {
-    const { data } = await api.get(`/ansible_collections/${ansibleCollectionId}`, {}, {organization_id: orgId()});
+    const { data } = await api.get(`/ansible_collections/${ansibleCollectionId}`, {}, { organization_id: orgId() });
     return dispatch({
       type: ANSIBLE_COLLECTION_DETAILS_SUCCESS,
       response: data,

--- a/webpack/scenes/AnsibleCollections/Details/__tests__/__snapshots__/AnsibleCollectionDetailsActions.test.js.snap
+++ b/webpack/scenes/AnsibleCollections/Details/__tests__/__snapshots__/AnsibleCollectionDetailsActions.test.js.snap
@@ -36,6 +36,10 @@ exports[`Ansible Collection details actions should load ansible collection detai
 Array [
   Array [
     "/ansible_collections/1",
+    Object {},
+    Object {
+      "organization_id": undefined,
+    },
   ],
 ]
 `;

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
@@ -1,4 +1,4 @@
-import api from '../../../services/api';
+import api, {orgId} from '../../../services/api';
 import {
   MODULE_STREAM_DETAILS_REQUEST,
   MODULE_STREAM_DETAILS_SUCCESS,
@@ -10,7 +10,7 @@ export const loadModuleStreamDetails = moduleStreamId => async (dispatch) => {
   dispatch({ type: MODULE_STREAM_DETAILS_REQUEST });
 
   try {
-    const { data } = await api.get(`/module_streams/${moduleStreamId}`);
+    const { data } = await api.get(`/module_streams/${moduleStreamId}`,{}, {organization_id: orgId()});
     return dispatch({
       type: MODULE_STREAM_DETAILS_SUCCESS,
       response: data,

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
@@ -1,4 +1,4 @@
-import api, {orgId} from '../../../services/api';
+import api, { orgId } from '../../../services/api';
 import {
   MODULE_STREAM_DETAILS_REQUEST,
   MODULE_STREAM_DETAILS_SUCCESS,
@@ -10,7 +10,7 @@ export const loadModuleStreamDetails = moduleStreamId => async (dispatch) => {
   dispatch({ type: MODULE_STREAM_DETAILS_REQUEST });
 
   try {
-    const { data } = await api.get(`/module_streams/${moduleStreamId}`,{}, {organization_id: orgId()});
+    const { data } = await api.get(`/module_streams/${moduleStreamId}`, {}, { organization_id: orgId() });
     return dispatch({
       type: MODULE_STREAM_DETAILS_SUCCESS,
       response: data,

--- a/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetailsActions.test.js.snap
+++ b/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetailsActions.test.js.snap
@@ -139,6 +139,10 @@ exports[`Module stream details actions should load module stream details on succ
 Array [
   Array [
     "/module_streams/1",
+    Object {},
+    Object {
+      "organization_id": undefined,
+    },
   ],
 ]
 `;


### PR DESCRIPTION
- [x] Add to other pages that need this.

**Steps to reproduce:**
1. Create a sync plan/product/activation-key etc under org1
2. Go to details page of the created resource
3. Change organization to a different organization.
4. User able to see the resource. You can also see the resource if you directly go to the record URL with it's id.

**Proposed Approach:**
Show a warning notification in this case - when user has access to the record but is in a different org that the record belongs to.

![4885381395513344](https://user-images.githubusercontent.com/21146741/76864771-0cc64880-6838-11ea-8c84-f504f6253c14.png)
