### PR TITLE
Fixes #29376 - Use Authorizable on Pools

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -75,10 +75,13 @@ module Katello
     param :id, :number, :desc => N_("Subscription identifier"), :required => true
     def show
       @resource = Katello::Pool.with_identifier(params[:id])
-      fail ActiveRecord::RecordNotFound, N_('Subscription not found') unless @resource
-      unless @resource.readable?
-        fail ActiveRecord::RecordNotFound, N_('This subscription is not relevant to the current user and organization.')
+
+      fail ActiveRecord::RecordNotFound, N_('Subscription not found') unless @resource&.readable?
+
+      if params[:organization_id] && @resource.organization_id != params[:organization_id].to_i
+        fail HttpErrors::BadRequest, N_('This subscription is not relevant to the current organization.')
       end
+
       respond(:resource => @resource)
     end
 

--- a/app/models/katello/authorization/pool.rb
+++ b/app/models/katello/authorization/pool.rb
@@ -2,13 +2,17 @@ module Katello
   module Authorization::Pool
     extend ActiveSupport::Concern
 
+    include Authorizable
+
     def readable?
       self.class.readable.where(id: self.id).any?
     end
 
     module ClassMethods
       def readable
-        where(:subscription_id => Katello::Subscription.readable)
+        relation = joins_authorized(Katello::Subscription, :view_subscriptions)
+        relation = relation.where(organization_id: User.current.organization_ids) unless User.current.admin?
+        relation
       end
     end
   end

--- a/app/models/katello/authorization/subscription.rb
+++ b/app/models/katello/authorization/subscription.rb
@@ -10,9 +10,7 @@ module Katello
 
     module ClassMethods
       def readable
-        return all if User.current.admin?
-
-        authorized(:view_subscriptions).where(organization_id: User.current.organization_ids)
+        authorized(:view_subscriptions)
       end
     end
   end


### PR DESCRIPTION
This PR fixes a problem where users with the view_subscriptions permission could not view subscriptions via API (/api/v2/subscriptions). I haven't been able to come up with my own reproducer but I patched an affected system with this change and things work. I think the key is in `joins_authorized`.

I think this regressed in a recent change to the permissions in SubscriptionsController#show and I also cleaned up some of the messaging there to match what I think is now more appropriate.

Here's how the queries to load subscriptions has changed (improved)

Before:

```
irb(main):001:0> User.current.admin?
=> true
irb(main):002:0> Katello::Pool.readable.to_sql
=> "SELECT \"katello_pools\".* FROM \"katello_pools\" WHERE \"katello_pools\".\"subscription_id\" IN (SELECT \"katello_subscriptions\".\"id\" FROM \"katello_subscriptions\")"

irb(main):003:0> User.current = User.find(9) #nonadmin
=> "SELECT \"katello_pools\".* FROM \"katello_pools\" WHERE \"katello_pools\".\"subscription_id\" IN (SELECT \"katello_subscriptions\".\"id\" FROM \"katello_subscriptions\" WHERE \"katello_subscriptions\".\"organization_id\" = 14)"
```

After:
```
irb(main):010:0> User.current.admin?
=> true
irb(main):011:0> Katello::Pool.readable.to_sql
=> "SELECT \"katello_pools\".* FROM \"katello_pools\" INNER JOIN \"katello_subscriptions\" ON \"katello_subscriptions\".\"id\" = \"katello_pools\".\"subscription_id\" WHERE (1=1)"


irb(main):012:0> User.current = User.find(9) #nonadmin
irb(main):013:0> Katello::Pool.readable.to_sql
=> "SELECT \"katello_pools\".* FROM \"katello_pools\" INNER JOIN \"katello_subscriptions\" ON \"katello_subscriptions\".\"id\" = \"katello_pools\".\"subscription_id\" WHERE \"katello_pools\".\"organization_id\" = 14"
```
