### PR TITLE
Fixes #29405 - Add info on Tracer tab and install status

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -198,6 +198,10 @@ module Katello
         self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => 'katello-agent').any?
       end
 
+      def tracer_installed?
+        self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => 'katello-host-tools-tracer').any?
+      end
+
       def update_errata_status
         host.get_status(::Katello::ErrataStatus).refresh!
         host.refresh_global_status!

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -20,6 +20,10 @@ child :content_facet => :content_facet_attributes do
   node :katello_agent_installed do |content_facet|
     content_facet.katello_agent_installed?
   end
+
+  node :katello_tracer_installed do |content_facet|
+    content_facet.tracer_installed?
+  end
 end
 
 attributes :description, :facts

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -16,6 +16,12 @@
     </p>
   </div>
 
+  <div bst-alert="info" ng-hide="host.content_facet_attributes.katello_tracer_installed">
+    <span translate>
+      To use Tracer, install the katello-host-tools-tracer package.
+    </span>
+  </div>
+
   <form id="traceActionForm" method="post" action="/katello/remote_execution">
     <input type="hidden" name="remote_action" value="service_restart"/>
     <input type="hidden" name="name" ng-value="traceActionFormValues.helper"/>
@@ -26,6 +32,7 @@
 
   <div bst-feature-flag="remote_actions">
     <h3 translate>Traces</h3>
+    <h4 translate>Tracer helps administrators identify applications that need to be restarted after a system is patched.</h4>
   </div>
 
   <div data-extend-template="layouts/partials/table.html">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -31,6 +31,17 @@
         <dt translate>Type</dt>
         <dd>{{ host.subscription_facet_attributes.host_type }}</dd>
 
+        <dt translate>Katello Tracer</dt>
+          <dd>
+          <span ng-show="host.content_facet_attributes.katello_tracer_installed">
+            <span class="{{ getHostStatusIcon(0) }}"></span>
+            <span translate>Installed</span>
+          </span>
+          <span ng-hide="host.content_facet_attributes.katello_tracer_installed">
+            <span translate>Not installed</span>
+          </span>
+        </dd>
+
         <dt bst-feature-flag="remote_actions">
           <span translate>Katello Agent</span>
         </dt>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register-client.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register-client.html
@@ -4,7 +4,7 @@
   <p translate>To report package & errata information:</p>
   <pre><code>yum -y install katello-host-tools</code></pre>
 
-  <p translate>To optionally report tracer information:</p>
+  <p translate>Tracer helps administrators identify applications that need to be restarted after a system is patched. To optionally report tracer information:</p>
   <pre><code>yum -y install katello-host-tools-tracer</code></pre>
 
   <p translate>For remote actions via katello-agent:</p>

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -32,6 +32,14 @@ module Katello
       assert host.reload.content_facet.katello_agent_installed?
     end
 
+    def test_tracer_installed?
+      refute host.content_facet.tracer_installed?
+
+      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-host-tools-tracer', 'nvra' => 'katello-host-tools-tracer-1.0.x86_64')
+
+      assert host.reload.content_facet.tracer_installed?
+    end
+
     def test_in_content_view_version_environments
       first_cvve = {:content_view_version => content_facet.content_view.version(content_facet.lifecycle_environment),
                     :environments => [content_facet.lifecycle_environment]}


### PR DESCRIPTION
This PR adds 2 things. 

- Info on the Traces tab inside of a content-host page about what the tab is used for and if the `katello-host-tools-tracer` package is not installed, then it will show a info box to use the tab then install the package.

- On the content-host details page it will show installed with a green icon or not installed with no icon based on if it detects the package just like katello-agent.

Screenshots showing how it works:

tracer-installed-only-note:

https://nimbusweb.me/s/share/4004101/q3t62gavcobcbn8naac1

tracer-installed:

https://nimbusweb.me/s/share/4004097/yvhpnt27pn36ut7lu3s7

no-tracer-notes:

https://nimbusweb.me/s/share/4004095/si8w9b2rgur47zfse1fb

no-tracer-installed:

https://nimbusweb.me/s/share/4004089/naezqwi2vuvid12ql9hh

Added a unit test for the Katello Rails side of things for the method of picking up if the `katello-host-tools-tracer` package is installed. 