### PR TITLE
Fixes #29098 - Katello Applicability config and generation w/ RPMs and Errata

### DIFF
--- a/app/lib/actions/katello/applicability/host/generate.rb
+++ b/app/lib/actions/katello/applicability/host/generate.rb
@@ -1,0 +1,28 @@
+module Actions
+  module Katello
+    module Applicability
+      module Host
+        class Generate < Actions::EntryAction
+          # This should be run through Katello::Events::GenerateHostApplicability
+
+          input_format do
+            param :host_id, Integer
+          end
+
+          def run
+            content_facet = ::Host.find(input[:host_id]).content_facet
+            content_facet.calculate_and_import_applicability
+          end
+
+          def resource_locks
+            :link
+          end
+
+          def humanized_name
+            _("Generate host applicability")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/applicability/hosts/generate.rb
+++ b/app/lib/actions/katello/applicability/hosts/generate.rb
@@ -1,0 +1,23 @@
+module Actions
+  module Katello
+    module Applicability
+      module Hosts
+        class Generate < Actions::EntryAction
+          input_format do
+            param :host_ids, Array
+          end
+
+          def run
+            input[:host_ids].each do |host_id|
+              ::Katello::EventQueue.push_event(::Katello::Events::GenerateHostApplicability::EVENT_TYPE, host_id)
+            end
+          end
+
+          def humanized_name
+            _("Bulk generate applicability for hosts")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/applicability/repository/regenerate.rb
+++ b/app/lib/actions/katello/applicability/repository/regenerate.rb
@@ -1,0 +1,26 @@
+module Actions
+  module Katello
+    module Applicability
+      module Repository
+        class Regenerate < Actions::EntryAction
+          middleware.use Actions::Middleware::ExecuteIfContentsChanged
+
+          input_format do
+            param :repo_id, Integer
+            param :contents_changed
+          end
+
+          def run
+            ::Katello::Repository.find(input[:repo_id]).content_facets.each do |facet|
+              ::Katello::EventQueue.push_event(::Katello::Events::GenerateHostApplicability::EVENT_TYPE, facet.host.id)
+            end
+          end
+
+          def humanized_name
+            _("Generate repository applicability")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/events/generate_host_applicability.rb
+++ b/app/models/katello/events/generate_host_applicability.rb
@@ -1,0 +1,27 @@
+module Katello
+  module Events
+    class GenerateHostApplicability
+      EVENT_TYPE = 'generate_host_applicability'.freeze
+
+      def self.retry_seconds
+        180
+      end
+
+      def initialize(host_id)
+        @host = ::Host.find_by_id(host_id)
+        Rails.logger.warn "Host not found for ID #{object_id}" if @host.nil?
+      end
+
+      def run
+        return unless @host
+
+        begin
+          ForemanTasks.async_task(::Actions::Katello::Applicability::Host::Generate, host_id: @host.id)
+        rescue => e
+          self.retry = true if e.is_a?(ForemanTasks::Lock::LockConflict)
+          raise e
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -1,0 +1,97 @@
+module Katello
+  module Applicability
+    class ApplicableContentHelper
+      attr_accessor :content_facet, :content_unit_class, :bound_library_instance_repos
+
+      def initialize(content_facet, content_unit_class, bound_library_instance_repos)
+        self.content_facet = content_facet
+        self.content_unit_class = content_unit_class
+        self.bound_library_instance_repos = bound_library_instance_repos
+      end
+
+      def calculate_and_import
+        if self.bound_library_instance_repos.any?
+          to_add, to_remove = applicable_differences
+          ActiveRecord::Base.transaction do
+            insert(to_add) unless to_add.blank?
+            remove(to_remove) unless to_remove.blank?
+          end
+        end
+      end
+
+      def fetch_content_ids
+        if self.content_unit_class == ::Katello::Erratum
+          # Query for all Errata ids that are attached to the host's applicable packages
+          query = 'select katello_repository_errata.erratum_id as id from katello_repository_errata
+                       inner join katello_erratum_packages
+                          on  katello_repository_errata.erratum_id  = katello_erratum_packages.erratum_id
+                       inner join katello_rpms
+                          on katello_rpms.nvra = katello_erratum_packages.nvrea
+                       inner join katello_content_facet_applicable_rpms on
+                           katello_content_facet_applicable_rpms.rpm_id = katello_rpms.id
+                       where
+                            "katello_content_facet_applicable_rpms"."content_facet_id" = :content_facet_id
+                       AND katello_repository_errata.repository_id IN (:repo_ids)'
+
+          return Katello::Erratum.find_by_sql([query, {content_facet_id: content_facet.id, repo_ids: self.bound_library_instance_repos} ]).map(&:id).uniq
+        elsif self.content_unit_class == ::Katello::ModuleStream
+          fail NotImplementedError
+        else
+          # Query for applicable RPM ids
+          return ::Katello::Rpm.joins("INNER JOIN katello_repository_rpms ON \
+                                      katello_rpms.id = katello_repository_rpms.rpm_id").
+                                      joins("INNER JOIN katello_installed_packages ON \
+                                            katello_rpms.name = katello_installed_packages.name AND \
+                                            katello_rpms.arch = katello_installed_packages.arch AND \
+                                            katello_rpms.evr > katello_installed_packages.evr").
+                                            joins("INNER JOIN katello_host_installed_packages ON \
+                                                  katello_installed_packages.id = \
+                                                  katello_host_installed_packages.installed_package_id WHERE \
+                                                  katello_repository_rpms.repository_id in \
+                                                  (#{self.bound_library_instance_repos.join(',')}) \
+                                                  and katello_host_installed_packages.host_id = \
+                                                  #{self.content_facet.host.id}").pluck(:id).uniq
+        end
+      end
+
+      def applicable_differences
+        consumer_ids = content_facet.send(applicable_units).pluck("#{content_unit_class.table_name}.id")
+        content_ids = fetch_content_ids
+
+        to_remove = consumer_ids - content_ids
+        to_add = content_ids - consumer_ids
+
+        [to_add, to_remove]
+      end
+
+      def insert(applicable_ids)
+        unless applicable_ids.empty?
+          inserts = applicable_ids.map { |applicable_id| "(#{applicable_id.to_i}, #{content_facet.id.to_i})" }
+          sql = "INSERT INTO #{content_facet_association_class.table_name} (#{content_unit_association_id}, content_facet_id) VALUES #{inserts.join(', ')}"
+          ActiveRecord::Base.connection.execute(sql)
+        end
+      end
+
+      def remove(applicable_ids)
+        content_facet_association_class.where(:content_facet_id => content_facet.id, content_unit_association_id => applicable_ids).delete_all
+      end
+
+      def content_unit_association_id
+        "#{content_unit_class.name.demodulize.underscore}_id".to_sym
+      end
+
+      def content_facet_association_class
+        # Example: ContentFacetErratum
+        self.content_unit_class.content_facet_association_class
+      end
+
+      def content_units
+        content_unit_class.name.demodulize.pluralize.underscore.to_sym
+      end
+
+      def applicable_units
+        "applicable_#{content_units}".to_sym
+      end
+    end
+  end
+end

--- a/config/initializers/monkeys.rb
+++ b/config/initializers/monkeys.rb
@@ -1,3 +1,5 @@
 #place where monkey patches are required
 require 'monkeys/passenger_tee_input'
 require 'monkeys/anemone'
+require 'monkeys/ar_postgres_evr_t'
+require 'monkeys/fx_sqlite_skip'

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -79,6 +79,10 @@
 #    :file:                     <true/false>
 #    :yum:                      <true/false>
 
+# Applicability can be calculated by Katello or Pulp 2.
+# Default is Pulp 2 (false).
+#  :katello_applicability: <true/false>
+
 # Logging configuration can be changed by uncommenting the loggers
 # section and the logger configuration desired.
 #

--- a/db/functions/empty_v01.sql
+++ b/db/functions/empty_v01.sql
@@ -1,0 +1,7 @@
+create or replace FUNCTION empty(t TEXT)
+	RETURNS BOOLEAN as $$
+	BEGIN
+		return t ~ '^[[:space:]]*$';
+	END;
+$$ language 'plpgsql';
+

--- a/db/functions/evr_trigger_v01.sql
+++ b/db/functions/evr_trigger_v01.sql
@@ -1,0 +1,9 @@
+CREATE FUNCTION evr_trigger() RETURNS trigger AS $$
+  BEGIN
+    NEW.evr = (select ROW(coalesce(NEW.epoch::numeric,0),
+                          rpmver_array(coalesce(NEW.version,'empty'))::evr_array_item[],
+                          rpmver_array(coalesce(NEW.release,'empty'))::evr_array_item[])::evr_t);
+    RETURN NEW;
+  END;
+$$ language 'plpgsql';
+

--- a/db/functions/isalpha_v01.sql
+++ b/db/functions/isalpha_v01.sql
@@ -1,0 +1,11 @@
+create or replace FUNCTION isalpha(ch CHAR)
+  RETURNS BOOLEAN as $$
+  BEGIN
+    if ascii(ch) between ascii('a') and ascii('z') or
+        ascii(ch) between ascii('A') and ascii('Z')
+    then
+      return TRUE;
+    end if;
+    return FALSE;
+  END;
+$$ language 'plpgsql';

--- a/db/functions/isalphanum_v01.sql
+++ b/db/functions/isalphanum_v01.sql
@@ -1,0 +1,12 @@
+create or replace FUNCTION isalphanum(ch CHAR)
+	RETURNS BOOLEAN as $$
+	BEGIN
+		if ascii(ch) between ascii('a') and ascii('z') or
+			ascii(ch) between ascii('A') and ascii('Z') or
+			ascii(ch) between ascii('0') and ascii('9')
+		then
+			return TRUE;
+		end if;
+		return FALSE;
+	END;
+$$ language 'plpgsql';

--- a/db/functions/isdigit_v01.sql
+++ b/db/functions/isdigit_v01.sql
@@ -1,0 +1,10 @@
+create or replace function isdigit(ch CHAR)
+	RETURNS BOOLEAN as $$
+	BEGIN
+	  if ascii(ch) between ascii('0') and ascii('9')
+	  then
+		return TRUE;
+	  end if;
+	  return FALSE;
+	END ;
+$$ language 'plpgsql';

--- a/db/functions/rpmver_array_v01.sql
+++ b/db/functions/rpmver_array_v01.sql
@@ -1,0 +1,60 @@
+create or replace FUNCTION rpmver_array (string1 IN VARCHAR)
+	RETURNS evr_array_item[] as $$
+	declare
+		str1 VARCHAR := string1;
+		digits VARCHAR(10) := '0123456789';
+		lc_alpha VARCHAR(27) := 'abcdefghijklmnopqrstuvwxyz';
+		uc_alpha VARCHAR(27) := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		alpha VARCHAR(54) := lc_alpha || uc_alpha;
+		one VARCHAR;
+		isnum BOOLEAN;
+		ver_array evr_array_item[] := ARRAY[]::evr_array_item[];
+	BEGIN
+		if str1 is NULL
+		then
+			RAISE EXCEPTION 'VALUE_ERROR.';
+		end if;
+
+		one := str1;
+		<<segment_loop>>
+		while one <> ''
+		loop
+			declare
+				segm1 VARCHAR;
+				segm1_n NUMERIC := 0;
+			begin
+				-- Throw out all non-alphanum characters
+				while one <> '' and not isalphanum(one)
+				loop
+					one := substr(one, 2);
+				end loop;
+				str1 := one;
+				if str1 <> '' and isdigit(str1)
+				then
+					str1 := ltrim(str1, digits);
+					isnum := true;
+				else
+					str1 := ltrim(str1, alpha);
+					isnum := false;
+				end if;
+				if str1 <> ''
+				then segm1 := substr(one, 1, length(one) - length(str1));
+				else segm1 := one;
+				end if;
+
+				if segm1 = '' then return ver_array; end if; /* arbitrary */
+				if isnum
+				then
+					segm1 := ltrim(segm1, '0');
+					if segm1 <> '' then segm1_n := segm1::numeric; end if;
+					segm1 := NULL;
+				else
+				end if;
+				ver_array := array_append(ver_array, (segm1_n, segm1)::evr_array_item);
+				one := str1;
+			end;
+		end loop segment_loop;
+
+		return ver_array;
+	END ;
+$$ language 'plpgsql';

--- a/db/migrate/20200213184848_create_evr_type.rb
+++ b/db/migrate/20200213184848_create_evr_type.rb
@@ -1,0 +1,49 @@
+require 'fx'
+
+class CreateEvrType < ActiveRecord::Migration[5.2]
+  def up
+    unless connection.adapter_name.downcase.include?('sqlite')
+
+      enable_extension "evr"
+
+      add_column :katello_rpms, :evr, :evr_t
+      add_column :katello_installed_packages, :evr, :evr_t
+
+      create_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
+      create_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
+      create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
+      create_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
+
+      execute <<-SQL
+        update katello_rpms SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+
+        update katello_installed_packages SET evr = (ROW(coalesce(epoch::numeric,0),
+                                                         rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                                         rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+
+      add_index :katello_rpms, [:name, :arch, :evr]
+      add_index :katello_erratum_packages, [:erratum_id, :nvrea]
+    end
+  end
+
+  def down
+    # fx doesn't seem to have support for dropping functions with parameters
+    unless connection.adapter_name.downcase.include?('sqlite')
+      remove_index :katello_rpms, column: [:name, :arch, :evr]
+      remove_index :katello_erratum_packages, column: [:erratum_id, :nvrea]
+
+      drop_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
+      drop_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
+      drop_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
+      drop_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
+
+      remove_column :katello_rpms, :evr
+      remove_column :katello_installed_packages, :evr
+
+      disable_extension "evr"
+    end
+  end
+end

--- a/db/triggers/evr_insert_trigger_katello_installed_packages_v01.sql
+++ b/db/triggers/evr_insert_trigger_katello_installed_packages_v01.sql
@@ -1,0 +1,5 @@
+CREATE TRIGGER evr_insert_trigger_katello_installed_packages
+  BEFORE INSERT
+  ON katello_installed_packages
+  FOR EACH ROW
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_insert_trigger_katello_rpms_v01.sql
+++ b/db/triggers/evr_insert_trigger_katello_rpms_v01.sql
@@ -1,0 +1,5 @@
+CREATE TRIGGER evr_insert_trigger_katello_rpms
+  BEFORE INSERT
+  ON katello_rpms
+  FOR EACH ROW
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_update_trigger_katello_installed_packages_v01.sql
+++ b/db/triggers/evr_update_trigger_katello_installed_packages_v01.sql
@@ -1,0 +1,10 @@
+CREATE TRIGGER evr_update_trigger_katello_installed_packages
+  BEFORE UPDATE OF epoch, version, release
+  ON katello_installed_packages
+  FOR EACH ROW
+  WHEN (
+    OLD.epoch IS DISTINCT FROM NEW.epoch OR
+    OLD.version IS DISTINCT FROM NEW.version OR
+    OLD.release IS DISTINCT FROM NEW.release
+  )
+  EXECUTE PROCEDURE evr_trigger();

--- a/db/triggers/evr_update_trigger_katello_rpms_v01.sql
+++ b/db/triggers/evr_update_trigger_katello_rpms_v01.sql
@@ -1,0 +1,10 @@
+CREATE TRIGGER evr_update_trigger_katello_rpms
+  BEFORE UPDATE OF epoch, version, release
+  ON katello_rpms
+  FOR EACH ROW
+  WHEN (
+    OLD.epoch IS DISTINCT FROM NEW.epoch OR
+    OLD.version IS DISTINCT FROM NEW.version OR
+    OLD.release IS DISTINCT FROM NEW.release
+  )
+  EXECUTE PROCEDURE evr_trigger();

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gettext_i18n_rails"
   gem.add_dependency "apipie-rails", ">= 0.5.14"
 
+  gem.add_dependency "fx", "< 1.0"
+
   # Pulp
   gem.add_dependency "runcible", ">= 2.13.0", "< 3.0.0"
   gem.add_dependency "anemone"

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -1,3 +1,5 @@
+require 'fx'
+
 module Katello
   HOST_TASKS_QUEUE = :hosts_queue
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -227,6 +227,7 @@ module Katello
       Katello::EventQueue.register_event(Katello::Events::ImportHostApplicability::EVENT_TYPE, Katello::Events::ImportHostApplicability)
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
       Katello::EventQueue.register_event(Katello::Events::AutoPublishCompositeView::EVENT_TYPE, Katello::Events::AutoPublishCompositeView)
+      Katello::EventQueue.register_event(Katello::Events::GenerateHostApplicability::EVENT_TYPE, Katello::Events::GenerateHostApplicability)
 
       Katello::EventDaemon.initialize
     end

--- a/lib/monkeys/ar_postgres_evr_t.rb
+++ b/lib/monkeys/ar_postgres_evr_t.rb
@@ -1,0 +1,24 @@
+if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  module PostgreSQLAdapterExtensions
+    private
+
+    def get_oid_type(oid, fmod, column_name, sql_type = "".freeze)
+      if type_map.instance_variable_get(:@mapping)["evr_t"].nil?
+        type_map.register_type "evr_t", ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::EvrT.new
+      end
+      super
+    end
+  end
+  module ActiveRecord
+    module ConnectionAdapters
+      module PostgreSQL
+        module OID # :nodoc:
+          class EvrT < Type::String; end # :nodoc:
+        end
+      end
+      class PostgreSQLAdapter < AbstractAdapter
+        prepend PostgreSQLAdapterExtensions
+      end
+    end
+  end
+end

--- a/lib/monkeys/fx_sqlite_skip.rb
+++ b/lib/monkeys/fx_sqlite_skip.rb
@@ -1,0 +1,13 @@
+module Fx
+  module SchemaDumper
+    # @api private
+    module Trigger
+      def tables(stream)
+        unless ActiveRecord::Migration[5.2].connection.adapter_name.downcase.include?('sqlite')
+          super
+          triggers(stream)
+        end
+      end
+    end
+  end
+end

--- a/test/actions/katello/applicability/generate_applicability_test.rb
+++ b/test/actions/katello/applicability/generate_applicability_test.rb
@@ -1,0 +1,33 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::Applicability::Host
+  class GenerateApplicabilityTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    before :all do
+      User.current = users(:admin)
+      @host = FactoryBot.build(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                               :lifecycle_environment => katello_environments(:library))
+      SETTINGS[:katello][:katello_applicability] = true
+    end
+
+    after :all do
+      SETTINGS[:katello][:katello_applicability] = false
+    end
+
+    describe 'Host Generate Applicability using Katello Applicability' do
+      let(:action_class) { ::Actions::Katello::Host::GenerateApplicability }
+
+      it 'plans' do
+        action = create_action action_class
+
+        plan_action action, [@host]
+
+        assert_action_planed_with(action, Actions::Katello::Applicability::Hosts::Generate,
+                                         :host_ids => [@host.id])
+      end
+    end
+  end
+end

--- a/test/actions/katello/applicability/generate_host_list_applicability_test.rb
+++ b/test/actions/katello/applicability/generate_host_list_applicability_test.rb
@@ -1,0 +1,36 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::Applicability::Hosts
+  class GenerateTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    before :all do
+      User.current = users(:admin)
+      @host = FactoryBot.build(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                               :lifecycle_environment => katello_environments(:library))
+      @host.save!
+      SETTINGS[:katello][:katello_applicability] = true
+    end
+
+    after :all do
+      SETTINGS[:katello][:katello_applicability] = false
+    end
+
+    describe 'Host List Generate Applicability using Katello Applicability' do
+      let(:action_class) { ::Actions::Katello::Applicability::Hosts::Generate }
+
+      it 'plans' do
+        action = create_action action_class
+
+        plan_action action, host_ids: [@host.id]
+        run_action action
+
+        event = Katello::Event.find_by(event_type: Katello::Events::GenerateHostApplicability::EVENT_TYPE,
+                                       object_id: @host.id)
+        refute_nil event
+      end
+    end
+  end
+end

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -466,6 +466,12 @@ module Katello
       assert_equal expected, results.map(&:pulp_id).sort
     end
 
+    def test_evr
+      rpm = Rpm.where(nvra: "abc123-2-1.0.0-1.0").first
+
+      assert_equal "(1,\"{\"\"(1,)\"\",\"\"(0,)\"\",\"\"(0,)\"\"}\",\"{\"\"(1,)\"\",\"\"(0,)\"\"}\")", rpm.evr
+    end
+
     def test_search_like
       # Disabled until https://github.com/wvanbergen/scoped_search/pull/178 is merged
       #results = Rpm.in_repositories(@repo).search_for("evr ~ :1.0.0-1")

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -466,12 +466,6 @@ module Katello
       assert_equal expected, results.map(&:pulp_id).sort
     end
 
-    def test_evr
-      rpm = Rpm.where(nvra: "abc123-2-1.0.0-1.0").first
-
-      assert_equal "(1,\"{\"\"(1,)\"\",\"\"(0,)\"\",\"\"(0,)\"\"}\",\"{\"\"(1,)\"\",\"\"(0,)\"\"}\")", rpm.evr
-    end
-
     def test_search_like
       # Disabled until https://github.com/wvanbergen/scoped_search/pull/178 is merged
       #results = Rpm.in_repositories(@repo).search_for("evr ~ :1.0.0-1")

--- a/test/services/katello/applicability/applicable_content_helper_test.rb
+++ b/test/services/katello/applicability/applicable_content_helper_test.rb
@@ -1,0 +1,119 @@
+require 'katello_test_helper'
+require 'support/evr_extension_support'
+module Katello
+  module Service
+    module Applicability
+      class ApplicableContentHelperTest < ActiveSupport::TestCase
+        FIXTURES_FILE = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "rpms.yml")
+
+        def setup
+          EvrExtensionSupport.set_rpm_evrs
+
+          @repo = katello_repositories(:fedora_17_x86_64)
+          @host = FactoryBot.build(:host, :with_content, :with_subscription,
+                                   :content_view => katello_content_views(:library_dev_view),
+                                   :lifecycle_environment => katello_environments(:library))
+          @host.save!
+
+          @rpm_one = katello_rpms(:one)
+          @rpm_two = katello_rpms(:two)
+          @rpm_three = katello_rpms(:three)
+          @rpm_one_two = katello_rpms(:one_two)
+
+          @rpm1 = Rpm.where(nvra: "one-1.0-1.el7.x86_64").first
+          @rpm2 = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
+
+          @erratum = Erratum.find_by(errata_id: "RHBA-2014-013")
+
+          @installed_package1 = InstalledPackage.create(name: @rpm1.name, nvra: @rpm1.nvra, epoch: @rpm1.epoch,
+                                                                   version: @rpm1.version, release: @rpm1.release,
+                                                                   arch: @rpm1.arch)
+          @installed_package2 = InstalledPackage.create(name: @rpm2.name, nvra: @rpm2.nvra, epoch: @rpm2.epoch,
+                                                                   version: @rpm2.version, release: @rpm2.release,
+                                                                   arch: @rpm2.arch)
+
+          EvrExtensionSupport.set_installed_package_evrs
+
+          HostInstalledPackage.create(host_id: @host.id, installed_package_id: @installed_package1.id)
+          HostInstalledPackage.create(host_id: @host.id, installed_package_id: @installed_package2.id)
+
+          ErratumPackage.create(erratum_id: @erratum.id,
+                                nvrea: @rpm2.nvra, name: @rpm2.name, filename: @rpm2.filename)
+
+          Katello::ContentFacetRepository.create(content_facet_id: @host.content_facet.id, repository_id: @repo.id)
+          Katello::RepositoryErratum.create(erratum_id: @erratum.id, repository_id: @repo.id)
+
+          @bound_repos = @host.content_facet.bound_repositories.collect do |repo|
+            repo.library_instance_id.nil? ? repo.id : repo.library_instance_id
+          end
+        end
+
+        def teardown
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).remove(@rpm2.id)
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).remove(@erratum.id)
+        end
+
+        def test_rpm_content_ids_returns_something
+          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).fetch_content_ids
+          assert_equal [@rpm2.id], package_content_ids
+        end
+
+        def test_rpm_content_ids_returns_nothing
+          @installed_package1.destroy
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).fetch_content_ids
+          assert_empty package_content_ids
+        end
+
+        def test_erratum_content_ids_returns_something
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).fetch_content_ids
+          assert_equal [@erratum.id], erratum_content_ids
+        end
+
+        def test_erratum_content_ids_returns_nothing
+          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).fetch_content_ids
+          assert_empty erratum_content_ids
+        end
+
+        def test_applicable_differences_adds_rpm_id
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          assert_equal [[@rpm2.id], []], rpm_differences
+        end
+
+        def test_applicable_differences_adds_and_removes_no_rpm_ids
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          assert_equal [[], []], rpm_differences
+        end
+
+        def test_applicable_differences_removes_rpm_id
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          @installed_package1.destroy
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          assert_equal [[], [@rpm2.id]], rpm_differences
+        end
+
+        def test_applicable_differences_adds_erratum_id
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          assert_equal [[@erratum.id], []], erratum_differences
+        end
+
+        def test_applicable_differences_adds_and_removes_no_errata_ids
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          assert_equal [[], []], erratum_differences
+        end
+
+        def test_applicable_differences_remove_erratum_id
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).calculate_and_import
+          @installed_package1.destroy
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          assert_equal [[], [@erratum.id]], erratum_differences
+        end
+      end
+    end
+  end
+end

--- a/test/support/evr_extension_support.rb
+++ b/test/support/evr_extension_support.rb
@@ -1,0 +1,21 @@
+module Katello
+  module EvrExtensionSupport
+    extend ActiveSupport::Concern
+
+    def self.set_rpm_evrs
+      ::ActiveRecord::Migration[5.2].execute <<-SQL
+        update katello_rpms SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+    end
+
+    def self.set_installed_package_evrs
+      ::ActiveRecord::Migration[5.2].execute <<-SQL
+        update katello_installed_packages SET evr = (ROW(coalesce(epoch::numeric,0),
+                                           rpmver_array(coalesce(version,'empty'))::evr_array_item[],
+                                           rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces package applicability calculations (with RPMs and not modules) using information indexed in Katello alone.  New classes:

1) `Actions::Katello::Applicability::Hosts::Generate`
  - Generates applicability for a list of hosts
2) `Actions::Katello::Applicability::Host::Generate`
  - Generates applicability for a single host
3) `Actions::Katello::Applicability::Repository::Regenerate`
  - Generates applicability for all hosts bound to a repository
4) `Katello::Events::GenerateHostApplicability`
 - Event to allow for simultaneous applicability generation requests
5) `Katello::Applicability::ApplicableContentHelper`
  - A new helper class for Katello Applicability

Current issues/questions:
-  The decisions on which applicability agent to use are `if` statements at the moment.  Should there be some kind of applicability selector like the pulp selector?  I'm thinking not since there aren't too many tasks to switch.
  - This also relates to dropping the consumer-related code when we drop Pulp 2.  Should we start that separation now? Will the `if` statements be sufficient until then?

TODO
- [x] Add more tests

Blocked by https://github.com/Katello/katello/pull/8579