### PR TITLE
Fixes #29421 - add pulp3 debian support

### DIFF
--- a/app/lib/actions/pulp3/repository/save_artifact.rb
+++ b/app/lib/actions/pulp3/repository/save_artifact.rb
@@ -11,7 +11,7 @@ module Actions
           artifact_href = input[:tasks].last[:created_resources].first
           content_type = input[:unit_type_id]
           content_backend_service = SmartProxy.pulp_primary.content_service(content_type)
-          output[:pulp_tasks] = [content_backend_service.content_api.create(input[:options][:file_name], artifact: artifact_href)]
+          output[:pulp_tasks] = [content_backend_service.content_api_create(relative_path: input[:options][:file_name], artifact: artifact_href)]
         end
       end
     end

--- a/app/services/katello/pulp3/api/apt.rb
+++ b/app/services/katello/pulp3/api/apt.rb
@@ -1,0 +1,57 @@
+require "pulpcore_client"
+
+module Katello
+  module Pulp3
+    module Api
+      class Apt < Core
+        def self.api_exception_class
+          PulpDebClient::ApiError
+        end
+
+        def self.client_module
+          PulpDebClient
+        end
+
+        def self.remote_class
+          PulpDebClient::DebAptRemote
+        end
+
+        def self.distribution_class
+          PulpDebClient::DebAptDistribution
+        end
+
+        def self.publication_class
+          PulpDebClient::DebAptPublication
+        end
+
+        def self.repository_sync_url_class
+          PulpDebClient::RepositorySyncURL
+        end
+
+        def api_client
+          PulpDebClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpDebClient::Configuration))
+        end
+
+        def repositories_api
+          PulpDebClient::RepositoriesAptApi.new(api_client)
+        end
+
+        def repository_versions_api
+          PulpDebClient::RepositoriesDebVersionsApi.new(api_client)
+        end
+
+        def remotes_api
+          PulpDebClient::RemotesAptApi.new(api_client)
+        end
+
+        def publications_api
+          PulpDebClient::PublicationsAptApi.new(api_client)
+        end
+
+        def distributions_api
+          PulpDebClient::DistributionsAptApi.new(api_client)
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -90,6 +90,10 @@ module Katello
           PulpcoreClient::UploadCommit
         end
 
+        def signing_services_api
+          PulpcoreClient::SigningServicesApi.new(core_api_client)
+        end
+
         def tasks_api
           PulpcoreClient::TasksApi.new(core_api_client)
         end

--- a/app/services/katello/pulp3/deb.rb
+++ b/app/services/katello/pulp3/deb.rb
@@ -1,0 +1,38 @@
+module Katello
+  module Pulp3
+    class Deb < PulpContentUnit
+      include LazyAccessor
+      CONTENT_TYPE = "deb".freeze
+
+      def self.content_api
+        PulpDebClient::ContentPackagesApi.new(Katello::Pulp3::Api::Apt.new(SmartProxy.pulp_primary!).api_client)
+      end
+
+      def self.content_api_create(opts = {})
+        self.content_api.create(opts)
+      end
+
+      def self.create_content(options)
+        fail _("Artifact Id and relative path are needed to create content") unless options.dig(:file_name) && options.dig(:artifact)
+        PulpDebClient::DebContent.new(relative_path: options[:file_name], artifact: options[:artifact])
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Apt.new(Katello::Repository.find(repo_id), SmartProxy.pulp_primary)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+
+      def update_model(model)
+        custom_json = {}
+        custom_json['checksum'] = backend_data['sha256']
+        custom_json['filename'] = backend_data['relative_path']
+        custom_json['name'] = backend_data['package']
+        custom_json['version'] = backend_data['version']
+        custom_json['description'] = backend_data['description']
+        custom_json['architecture'] = backend_data['architecture']
+        model.update!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -11,6 +11,11 @@ module Katello
         fail NotImplementedError
       end
 
+      def self.content_api_create(opts = {})
+        relative_path = opts.delete(:relative_path)
+        self.content_api.create(relative_path, opts)
+      end
+
       def self.create_content
         fail NotImplementedError
       end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -205,8 +205,14 @@ module Katello
       end
 
       def create_publication
-        publication_data = api.class.publication_class.new(repository_version: repo.version_href)
+        publication_data = api.class.publication_class.new(publication_options(repo.version_href))
         api.publications_api.create(publication_data)
+      end
+
+      def publication_options(repository_version)
+        {
+          repository_version: repository_version
+        }
       end
 
       def relative_path

--- a/app/services/katello/pulp3/repository/apt.rb
+++ b/app/services/katello/pulp3/repository/apt.rb
@@ -1,0 +1,63 @@
+require 'pulp_deb_client'
+
+module Katello
+  module Pulp3
+    class Repository
+      class Apt < ::Katello::Pulp3::Repository
+        SIGNING_SERVICE_NAME = 'katello_deb_sign'.freeze
+
+        def remote_options
+          deb_remote_options = {
+            distributions: root.deb_releases
+          }
+          deb_remote_options[:components] = root.deb_components.present? ? root.deb_components : nil
+          deb_remote_options[:architectures] = root.deb_architectures.present? ? root.deb_architectures : nil
+
+          if root.url.blank?
+            deb_remote_options[:url] = nil
+          end
+
+          deb_remote_options[:gpgkey] = root.gpg_key.present? ? root.gpg_key.content : nil
+
+          common_remote_options.merge(deb_remote_options)
+        end
+
+        def publication_options(repository_version)
+          ss = api.signing_services_api.list(name: SIGNING_SERVICE_NAME).results
+          popts = super(repository_version)
+          popts.merge!(
+            {
+              # structured is not necessary for subscription-manager
+              #structured: true, # publish real suites (e.g. 'stable')
+              simple: true # publish all into 'default'-suite
+            }
+          )
+          popts[:signing_service] = ss[0].pulp_href if ss && ss.length == 1
+          popts
+        end
+
+        def distribution_options(path)
+          {
+            base_path: path,
+            publication: repo.publication_href,
+            name: "#{generate_backend_object_name}"
+          }
+        end
+
+        def partial_repo_path
+          "/pulp/deb/#{repo.relative_path}/".sub('//', '/')
+        end
+
+        def copy_content_for_source
+          # TODO
+          fail NotImplementedError
+        end
+
+        def regenerate_applicability
+          # TODO
+          fail NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.2.0", "< 1.4.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.2", "< 0.5"
   gem.add_dependency "pulp_container_client", ">= 2.0.0", "< 2.2.0"
+  gem.add_dependency "pulp_deb_client", ">= 2.6.0", "< 2.8.0"
   gem.add_dependency "pulp_rpm_client", ">=3.6.2", "< 3.8.0"
   gem.add_dependency "pulp_2to3_migration_client", ">= 0.3.0", "< 0.6.0", "!= 0.4.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"

--- a/lib/katello/repository_types/deb.rb
+++ b/lib/katello/repository_types/deb.rb
@@ -1,6 +1,14 @@
 Katello::RepositoryTypeManager.register(::Katello::Repository::DEB_TYPE) do
   service_class Katello::Pulp::Repository::Deb
+  pulp3_service_class Katello::Pulp3::Repository::Apt
+  pulp3_api_class Katello::Pulp3::Api::Apt
+  pulp3_plugin 'pulp_deb'
   prevent_unneeded_metadata_publish
+
   default_managed_content_type Katello::Deb
-  content_type Katello::Deb, :pulp2_service_class => ::Katello::Pulp::Deb, :removable => true, :uploadable => true
+  content_type Katello::Deb,
+    :pulp2_service_class => ::Katello::Pulp::Deb,
+    :pulp3_service_class => ::Katello::Pulp3::Deb,
+    :removable => true,
+    :uploadable => true
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -147,7 +147,7 @@ module Katello
     def test_index_available_for_content_view
       ids = @view.organization.default_content_view.versions.first.repositories.pluck(:id) - @view.repositories.pluck(:id)
 
-      response = get :index, params: { :content_view_id => @view.id, :available_for => :content_view, :organization_id => @organization.id }
+      response = get :index, params: { :content_view_id => @view.id, :available_for => :content_view, :organization_id => @organization.id, :per_page => 100 }
 
       assert_response :success
       assert_template 'api/v2/repositories/index'

--- a/test/fixtures/actions/pulp3/repository/sync/success_apt.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/success_apt.yaml
@@ -1,0 +1,50 @@
+---
+  task_groups: []
+  pulp_tasks:
+    - pulp_href: "/pulp/api/v3/tasks/aae95f53-bbdb-4c7a-8795-0da3bc1cf318/"
+      pulp_created: '2020-04-24T13:47:48.666+00:00'
+      state: completed
+      name: pulp_deb.app.tasks.synchronizing.synchronize
+      started_at: '2020-04-24T13:47:48.783+00:00'
+      finished_at: '2020-04-24T13:47:56.229+00:00'
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/8fd4352b-d961-4e02-a78e-68b7b79eec60/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Downloading Artifacts
+        code: downloading.artifacts
+        state: completed
+        done: 16
+        suffix: 
+        total: 
+      - message: Update ReleaseFile units
+        code: update.release_file
+        state: completed
+        done: 1
+        suffix: 
+        total: 
+      - message: Update PackageIndex units
+        code: update.packageindex
+        state: completed
+        done: 2
+        suffix: 
+        total: 
+      - message: Associating Content
+        code: associating.content
+        state: completed
+        done: 67
+        suffix: 
+        total: 
+      - message: Un-Associating Content
+        code: unassociating.content
+        state: completed
+        done: 7
+        suffix: 
+        total: 
+      created_resources:
+      - "/pulp/api/v3/repositories/deb/apt/e1e243cf-b0f9-4036-80b1-8740373b51dc/versions/2/"
+      reserved_resources_record:
+      - "/pulp/api/v3/repositories/deb/apt/e1e243cf-b0f9-4036-80b1-8740373b51dc/"
+      - "/pulp/api/v3/remotes/deb/apt/5fc64e41-baf4-4b8a-b36d-005540ace540/"

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -369,3 +369,10 @@ pulp3_docker_1:
   relative_path:        '/Default_Organization/library/pulp3_Docker_1'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+pulp3_deb_1:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:pulp3_deb_root_1) %>
+  pulp_id:              "Default_Organization-Cabinet-pulp3_Deb_1"
+  relative_path:        'Default_Organization/library/pulp3_Deb_1'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -204,3 +204,15 @@ pulp3_docker_root_1:
   unprotected:           <%= true %>
   url:                  "https://registry-1.docker.io/"
   docker_upstream_name: "fedora/ssh"
+
+pulp3_deb_root_1:
+  name:                 Pulp3 Deb 1
+  content_id:           11
+  content_type:         deb
+  label:                Pulp3_Deb_1
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:debian) %>
+  unprotected:           <%= true %>
+  url:                  "http://ftp.debian.mymirror.org/debian"
+  deb_releases:         buster
+  deb_components:       main
+  deb_architectures:    amd64

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,234 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '3076'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '247'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzI4ODE3NWI2LTQ5NzktNGNkZi1iNjlmLWIzNzEyZTg0ODEw
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjExOjU4LjcyNDIz
-        NVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMjg4MTc1YjYtNDk3OS00Y2RmLWI2OWYtYjM3MTJlODQ4
-        MTBmL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8yODgxNzViNi00OTc5LTRj
-        ZGYtYjY5Zi1iMzcxMmU4NDgxMGYvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
-        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0
-        aW9uIjpudWxsLCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/288175b6-4979-4cdf-b69f-b3712e84810f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -258,23 +31,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5MTYyODhlLTM1NDItNDA5
-        OC1hODM4LWVhN2FlNGU3M2JmYS8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,62 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '347'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS9mNDk2Nzc1MS1kNjk4LTRlZWUtOTZhNi0xNTBiZjM4YjVmNzQvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMTo1OC44Mzg0NjRaIiwi
-        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
-        LCJ1cmwiOiJodHRwczovL2ZpeHR1cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxl
-        Mi8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0
-        IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
-        ZSwicHJveHlfdXJsIjpudWxsLCJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQi
-        Om51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMC0wOC0yMFQxOToxMTo1
-        OC44Mzg0OTBaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjEwLCJwb2xpY3ki
-        OiJpbW1lZGlhdGUifV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/f4967751-d698-4eee-96a6-150bf38b5f74/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -358,23 +76,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjOTcwZTRjLWMzOWUtNDZm
-        Zi1iNWM4LTFiNjU1M2ZhZGNlYi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -395,62 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '314'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS84ODUwZjNiZC0wNDVjLTQ2MDEtYTZiNi1hMTg2MmU1MWI0
-        NmUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMjowMS4wNDcx
-        NDVaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cDovL2RldmVsMi5iYWxtb3Jh
-        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
-        bi9saWJyYXJ5L015X0ZpbGVzLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5h
-        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwi
-        cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUv
-        ZmlsZS9hMGE0OTEwMC00YTQzLTQ1NzUtOTA0Mi1lN2I2OGZkNDQ2NTkvIn1d
-        fQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/8850f3bd-045c-4601-a6b6-a1862e51b46e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -458,23 +121,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwNTNiZWVlLWZiNDktNDM4
-        Yi04YTNhLTMyMjJmYzE5ODQ2My8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -495,60 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '282'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS84ODUwZjNiZC0wNDVjLTQ2MDEtYTZiNi1hMTg2MmU1MWI0
-        NmUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMjowMS4wNDcx
-        NDVaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cDovL2RldmVsMi5iYWxtb3Jh
-        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
-        bi9saWJyYXJ5L015X0ZpbGVzLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5h
-        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwi
-        cHVibGljYXRpb24iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:53 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/8850f3bd-045c-4601-a6b6-a1862e51b46e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:54 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -556,23 +166,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0Mjg5MTg3LTFjNzMtNDM0
-        Zi05Y2Y5LTJkMTljMWZiYzAyMi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0916288e-3542-4098-a838-ea7ae4e73bfa/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -580,7 +190,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -593,228 +203,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:54 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '342'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDkxNjI4OGUtMzU0
-        Mi00MDk4LWE4MzgtZWE3YWU0ZTczYmZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTI6NTMuMzYwNTc3WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTI6NTMuNTYxNDgx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMjo1My43ODk2NzFa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzI4ODE3NWI2LTQ5NzktNGNkZi1i
-        NjlmLWIzNzEyZTg0ODEwZi8iXX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:54 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/2c970e4c-c39e-46ff-b5c8-1b6553fadceb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:54 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '340'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmM5NzBlNGMtYzM5
-        ZS00NmZmLWI1YzgtMWI2NTUzZmFkY2ViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTI6NTMuNTE2NTUwWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTI6NTMuNzc0MzUy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMjo1My44Njc1ODda
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS9mNDk2Nzc1MS1kNjk4LTRlZWUtOTZhNi0x
-        NTBiZjM4YjVmNzQvIl19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:54 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3053beee-fb49-438b-8a3a-3222fc198463/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:54 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '316'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA1M2JlZWUtZmI0
-        OS00MzhiLThhM2EtMzIyMmZjMTk4NDYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTI6NTMuODA0OTE0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTI6NTQuMzcwOTI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMjo1NC40NjU0Mjla
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
-        dHJpYnV0aW9ucy8iXX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:54 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/84289187-1c73-434f-9cf9-2d19c1fbc022/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:54 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '663'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODQyODkxODctMWM3
-        My00MzRmLTljZjktMmQxOWMxZmJjMDIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTI6NTQuMDI1NjU5WiIsInN0YXRlIjoiZmFpbGVkIiwi
-        bmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVsZXRl
-        Iiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTI6NTQuNzkyNjcxWiIs
-        ImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMjo1NC44NDQzODdaIiwi
-        ZXJyb3IiOnsidHJhY2ViYWNrIjoiICBGaWxlIFwiL3Vzci9sb2NhbC9saWIv
-        cHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcnEvd29ya2VyLnB5XCIsIGxpbmUg
-        ODgzLCBpbiBwZXJmb3JtX2pvYlxuICAgIHJ2ID0gam9iLnBlcmZvcm0oKVxu
-        ICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHl0aG9uMy42L3NpdGUtcGFja2Fn
-        ZXMvcnEvam9iLnB5XCIsIGxpbmUgNjU3LCBpbiBwZXJmb3JtXG4gICAgc2Vs
-        Zi5fcmVzdWx0ID0gc2VsZi5fZXhlY3V0ZSgpXG4gIEZpbGUgXCIvdXNyL2xv
-        Y2FsL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9ycS9qb2IucHlcIiwg
-        bGluZSA2NjMsIGluIF9leGVjdXRlXG4gICAgcmV0dXJuIHNlbGYuZnVuYygq
-        c2VsZi5hcmdzLCAqKnNlbGYua3dhcmdzKVxuICBGaWxlIFwiL3Vzci9sb2Nh
-        bC9saWIvcHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcHVscGNvcmUvYXBwL3Rh
-        c2tzL2Jhc2UucHlcIiwgbGluZSA5MCwgaW4gZ2VuZXJhbF9kZWxldGVcbiAg
-        ICBpbnN0YW5jZSA9IHNlcmlhbGl6ZXJfY2xhc3MuTWV0YS5tb2RlbC5vYmpl
-        Y3RzLmdldChwaz1pbnN0YW5jZV9pZCkuY2FzdCgpXG4gIEZpbGUgXCIvdXNy
-        L2xvY2FsL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFuZ28vZGIv
-        bW9kZWxzL21hbmFnZXIucHlcIiwgbGluZSA4MiwgaW4gbWFuYWdlcl9tZXRo
-        b2RcbiAgICByZXR1cm4gZ2V0YXR0cihzZWxmLmdldF9xdWVyeXNldCgpLCBu
-        YW1lKSgqYXJncywgKiprd2FyZ3MpXG4gIEZpbGUgXCIvdXNyL2xvY2FsL2xp
-        Yi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFuZ28vZGIvbW9kZWxzL3F1
-        ZXJ5LnB5XCIsIGxpbmUgNDA4LCBpbiBnZXRcbiAgICBzZWxmLm1vZGVsLl9t
-        ZXRhLm9iamVjdF9uYW1lXG4iLCJkZXNjcmlwdGlvbiI6IkZpbGVEaXN0cmli
-        dXRpb24gbWF0Y2hpbmcgcXVlcnkgZG9lcyBub3QgZXhpc3QuIn0sIndvcmtl
-        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzEyNDMxOTY4LWNhNTMtNDJmZi1h
-        OWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRf
-        dGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
-        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -837,13 +250,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:55 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/bdd7bb15-cb4e-4d92-be92-fe407855e103/"
+      - "/pulp/api/v3/repositories/file/file/8ebd7443-5ee4-4083-b353-fafa0e2968cf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -853,25 +266,25 @@ http_interactions:
       Content-Length:
       - '424'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS9iZGQ3YmIxNS1jYjRlLTRkOTItYmU5Mi1mZTQwNzg1NWUxMDMvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMjo1NS4yNjk0OTBaIiwi
+        ZmlsZS84ZWJkNzQ0My01ZWU0LTQwODMtYjM1My1mYWZhMGUyOTY4Y2YvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODoxNi4zNjk3ODdaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlL2JkZDdiYjE1LWNiNGUtNGQ5Mi1iZTkyLWZlNDA3ODU1ZTEwMy92
+        ZS9maWxlLzhlYmQ3NDQzLTVlZTQtNDA4My1iMzUzLWZhZmEwZTI5NjhjZi92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvYmRkN2JiMTUtY2I0ZS00ZDkyLWJl
-        OTItZmU0MDc4NTVlMTAzL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvOGViZDc0NDMtNWVlNC00MDgzLWIz
+        NTMtZmFmYTBlMjk2OGNmL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
         bnVsbCwicmVtb3RlIjpudWxsfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -896,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:55 GMT
+      - Wed, 07 Oct 2020 17:48:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/995417f3-847d-43dc-821c-7986e5f58e4b/"
+      - "/pulp/api/v3/remotes/file/file/008557a9-45ea-479d-8d39-88de3152b6df/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -912,25 +325,25 @@ http_interactions:
       Content-Length:
       - '436'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        OTk1NDE3ZjMtODQ3ZC00M2RjLTgyMWMtNzk4NmU1ZjU4ZTRiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTI6NTUuNDM0ODc2WiIsIm5hbWUi
+        MDA4NTU3YTktNDVlYS00NzlkLThkMzktODhkZTMxNTJiNmRmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MTYuNDgyMTU5WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJ1c2VybmFt
         ZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyMC0wOC0yMFQxOToxMjo1NS40MzQ5MjBaIiwiZG93bmxvYWRfY29uY3Vy
+        MjAyMC0xMC0wN1QxNzo0ODoxNi40ODIxNzdaIiwiZG93bmxvYWRfY29uY3Vy
         cmVuY3kiOjEwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/995417f3-847d-43dc-821c-7986e5f58e4b/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/008557a9-45ea-479d-8d39-88de3152b6df/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -951,7 +364,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:12:59 GMT
+      - Wed, 07 Oct 2020 17:48:18 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -965,17 +378,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2ZjI0M2ViLWM2NjYtNDhl
-        OS05YTA0LTIzZTQ5NmYyMGVhMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0ZGU5ZjZlLTM2MTQtNGE2
+        NS1hYzBiLTJiYjZhNzA3Y2MwNy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:18 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b6f243eb-c666-48e9-9a04-23e496f20ea1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/b4de9f6e-3614-4a65-ac0b-2bb6a707cc07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -983,7 +396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -996,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1008,30 +421,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZmMjQzZWItYzY2
-        Ni00OGU5LTlhMDQtMjNlNDk2ZjIwZWExLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTI6NTkuODM4MzIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjRkZTlmNmUtMzYx
+        NC00YTY1LWFjMGItMmJiNmE3MDdjYzA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTguOTYzMjYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTM6MDAuMDExOTc2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzowMC4wNzYyMzda
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTkuMTA1OTY0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxOS4xNTg1MzVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS85OTU0MTdmMy04NDdkLTQzZGMtODIxYy03
-        OTg2ZTVmNThlNGIvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS8wMDg1NTdhOS00NWVhLTQ3OWQtOGQzOS04
+        OGRlMzE1MmI2ZGYvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/bdd7bb15-cb4e-4d92-be92-fe407855e103/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/8ebd7443-5ee4-4083-b353-fafa0e2968cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,7 +465,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1066,17 +479,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4M2NjYjY4LWVhZGItNGFk
-        OS1iYjc1LTRhMzBhMWFkNmUyZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0MTdiMWY5LTdkMDEtNGRh
+        My05NDNjLTg0ZThjZDEyOWYzMS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f83ccb68-eadb-4ad9-bb75-4a30a1ad6e2e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/0417b1f9-7d01-4da3-943c-84e8cd129f31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1084,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1097,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1109,30 +522,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjgzY2NiNjgtZWFk
-        Yi00YWQ5LWJiNzUtNGEzMGExYWQ2ZTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTM6MDAuMjY2MTM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQxN2IxZjktN2Qw
+        MS00ZGEzLTk0M2MtODRlOGNkMTI5ZjMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTkuMjU3NzMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTM6MDAuNDM3MTEx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzowMC41MjkyNzJa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTkuNDA1MTk0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxOS40NzI0NDFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2JkZDdiYjE1LWNiNGUtNGQ5Mi1i
-        ZTkyLWZlNDA3ODU1ZTEwMy8iXX0=
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzhlYmQ3NDQzLTVlZTQtNDA4My1i
+        MzUzLWZhZmEwZTI5NjhjZi8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1140,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1153,431 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '257'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3
-        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0
-        NWU4L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQw
-        YTItYjkzNy1iZjQxYTYzZjQ1ZTgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVi
-        bGlzaGVkIExpYnJhcnkgYW5kIGRldiB2aWV3LTcwMDk3MzQ1My05MDkwNTgz
-        NDciLCJkZXNjcmlwdGlvbiI6IlB1Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYg
-        dmlldy03MDA5NzM0NTMtOTA5MDU4MzQ3IiwicmVtb3RlIjpudWxsfV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '370'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMjo0Ni4xMjY1Mjla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAy
-        OS1mZmRiMzMxOWM5OGMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNh
-        dGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0
-        YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNp
-        b25zIjowfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUy
-        ODUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMDo0Ny40MDk2
-        NjRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUy
-        ODUvdmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmIt
-        YTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMi8iLCJuYW1lIjoiMiIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/de80535c-d2ec-4633-b029-ffdb3319c98c/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEy
-        OjQ2LjEzOTQwM1oiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/591e4778-2450-4ebb-a82e-2e1b238fe285/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '495'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUyODUv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEw
-        OjU1LjM1NzUwNFoiLCJudW1iZXIiOjIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlZW52aXJv
-        bm1lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWVudmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9u
-        X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFl
-        NDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMi8i
-        fX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAtNGViYi1hODJlLTJlMWIy
-        MzhmZTI4NS92ZXJzaW9ucy8yLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUi
-        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        ZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAtNGVi
-        Yi1hODJlLTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8yLyJ9LCJycG0ubW9kdWxl
-        bWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAtNGViYi1hODJl
-        LTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2FnZSI6eyJj
-        b3VudCI6MTksImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIz
-        OGZlMjg1L3ZlcnNpb25zLzIvIn0sInJwbS5wYWNrYWdlZW52aXJvbm1lbnQi
-        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWVudmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRl
-        YmItYTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMi8ifSwicnBtLnBhY2th
-        Z2Vncm91cCI6eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAt
-        NGViYi1hODJlLTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8yLyJ9LCJycG0ucmVw
-        b19tZXRhZGF0YV9maWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        NTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNpb25z
-        LzIvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZl
-        Mjg1L3ZlcnNpb25zLzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQx
-        OToxMDo1NC4xODk2MDVaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTkxZTQ3NzgtMjQ1
-        MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNpb25zLzAvIiwiY29udGVu
-        dF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6
-        NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAtNGViYi1hODJlLTJlMWIy
-        MzhmZTI4NS92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUi
-        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        ZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0
-        NTAtNGViYi1hODJlLTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8xLyJ9LCJycG0u
-        bW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0
-        NTAtNGViYi1hODJlLTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8xLyJ9LCJycG0u
-        cGFja2FnZSI6eyJjb3VudCI6MTksImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTkxZTQ3NzgtMjQ1
-        MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNpb25zLzEvIn0sInJwbS5w
-        YWNrYWdlZ3JvdXAiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92ZXJzaW9u
-        X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFl
-        NDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMS8i
-        fSwicnBtLnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRhX2ZpbGVz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4LTI0NTAtNGViYi1hODJlLTJlMWIy
-        MzhmZTI4NS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
-        OnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50Ijo0LCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTkxZTQ3Nzgt
-        MjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNpb25zLzEvIn0sInJw
-        bS5kaXN0cmlidXRpb25fdHJlZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNp
-        b25zLzEvIn0sInJwbS5tb2R1bGVtZCI6eyJjb3VudCI6NiwiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTkx
-        ZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3ZlcnNpb25zLzEv
-        In0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxOSwiaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
-        PS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFlNDc3OC0y
-        NDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMS8ifSwicnBt
-        LnBhY2thZ2Vncm91cCI6eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU5MWU0Nzc4
-        LTI0NTAtNGViYi1hODJlLTJlMWIyMzhmZTI4NS92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ucmVwb19tZXRhZGF0YV9maWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmlsZXMvP3Jl
-        cG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3Jw
-        bS9ycG0vNTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUxYjIzOGZlMjg1L3Zl
-        cnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNTkxZTQ3NzgtMjQ1MC00ZWJiLWE4MmUtMmUx
-        YjIzOGZlMjg1L3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0w
-        OC0yMFQxOToxMDo0Ny40MTY0NTNaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNp
-        b24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92
-        ZWQiOnt9LCJwcmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1591,17 +580,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1609,7 +598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1622,41 +611,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1664,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1677,57 +656,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '227'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/591e4778-2450-4ebb-a82e-2e1b238fe285/versions/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1735,23 +664,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3YmZkZGQ2LWFiMDgtNDIz
-        Ni1iOTFiLTk1OGMwNWRkOTE3NC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/591e4778-2450-4ebb-a82e-2e1b238fe285/versions/1/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1759,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1768,11 +697,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1780,23 +709,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwNWU1OGZiLTNmNmQtNDE3
-        Ny1hZjdiLTk2YTJjOGUyZWFhYi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1804,7 +733,52 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1817,7 +791,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:01 GMT
+      - Wed, 07 Oct 2020 17:48:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1831,17 +805,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlM2I0NjgyLWNiZDgtNDJk
-        ZC1hNTQxLWYzMTQxZTYxNjA4ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NmOTg2NTc4LTRlNWItNGI1
+        YS05MGMwLWEyMzAyNmIyODc2ZC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:01 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0e3b4682-cbd8-42dd-a541-f3141e61608d/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/cf986578-4e5b-4b5a-90c0-a23026b2876d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1849,7 +823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1862,7 +836,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:04 GMT
+      - Wed, 07 Oct 2020 17:48:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1874,29 +848,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '388'
+      - '381'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGUzYjQ2ODItY2Jk
-        OC00MmRkLWE1NDEtZjMxNDFlNjE2MDhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTM6MDEuODU5OTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2Y5ODY1NzgtNGU1
+        Yi00YjVhLTkwYzAtYTIzMDI2YjI4NzZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTkuODQzNzQwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzowMi40MjUx
-        NTRaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjEzOjA0LjMyMzc5
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxOS45MjE4
+        OTNaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjIwLjAyODk1
         NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
         cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6ODIsImRvbmUiOjgyLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFj
-        dHMiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIsInN0YXRlIjoiY29tcGxl
-        dGVkIiwidG90YWwiOjk3LCJkb25lIjo5Nywic3VmZml4IjpudWxsfV0sImNy
-        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6W119
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0aWZhY3Rz
+        IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:04 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:20 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
@@ -3062,101 +3062,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:44:35 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:55 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:55 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:56 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/39c0ecee-5822-43b1-a8c2-992c01f29fe9/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '130'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8zOWMwZWNlZS01
-        ODIyLTQzYjEtYThjMi05OTJjMDFmMjlmZTkvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMC0wOC0yMFQxOToxMjo1Ni4wOTg5MTdaIiwic2l6ZSI6NzQwfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:56 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/39c0ecee-5822-43b1-a8c2-992c01f29fe9/
     body:
@@ -3335,62 +3240,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:12:56 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWY1MTZmZjZlMDU2YzA4
-        MmUxNzExYTI4MmZhMjJjMzAzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZjUxNmZmNmUw
-        NTZjMDgyZTE3MTFhMjgyZmEyMmMzMDMNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvODM3NjM4YTYtY2Q1MS00ZDJjLTk2NTgtYzhiMjdlMmViYjQ0
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWY1MTZmZjZlMDU2
-        YzA4MmUxNzExYTI4MmZhMjJjMzAzLS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-f516ff6e056c082e1711a282fa22c303
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:57 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVjOGY2MTg4LTQ5NjEtNDJj
-        OS1iNzQ3LWNhYzQ3N2UxMjhhOS8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:57 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/5c8f6188-4961-42c9-b747-cac477e128a9/
     body:
@@ -3553,4 +3402,496 @@ http_interactions:
         LWJlOTItZmU0MDc4NTVlMTAzLyJdfQ==
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:12:58 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/10d2b36f-09e6-4cfc-b997-03598bb058cf/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '130'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8xMGQyYjM2Zi0w
+        OWU2LTRjZmMtYjk5Ny0wMzU5OGJiMDU4Y2YvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoxNi44MTIyMjFaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/10d2b36f-09e6-4cfc-b997-03598bb058cf/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNjOTMwZWI2MGFjMmU3
+        ZmE1NjBhZjRkM2U2ZGQ5NWNmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMDEw
+        MDctMzAxODItMXM2Y2N4NiINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1jYzkzMGViNjBh
+        YzJlN2ZhNTYwYWY0ZDNlNmRkOTVjZi0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-cc930eb60ac2e7fa560af4d3e6dd95cf
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8xMGQyYjM2Zi0w
+        OWU2LTRjZmMtYjk5Ny0wMzU5OGJiMDU4Y2YvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoxNi44MTIyMjFaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/10d2b36f-09e6-4cfc-b997-03598bb058cf/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwODI4NThmLWNmYWUtNGIz
+        OS04OTQ1LTQwZDk4ODY4MGY5NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/7082858f-cfae-4b39-8945-40d988680f94/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '363'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzA4Mjg1OGYtY2Zh
+        ZS00YjM5LTg5NDUtNDBkOTg4NjgwZjk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTYuODkxNDg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        c3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTcuMDQzNjQ3WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNy4xMDU3OTBaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA5NTM5
+        Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy9hMGIwNzAwMS04OTIzLTQ5OTEtOGUzMC03
+        ZGU4NTFjYWM4NmMvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
+        L3B1bHAvYXBpL3YzL3VwbG9hZHMvMTBkMmIzNmYtMDllNi00Y2ZjLWI5OTct
+        MDM1OThiYjA1OGNmLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:17 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWIzODdhMjcwYTQ4MmNm
+        NzAyMWM0MjIzZDI0YTQwNDQ1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYjM4N2EyNzBh
+        NDgyY2Y3MDIxYzQyMjNkMjRhNDA0NDUNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvYTBiMDcwMDEtODkyMy00OTkxLThlMzAtN2RlODUxY2FjODZj
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWIzODdhMjcwYTQ4
+        MmNmNzAyMWM0MjIzZDI0YTQwNDQ1LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-b387a270a482cf7021c4223d24a40445
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwMjRmN2MzLTViNDktNDNh
+        Ny1hZjAwLTNhMWFiOTE5YzMzNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/4024f7c3-5b49-43a7-af00-3a1ab919c334/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDAyNGY3YzMtNWI0
+        OS00M2E3LWFmMDAtM2ExYWI5MTljMzM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTcuMjQyOTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTcuMzgzNDUw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNy41MTkzNTla
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy82NWNkMDdjMi1l
+        MjYxLTQzN2QtOGQ1OS02ZTE4YjcyNDAyMTQvIl0sInJlc2VydmVkX3Jlc291
+        cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hMGIwNzAw
+        MS04OTIzLTQ5OTEtOGUzMC03ZGU4NTFjYWM4NmMvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:17 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/8ebd7443-5ee4-4083-b353-fafa0e2968cf/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzY1Y2QwN2MyLWUyNjEtNDM3ZC04ZDU5LTZlMThiNzI0MDIx
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0YWI2MjQ5LTIyYjktNGMx
+        OS05NTA0LWNmMGY4ZGIyODEyNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/e4ab6249-22b9-4c19-9504-cf0f8db28126/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '357'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTRhYjYyNDktMjJi
+        OS00YzE5LTk1MDQtY2YwZjhkYjI4MTI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTcuNjQ4NDgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTcu
+        ODEzMDk3WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNy45
+        MDgyNTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        OGViZDc0NDMtNWVlNC00MDgzLWIzNTMtZmFmYTBlMjk2OGNmL3ZlcnNpb25z
+        LzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvOGViZDc0NDMtNWVlNC00MDgz
+        LWIzNTMtZmFmYTBlMjk2OGNmLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:17 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
@@ -935,67 +935,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:44:36 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:12:58 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '505'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvYzEzNWMxMDgtY2I3Yi00MzFkLWFlNzEtMDU2MGFmMjAxODViLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTI6NTcuNTE0NTQxWiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84Mzc2MzhhNi1j
-        ZDUxLTRkMmMtOTY1OC1jOGIyN2UyZWJiNDQvIiwicmVsYXRpdmVfcGF0aCI6
-        InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjoiNDI3NmUxNTY4ZDY0ZTMzMzgx
-        OTQ5Y2MwZDQxYTFmMDQiLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4
-        ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJh
-        NmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwi
-        c2hhMjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
-        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUy
-        OGQyMTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0
-        ZWE5MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlm
-        ZCIsInNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFk
-        ODUyN2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdm
-        ZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5
-        MDJlZTI4In1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:12:58 GMT
-- request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/bdd7bb15-cb4e-4d92-be92-fe407855e103/modify/
     body:
@@ -1099,4 +1038,169 @@ http_interactions:
         NGQ5Mi1iZTkyLWZlNDA3ODU1ZTEwMy8iXX0=
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:12:59 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '502'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvNjVjZDA3YzItZTI2MS00MzdkLThkNTktNmUxOGI3MjQwMjE0LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MTcuNTAzNDIyWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hMGIwNzAwMS04
+        OTIzLTQ5OTEtOGUzMC03ZGU4NTFjYWM4NmMvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjoiNDI3NmUxNTY4ZDY0ZTMzMzgx
+        OTQ5Y2MwZDQxYTFmMDQiLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4
+        ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJh
+        NmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwi
+        c2hhMjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
+        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUy
+        OGQyMTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0
+        ZWE5MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlm
+        ZCIsInNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFk
+        ODUyN2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdm
+        ZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5
+        MDJlZTI4In1dfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:18 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/8ebd7443-5ee4-4083-b353-fafa0e2968cf/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzY1Y2QwN2MyLWUyNjEtNDM3ZC04ZDU5LTZlMThiNzI0MDIx
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxZDgzYmYyLWJiYmUtNDg1
+        My05ODY1LWU0ZmI1ODA2NTUyNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/71d83bf2-bbbe-4853-9865-e4fb58065524/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '344'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzFkODNiZjItYmJi
+        ZS00ODUzLTk4NjUtZTRmYjU4MDY1NTI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTguMzU3MTU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTgu
+        NDg4NDY4WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxOC41
+        NzYyOTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzhlYmQ3NDQzLTVlZTQt
+        NDA4My1iMzUzLWZhZmEwZTI5NjhjZi8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:18 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,159 +23,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:05 GMT
+      - Wed, 07 Oct 2020 17:48:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:05 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:20 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:05 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:05 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -241,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:05 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:05 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -286,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:05 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +172,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:05 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -331,7 +203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:05 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +217,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:05 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -378,13 +250,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:06 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/5453726f-2b13-420f-857c-b27132810672/"
+      - "/pulp/api/v3/repositories/file/file/4a317284-49bb-4c05-836d-68f46314cf70/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -394,25 +266,25 @@ http_interactions:
       Content-Length:
       - '424'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS81NDUzNzI2Zi0yYjEzLTQyMGYtODU3Yy1iMjcxMzI4MTA2NzIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMzowNi4wMDgxMjZaIiwi
+        ZmlsZS80YTMxNzI4NC00OWJiLTRjMDUtODM2ZC02OGY0NjMxNGNmNzAvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODoyMS4zMjAwMThaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzU0NTM3MjZmLTJiMTMtNDIwZi04NTdjLWIyNzEzMjgxMDY3Mi92
+        ZS9maWxlLzRhMzE3Mjg0LTQ5YmItNGMwNS04MzZkLTY4ZjQ2MzE0Y2Y3MC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTQ1MzcyNmYtMmIxMy00MjBmLTg1
-        N2MtYjI3MTMyODEwNjcyL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNGEzMTcyODQtNDliYi00YzA1LTgz
+        NmQtNjhmNDYzMTRjZjcwL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
         bnVsbCwicmVtb3RlIjpudWxsfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:06 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -437,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:06 GMT
+      - Wed, 07 Oct 2020 17:48:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/ccbbd65e-fbbc-42ae-906a-45ac2f16c76d/"
+      - "/pulp/api/v3/remotes/file/file/1493b248-4b41-4d0d-9cb6-694e3f249add/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -453,25 +325,25 @@ http_interactions:
       Content-Length:
       - '436'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        Y2NiYmQ2NWUtZmJiYy00MmFlLTkwNmEtNDVhYzJmMTZjNzZkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTM6MDYuMTEzOTk1WiIsIm5hbWUi
+        MTQ5M2IyNDgtNGI0MS00ZDBkLTljYjYtNjk0ZTNmMjQ5YWRkLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MjEuNDE1NTE4WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJ1c2VybmFt
         ZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyMC0wOC0yMFQxOToxMzowNi4xMTQwMTRaIiwiZG93bmxvYWRfY29uY3Vy
+        MjAyMC0xMC0wN1QxNzo0ODoyMS40MTU1MzdaIiwiZG93bmxvYWRfY29uY3Vy
         cmVuY3kiOjEwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:06 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/ccbbd65e-fbbc-42ae-906a-45ac2f16c76d/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/1493b248-4b41-4d0d-9cb6-694e3f249add/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -492,7 +364,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:08 GMT
+      - Wed, 07 Oct 2020 17:48:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -506,17 +378,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UwOTFhMzdkLTljYmItNGEw
-        OC05YThkLTBmMzU5YzAxN2ZiOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4NmI4YzNkLTE2MmYtNGZk
+        Mi1iNDgwLTdiZGEyYTkwZjhhMi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:23 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/e091a37d-9cbb-4a08-9a8d-0f359c017fb9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/286b8c3d-162f-4fd2-b480-7bda2a90f8a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -524,7 +396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -537,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:08 GMT
+      - Wed, 07 Oct 2020 17:48:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -549,131 +421,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '339'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTA5MWEzN2QtOWNi
-        Yi00YTA4LTlhOGQtMGYzNTljMDE3ZmI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTM6MDguNjM3OTA1WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTM6MDguODUwNTI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzowOC45MzQ4Mjha
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS9jY2JiZDY1ZS1mYmJjLTQyYWUtOTA2YS00
-        NWFjMmYxNmM3NmQvIl19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:08 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5453726f-2b13-420f-857c-b27132810672/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjMGZmOGVlLWYwZDktNDI2
-        Mi1iNGUzLTkzMzQyZmUwMGQ1Mi8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/4c0ff8ee-f0d9-4262-b4e3-93342fe00d52/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGMwZmY4ZWUtZjBk
-        OS00MjYyLWI0ZTMtOTMzNDJmZTAwZDUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTM6MDkuMDY4MzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjg2YjhjM2QtMTYy
+        Zi00ZmQyLWI0ODAtN2JkYTJhOTBmOGEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjMuMzAyMDI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTM6MDkuMzE5NzE2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzowOS40MjUyNzNa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjMuNDY3Nzkx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyMy41MTc0MzVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU0NTM3MjZmLTJiMTMtNDIwZi04
-        NTdjLWIyNzEzMjgxMDY3Mi8iXX0=
+        My9yZW1vdGVzL2ZpbGUvZmlsZS8xNDkzYjI0OC00YjQxLTRkMGQtOWNiNi02
+        OTRlM2YyNDlhZGQvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:23 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/4a317284-49bb-4c05-836d-68f46314cf70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -690,45 +461,35 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 200
-      message: OK
+      code: 202
+      message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
+      - Wed, 07 Oct 2020 17:48:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '257'
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3
-        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0
-        NWU4L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQw
-        YTItYjkzNy1iZjQxYTYzZjQ1ZTgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVi
-        bGlzaGVkIExpYnJhcnkgYW5kIGRldiB2aWV3LTcwMDk3MzQ1My05MDkwNTgz
-        NDciLCJkZXNjcmlwdGlvbiI6IlB1Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYg
-        dmlldy03MDA5NzM0NTMtOTA5MDU4MzQ3IiwicmVtb3RlIjpudWxsfV19
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmNDhlYTMyLTJhZjEtNDAz
+        MC1hNTBhLTljOTJiYmE1ZjU2OC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:23 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/7f48ea32-2af1-4030-a50a-9c92bba5f568/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -736,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -749,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
+      - Wed, 07 Oct 2020 17:48:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -757,28 +518,34 @@ http_interactions:
       Vary:
       - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '222'
+      - '343'
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y0OGVhMzItMmFm
+        MS00MDMwLWE1MGEtOWM5MmJiYTVmNTY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjMuNjU4NTIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjMuNzk1MjM4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyMy44NjY4MjVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzRhMzE3Mjg0LTQ5YmItNGMwNS04
+        MzZkLTY4ZjQ2MzE0Y2Y3MC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:23 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -786,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -799,232 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '369'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMjo0Ni4xMjY1Mjla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAy
-        OS1mZmRiMzMxOWM5OGMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNh
-        dGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0
-        YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNp
-        b25zIjowfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUy
-        ODUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMDo0Ny40MDk2
-        NjRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUy
-        ODUvdmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmIt
-        YTgyZS0yZTFiMjM4ZmUyODUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/de80535c-d2ec-4633-b029-ffdb3319c98c/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:09 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTgwNTM1Yy1kMmVjLTQ2MzMtYjAyOS1mZmRiMzMxOWM5OGMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEy
-        OjQ2LjEzOTQwM1oiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/591e4778-2450-4ebb-a82e-2e1b238fe285/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81OTFlNDc3OC0yNDUwLTRlYmItYTgyZS0yZTFiMjM4ZmUyODUv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEw
-        OjQ3LjQxNjQ1M1oiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
+      - Wed, 07 Oct 2020 17:48:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1038,17 +580,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1056,7 +598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1069,41 +611,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
+      - Wed, 07 Oct 2020 17:48:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1111,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1124,36 +656,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
+      - Wed, 07 Oct 2020 17:48:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '227'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1161,7 +688,97 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1174,7 +791,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
+      - Wed, 07 Oct 2020 17:48:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1188,17 +805,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2MTk5YzM1LWY3ZTktNDE5
-        YS04ZDgxLWU3YTFhZDQ1ZTBkMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkODliNGMzLTgwYjctNGVl
+        My05MDI0LTQ0NjUzOWRiNmQ2Yi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/16199c35-f7e9-419a-8d81-e7a1ad45e0d1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9d89b4c3-80b7-4ee3-9024-446539db6d6b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1206,7 +823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1219,7 +836,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:13:10 GMT
+      - Wed, 07 Oct 2020 17:48:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1231,20 +848,20 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '376'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTYxOTljMzUtZjdl
-        OS00MTlhLThkODEtZTdhMWFkNDVlMGQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTM6MTAuMjU2OTA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWQ4OWI0YzMtODBi
+        Ny00ZWUzLTkwMjQtNDQ2NTM5ZGI2ZDZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjQuMjc0NjMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMzoxMC4zNTk4
-        NjFaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjEzOjEwLjQ2MzAz
-        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyNC4zNTQy
+        OTFaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjI0LjQ0OTYx
+        NVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
         cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
@@ -1255,5 +872,5 @@ http_interactions:
         ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
         XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:24 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
@@ -3062,101 +3062,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:44:48 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:06 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:06 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:06 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/86003051-7268-4a95-8546-424ee091e49b/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '130'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84NjAwMzA1MS03
-        MjY4LTRhOTUtODU0Ni00MjRlZTA5MWU0OWIvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMC0wOC0yMFQxOToxMzowNi40MjQwMjFaIiwic2l6ZSI6NzQwfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:06 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/86003051-7268-4a95-8546-424ee091e49b/
     body:
@@ -3335,62 +3240,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:13:06 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVlNmQ3NjIwNDAwMjJk
-        MGJkNzhjOGViNTc4NjdmZGNlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNWU2ZDc2MjA0
-        MDAyMmQwYmQ3OGM4ZWI1Nzg2N2ZkY2UNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvYWZkMDI4NGUtY2YwNy00YzA3LWE0M2QtNmZmMTMwMWJkY2M4
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVlNmQ3NjIwNDAw
-        MjJkMGJkNzhjOGViNTc4NjdmZGNlLS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-5e6d762040022d0bd78c8eb57867fdce
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:13:07 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwNThmYTdmLTAxZmEtNGQy
-        ZS1iNDM4LTEzZmJhOTJjN2Q3YS8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:13:07 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/a058fa7f-01fa-4d2e-b438-13fba92c7d7a/
     body:
@@ -3553,4 +3402,496 @@ http_interactions:
         LTg1N2MtYjI3MTMyODEwNjcyLyJdfQ==
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:13:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:21 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:21 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/27929790-8e2e-4364-b7a3-230b3f9b2a34/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '130'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8yNzkyOTc5MC04
+        ZTJlLTQzNjQtYjdhMy0yMzBiM2Y5YjJhMzQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoyMS43NDY1MzdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/27929790-8e2e-4364-b7a3-230b3f9b2a34/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTlkN2M5ZTliZGNhZTZm
+        MTUzYzI5NjVmYTkxYWNmNTBlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMDEw
+        MDctMzAxODItMTByNXA1YyINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC05ZDdjOWU5YmRj
+        YWU2ZjE1M2MyOTY1ZmE5MWFjZjUwZS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-9d7c9e9bdcae6f153c2965fa91acf50e
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:21 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8yNzkyOTc5MC04
+        ZTJlLTQzNjQtYjdhMy0yMzBiM2Y5YjJhMzQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoyMS43NDY1MzdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/27929790-8e2e-4364-b7a3-230b3f9b2a34/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:21 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxYmQwODdmLTFiZjUtNDhj
+        MC04NTIyLTgxMjVhZGI0NzMzNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:21 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/91bd087f-1bf5-48c0-8522-8125adb47336/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '365'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFiZDA4N2YtMWJm
+        NS00OGMwLTg1MjItODEyNWFkYjQ3MzM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjEuODI0MjkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        c3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjEuOTYwNTY0WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyMi4wMjI0NDRaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA5NTM5
+        Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy8zYmVmMWEzZC05Mzg0LTQxNjktYjMzOC0y
+        YjI2Y2YzZTBlNDIvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
+        L3B1bHAvYXBpL3YzL3VwbG9hZHMvMjc5Mjk3OTAtOGUyZS00MzY0LWI3YTMt
+        MjMwYjNmOWIyYTM0LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:22 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQ2NmNhNWI2Nzc0OGRk
+        YzNlZGRiZWE1Nzc1NWFlZjE5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZDY2Y2E1YjY3
+        NzQ4ZGRjM2VkZGJlYTU3NzU1YWVmMTkNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvM2JlZjFhM2QtOTM4NC00MTY5LWIzMzgtMmIyNmNmM2UwZTQy
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQ2NmNhNWI2Nzc0
+        OGRkYzNlZGRiZWE1Nzc1NWFlZjE5LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-d66ca5b67748ddc3eddbea57755aef19
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxMWU2ZDkxLTM1ZDItNDdj
+        OC1iMjlmLTk4YWFmZDA5MmM5ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:22 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/811e6d91-35d2-47c8-b29f-98aafd092c9d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODExZTZkOTEtMzVk
+        Mi00N2M4LWIyOWYtOThhYWZkMDkyYzlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjIuMTE2MjQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjIuMjg1Njk5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyMi40MjY3MTha
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8wNzg2NjQyMy04
+        ZjgwLTQ2YjUtOGYxOS0wY2Y5ZDllMTk1NjQvIl0sInJlc2VydmVkX3Jlc291
+        cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zYmVmMWEz
+        ZC05Mzg0LTQxNjktYjMzOC0yYjI2Y2YzZTBlNDIvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:22 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/4a317284-49bb-4c05-836d-68f46314cf70/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzA3ODY2NDIzLThmODAtNDZiNS04ZjE5LTBjZjlkOWUxOTU2
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M0ZDA0ZWM1LTIzOTQtNDFl
+        NC1hODc4LWM1ZGQ1Nzk3ZGU5OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:22 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/c4d04ec5-2394-41e4-a878-c5dd5797de98/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '356'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzRkMDRlYzUtMjM5
+        NC00MWU0LWE4NzgtYzVkZDU3OTdkZTk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjIuNTYyMDU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjIu
+        NzEwNzkwWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyMi44
+        MTUyMjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        NGEzMTcyODQtNDliYi00YzA1LTgzNmQtNjhmNDYzMTRjZjcwL3ZlcnNpb25z
+        LzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNGEzMTcyODQtNDliYi00YzA1
+        LTgzNmQtNjhmNDYzMTRjZjcwLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:22 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,159 +23,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:08 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:08 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -241,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:08 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -286,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:08 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +172,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -331,7 +203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:08 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +217,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -363,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -376,159 +248,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -549,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -563,17 +307,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -608,17 +352,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -639,7 +383,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -653,17 +397,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -698,17 +442,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:25 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -731,13 +475,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/"
+      - "/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -747,25 +491,25 @@ http_interactions:
       Content-Length:
       - '428'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS9iNTJiNmYxMy0xZWEzLTQwZDEtYTZmMS1iMDg4ZjI1YTA2YjkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMDowOS4zNjg1MzFaIiwi
+        ZmlsZS83OTgyMTQ5MS1jZTdmLTQ0M2UtYWU2ZS03NmM1MGY2MThkYzQvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODoyNi4wNDI5NDJaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZiOS92
+        ZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRjNC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2
-        ZjEtYjA4OGYyNWEwNmI5L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFl
+        NmUtNzZjNTBmNjE4ZGM0L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRp
         b24iOm51bGwsInJlbW90ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:26 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -791,13 +535,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/88b17e06-edca-4070-a695-91a7ce012c54/"
+      - "/pulp/api/v3/remotes/file/file/9206a593-16bb-481b-b197-92018a704f66/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -807,26 +551,26 @@ http_interactions:
       Content-Length:
       - '462'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ODhiMTdlMDYtZWRjYS00MDcwLWE2OTUtOTFhN2NlMDEyYzU0LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTA6MDkuNDc4OTMzWiIsIm5hbWUi
+        OTIwNmE1OTMtMTZiYi00ODFiLWIxOTctOTIwMThhNzA0ZjY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MjYuMTMxNDE0WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVl
         LCJwcm94eV91cmwiOm51bGwsInVzZXJuYW1lIjpudWxsLCJwYXNzd29yZCI6
-        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEwOjA5
-        LjQ3ODk1MloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
+        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjI2
+        LjEzMTQzM1oiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
         ImltbWVkaWF0ZSJ9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:26 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -849,7 +593,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -863,17 +607,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxM2EwODFhLThiYTYtNDk5
-        Ny1hYTVjLTc5MzMyNjNlOTkzYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzN2RjM2JiLTliOTEtNDE1
+        NS05ZjA0LTk2ZTlhZThjNzlkNi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:26 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/88b17e06-edca-4070-a695-91a7ce012c54/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/9206a593-16bb-481b-b197-92018a704f66/
     body:
       encoding: UTF-8
       base64_string: |
@@ -899,7 +643,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:09 GMT
+      - Wed, 07 Oct 2020 17:48:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -913,17 +657,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllYmUyMTE5LWJjYWQtNGUw
-        MS04ZmVmLWNkMzI2NTE2OWZhNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmNDA2NDg5LTZhNDQtNGFl
+        NS1iZDkzLTY5OTBhNDhmYzI1My8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:26 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -948,7 +692,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:10 GMT
+      - Wed, 07 Oct 2020 17:48:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -962,17 +706,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2ZWRhNjY1LTk5MzQtNDQ4
-        MS04NGRhLWM1MTE4MDVkMmJlOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlYzFiYmM1LTYyODctNDYw
+        YS04ZDUyLWE1YjM0ZTkzNTJmNy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/56eda665-9934-4481-84da-c511805d2be9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/dec1bbc5-6287-460a-8d52-a5b34e9352f7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -980,7 +724,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +737,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:10 GMT
+      - Wed, 07 Oct 2020 17:48:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1005,30 +749,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '346'
+      - '350'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTZlZGE2NjUtOTkz
-        NC00NDgxLTg0ZGEtYzUxMTgwNWQyYmU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTAuMDc4ODc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGVjMWJiYzUtNjI4
+        Ny00NjBhLThkNTItYTViMzRlOTM1MmY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjYuNzA1MDY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTAuNDY0NDU1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxMC43NTczODBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjYuOTYzOTMx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyNy4xNjI4NDRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzk0NDUz
-        NzZmLWFmYWItNDk4MC1iOTlkLTRmMDUxZTdlMDUyYS8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2FiNDRk
+        YzZlLWU2NDMtNDBmOC04ZGExLWUyOWJjNmE2ZjQ4My8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1049,7 +793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:10 GMT
+      - Wed, 07 Oct 2020 17:48:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1061,31 +805,31 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '252'
+      - '256'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvOTQ0NTM3NmYtYWZhYi00OTgwLWI5OWQtNGYwNTFlN2UwNTJhLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTA6MTAuNzMyMDE5WiIs
+        L2ZpbGUvYWI0NGRjNmUtZTY0My00MGY4LThkYTEtZTI5YmM2YTZmNDgzLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MjcuMTM5NjE2WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
-        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9u
-        L2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
-        bGVfMSIsInB1YmxpY2F0aW9uIjpudWxsfQ==
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2Fu
+        aXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJk
+        IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:27 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvODhi
-        MTdlMDYtZWRjYS00MDcwLWE2OTUtOTFhN2NlMDEyYzU0LyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOTIw
+        NmE1OTMtMTZiYi00ODFiLWIxOTctOTIwMThhNzA0ZjY2LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1104,7 +848,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:11 GMT
+      - Wed, 07 Oct 2020 17:48:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1118,17 +862,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjNjIxZjI5LTU0NzYtNDgy
-        YS1iYTY5LTc0YjMxMjQ2ZDI2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhZjk1MjIyLTI3MmMtNGMz
+        MC1hMzI2LWUyNDYwZWVmYmEzMS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/2c621f29-5476-482a-ba69-74b31246d269/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/daf95222-272c-4c30-a326-e2460eefba31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1136,7 +880,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,7 +893,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:12 GMT
+      - Wed, 07 Oct 2020 17:48:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1161,53 +905,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '533'
+      - '534'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmM2MjFmMjktNTQ3
-        Ni00ODJhLWJhNjktNzRiMzEyNDZkMjY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTEuMjkwMDY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGFmOTUyMjItMjcy
+        Yy00YzMwLWEzMjYtZTI0NjBlZWZiYTMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjcuNTQxMjc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjEwOjEx
-        LjQ5MjM5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTIu
-        MzE4MDY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMGUzZTYyZi1jOTc2LTRjN2EtYjEzNS0zODE2NDg5NDQ4MDUv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjI3
+        LjcyNjk5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6Mjku
+        Mzc2MTMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy9mMzc4OWU1MS01ZjQ2LTRlMzEtYmMyMy04ODE5ZWExYzAyMDcv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
-        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
-        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
-        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
-        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
+        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
+        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
+        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
+        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4
-        OGYyNWEwNmI5L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        YjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEwNmI5LyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS84OGIxN2UwNi1lZGNhLTQwNzAt
-        YTY5NS05MWE3Y2UwMTJjNTQvIl19
+        aXRvcmllcy9maWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZj
+        NTBmNjE4ZGM0L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzkyMDZh
+        NTkzLTE2YmItNDgxYi1iMTk3LTkyMDE4YTcwNGY2Ni8iLCIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0M2Ut
+        YWU2ZS03NmM1MGY2MThkYzQvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:29 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS9iNTJiNmYxMy0xZWEzLTQwZDEtYTZmMS1iMDg4ZjI1
-        YTA2YjkvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0M2UtYWU2ZS03NmM1MGY2
+        MThkYzQvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1226,7 +970,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:12 GMT
+      - Wed, 07 Oct 2020 17:48:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1240,17 +984,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczZDg4MmYxLTA5MDEtNDMz
-        MS1iZmY5LTE3YzNjYzk3OWJlZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwNTgxNDdmLWMwMjktNDRj
+        Ni05ZGMwLTA0MmE1OTJhMTNiNC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:29 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/73d882f1-0901-4331-bff9-17c3cc979bee/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/f058147f-c029-44c6-9dc0-042a592a13b4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1258,7 +1002,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1271,7 +1015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:13 GMT
+      - Wed, 07 Oct 2020 17:48:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1283,39 +1027,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '371'
+      - '375'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzNkODgyZjEtMDkw
-        MS00MzMxLWJmZjktMTdjM2NjOTc5YmVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTIuNjg3NTYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjA1ODE0N2YtYzAy
+        OS00NGM2LTlkYzAtMDQyYTU5MmExM2I0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjkuNTM2NDUzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTIuOTYyMTg0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxMy4xNDcxOTBa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MjkuNjg0NDE3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoyOS43ODE3NDZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWVjMzZj
-        ZWYtMTY3OC00OWMyLWJjYjMtMzkyZDczMDc0ZTIxLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTRhMzI0
+        YzEtNDczYy00OTU5LWJjODEtOWE2YWVmZWJiYTQ5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZi
-        OS8iXX0=
+        ZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRj
+        NC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:13 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:29 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWVjMzZj
-        ZWYtMTY3OC00OWMyLWJjYjMtMzkyZDczMDc0ZTIxLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTRhMzI0
+        YzEtNDczYy00OTU5LWJjODEtOWE2YWVmZWJiYTQ5LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1333,7 +1077,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:13 GMT
+      - Wed, 07 Oct 2020 17:48:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1347,17 +1091,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwNWM5NTI5LWIzYTgtNDZk
-        Mi1iN2ZkLWFhZjVhOGJhOTZkNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlMzFmZTcyLWI4NGYtNDhk
+        Yi1hNTA5LTU2YzQwZmNlYWNjOS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:13 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:29 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/a05c9529-b3a8-46d2-b7fd-aaf5a8ba96d7/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/ce31fe72-b84f-48db-a509-56c40fceacc9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1365,7 +1109,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1378,7 +1122,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:14 GMT
+      - Wed, 07 Oct 2020 17:48:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1390,36 +1134,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '318'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTA1Yzk1MjktYjNh
-        OC00NmQyLWI3ZmQtYWFmNWE4YmE5NmQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTMuNTMwNDM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2UzMWZlNzItYjg0
+        Zi00OGRiLWE1MDktNTZjNDBmY2VhY2M5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MjkuOTQ1NjE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTMuNzc3OTQ0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxNC4yMDI5Mjha
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzAuMTA1MDg4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozMC4zNjQwODVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:14 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:30 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWVjMzZj
-        ZWYtMTY3OC00OWMyLWJjYjMtMzkyZDczMDc0ZTIxLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTRhMzI0
+        YzEtNDczYy00OTU5LWJjODEtOWE2YWVmZWJiYTQ5LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1437,7 +1181,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:14 GMT
+      - Wed, 07 Oct 2020 17:48:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1451,17 +1195,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1ZjFlMGUzLWIzNDMtNGRl
-        NS1hOTJkLWFmOGRkOWY0Nzc2MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5MTRmMTc2LWRlZjItNGZm
+        My1hMTIzLTAxNjc1MTExNjFjOC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:14 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:30 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1484,7 +1228,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:14 GMT
+      - Wed, 07 Oct 2020 17:48:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1498,17 +1242,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzODI1ZGFiLWMzYTMtNDdi
-        OC1hNjg4LWQ5NDU1MTgxMGJlYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlNWVlY2MyLTk4YTYtNDdk
+        My04Mzg4LTE0Nzg5ZmQxNDBhMS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:14 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:30 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/88b17e06-edca-4070-a695-91a7ce012c54/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/9206a593-16bb-481b-b197-92018a704f66/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1534,7 +1278,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:15 GMT
+      - Wed, 07 Oct 2020 17:48:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1548,24 +1292,24 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjODQ5N2YyLWY5ODQtNGNl
-        MC05MDhkLWNhNDllNmMyY2RlMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhMTYxNmVkLTE4YWItNGEy
+        Ni1iNWIyLTJlMzEwMjYxYWQ1ZS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:15 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:30 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWVjMzZj
-        ZWYtMTY3OC00OWMyLWJjYjMtMzkyZDczMDc0ZTIxLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTRhMzI0
+        YzEtNDczYy00OTU5LWJjODEtOWE2YWVmZWJiYTQ5LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1583,7 +1327,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:15 GMT
+      - Wed, 07 Oct 2020 17:48:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1597,17 +1341,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkMDhiN2UzLWY1MDEtNGNi
-        Ni04OTg2LWNiNzdkZDlhM2ZiMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxYWY5NTk3LTYzNTgtNGM2
+        Yi1hMjgxLTRmYjkyZDQ5Mzc2Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:15 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:31 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/5d08b7e3-f501-4cb6-8986-cb77dd9a3fb1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/c1af9597-6358-4c6b-a281-4fb92d493766/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1615,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1628,7 +1372,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:16 GMT
+      - Wed, 07 Oct 2020 17:48:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1640,36 +1384,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWQwOGI3ZTMtZjUw
-        MS00Y2I2LTg5ODYtY2I3N2RkOWEzZmIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTUuMjkyMDQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzFhZjk1OTctNjM1
+        OC00YzZiLWEyODEtNGZiOTJkNDkzNzY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzEuMDU4OTU5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTUuNzczNDUw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxNi4yNDU2Mzha
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzEuNTQyNDQ1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozMS44MDI4NTRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:31 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWVjMzZj
-        ZWYtMTY3OC00OWMyLWJjYjMtMzkyZDczMDc0ZTIxLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTRhMzI0
+        YzEtNDczYy00OTU5LWJjODEtOWE2YWVmZWJiYTQ5LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1687,7 +1431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:16 GMT
+      - Wed, 07 Oct 2020 17:48:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1701,22 +1445,22 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5NmUzZWZjLWM2NmUtNDMz
-        ZS05OWI1LTUwNDViNjczZDMwOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1NWY5NDI0LTRiMDYtNGU4
+        ZS04MDgyLTNmNTRjZGNiZTc1Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:31 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvODhi
-        MTdlMDYtZWRjYS00MDcwLWE2OTUtOTFhN2NlMDEyYzU0LyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOTIw
+        NmE1OTMtMTZiYi00ODFiLWIxOTctOTIwMThhNzA0ZjY2LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1735,7 +1479,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:17 GMT
+      - Wed, 07 Oct 2020 17:48:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1749,17 +1493,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3MTdhNDMxLTlkNTItNDUx
-        Ny04ZTk0LTU1NDFkOWJlNzgwYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MGY4Y2QyLTQwZWEtNGYz
+        Ni05MTQ5LTFjODFhMDRkN2FmYS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:32 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/6717a431-9d52-4517-8e94-5541d9be780b/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/250f8cd2-40ea-4f36-9149-1c81a04d7afa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1767,7 +1511,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1780,7 +1524,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:18 GMT
+      - Wed, 07 Oct 2020 17:48:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1792,53 +1536,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '530'
+      - '531'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjcxN2E0MzEtOWQ1
-        Mi00NTE3LThlOTQtNTU0MWQ5YmU3ODBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTYuOTYxODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjUwZjhjZDItNDBl
+        YS00ZjM2LTkxNDktMWM4MWEwNGQ3YWZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzIuMjQyMTYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjEwOjE3
-        LjI1MTE0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTgu
-        MTQwNzI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjMy
+        LjQ1MDk2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzMu
+        NzY3MDQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy9mMzc4OWU1MS01ZjQ2LTRlMzEtYmMyMy04ODE5ZWExYzAyMDcv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
-        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
-        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
-        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
-        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
-        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
-        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
+        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
+        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
+        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
+        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4
-        OGYyNWEwNmI5L3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        YjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEwNmI5LyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS84OGIxN2UwNi1lZGNhLTQwNzAt
-        YTY5NS05MWE3Y2UwMTJjNTQvIl19
+        aXRvcmllcy9maWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZj
+        NTBmNjE4ZGM0L3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzkyMDZh
+        NTkzLTE2YmItNDgxYi1iMTk3LTkyMDE4YTcwNGY2Ni8iLCIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0M2Ut
+        YWU2ZS03NmM1MGY2MThkYzQvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:33 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS9iNTJiNmYxMy0xZWEzLTQwZDEtYTZmMS1iMDg4ZjI1
-        YTA2YjkvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0M2UtYWU2ZS03NmM1MGY2
+        MThkYzQvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1857,7 +1601,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:18 GMT
+      - Wed, 07 Oct 2020 17:48:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1871,17 +1615,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiMWUwNGMxLTA3NzgtNGUy
-        NC1iMDExLTYyYTE3M2I3ZjM2Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiYzdjMDEyLWIzOWYtNDU0
+        MC05NTA3LWQ4MDUxYzNhYTM0MS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:33 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/6b1e04c1-0778-4e24-b011-62a173b7f367/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/bbc7c012-b39f-4540-9507-d8051c3aa341/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1889,7 +1633,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1902,7 +1646,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:18 GMT
+      - Wed, 07 Oct 2020 17:48:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1914,39 +1658,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '373'
+      - '376'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmIxZTA0YzEtMDc3
-        OC00ZTI0LWIwMTEtNjJhMTczYjdmMzY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTguNDI0ODkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmJjN2MwMTItYjM5
+        Zi00NTQwLTk1MDctZDgwNTFjM2FhMzQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzMuOTYzMTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTguNjUzMDMx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxOC44MDMyNjBa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzQuMTA5NzE3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozNC4yMDcyNTla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZGJmOWFm
-        MjQtNmMyNy00YzkzLWFlYWMtMmVlMjUxNjM2ODQzLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWZkMzJk
+        MTItYzZhZC00ZThkLWFhZDktYjVkNDcxYjhjMGY4LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZi
-        OS8iXX0=
+        ZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRj
+        NC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:34 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZGJmOWFm
-        MjQtNmMyNy00YzkzLWFlYWMtMmVlMjUxNjM2ODQzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWZkMzJk
+        MTItYzZhZC00ZThkLWFhZDktYjVkNDcxYjhjMGY4LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1964,7 +1708,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:19 GMT
+      - Wed, 07 Oct 2020 17:48:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1978,17 +1722,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiMzQ5MmQ0LTA0NDMtNGI1
-        Zi04MTFlLTgxN2I3NDlkYzdiNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1ZDk2NzI5LWI3YjQtNGIy
+        YS04MGQyLTMzNTE0ODNjNWM4Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:34 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/fb3492d4-0443-4b5f-811e-817b749dc7b7/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/15d96729-b7b4-4b2a-80d2-3351483c5c86/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1996,7 +1740,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2009,7 +1753,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:19 GMT
+      - Wed, 07 Oct 2020 17:48:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2021,36 +1765,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '315'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmIzNDkyZDQtMDQ0
-        My00YjVmLTgxMWUtODE3Yjc0OWRjN2I3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MTkuMDQwNTI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTVkOTY3MjktYjdi
+        NC00YjJhLTgwZDItMzM1MTQ4M2M1Yzg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzQuMzc3ODA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MTkuMjc1MTk1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoxOS42NjkxMjRa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzQuNTMxNDgx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozNC43NjQwNDFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:34 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZGJmOWFm
-        MjQtNmMyNy00YzkzLWFlYWMtMmVlMjUxNjM2ODQzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWZkMzJk
+        MTItYzZhZC00ZThkLWFhZDktYjVkNDcxYjhjMGY4LyJ9
     headers:
       Content-Type:
       - application/json
@@ -2068,7 +1812,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:19 GMT
+      - Wed, 07 Oct 2020 17:48:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2082,17 +1826,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxY2E5NTExLTVkOTktNDI4
-        Yi1hZTMyLTU3MjljOTZkMWY0Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwZTYyMGYzLWYzNDEtNDYx
+        ZC04Zjg0LWIxYTczYWNmMGNkOC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:34 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2100,7 +1844,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2113,578 +1857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:20 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '346'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZi
-        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEwOjA5LjM2ODUz
-        MVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEw
-        NmI5L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iNTJiNmYxMy0xZWEzLTQw
-        ZDEtYTZmMS1iMDg4ZjI1YTA2YjkvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
-        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
-        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNWZmYTU5Mzct
-        YjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNpb25zLyIsImxhdGVz
-        dF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
-        bGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQwYTItYjkzNy1iZjQxYTYzZjQ1ZTgv
-        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVibGlzaGVkIExpYnJhcnkgYW5kIGRl
-        diB2aWV3LTcwMDk3MzQ1My05MDkwNTgzNDciLCJkZXNjcmlwdGlvbiI6IlB1
-        Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYgdmlldy03MDA5NzM0NTMtOTA5MDU4
-        MzQ3IiwicmVtb3RlIjpudWxsfV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:20 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '322'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZi
-        OS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MTA6MTcuMzE2MDA2WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
-        dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIw
-        ODhmMjVhMDZiOS92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
-        bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
-        aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iNTJiNmYxMy0xZWEzLTQw
-        ZDEtYTZmMS1iMDg4ZjI1YTA2YjkvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
-        OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMt
-        NDBkMS1hNmYxLWIwODhmMjVhMDZiOS92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        YjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEwNmI5L3ZlcnNpb25z
-        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMDoxMS41NTI4
-        NDVaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
-        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEwNmI5
-        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
-        LmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvYjUyYjZmMTMtMWVhMy00MGQxLWE2
-        ZjEtYjA4OGYyNWEwNmI5L3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iNTJiNmYx
-        My0xZWEzLTQwZDEtYTZmMS1iMDg4ZjI1YTA2YjkvdmVyc2lvbnMvMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEwOjA5LjM3MzU5MFoiLCJu
-        dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:20 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:20 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '366'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowOTo1NC43NTU0OTRa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4
-        NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMi8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA5OjUzLjIyMTY0OVoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2Nj
-        NDYwNTE3Zi92ZXJzaW9ucy8xLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/bd86e48a-1ed7-4b33-a884-a537ff14b5e2/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:20 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '458'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEw
-        OjA1LjQxOTExNFoiLCJudW1iZXIiOjIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkODZlNDhhLTFlZDctNGIzMy1hODg0
-        LWE1MzdmZjE0YjVlMi92ZXJzaW9ucy8yLyJ9LCJycG0uZGlzdHJpYnV0aW9u
-        X3RyZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkODZl
-        NDhhLTFlZDctNGIzMy1hODg0LWE1MzdmZjE0YjVlMi92ZXJzaW9ucy8yLyJ9
-        LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkODZl
-        NDhhLTFlZDctNGIzMy1hODg0LWE1MzdmZjE0YjVlMi92ZXJzaW9ucy8yLyJ9
-        LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MTksImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
-        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmQ4NmU0
-        OGEtMWVkNy00YjMzLWE4ODQtYTUzN2ZmMTRiNWUyL3ZlcnNpb25zLzIvIn0s
-        InJwbS5wYWNrYWdlZ3JvdXAiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lv
-        bnMvMi8ifSwicnBtLnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwi
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
-        X2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtL2JkODZlNDhhLTFlZDctNGIzMy1hODg0
-        LWE1MzdmZjE0YjVlMi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50Ijo0LCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYmQ4
-        NmU0OGEtMWVkNy00YjMzLWE4ODQtYTUzN2ZmMTRiNWUyL3ZlcnNpb25zLzIv
-        In0sInJwbS5kaXN0cmlidXRpb25fdHJlZSI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMv
-        P3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vYmQ4NmU0OGEtMWVkNy00YjMzLWE4ODQtYTUzN2ZmMTRiNWUy
-        L3ZlcnNpb25zLzIvIn0sInJwbS5tb2R1bGVtZCI6eyJjb3VudCI6NiwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYmQ4NmU0OGEtMWVkNy00YjMzLWE4ODQtYTUzN2ZmMTRiNWUyL3ZlcnNp
-        b25zLzIvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxOSwiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2
-        ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMi8i
-        fSwicnBtLnBhY2thZ2VlbnZpcm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2JkODZlNDhhLTFlZDctNGIzMy1hODg0LWE1MzdmZjE0YjVl
-        Mi92ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50Ijoy
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYmQ4NmU0OGEtMWVkNy00YjMzLWE4ODQtYTUzN2ZmMTRi
-        NWUyL3ZlcnNpb25zLzIvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsi
-        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVw
-        b19tZXRhZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMt
-        YTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4
-        YS0xZWQ3LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjEwOjA0LjU0Mzg0M1oiLCJu
-        dW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
-        dmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMt
-        YTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
-        dmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3LTRiMzMtYTg4NC1h
-        NTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iZDg2ZTQ4YS0xZWQ3
-        LTRiMzMtYTg4NC1hNTM3ZmYxNGI1ZTIvdmVyc2lvbnMvMC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA5OjU0Ljc2NjU4MFoiLCJudW1iZXIi
-        OjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
-        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/9eaeedf9-aaae-4c98-99ac-ceccc460517f/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '457'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlhYy1jZWNjYzQ2MDUxN2Yv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA5
-        OjU1Ljc5NzI0NVoiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYWVlZGY5LWFhYWUtNGM5OC05OWFj
-        LWNlY2NjNDYwNTE3Zi92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9u
-        X3RyZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYWVl
-        ZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJzaW9ucy8xLyJ9
-        LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYWVl
-        ZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJzaW9ucy8xLyJ9
-        LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQiOjMsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvP3Jl
-        cG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOWVhZWVkZjktYWFhZS00Yzk4LTk5YWMtY2VjY2M0NjA1
-        MTdmL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxOSwi
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlhYy1jZWNjYzQ2MDUx
-        N2YvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3Vu
-        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        Y2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgt
-        OTlhYy1jZWNjYzQ2MDUxN2YvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2Vl
-        bnZpcm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3Zl
-        cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJzaW9u
-        cy8xLyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vOWVhZWVkZjktYWFhZS00Yzk4LTk5YWMtY2VjY2M0NjA1MTdm
-        L3ZlcnNpb25zLzEvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291
-        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19t
-        ZXRhZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRj
-        OTgtOTlhYy1jZWNjYzQ2MDUxN2YvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQi
-        Ont9LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6NiwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJz
-        aW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQiOjEs
-        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0aW9u
-        X3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2Nj
-        NDYwNTE3Zi92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWQiOnsiY291bnQi
-        OjYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzllYWVlZGY5LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3
-        Zi92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291
-        bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRfZGVmYXVsdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vOWVhZWVkZjktYWFhZS00Yzk4LTk5YWMt
-        Y2VjY2M0NjA1MTdmL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNv
-        dW50IjoxOSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlhYy1jZWNjYzQ2
-        MDUxN2YvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJj
-        b3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlY2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlh
-        Yy1jZWNjYzQ2MDUxN2YvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZp
-        cm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzllYWVlZGY5
-        LWFhYWUtNGM5OC05OWFjLWNlY2NjNDYwNTE3Zi92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOWVhZWVk
-        ZjktYWFhZS00Yzk4LTk5YWMtY2VjY2M0NjA1MTdmL3ZlcnNpb25zLzEvIn0s
-        InJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy8/
-        cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlhYy1jZWNjYzQ2MDUxN2Yv
-        dmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS85ZWFlZWRmOS1hYWFlLTRjOTgtOTlhYy1j
-        ZWNjYzQ2MDUxN2YvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA5OjUzLjIyODAzMVoiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
+      - Wed, 07 Oct 2020 17:48:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2698,17 +1871,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2716,7 +1889,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2729,7 +1902,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
+      - Wed, 07 Oct 2020 17:48:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2741,29 +1959,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '251'
+      - '245'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        ZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRj
+        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjI2LjA0Mjk0
+        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZjNTBmNjE4
+        ZGM0L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0
+        M2UtYWU2ZS03NmM1MGY2MThkYzQvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2771,7 +1988,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2784,7 +2001,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
+      - Wed, 07 Oct 2020 17:48:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2796,24 +2013,143 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '227'
+      - '322'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        ZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRj
+        NC92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6
+        NDg6MzIuNDk5NzA5WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
+        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
+        dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
+        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2
+        YzUwZjYxOGRjNC92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
+        bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0
+        M2UtYWU2ZS03NmM1MGY2MThkYzQvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
+        OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ODIxNDkxLWNlN2Yt
+        NDQzZS1hZTZlLTc2YzUwZjYxOGRjNC92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        Nzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZjNTBmNjE4ZGM0L3ZlcnNpb25z
+        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODoyNy43NjIx
+        MTZaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZjNTBmNjE4ZGM0
+        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
+        LmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNzk4MjE0OTEtY2U3Zi00NDNlLWFl
+        NmUtNzZjNTBmNjE4ZGM0L3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5
+        MS1jZTdmLTQ0M2UtYWU2ZS03NmM1MGY2MThkYzQvdmVyc2lvbnMvMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjI2LjA0NzEwN1oiLCJu
+        dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
+        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/versions/1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2834,7 +2170,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
+      - Wed, 07 Oct 2020 17:48:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2848,17 +2184,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlMDllZjU5LWMzNjktNGVk
-        OC1hMmU1LWEwZGQ1MTU1OTcwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmYmQwYWVkLTZmOGUtNDVl
+        MS04NWMzLTJmOGJhZWZkNzk2MS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/bd86e48a-1ed7-4b33-a884-a537ff14b5e2/versions/2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2866,7 +2202,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2879,142 +2215,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyNGNiMDhlLTc2ZmQtNGVk
-        NS04YmE0LTgzYTM5ZDFkMDRkZi8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/bd86e48a-1ed7-4b33-a884-a537ff14b5e2/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkYmUzY2U1LWZhNTMtNDQz
-        MS05MDEwLTljOWE1MzgzOTQxOC8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:21 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/9eaeedf9-aaae-4c98-99ac-ceccc460517f/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:22 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5MGQ4M2VkLWRhMzgtNDRk
-        ZC05ZTg4LWE5NjVjNjAxMmQ3Yy8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:22 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:10:22 GMT
+      - Wed, 07 Oct 2020 17:48:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3028,17 +2229,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1OTcxYjRjLTBiYjktNDJk
-        My1iNTg3LTRjMzg4ZGIxYWM0Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0MjhiZGNhLWI2ZDYtNDY0
+        MC1iYThhLWUyNzliMjYyYWY3Zi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/15971b4c-0bb9-42d3-b587-4c388db1ac4c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/5428bdca-b6d6-4640-ba8a-e279b262af7f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3046,7 +2247,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3059,7 +2260,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:24 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3071,34 +2272,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '388'
+      - '382'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTU5NzFiNGMtMGJi
-        OS00MmQzLWI1ODctNGMzODhkYjFhYzRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MjIuMjAxNzQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTQyOGJkY2EtYjZk
+        Ni00NjQwLWJhOGEtZTI3OWIyNjJhZjdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzUuNTcyODk0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoyMy4zOTIz
-        NTlaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjEwOjI0LjQyMDky
-        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozNi4wMTk4
+        MDNaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjM2LjE1NTA4
+        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
-        cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NTIsImRvbmUiOjUyLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFj
-        dHMiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIsInN0YXRlIjoiY29tcGxl
-        dGVkIiwidG90YWwiOjYxLCJkb25lIjo2MSwic3VmZml4IjpudWxsfV0sImNy
-        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6W119
+        cCBvcnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBDb250ZW50
+        IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/versions/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/versions/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3119,7 +2320,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:24 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3131,41 +2332,41 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '296'
+      - '298'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIwODhmMjVhMDZi
-        OS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MTA6MTcuMzE2MDA2WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
+        ZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2YzUwZjYxOGRj
+        NC92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6
+        NDg6MzIuNDk5NzA5WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
         LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
         dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
         cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1hNmYxLWIw
-        ODhmMjVhMDZiOS92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
+        c2l0b3JpZXMvZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1hZTZlLTc2
+        YzUwZjYxOGRjNC92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
         bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
         aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iNTJiNmYxMy0xZWEzLTQw
-        ZDEtYTZmMS1iMDg4ZjI1YTA2YjkvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OTgyMTQ5MS1jZTdmLTQ0
+        M2UtYWU2ZS03NmM1MGY2MThkYzQvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
         OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
         L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMt
-        NDBkMS1hNmYxLWIwODhmMjVhMDZiOS92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ODIxNDkxLWNlN2Yt
+        NDQzZS1hZTZlLTc2YzUwZjYxOGRjNC92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        YjUyYjZmMTMtMWVhMy00MGQxLWE2ZjEtYjA4OGYyNWEwNmI5L3ZlcnNpb25z
-        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxMDowOS4zNzM1
-        OTBaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        Nzk4MjE0OTEtY2U3Zi00NDNlLWFlNmUtNzZjNTBmNjE4ZGM0L3ZlcnNpb25z
+        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODoyNi4wNDcx
+        MDdaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
         c3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7
         fX19XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/88b17e06-edca-4070-a695-91a7ce012c54/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/9206a593-16bb-481b-b197-92018a704f66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3186,7 +2387,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:25 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3200,17 +2401,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzk0NGFlLTI5ZGUtNGJm
-        Yi04NDUyLTU2YWY1OTk1ODFhMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhYTIwNGE1LTZhNWUtNDI2
+        Zi05NjI3LWE2MTIxYWMyMDc4Zi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/dcc944ae-29de-4bfb-8452-56af599581a3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9aa204a5-6a5e-426f-9627-a6121ac2078f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3218,7 +2419,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3231,7 +2432,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:25 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3243,30 +2444,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '339'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGNjOTQ0YWUtMjlk
-        ZS00YmZiLTg0NTItNTZhZjU5OTU4MWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MjUuMDI0MDM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWFhMjA0YTUtNmE1
+        ZS00MjZmLTk2MjctYTYxMjFhYzIwNzhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzYuNDUxMTA1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MjUuMjY2Mjgy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoyNS4zNDUyMzla
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzYuNjAyNTk2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozNi42NTEzNTla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS84OGIxN2UwNi1lZGNhLTQwNzAtYTY5NS05
-        MWE3Y2UwMTJjNTQvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS85MjA2YTU5My0xNmJiLTQ4MWItYjE5Ny05
+        MjAxOGE3MDRmNjYvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9445376f-afab-4980-b99d-4f051e7e052a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ab44dc6e-e643-40f8-8da1-e29bc6a6f483/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3287,7 +2488,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:25 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3301,17 +2502,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3ZTBjOTgwLTM1NDQtNDAx
-        Yy05NmU0LWE3YzllNzg5OTMxMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0M2Y0MjAyLTdiZDgtNDM1
+        MC05ZDg3LWY2MzVlOGEyZTI5MS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/b52b6f13-1ea3-40d1-a6f1-b088f25a06b9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/79821491-ce7f-443e-ae6e-76c50f618dc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3332,7 +2533,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:25 GMT
+      - Wed, 07 Oct 2020 17:48:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3346,17 +2547,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0OGM3ZmY3LTkyZTYtNGIz
-        Yi05NDgwLTlhMzk4ODNjNjYyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiNDVhODNmLWMyY2MtNDQw
+        NC05YWQ2LTU1OTA1ZmViNTg3Ny8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/948c7ff7-92e6-4b3b-9480-9a39883c6626/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/bb45a83f-c2cc-4404-9ad6-55905feb5877/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3364,7 +2565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3377,7 +2578,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:10:26 GMT
+      - Wed, 07 Oct 2020 17:48:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3389,25 +2590,25 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '343'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ4YzdmZjctOTJl
-        Ni00YjNiLTk0ODAtOWEzOTg4M2M2NjI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTA6MjUuNjk0Mzg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmI0NWE4M2YtYzJj
+        Yy00NDA0LTlhZDYtNTU5MDVmZWI1ODc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzYuODIwNzkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTA6MjYuMDY0OTU4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxMDoyNi4yNTc0NjRa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzcuMDg0OTMy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozNy4yMjc0OTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2I1MmI2ZjEzLTFlYTMtNDBkMS1h
-        NmYxLWIwODhmMjVhMDZiOS8iXX0=
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ODIxNDkxLWNlN2YtNDQzZS1h
+        ZTZlLTc2YzUwZjYxOGRjNC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:10:26 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:37 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,180 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:43 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '3076'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:43 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +37,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -228,7 +55,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -273,7 +100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -318,7 +145,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +172,62 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:00 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiRmVkb3JhXzE3In0=
@@ -365,7 +237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +250,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7e436a5a-54f7-457f-81dc-5d588be0a285/"
+      - "/pulp/api/v3/repositories/rpm/rpm/fc183d5c-f0b1-4872-ac95-ce44a57aa2c1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -394,25 +266,25 @@ http_interactions:
       Content-Length:
       - '450'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2U0MzZhNWEtNTRmNy00NTdmLTgxZGMtNWQ1ODhiZTBhMjg1LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MDg6NDQuNTcwMzQzWiIsInZl
+        cG0vZmMxODNkNWMtZjBiMS00ODcyLWFjOTUtY2U0NGE1N2FhMmMxLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MDAuNTc3MDE2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2U0MzZhNWEtNTRmNy00NTdmLTgxZGMtNWQ1ODhiZTBhMjg1L3ZlcnNp
+        cG0vZmMxODNkNWMtZjBiMS00ODcyLWFjOTUtY2U0NGE1N2FhMmMxL3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vN2U0MzZhNWEtNTRmNy00NTdmLTgxZGMtNWQ1
-        ODhiZTBhMjg1L3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
+        b3NpdG9yaWVzL3JwbS9ycG0vZmMxODNkNWMtZjBiMS00ODcyLWFjOTUtY2U0
+        NGE1N2FhMmMxL3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
         c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
         bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -424,7 +296,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -437,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:44 GMT
+      - Wed, 07 Oct 2020 17:48:00 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/39c81b55-5556-4239-bbf1-a0599b02e6f5/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b32bb336-2691-47e7-9245-ec6194fd8278/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -453,25 +325,25 @@ http_interactions:
       Content-Length:
       - '415'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzM5
-        YzgxYjU1LTU1NTYtNDIzOS1iYmYxLWEwNTk5YjAyZTZmNS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA4OjQ0Ljc4NzkxMloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Iz
+        MmJiMzM2LTI2OTEtNDdlNy05MjQ1LWVjNjE5NGZkODI3OC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjAwLjc2Njg1N1oiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwi
         dGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwidXNlcm5h
         bWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwdWxwX2xhc3RfdXBkYXRlZCI6
-        IjIwMjAtMDgtMjBUMTk6MDg6NDQuNzg3OTQ2WiIsImRvd25sb2FkX2NvbmN1
+        IjIwMjAtMTAtMDdUMTc6NDg6MDAuNzY2ODc1WiIsImRvd25sb2FkX2NvbmN1
         cnJlbmN5IjoxMCwicG9saWN5Ijoib25fZGVtYW5kIiwic2xlc19hdXRoX3Rv
         a2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:44 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/39c81b55-5556-4239-bbf1-a0599b02e6f5/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/b32bb336-2691-47e7-9245-ec6194fd8278/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -479,7 +351,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -492,7 +364,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:51 GMT
+      - Wed, 07 Oct 2020 17:48:03 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -506,17 +378,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3YTNhNWFlLTI0NTItNDkw
-        OC05YzVmLTExMzZmNWExMzdmYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkY2Q0ZDhjLWMyYTctNDA5
+        My05Yzk2LTljMTdiNzRiZmM5Yy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:51 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:03 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/97a3a5ae-2452-4908-9c5f-1136f5a137fa/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/edcd4d8c-c2a7-4093-9c96-9c17b74bfc9c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -524,7 +396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -537,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:51 GMT
+      - Wed, 07 Oct 2020 17:48:03 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -549,30 +421,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '338'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdhM2E1YWUtMjQ1
-        Mi00OTA4LTljNWYtMTEzNmY1YTEzN2ZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6NTEuMDUxMzI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRjZDRkOGMtYzJh
+        Ny00MDkzLTljOTYtOWMxN2I3NGJmYzljLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDMuMzgyMTM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6NTEuNDM2OTg2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODo1MS41NDE1MDVa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDMuNTI0MDc0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMy41ODY1NjRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vMzljODFiNTUtNTU1Ni00MjM5LWJiZjEtYTA1
-        OTliMDJlNmY1LyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vYjMyYmIzMzYtMjY5MS00N2U3LTkyNDUtZWM2
+        MTk0ZmQ4Mjc4LyJdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:51 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:03 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/7e436a5a-54f7-457f-81dc-5d588be0a285/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/fc183d5c-f0b1-4872-ac95-ce44a57aa2c1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -580,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -593,7 +465,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:51 GMT
+      - Wed, 07 Oct 2020 17:48:03 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -607,17 +479,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzNzk2NTY3LWU1YWEtNGVi
-        OS1iYzAxLWQ4NzZhYzMzNTBhMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiNWI0M2E2LThiMWEtNDRl
+        OC1iNDA3LTk5NDQ1MjBhMTU5NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:51 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:03 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/93796567-e5aa-4eb9-bc01-d876ac3350a3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/1b5b43a6-8b1a-44e8-b407-9944520a1595/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -625,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -638,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:52 GMT
+      - Wed, 07 Oct 2020 17:48:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -650,30 +522,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '343'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTM3OTY1NjctZTVh
-        YS00ZWI5LWJjMDEtZDg3NmFjMzM1MGEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6NTEuODQ4MzYwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWI1YjQzYTYtOGIx
+        YS00NGU4LWI0MDctOTk0NDUyMGExNTk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDMuNzM0MzQ5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6NTIuMjQzMTI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODo1Mi40MjU5OTZa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDMuODY0Nzc0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMy45NDQ4MDFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ZTQzNmE1YS01NGY3LTQ1N2YtODFk
-        Yy01ZDU4OGJlMGEyODUvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYzE4M2Q1Yy1mMGIxLTQ4NzItYWM5
+        NS1jZTQ0YTU3YWEyYzEvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -681,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -694,397 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:52 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '344'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3
-        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0
-        NWU4L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQw
-        YTItYjkzNy1iZjQxYTYzZjQ1ZTgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVi
-        bGlzaGVkIExpYnJhcnkgYW5kIGRldiB2aWV3LTcwMDk3MzQ1My05MDkwNTgz
-        NDciLCJkZXNjcmlwdGlvbiI6IlB1Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYg
-        dmlldy03MDA5NzM0NTMtOTA5MDU4MzQ3IiwicmVtb3RlIjpudWxsfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYzZS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjQ3LjM5MDI1NVoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDNlY2YyMGItNzE4Mi00ZDg5LWI3YzktNDJmM2U3ODM0NjNlL3ZlcnNp
-        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wM2VjZjIwYi03MTgyLTRkODktYjdjOS00
-        MmYzZTc4MzQ2M2UvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdh
-        bml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:52 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/03ecf20b-7182-4d89-b7c9-42f3e783463e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYz
-        ZS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NDcuMzk2OTAxWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '366'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowNzoyNC4xNjA5MzNa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3
-        ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjIzLjE4NjU4MFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNh
-        Njg5YTFiMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/cbd99477-e25a-4b4b-947d-b5ccba68872f/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjI0LjE2NjAxMFoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/72f97fcf-61e1-477e-bb07-2cb3a689a1b0/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4OWExYjAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjIzLjE5MzE3NFoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
+      - Wed, 07 Oct 2020 17:48:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1098,17 +580,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1116,7 +598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1129,41 +611,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:53 GMT
+      - Wed, 07 Oct 2020 17:48:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1171,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1184,36 +656,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:54 GMT
+      - Wed, 07 Oct 2020 17:48:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '227'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1221,7 +688,97 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:04 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:04 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1234,7 +791,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:54 GMT
+      - Wed, 07 Oct 2020 17:48:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1248,17 +805,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzNzdkYzNjLTQ0MjktNGUy
-        NC05NmU0LTZkYThkYzM0YzA4Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzMGVjZTg5LWE0MWQtNDA1
+        ZS04OTZkLWY2NjM4NTUwNDg2NC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/e377dc3c-4429-4e24-96e4-6da8dc34c087/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/d30ece89-a41d-405e-896d-f66385504864/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1266,7 +823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1279,7 +836,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:54 GMT
+      - Wed, 07 Oct 2020 17:48:10 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1291,29 +848,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '375'
+      - '388'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTM3N2RjM2MtNDQy
-        OS00ZTI0LTk2ZTQtNmRhOGRjMzRjMDg3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6NTQuMjEwNjcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDMwZWNlODktYTQx
+        ZC00MDVlLTg5NmQtZjY2Mzg1NTA0ODY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDQuMzY1NTM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODo1NC4zNzkx
-        OTRaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjA4OjU0LjUzMjkw
-        N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowNC40NTQ5
+        MTNaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjEwLjM5MTcy
+        NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
         cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4
-        IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0aWZhY3Rz
-        IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRl
-        ZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
-        ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
-        XX0=
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NTE2LCJkb25lIjo1MTYsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
+        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6NTI0LCJkb25lIjo1MjQsInN1ZmZpeCI6bnVsbH1d
+        LCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:10 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
@@ -2563,101 +2563,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:54:38 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:45 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:45 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo2NTQwfQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:45 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/8b4aca06-d3d1-47e0-8b2e-188bc3126876/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84YjRhY2EwNi1k
-        M2QxLTQ3ZTAtOGIyZS0xODhiYzMxMjY4NzYvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMC0wOC0yMFQxOTowODo0NS4zNTk2MDJaIiwic2l6ZSI6NjU0MH0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:45 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/8b4aca06-d3d1-47e0-8b2e-188bc3126876/
     body:
@@ -2965,62 +2870,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:46 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdjMjcyM2Y0NjFmY2E5
-        Nzc3MmIyNmM3NjNlMTEwN2FhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
-        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdjMjcy
-        M2Y0NjFmY2E5Nzc3MmIyNmM3NjNlMTEwN2FhDQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
-        djMvYXJ0aWZhY3RzLzliY2ZkZTc2LTQ5MWEtNGRlOS05YjUzLTBmMWFkZWM3
-        ODZmMi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC03YzI3MjNm
-        NDYxZmNhOTc3NzJiMjZjNzYzZTExMDdhYS0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-7c2723f461fca97772b26c763e1107aa
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '389'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:46 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlMWRjMTQwLTgxYzgtNDBl
-        Ny05MGUwLTE5ZDdlMTk2YjMzNy8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:46 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8e1dc140-81c8-40e7-90e0-19d7e196b337/
     body:
@@ -3183,4 +3032,625 @@ http_interactions:
         Yy01ZDU4OGJlMGEyODUvIl19
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:00 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:00 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo2NTQwfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/cc66d7c3-446c-410c-8910-c3e6a9ccd4ac/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9jYzY2ZDdjMy00
+        NDZjLTQxMGMtODkxMC1jM2U2YTljY2Q0YWMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODowMS4wNjE5NjVaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/cc66d7c3-446c-410c-8910-c3e6a9ccd4ac/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTgwYzdiYWU3MTllZGYw
+        ZTcyNWVkNWIxNTM4M2NiY2NjDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMDEw
+        MDctMzAxODItMWpveGI2OCINCkNvbnRlbnQtTGVuZ3RoOiA2NTQwDQpDb250
+        ZW50LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1U
+        cmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCu2r7tsDAAAAAAFkdWNrLTAu
+        Ny0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAQAFAAAAAAAAAAAAAAAAAAAAAI6t6AEAAAAAAAAA
+        BwAAELQAAAA+AAAABwAAEKQAAAAQAAABDQAAAAYAAAAAAAAAAQAAAREAAAAG
+        AAAAKQAAAAEAAAPoAAAABAAAAGwAAAABAAAD7AAAAAcAAABwAAAAEAAAA+8A
+        AAAEAAAAgAAAAAEAAAPwAAAABwAAAIQAABAgZTUwNjU0ZWIxMjRlNDQzMDli
+        YzIyMWE4MGYwZTI4N2EzYTcxYTA4MwA5MTM5NzdjY2QyYWQzYTUxMDYyNDhl
+        YjAxY2VmYmNhMzZlMzU0M2ZlYThhOGIzMjlhY2YyMjk1OWQ5MmM4N2E2AAAA
+        AAAH9KY3Qi0Z56rnX7dFWyCqwLIAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAPgAAAAf///+QAAAAEAAAAACOregBAAAAAAAAADQA
+        AAP0AAAAPwAAAAcAAAPkAAAAEAAAAGQAAAAIAAAAAAAAAAEAAAPoAAAABgAA
+        AAIAAAABAAAD6QAAAAYAAAAHAAAAAQAAA+oAAAAGAAAACwAAAAEAAAPsAAAA
+        CQAAAA0AAAABAAAD7QAAAAkAAAAsAAAAAQAAA+4AAAAEAAAATAAAAAEAAAPv
+        AAAABgAAAFAAAAABAAAD8QAAAAQAAABoAAAAAQAAA/YAAAAGAAAAbAAAAAEA
+        AAP4AAAACQAAAHoAAAABAAAD/QAAAAYAAACGAAAAAQAAA/4AAAAGAAAAjAAA
+        AAEAAAQEAAAABAAAAJQAAAABAAAEBgAAAAMAAACYAAAAAQAABAkAAAADAAAA
+        mgAAAAEAAAQKAAAABAAAAJwAAAABAAAECwAAAAgAAACgAAAAAQAABAwAAAAI
+        AAAA4QAAAAEAAAQNAAAABAAAAOQAAAABAAAEDwAAAAgAAADoAAAAAQAABBAA
+        AAAIAAAA7QAAAAEAAAQUAAAABgAAAPIAAAABAAAEFQAAAAQAAAEIAAAAAQAA
+        BBcAAAAIAAABDAAAAAEAAAQYAAAABAAAARQAAAAEAAAEGQAAAAgAAAEkAAAA
+        BAAABBoAAAAIAAABhwAAAAQAAAQoAAAABgAAAaMAAAABAAAERgAAAAYAAAGq
+        AAAAAQAABEcAAAAEAAABzAAAAAEAAARIAAAABAAAAdAAAAABAAAESQAAAAgA
+        AAHUAAAAAQAABFgAAAAEAAAB2AAAAAEAAARZAAAACAAAAdwAAAABAAAEXAAA
+        AAQAAAHkAAAAAQAABF0AAAAIAAAB6AAAAAEAAAReAAAACAAAAfEAAAABAAAE
+        YgAAAAYAAAH7AAAAAQAABGQAAAAGAAADSwAAAAEAAARlAAAABgAAA1AAAAAB
+        AAAEZgAAAAYAAANTAAAAAQAABGwAAAAGAAADVQAAAAEAAAR0AAAABAAAA3AA
+        AAABAAAEdQAAAAQAAAN0AAAAAQAABHYAAAAIAAADeAAAAAEAAAR6AAAABwAA
+        A4MAAAAQAAATkwAAAAQAAAOUAAAAAQAAE8YAAAAGAAADmAAAAAEAABPkAAAA
+        CAAAA54AAAABAAAT5QAAAAQAAAPgAAAAAUMAZHVjawAwLjcAMQBRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4AQSBmaXh0dXJlIFJQTSBmb3IgdGVz
+        dGluZyBQdWxwLgBbYLshbG9jYWxob3N0LmxvY2FsZG9tYWluAAAAAAAABVB1
+        YmxpYyBEb21haW4AVW5zcGVjaWZpZWQAbGludXgAbm9hcmNoAAAAAAAFgaQA
+        AFtfdKY1MTg5MTQ4YmVmNjZmNDc0M2E4MjE0ZjBjOTkwYWRiMmZkNzY2MWEx
+        OTkwYzc0YzgyYmVjZTRmODQyMWIxNjMxAAAAAAAAAAByb290AHJvb3QAZHVj
+        ay0wLjctMS5zcmMucnBtAAAAAP////9kdWNrAAAAAAEAAAoBAAAKAQAACgEA
+        AApycG1saWIoQ29tcHJlc3NlZEZpbGVOYW1lcykAcnBtbGliKEZpbGVEaWdl
+        c3RzKQBycG1saWIoUGF5bG9hZEZpbGVzSGF2ZVByZWZpeCkAcnBtbGliKFBh
+        eWxvYWRJc1h6KQAzLjAuNC0xADQuNi4wLTEANC4wLTEANS4yLTEANC4xNC4x
+        AGxvY2FsaG9zdC5sb2NhbGRvbWFpbiAxNTMzMDY2MDE3AAAAAAABAAAAAQAA
+        AAAAAAAIMC43LTEAAAAAAAAAZHVjay50eHQAL3Vzci9iaW4vAC1PMiAtZyAt
+        cGlwZSAtV2FsbCAtV2Vycm9yPWZvcm1hdC1zZWN1cml0eSAtV3AsLURfRk9S
+        VElGWV9TT1VSQ0U9MiAtV3AsLURfR0xJQkNYWF9BU1NFUlRJT05TIC1mZXhj
+        ZXB0aW9ucyAtZnN0YWNrLXByb3RlY3Rvci1zdHJvbmcgLWdyZWNvcmQtZ2Nj
+        LXN3aXRjaGVzIC1zcGVjcz0vdXNyL2xpYi9ycG0vcmVkaGF0L3JlZGhhdC1o
+        YXJkZW5lZC1jYzEgLXNwZWNzPS91c3IvbGliL3JwbS9yZWRoYXQvcmVkaGF0
+        LWFubm9iaW4tY2MxIC1tNjQgLW10dW5lPWdlbmVyaWMgLWZhc3luY2hyb25v
+        dXMtdW53aW5kLXRhYmxlcyAtZnN0YWNrLWNsYXNoLXByb3RlY3Rpb24gLWZj
+        Zi1wcm90ZWN0aW9uAGNwaW8AeHoAMgBub2FyY2gtcmVkaGF0LWxpbnV4LWdu
+        dQAAAAAAAAAAAAAAAEFTQ0lJIHRleHQAH1uJtmAcqkPO6JoBUZ3VrAAAAAAI
+        dXRmLTgAODRlMzc2NzMwMWE5NDUxNTVkNDkwOGU3NDIyOTA5ZDQwOTMxMjEx
+        ZDJhMTUxMjdhNTExMzYwNWUyZjI2YWVjOQAAAAAACAAAAD8AAAAH///8wAAA
+        ABD9N3pYWgAACuH7DKECACEBEgAAACO4hyzgAQcAVV0AGA3dBGIy+XULgKK9
+        D1EGe8RLF4G4znKjZyb3n24+qRcnZi1qCdIPxoNahAwN6xWl6IjH2ObDlkSv
+        IwJ2iBnPvWx2Njnu1omGGvElqIweFqDe3Dqt9AAAAADfX9NVWh7JiGla/BKU
+        kEUtm8YJaxNQSt2aWeBtbaunfAABiQGIAgAAx/Lj7Lbp3xwCAAAAAApZWg0K
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTgwYzdiYWU3MTllZGYw
+        ZTcyNWVkNWIxNTM4M2NiY2NjLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-80c7bae719edf0e725ed5b15383cbccc
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6862'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9jYzY2ZDdjMy00
+        NDZjLTQxMGMtODkxMC1jM2U2YTljY2Q0YWMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODowMS4wNjE5NjVaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/cc66d7c3-446c-410c-8910-c3e6a9ccd4ac/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlNDQzOTQ5LTkzNDQtNDQ2
+        My1iMDlhLTA3NjkzMmE3ZDc3NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/ae443949-9344-4463-b09a-076932a7d774/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWU0NDM5NDktOTM0
+        NC00NDYzLWIwOWEtMDc2OTMyYTdkNzc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDEuMTUzNjM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        c3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDEuMzM2MTU2WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMS40MDU5MTNaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzL2YzNzg5
+        ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy9lY2M4MzY1Ni05NjM2LTQwNzAtYmRhNy0w
+        Y2NiMTVkOWM0N2IvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
+        L3B1bHAvYXBpL3YzL3VwbG9hZHMvY2M2NmQ3YzMtNDQ2Yy00MTBjLTg5MTAt
+        YzNlNmE5Y2NkNGFjLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJjY2Y2YmNkNWNlNjVi
+        NzRlYjViNzAwYzhmN2YxZGZiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
+        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJjY2Y2
+        YmNkNWNlNjViNzRlYjViNzAwYzhmN2YxZGZiDQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzL2VjYzgzNjU2LTk2MzYtNDA3MC1iZGE3LTBjY2IxNWQ5
+        YzQ3Yi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC0yY2NmNmJj
+        ZDVjZTY1Yjc0ZWI1YjcwMGM4ZjdmMWRmYi0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-2ccf6bcd5ce65b74eb5b700c8f7f1dfb
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '389'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3YmY3ZGU2LWU0M2YtNGE0
+        Ni05ZjYzLWU2YzE4ZjY5NThhYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/77bf7de6-e43f-4a46-9f63-e6c18f6958ab/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '376'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzdiZjdkZTYtZTQz
+        Zi00YTQ2LTlmNjMtZTZjMThmNjk1OGFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDEuNTIwMTcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDEuNjg3NjUw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMS44NDEwMzRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzk0M2MxM2Jm
+        LTJmYWMtNDEyYy05MGY1LTM4N2QwNGM2OTNkMC8iXSwicmVzZXJ2ZWRfcmVz
+        b3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VjYzgz
+        NjU2LTk2MzYtNDA3MC1iZGE3LTBjY2IxNWQ5YzQ3Yi8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/fc183d5c-f0b1-4872-ac95-ce44a57aa2c1/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTQzYzEzYmYtMmZhYy00MTJjLTkwZjUtMzg3ZDA0YzY5
+        M2QwLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:01 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwOGVhMmI2LTI4ZGYtNDM3
+        Yy1iNjliLTFhZjE4YzY4ODgwMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:01 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/808ea2b6-28df-437c-b69b-1af18c688802/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:02 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '360'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODA4ZWEyYjYtMjhk
+        Zi00MzdjLWI2OWItMWFmMThjNjg4ODAyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDEuOTU4NjMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDIu
+        MTI5NTE2WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMi4z
+        NTExMzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Zj
+        MTgzZDVjLWYwYjEtNDg3Mi1hYzk1LWNlNDRhNTdhYTJjMS92ZXJzaW9ucy8x
+        LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYzE4M2Q1Yy1mMGIxLTQ4NzItYWM5
+        NS1jZTQ0YTU3YWEyYzEvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
@@ -729,76 +729,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:54:38 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:48 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '688'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8wOTZmYjM3YS1kNjFiLTRhOWQtYWMyYi1lNzQwMGYzZWIwNWEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowODo0Ni43ODYxNTBa
-        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzliY2ZkZTc2
-        LTQ5MWEtNGRlOS05YjUzLTBmMWFkZWM3ODZmMi8iLCJuYW1lIjoiZHVjayIs
-        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIsImFy
-        Y2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNh
-        M2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJj
-        aGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2Ug
-        YSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0dXJl
-        IFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxvZ3Mi
-        OltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0sInJl
-        cXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIwLjci
-        LCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
-        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInNo
-        YTI1NiI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQx
-        NDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJzdXBwbGVtZW50cyI6W10s
-        ImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjcu
-        MS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6ImxvY2FsaG9zdC5sb2Nh
-        bGRvbWFpbiIsInJwbV9ncm91cCI6IlVuc3BlY2lmaWVkIiwicnBtX2xpY2Vu
-        c2UiOiJQdWJsaWMgRG9tYWluIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3Nv
-        dXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIi
-        LCJycG1faGVhZGVyX3N0YXJ0Ijo0NTA0LCJycG1faGVhZGVyX2VuZCI6NjM2
-        NCwiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6MjY0LCJzaXpl
-        X2luc3RhbGxlZCI6NSwic2l6ZV9wYWNrYWdlIjo2NTQwLCJ0aW1lX2J1aWxk
-        IjoxNTMzMDY2MDE3LCJ0aW1lX2ZpbGUiOjE1OTc5NTA1MjZ9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:48 GMT
-- request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/7e436a5a-54f7-457f-81dc-5d588be0a285/modify/
     body:
@@ -902,4 +832,178 @@ http_interactions:
         N2YtODFkYy01ZDU4OGJlMGEyODUvIl19
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:02 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '690'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy85NDNjMTNiZi0yZmFjLTQxMmMtOTBmNS0zODdkMDRjNjkzZDAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNzo0ODowMS44MDk0NjFa
+        IiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2VjYzgzNjU2
+        LTk2MzYtNDA3MC1iZGE3LTBjY2IxNWQ5YzQ3Yi8iLCJuYW1lIjoiZHVjayIs
+        ImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIsImFy
+        Y2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNh
+        M2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJj
+        aGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2Ug
+        YSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0dXJl
+        IFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxvZ3Mi
+        OltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0sInJl
+        cXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIwLjci
+        LCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
+        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInNo
+        YTI1NiI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQx
+        NDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJzdXBwbGVtZW50cyI6W10s
+        ImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiZHVjay0wLjcu
+        MS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6ImxvY2FsaG9zdC5sb2Nh
+        bGRvbWFpbiIsInJwbV9ncm91cCI6IlVuc3BlY2lmaWVkIiwicnBtX2xpY2Vu
+        c2UiOiJQdWJsaWMgRG9tYWluIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3Nv
+        dXJjZXJwbSI6ImR1Y2stMC43LTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIi
+        LCJycG1faGVhZGVyX3N0YXJ0Ijo0NTA0LCJycG1faGVhZGVyX2VuZCI6NjM2
+        NCwiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6MjY0LCJzaXpl
+        X2luc3RhbGxlZCI6NSwic2l6ZV9wYWNrYWdlIjo2NTQwLCJ0aW1lX2J1aWxk
+        IjoxNTMzMDY2MDE3LCJ0aW1lX2ZpbGUiOjE2MDIwOTI4ODF9XX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:02 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/fc183d5c-f0b1-4872-ac95-ce44a57aa2c1/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvOTQzYzEzYmYtMmZhYy00MTJjLTkwZjUtMzg3ZDA0YzY5
+        M2QwLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:02 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyNjE5ZWIzLWQ3OWUtNDZm
+        OC05MjZlLWRlMGM2YzNmNGNhMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:02 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/02619eb3-d79e-46f8-926e-de0c6c3f4ca2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:03 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '345'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDI2MTllYjMtZDc5
+        ZS00NmY4LTkyNmUtZGUwYzZjM2Y0Y2EyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MDIuNzk2MzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MDIu
+        OTQxNjIzWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODowMy4x
+        MTcyNzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYzE4M2Q1Yy1mMGIxLTQ4
+        NzItYWM5NS1jZTQ0YTU3YWEyYzEvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:03 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,180 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '3076'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +37,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -228,7 +55,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -273,7 +100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -318,7 +145,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +172,62 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:11 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiRmVkb3JhXzE3In0=
@@ -365,7 +237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +250,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/eabd96ed-4d98-44de-bd79-2a817e50feb7/"
+      - "/pulp/api/v3/repositories/rpm/rpm/c84a9b28-dbb3-410e-8ab9-acb157eed653/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -394,25 +266,25 @@ http_interactions:
       Content-Length:
       - '450'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWFiZDk2ZWQtNGQ5OC00NGRlLWJkNzktMmE4MTdlNTBmZWI3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MDg6NTYuNjIxNDY1WiIsInZl
+        cG0vYzg0YTliMjgtZGJiMy00MTBlLThhYjktYWNiMTU3ZWVkNjUzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MTEuODgzNTMwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZWFiZDk2ZWQtNGQ5OC00NGRlLWJkNzktMmE4MTdlNTBmZWI3L3ZlcnNp
+        cG0vYzg0YTliMjgtZGJiMy00MTBlLThhYjktYWNiMTU3ZWVkNjUzL3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vZWFiZDk2ZWQtNGQ5OC00NGRlLWJkNzktMmE4
-        MTdlNTBmZWI3L3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
+        b3NpdG9yaWVzL3JwbS9ycG0vYzg0YTliMjgtZGJiMy00MTBlLThhYjktYWNi
+        MTU3ZWVkNjUzL3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
         c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
         bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -424,7 +296,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -437,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
+      - Wed, 07 Oct 2020 17:48:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/af6073fc-c8c3-4657-bde8-4db002914c25/"
+      - "/pulp/api/v3/remotes/rpm/rpm/824f495e-d6c1-4a3d-b623-928ec713d3bf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -453,25 +325,25 @@ http_interactions:
       Content-Length:
       - '415'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Fm
-        NjA3M2ZjLWM4YzMtNDY1Ny1iZGU4LTRkYjAwMjkxNGMyNS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA4OjU2Ljc2NDM2M1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzgy
+        NGY0OTVlLWQ2YzEtNGEzZC1iNjIzLTkyOGVjNzEzZDNiZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjExLjk3NDQ5MVoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwi
         dGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwidXNlcm5h
         bWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwdWxwX2xhc3RfdXBkYXRlZCI6
-        IjIwMjAtMDgtMjBUMTk6MDg6NTYuNzY0MzkyWiIsImRvd25sb2FkX2NvbmN1
+        IjIwMjAtMTAtMDdUMTc6NDg6MTEuOTc0NTA4WiIsImRvd25sb2FkX2NvbmN1
         cnJlbmN5IjoxMCwicG9saWN5Ijoib25fZGVtYW5kIiwic2xlc19hdXRoX3Rv
         a2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:11 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/af6073fc-c8c3-4657-bde8-4db002914c25/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/824f495e-d6c1-4a3d-b623-928ec713d3bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -479,7 +351,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -492,7 +364,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:58 GMT
+      - Wed, 07 Oct 2020 17:48:13 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -506,17 +378,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjNjVkNTkzLWRlNzYtNDIz
-        Zi1iN2M0LTEyMTQwZDgzZjA4MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkODMzM2YyLWMxYTUtNDIw
+        Zi1hYTJhLTFhMjVmNGQyZjM3NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:13 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0c65d593-de76-423f-b7c4-12140d83f080/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/bd8333f2-c1a5-420f-aa2a-1a25f4d2f375/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -524,7 +396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -537,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -549,30 +421,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '339'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGM2NWQ1OTMtZGU3
-        Ni00MjNmLWI3YzQtMTIxNDBkODNmMDgwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6NTguOTU5MTU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmQ4MzMzZjItYzFh
+        NS00MjBmLWFhMmEtMWEyNWY0ZDJmMzc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTMuOTEwNTk2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6NTkuMTQ1NTgx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODo1OS4yMTQ1NTRa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTQuMDcxMDY2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNC4xMTkyNzda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vYWY2MDczZmMtYzhjMy00NjU3LWJkZTgtNGRi
-        MDAyOTE0YzI1LyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vODI0ZjQ5NWUtZDZjMS00YTNkLWI2MjMtOTI4
+        ZWM3MTNkM2JmLyJdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/eabd96ed-4d98-44de-bd79-2a817e50feb7/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/c84a9b28-dbb3-410e-8ab9-acb157eed653/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -580,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -593,7 +465,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -607,17 +479,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiZGM2Yjc2LWI0ZTAtNDg5
-        ZC04NzM3LTY5ZWY1MzBjNDA4Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlZTkyMGUyLWI2ODEtNGYw
+        MS05YjJjLTNmZWU1ZWIwOTY3OS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0bdc6b76-b4e0-489d-8737-69ef530c408c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/7ee920e2-b681-4f01-9b2c-3fee5eb09679/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -625,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -638,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -650,30 +522,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '341'
+      - '342'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJkYzZiNzYtYjRl
-        MC00ODlkLTg3MzctNjllZjUzMGM0MDhjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6NTkuMzE2NTAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2VlOTIwZTItYjY4
+        MS00ZjAxLTliMmMtM2ZlZTVlYjA5Njc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTQuMjEwMjI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6NTkuNTA3MzAx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODo1OS41OTY1NjFa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTQuMzkxOTMx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNC40NTI2ODNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lYWJkOTZlZC00ZDk4LTQ0ZGUtYmQ3
-        OS0yYTgxN2U1MGZlYjcvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jODRhOWIyOC1kYmIzLTQxMGUtOGFi
+        OS1hY2IxNTdlZWQ2NTMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -681,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -694,397 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '344'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3
-        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0
-        NWU4L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQw
-        YTItYjkzNy1iZjQxYTYzZjQ1ZTgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVi
-        bGlzaGVkIExpYnJhcnkgYW5kIGRldiB2aWV3LTcwMDk3MzQ1My05MDkwNTgz
-        NDciLCJkZXNjcmlwdGlvbiI6IlB1Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYg
-        dmlldy03MDA5NzM0NTMtOTA5MDU4MzQ3IiwicmVtb3RlIjpudWxsfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYzZS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjQ3LjM5MDI1NVoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDNlY2YyMGItNzE4Mi00ZDg5LWI3YzktNDJmM2U3ODM0NjNlL3ZlcnNp
-        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wM2VjZjIwYi03MTgyLTRkODktYjdjOS00
-        MmYzZTc4MzQ2M2UvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdh
-        bml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/03ecf20b-7182-4d89-b7c9-42f3e783463e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:59 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYz
-        ZS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NDcuMzk2OTAxWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:59 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '366'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowNzoyNC4xNjA5MzNa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3
-        ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjIzLjE4NjU4MFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNh
-        Njg5YTFiMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/cbd99477-e25a-4b4b-947d-b5ccba68872f/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjI0LjE2NjAxMFoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/72f97fcf-61e1-477e-bb07-2cb3a689a1b0/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4OWExYjAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjIzLjE5MzE3NFoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1098,17 +580,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1116,7 +598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1129,41 +611,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1171,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1184,36 +656,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '227'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1221,7 +688,97 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:14 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:14 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1234,7 +791,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
+      - Wed, 07 Oct 2020 17:48:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1248,17 +805,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmZjNkZjM2LTY1NWUtNDgy
-        Yi1iNjljLTc0OTY4MTM5MzYyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkMTczYzc0LTBjMzEtNGVi
+        OC04NjA3LTEzNmZmY2YyYzgzMi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:14 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8ff3df36-655e-482b-b69c-749681393626/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/3d173c74-0c31-4eb8-8607-136ffcf2c832/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1266,7 +823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1279,7 +836,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:09:00 GMT
+      - Wed, 07 Oct 2020 17:48:15 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1291,20 +848,20 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '376'
+      - '377'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGZmM2RmMzYtNjU1
-        ZS00ODJiLWI2OWMtNzQ5NjgxMzkzNjI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDk6MDAuMzgzMDIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2QxNzNjNzQtMGMz
+        MS00ZWI4LTg2MDctMTM2ZmZjZjJjODMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTQuODYwNTU3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowOTowMC40ODc0
-        NzhaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjA5OjAwLjYyNzg4
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxNC45NDQ4
+        MjFaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjE1LjA1NjYx
         OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
         cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
@@ -1315,5 +872,5 @@ http_interactions:
         ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
         XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:09:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:15 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
@@ -2199,101 +2199,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:54:42 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:56 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:56 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo2NTQwfQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:57 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/f5549c02-54bc-4b83-90d3-6bd1eff7b923/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9mNTU0OWMwMi01
-        NGJjLTRiODMtOTBkMy02YmQxZWZmN2I5MjMvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMC0wOC0yMFQxOTowODo1Ny4xMjY3MjVaIiwic2l6ZSI6NjU0MH0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:57 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/f5549c02-54bc-4b83-90d3-6bd1eff7b923/
     body:
@@ -2601,62 +2506,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:57 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWZiOTQ5NTk2M2YwZDA1
-        YjllYjdmZDVkZWQ5ZjRlN2UyDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
-        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWZiOTQ5
-        NTk2M2YwZDA1YjllYjdmZDVkZWQ5ZjRlN2UyDQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
-        djMvYXJ0aWZhY3RzLzljNGQ2OGQzLTQ4NTMtNDNlMi1hYjUyLTAxZjhmYThh
-        ZDAyMi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1mYjk0OTU5
-        NjNmMGQwNWI5ZWI3ZmQ1ZGVkOWY0ZTdlMi0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-fb9495963f0d05b9eb7fd5ded9f4e7e2
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '389'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:57 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1YjkyNThjLTVjMDQtNDgy
-        Yi1iYWQwLTdjN2ZiMzdlNGEzNy8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:57 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/a5b9258c-5c04-482b-bad0-7c7fb37e4a37/
     body:
@@ -2819,4 +2668,625 @@ http_interactions:
         OS0yYTgxN2U1MGZlYjcvIl19
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:58 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo2NTQwfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/96555cdb-e89d-41fe-a563-e3d2c7572cf2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy85NjU1NWNkYi1l
+        ODlkLTQxZmUtYTU2My1lM2QyYzc1NzJjZjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoxMi4yOTIxMTRaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/96555cdb-e89d-41fe-a563-e3d2c7572cf2/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTc2ZWNkMWZlODU1MDk0
+        ZTMwNjA5NTUyZDgyNjA4MmI1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMDEw
+        MDctMzAxODItMXdkeXNqZiINCkNvbnRlbnQtTGVuZ3RoOiA2NTQwDQpDb250
+        ZW50LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1U
+        cmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCu2r7tsDAAAAAAFkdWNrLTAu
+        Ny0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAQAFAAAAAAAAAAAAAAAAAAAAAI6t6AEAAAAAAAAA
+        BwAAELQAAAA+AAAABwAAEKQAAAAQAAABDQAAAAYAAAAAAAAAAQAAAREAAAAG
+        AAAAKQAAAAEAAAPoAAAABAAAAGwAAAABAAAD7AAAAAcAAABwAAAAEAAAA+8A
+        AAAEAAAAgAAAAAEAAAPwAAAABwAAAIQAABAgZTUwNjU0ZWIxMjRlNDQzMDli
+        YzIyMWE4MGYwZTI4N2EzYTcxYTA4MwA5MTM5NzdjY2QyYWQzYTUxMDYyNDhl
+        YjAxY2VmYmNhMzZlMzU0M2ZlYThhOGIzMjlhY2YyMjk1OWQ5MmM4N2E2AAAA
+        AAAH9KY3Qi0Z56rnX7dFWyCqwLIAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAPgAAAAf///+QAAAAEAAAAACOregBAAAAAAAAADQA
+        AAP0AAAAPwAAAAcAAAPkAAAAEAAAAGQAAAAIAAAAAAAAAAEAAAPoAAAABgAA
+        AAIAAAABAAAD6QAAAAYAAAAHAAAAAQAAA+oAAAAGAAAACwAAAAEAAAPsAAAA
+        CQAAAA0AAAABAAAD7QAAAAkAAAAsAAAAAQAAA+4AAAAEAAAATAAAAAEAAAPv
+        AAAABgAAAFAAAAABAAAD8QAAAAQAAABoAAAAAQAAA/YAAAAGAAAAbAAAAAEA
+        AAP4AAAACQAAAHoAAAABAAAD/QAAAAYAAACGAAAAAQAAA/4AAAAGAAAAjAAA
+        AAEAAAQEAAAABAAAAJQAAAABAAAEBgAAAAMAAACYAAAAAQAABAkAAAADAAAA
+        mgAAAAEAAAQKAAAABAAAAJwAAAABAAAECwAAAAgAAACgAAAAAQAABAwAAAAI
+        AAAA4QAAAAEAAAQNAAAABAAAAOQAAAABAAAEDwAAAAgAAADoAAAAAQAABBAA
+        AAAIAAAA7QAAAAEAAAQUAAAABgAAAPIAAAABAAAEFQAAAAQAAAEIAAAAAQAA
+        BBcAAAAIAAABDAAAAAEAAAQYAAAABAAAARQAAAAEAAAEGQAAAAgAAAEkAAAA
+        BAAABBoAAAAIAAABhwAAAAQAAAQoAAAABgAAAaMAAAABAAAERgAAAAYAAAGq
+        AAAAAQAABEcAAAAEAAABzAAAAAEAAARIAAAABAAAAdAAAAABAAAESQAAAAgA
+        AAHUAAAAAQAABFgAAAAEAAAB2AAAAAEAAARZAAAACAAAAdwAAAABAAAEXAAA
+        AAQAAAHkAAAAAQAABF0AAAAIAAAB6AAAAAEAAAReAAAACAAAAfEAAAABAAAE
+        YgAAAAYAAAH7AAAAAQAABGQAAAAGAAADSwAAAAEAAARlAAAABgAAA1AAAAAB
+        AAAEZgAAAAYAAANTAAAAAQAABGwAAAAGAAADVQAAAAEAAAR0AAAABAAAA3AA
+        AAABAAAEdQAAAAQAAAN0AAAAAQAABHYAAAAIAAADeAAAAAEAAAR6AAAABwAA
+        A4MAAAAQAAATkwAAAAQAAAOUAAAAAQAAE8YAAAAGAAADmAAAAAEAABPkAAAA
+        CAAAA54AAAABAAAT5QAAAAQAAAPgAAAAAUMAZHVjawAwLjcAMQBRdWFjayBs
+        aWtlIGEgZHVjayBhdCB0aGUgcGFyay4AQSBmaXh0dXJlIFJQTSBmb3IgdGVz
+        dGluZyBQdWxwLgBbYLshbG9jYWxob3N0LmxvY2FsZG9tYWluAAAAAAAABVB1
+        YmxpYyBEb21haW4AVW5zcGVjaWZpZWQAbGludXgAbm9hcmNoAAAAAAAFgaQA
+        AFtfdKY1MTg5MTQ4YmVmNjZmNDc0M2E4MjE0ZjBjOTkwYWRiMmZkNzY2MWEx
+        OTkwYzc0YzgyYmVjZTRmODQyMWIxNjMxAAAAAAAAAAByb290AHJvb3QAZHVj
+        ay0wLjctMS5zcmMucnBtAAAAAP////9kdWNrAAAAAAEAAAoBAAAKAQAACgEA
+        AApycG1saWIoQ29tcHJlc3NlZEZpbGVOYW1lcykAcnBtbGliKEZpbGVEaWdl
+        c3RzKQBycG1saWIoUGF5bG9hZEZpbGVzSGF2ZVByZWZpeCkAcnBtbGliKFBh
+        eWxvYWRJc1h6KQAzLjAuNC0xADQuNi4wLTEANC4wLTEANS4yLTEANC4xNC4x
+        AGxvY2FsaG9zdC5sb2NhbGRvbWFpbiAxNTMzMDY2MDE3AAAAAAABAAAAAQAA
+        AAAAAAAIMC43LTEAAAAAAAAAZHVjay50eHQAL3Vzci9iaW4vAC1PMiAtZyAt
+        cGlwZSAtV2FsbCAtV2Vycm9yPWZvcm1hdC1zZWN1cml0eSAtV3AsLURfRk9S
+        VElGWV9TT1VSQ0U9MiAtV3AsLURfR0xJQkNYWF9BU1NFUlRJT05TIC1mZXhj
+        ZXB0aW9ucyAtZnN0YWNrLXByb3RlY3Rvci1zdHJvbmcgLWdyZWNvcmQtZ2Nj
+        LXN3aXRjaGVzIC1zcGVjcz0vdXNyL2xpYi9ycG0vcmVkaGF0L3JlZGhhdC1o
+        YXJkZW5lZC1jYzEgLXNwZWNzPS91c3IvbGliL3JwbS9yZWRoYXQvcmVkaGF0
+        LWFubm9iaW4tY2MxIC1tNjQgLW10dW5lPWdlbmVyaWMgLWZhc3luY2hyb25v
+        dXMtdW53aW5kLXRhYmxlcyAtZnN0YWNrLWNsYXNoLXByb3RlY3Rpb24gLWZj
+        Zi1wcm90ZWN0aW9uAGNwaW8AeHoAMgBub2FyY2gtcmVkaGF0LWxpbnV4LWdu
+        dQAAAAAAAAAAAAAAAEFTQ0lJIHRleHQAH1uJtmAcqkPO6JoBUZ3VrAAAAAAI
+        dXRmLTgAODRlMzc2NzMwMWE5NDUxNTVkNDkwOGU3NDIyOTA5ZDQwOTMxMjEx
+        ZDJhMTUxMjdhNTExMzYwNWUyZjI2YWVjOQAAAAAACAAAAD8AAAAH///8wAAA
+        ABD9N3pYWgAACuH7DKECACEBEgAAACO4hyzgAQcAVV0AGA3dBGIy+XULgKK9
+        D1EGe8RLF4G4znKjZyb3n24+qRcnZi1qCdIPxoNahAwN6xWl6IjH2ObDlkSv
+        IwJ2iBnPvWx2Njnu1omGGvElqIweFqDe3Dqt9AAAAADfX9NVWh7JiGla/BKU
+        kEUtm8YJaxNQSt2aWeBtbaunfAABiQGIAgAAx/Lj7Lbp3xwCAAAAAApZWg0K
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTc2ZWNkMWZlODU1MDk0
+        ZTMwNjA5NTUyZDgyNjA4MmI1LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-76ecd1fe855094e30609552d826082b5
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6862'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy85NjU1NWNkYi1l
+        ODlkLTQxZmUtYTU2My1lM2QyYzc1NzJjZjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODoxMi4yOTIxMTRaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/96555cdb-e89d-41fe-a563-e3d2c7572cf2/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0OWE0MThkLTI2MzAtNDU1
+        ZC1hYjE5LTdlMGJiZDMwZjg1Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/949a418d-2630-455d-ab19-7e0bbd30f85b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '364'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ5YTQxOGQtMjYz
+        MC00NTVkLWFiMTktN2UwYmJkMzBmODViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTIuMzczNjY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        c3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTIuNTI1ODc2WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxMi41OTAzMjNaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzL2YzNzg5
+        ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy83MzE3ODkxZC02Y2MxLTQ4YmQtYTY1Zi02
+        YTI3OTcwMWRjMDUvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
+        L3B1bHAvYXBpL3YzL3VwbG9hZHMvOTY1NTVjZGItZTg5ZC00MWZlLWE1NjMt
+        ZTNkMmM3NTcyY2YyLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTIzNjY5Y2MxYTc1Y2Q3
+        YWFmODEwNjBlNGEwZTkxMDJhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
+        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTIzNjY5
+        Y2MxYTc1Y2Q3YWFmODEwNjBlNGEwZTkxMDJhDQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzczMTc4OTFkLTZjYzEtNDhiZC1hNjVmLTZhMjc5NzAx
+        ZGMwNS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC0yMzY2OWNj
+        MWE3NWNkN2FhZjgxMDYwZTRhMGU5MTAyYS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-23669cc1a75cd7aaf81060e4a0e9102a
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '389'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:12 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNDI3M2JjLTk1YmYtNDE2
+        My1iZGYxLWUzYmJmMjAwMTk2Mi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/5e4273bc-95bf-4163-bdf1-e3bbf2001962/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:13 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWU0MjczYmMtOTVi
+        Zi00MTYzLWJkZjEtZTNiYmYyMDAxOTYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTIuNzEzNDExWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTIuODQzMTcz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxMi45OTIyMjVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzFkMTFhYzQ1
+        LTQ3MDktNGRmNy05MmRjLWI2NDQ2NWIwMjJkOS8iXSwicmVzZXJ2ZWRfcmVz
+        b3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzczMTc4
+        OTFkLTZjYzEtNDhiZC1hNjVmLTZhMjc5NzAxZGMwNS8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:13 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/c84a9b28-dbb3-410e-8ab9-acb157eed653/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMWQxMWFjNDUtNDcwOS00ZGY3LTkyZGMtYjY0NDY1YjAy
+        MmQ5LyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:13 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1ZmQ0ZDIxLWZjZmYtNGNk
+        MC04ZDUwLTZlYTYwY2JhZjAwZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:13 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/65fd4d21-fcff-4cd0-8d50-6ea60cbaf00e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:13 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '358'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVmZDRkMjEtZmNm
+        Zi00Y2QwLThkNTAtNmVhNjBjYmFmMDBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MTMuMTI3ODI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MTMu
+        Mjc2OTg1WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODoxMy40
+        NTgzMjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M4
+        NGE5YjI4LWRiYjMtNDEwZS04YWI5LWFjYjE1N2VlZDY1My92ZXJzaW9ucy8x
+        LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jODRhOWIyOC1kYmIzLTQxMGUtOGFi
+        OS1hY2IxNTdlZWQ2NTMvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:13 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,180 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:30 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '3076'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:30 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:30 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +37,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -228,7 +55,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -273,7 +100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -318,7 +145,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +172,62 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiRmVkb3JhXzE3In0=
@@ -365,7 +237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +250,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/61dfe7ac-679f-48e4-8f2c-9f0635dd00ef/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d78160a1-3e79-4dd5-8529-3e7a297f2d2c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -394,25 +266,25 @@ http_interactions:
       Content-Length:
       - '450'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjFkZmU3YWMtNjc5Zi00OGU0LThmMmMtOWYwNjM1ZGQwMGVmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MDg6MzEuMzI1MzMzWiIsInZl
+        cG0vZDc4MTYwYTEtM2U3OS00ZGQ1LTg1MjktM2U3YTI5N2YyZDJjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTc6NDg6MzguNjYyNDQ0WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjFkZmU3YWMtNjc5Zi00OGU0LThmMmMtOWYwNjM1ZGQwMGVmL3ZlcnNp
+        cG0vZDc4MTYwYTEtM2U3OS00ZGQ1LTg1MjktM2U3YTI5N2YyZDJjL3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNjFkZmU3YWMtNjc5Zi00OGU0LThmMmMtOWYw
-        NjM1ZGQwMGVmL3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
+        b3NpdG9yaWVzL3JwbS9ycG0vZDc4MTYwYTEtM2U3OS00ZGQ1LTg1MjktM2U3
+        YTI5N2YyZDJjL3ZlcnNpb25zLzAvIiwibmFtZSI6IkZlZG9yYV8xNyIsImRl
         c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
         bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -424,7 +296,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -437,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
+      - Wed, 07 Oct 2020 17:48:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/c727b634-1f3d-4ef1-87f2-86d56f259c0e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c807b005-27ff-4ee3-a5cc-8fa3acebb827/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -453,25 +325,25 @@ http_interactions:
       Content-Length:
       - '415'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M3
-        MjdiNjM0LTFmM2QtNGVmMS04N2YyLTg2ZDU2ZjI1OWMwZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA4OjMxLjQ0MTk1NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2M4
+        MDdiMDA1LTI3ZmYtNGVlMy1hNWNjLThmYTNhY2ViYjgyNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTEwLTA3VDE3OjQ4OjM4Ljc1MDc4N1oiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwi
         dGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwidXNlcm5h
         bWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwdWxwX2xhc3RfdXBkYXRlZCI6
-        IjIwMjAtMDgtMjBUMTk6MDg6MzEuNDQxOTc3WiIsImRvd25sb2FkX2NvbmN1
+        IjIwMjAtMTAtMDdUMTc6NDg6MzguNzUwODA1WiIsImRvd25sb2FkX2NvbmN1
         cnJlbmN5IjoxMCwicG9saWN5Ijoib25fZGVtYW5kIiwic2xlc19hdXRoX3Rv
         a2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/c727b634-1f3d-4ef1-87f2-86d56f259c0e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/rpm/rpm/c807b005-27ff-4ee3-a5cc-8fa3acebb827/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -479,7 +351,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -492,7 +364,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:34 GMT
+      - Wed, 07 Oct 2020 17:48:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -506,17 +378,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlOTZhZDYxLTgzM2YtNDRi
-        MC1iYzAzLWU1YWZlZWE5YzZlMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzNzdiZDk0LWJlYTEtNGVk
+        OC1iMDhmLTY0NzViZmQ0ODMxYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:34 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:40 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/ee96ad61-833f-44b0-bc03-e5afeea9c6e3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9377bd94-bea1-4ed8-b08f-6475bfd4831c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -524,7 +396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -537,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:34 GMT
+      - Wed, 07 Oct 2020 17:48:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -549,30 +421,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '338'
+      - '339'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWU5NmFkNjEtODMz
-        Zi00NGIwLWJjMDMtZTVhZmVlYTljNmUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6MzQuMDE0NDQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTM3N2JkOTQtYmVh
+        MS00ZWQ4LWIwOGYtNjQ3NWJmZDQ4MzFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6NDAuNjA1NzI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6MzQuMjAzNTg5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODozNC4yNjY2NTNa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6NDAuNzQ5MzI1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODo0MC43OTM3MTNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vYzcyN2I2MzQtMWYzZC00ZWYxLTg3ZjItODZk
-        NTZmMjU5YzBlLyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vYzgwN2IwMDUtMjdmZi00ZWUzLWE1Y2MtOGZh
+        M2FjZWJiODI3LyJdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:34 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:40 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/61dfe7ac-679f-48e4-8f2c-9f0635dd00ef/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d78160a1-3e79-4dd5-8529-3e7a297f2d2c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -580,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -593,7 +465,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:34 GMT
+      - Wed, 07 Oct 2020 17:48:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -607,17 +479,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0MzdmNDkyLWRhYzMtNGU5
-        YS1hYjZiLTc0M2Y1N2Y4M2MwZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxMzdkZWNiLTlhMjAtNDRh
+        OC1iNDc1LTg2OWI1NWUzMThjZS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:34 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:40 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/4437f492-dac3-4e9a-ab6b-743f57f83c0e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/2137decb-9a20-44a8-b475-869b55e318ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -625,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -638,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:34 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -650,30 +522,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDQzN2Y0OTItZGFj
-        My00ZTlhLWFiNmItNzQzZjU3ZjgzYzBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6MzQuMzg4NzY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjEzN2RlY2ItOWEy
+        MC00NGE4LWI0NzUtODY5YjU1ZTMxOGNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6NDAuOTI3ODcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MDg6MzQuNjIyMTMz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODozNC43MDc3NDVa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6NDEuMDgyNTg1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODo0MS4xNjUxNDNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MWRmZTdhYy02NzlmLTQ4ZTQtOGYy
-        Yy05ZjA2MzVkZDAwZWYvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNzgxNjBhMS0zZTc5LTRkZDUtODUy
+        OS0zZTdhMjk3ZjJkMmMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:34 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -681,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -694,596 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '344'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3
-        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0
-        NWU4L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQw
-        YTItYjkzNy1iZjQxYTYzZjQ1ZTgvdmVyc2lvbnMvMS8iLCJuYW1lIjoiUHVi
-        bGlzaGVkIExpYnJhcnkgYW5kIGRldiB2aWV3LTcwMDk3MzQ1My05MDkwNTgz
-        NDciLCJkZXNjcmlwdGlvbiI6IlB1Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYg
-        dmlldy03MDA5NzM0NTMtOTA5MDU4MzQ3IiwicmVtb3RlIjpudWxsfSx7InB1
-        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYzZS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjQ3LjM5MDI1NVoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDNlY2YyMGItNzE4Mi00ZDg5LWI3YzktNDJmM2U3ODM0NjNlL3ZlcnNp
-        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wM2VjZjIwYi03MTgyLTRkODktYjdjOS00
-        MmYzZTc4MzQ2M2UvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdh
-        bml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '289'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTguOTQ0Mzk4WiIsIm51bWJlciI6MSwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
-        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJm
-        NDFhNjNmNDVlOC92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC92ZXJzaW9ucy8xLyJ9fX19LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvNWZmYTU5MzctYjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNp
-        b25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowNzo1Ny45
-        MTIyNTBaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRl
-        bnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50
-        Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/03ecf20b-7182-4d89-b7c9-42f3e783463e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '292'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYz
-        ZS92ZXJzaW9ucy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTguNDQ4MzM3WiIsIm51bWJlciI6MSwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
-        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlLzAzZWNmMjBiLTcxODItNGQ4OS1iN2M5LTQy
-        ZjNlNzgzNDYzZS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAzZWNmMjBiLTcx
-        ODItNGQ4OS1iN2M5LTQyZjNlNzgzNDYzZS92ZXJzaW9ucy8xLyJ9fX19LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDNlY2YyMGItNzE4Mi00ZDg5LWI3YzktNDJmM2U3ODM0NjNlL3ZlcnNp
-        b25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowNzo0Ny4z
-        OTY5MDFaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRl
-        bnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50
-        Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '366'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTowNzoyNC4xNjA5MzNa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3
-        ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjIzLjE4NjU4MFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNh
-        Njg5YTFiMC92ZXJzaW9ucy8xLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8xLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/cbd99477-e25a-4b4b-947d-b5ccba68872f/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '453'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjMwLjU3MDQ5OFoiLCJudW1iZXIiOjIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiZDk5NDc3LWUyNWEtNGI0Yi05NDdk
-        LWI1Y2NiYTY4ODcyZi92ZXJzaW9ucy8yLyJ9LCJycG0uZGlzdHJpYnV0aW9u
-        X3RyZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiZDk5
-        NDc3LWUyNWEtNGI0Yi05NDdkLWI1Y2NiYTY4ODcyZi92ZXJzaW9ucy8yLyJ9
-        LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiZDk5
-        NDc3LWUyNWEtNGI0Yi05NDdkLWI1Y2NiYTY4ODcyZi92ZXJzaW9ucy8yLyJ9
-        LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MTMsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
-        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2JkOTk0
-        NzctZTI1YS00YjRiLTk0N2QtYjVjY2JhNjg4NzJmL3ZlcnNpb25zLzIvIn0s
-        InJwbS5wYWNrYWdlZ3JvdXAiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lv
-        bnMvMi8ifSwicnBtLnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwi
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRh
-        X2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtL2NiZDk5NDc3LWUyNWEtNGI0Yi05NDdk
-        LWI1Y2NiYTY4ODcyZi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2Jk
-        OTk0NzctZTI1YS00YjRiLTk0N2QtYjVjY2JhNjg4NzJmL3ZlcnNpb25zLzIv
-        In0sInJwbS5kaXN0cmlidXRpb25fdHJlZSI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMv
-        P3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vY2JkOTk0NzctZTI1YS00YjRiLTk0N2QtYjVjY2JhNjg4NzJm
-        L3ZlcnNpb25zLzIvIn0sInJwbS5tb2R1bGVtZCI6eyJjb3VudCI6NiwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vY2JkOTk0NzctZTI1YS00YjRiLTk0N2QtYjVjY2JhNjg4NzJmL3ZlcnNp
-        b25zLzIvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxMywiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5
-        OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMi8i
-        fSwicnBtLnBhY2thZ2VlbnZpcm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2NiZDk5NDc3LWUyNWEtNGI0Yi05NDdkLWI1Y2NiYTY4ODcy
-        Zi92ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50Ijoy
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91
-        cHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vY2JkOTk0NzctZTI1YS00YjRiLTk0N2QtYjVjY2JhNjg4
-        NzJmL3ZlcnNpb25zLzIvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsi
-        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVw
-        b19tZXRhZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGIt
-        OTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3
-        Ny1lMjVhLTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjI5Ljg0MzYyNloiLCJu
-        dW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
-        dmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGIt
-        OTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVu
-        dmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVhLTRiNGItOTQ3ZC1i
-        NWNjYmE2ODg3MmYvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYmQ5OTQ3Ny1lMjVh
-        LTRiNGItOTQ3ZC1iNWNjYmE2ODg3MmYvdmVyc2lvbnMvMC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3OjI0LjE2NjAxMFoiLCJudW1iZXIi
-        OjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
-        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/72f97fcf-61e1-477e-bb07-2cb3a689a1b0/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '456'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4OWExYjAv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA3
-        OjI0Ljc3MTk2OVoiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3
-        LTJjYjNhNjg5YTFiMC92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9u
-        X3RyZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyZjk3
-        ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9ucy8xLyJ9
-        LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
-        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyZjk3
-        ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9ucy8xLyJ9
-        LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQiOjMsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvP3Jl
-        cG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNzJmOTdmY2YtNjFlMS00NzdlLWJiMDctMmNiM2E2ODlh
-        MWIwL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxOSwi
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4OWEx
-        YjAvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3Vu
-        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        Y2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2Ut
-        YmIwNy0yY2IzYTY4OWExYjAvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2Vl
-        bnZpcm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3Zl
-        cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9u
-        cy8xLyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vNzJmOTdmY2YtNjFlMS00NzdlLWJiMDctMmNiM2E2ODlhMWIw
-        L3ZlcnNpb25zLzEvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291
-        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19t
-        ZXRhZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3
-        N2UtYmIwNy0yY2IzYTY4OWExYjAvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQi
-        Ont9LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6NiwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJz
-        aW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQiOjEs
-        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0aW9u
-        X3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNh
-        Njg5YTFiMC92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWQiOnsiY291bnQi
-        OjYsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzcyZjk3ZmNmLTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFi
-        MC92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291
-        bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxl
-        bWRfZGVmYXVsdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vNzJmOTdmY2YtNjFlMS00NzdlLWJiMDct
-        MmNiM2E2ODlhMWIwL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNv
-        dW50IjoxOSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4
-        OWExYjAvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJj
-        b3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNr
-        YWdlY2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIw
-        Ny0yY2IzYTY4OWExYjAvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZp
-        cm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcyZjk3ZmNm
-        LTYxZTEtNDc3ZS1iYjA3LTJjYjNhNjg5YTFiMC92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzJmOTdm
-        Y2YtNjFlMS00NzdlLWJiMDctMmNiM2E2ODlhMWIwL3ZlcnNpb25zLzEvIn0s
-        InJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy8/
-        cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0yY2IzYTY4OWExYjAv
-        dmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS83MmY5N2ZjZi02MWUxLTQ3N2UtYmIwNy0y
-        Y2IzYTY4OWExYjAvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA3OjIzLjE5MzE3NFoiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '323'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE5
-        OjMwLjIxMDA2NFoiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2Ez
-        LTgwYmRmYThhZTcwMC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJj
-        b3VudCI6MzIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMTE2YzZhYmItN2IwMS00MjBjLTkzYTMt
-        ODBiZGZhOGFlNzAwL3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJl
-        c2VudCI6eyJycG0uYWR2aXNvcnkiOnsiY291bnQiOjQsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMTZj
-        NmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAvdmVyc2lvbnMvMS8i
-        fSwicnBtLnBhY2thZ2UiOnsiY291bnQiOjMyLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdi
-        MDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJzaW9ucy8xLyJ9fX19LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTU6MTg6MTUuODEx
-        MzY1WiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50
-        X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6
-        e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1297,17 +580,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1315,7 +598,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1328,41 +611,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1370,7 +643,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1383,88 +656,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '336'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2Ljg2MjMwOFoiLCJudW1iZXIiOjEsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImNvbnRh
-        aW5lci5ibG9iIjp7ImNvdW50Ijo0LCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvY29udGFpbmVyL2Jsb2JzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
-        bmVyL2Q5YzNiYWU0LTgwOTEtNDE5YS1iNzg2LTNlNjU4YWRiYTljYy92ZXJz
-        aW9ucy8xLyJ9LCJjb250YWluZXIubWFuaWZlc3QiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3Rz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2Q5YzNiYWU0LTgwOTEtNDE5
-        YS1iNzg2LTNlNjU4YWRiYTljYy92ZXJzaW9ucy8xLyJ9LCJjb250YWluZXIu
-        dGFnIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        Y29udGFpbmVyL3RhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZDlj
-        M2JhZTQtODA5MS00MTlhLWI3ODYtM2U2NThhZGJhOWNjL3ZlcnNpb25zLzEv
-        In19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJjb250YWluZXIuYmxvYiI6
-        eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRh
-        aW5lci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMS8ifSwiY29udGFp
-        bmVyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0cy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRh
-        aW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVy
-        c2lvbnMvMS8ifSwiY29udGFpbmVyLnRhZyI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2NvbnRhaW5lci90YWdzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWlu
-        ZXIvY29udGFpbmVyL2Q5YzNiYWU0LTgwOTEtNDE5YS1iNzg2LTNlNjU4YWRi
-        YTljYy92ZXJzaW9ucy8xLyJ9fX19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2Q5YzNiYWU0
-        LTgwOTEtNDE5YS1iNzg2LTNlNjU4YWRiYTljYy92ZXJzaW9ucy8wLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MDg6MjYuMjI5NTc3WiIsIm51
-        bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
-        OnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1472,23 +664,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViYjUzYjJmLTQ0NjUtNDhk
-        ZS1iOTQ0LWRkNDhiMjU3YTVmYy8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/03ecf20b-7182-4d89-b7c9-42f3e783463e/versions/1/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1496,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1505,11 +697,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1517,23 +709,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5OWFmZDFmLTJlNzgtNDk1
-        My1hNDI2LWMxYzE5YWJjOTIyOC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/cbd99477-e25a-4b4b-947d-b5ccba68872f/versions/2/
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1541,7 +733,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1550,11 +742,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:36 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1562,23 +754,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmN2E0MTQ0LWYxNTUtNDQ4
-        MS1hMjhmLWRkMzdhMmZhMjc2ZC8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/cbd99477-e25a-4b4b-947d-b5ccba68872f/versions/1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1586,7 +778,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1599,187 +791,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:37 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmN2ZlNjEyLWUyMGQtNGQ5
-        YS1iNWM0LTY3YWY1NjY2M2E1Yy8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:37 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/72f97fcf-61e1-477e-bb07-2cb3a689a1b0/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:37 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4NjhiYzUxLTYzY2YtNDAz
-        Ni1hNzhkLTkzM2UzZGE0MTJhNC8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:37 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:37 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YTA3ZWZkLWYwMDItNDY4
-        YS04NmI4LTY0ZTljMDcxYTVkMS8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:37 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:37 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzZTI2OGRjLTZkOTEtNDRi
-        ZS04NDRhLTliMjY2MGI4YjU4OC8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:37 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:37 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1793,17 +805,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyZWRjYjc5LTdjNWQtNDRj
-        Ni1iYjZmLTE5N2U1ZDI0MzZjNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4NjgwMmZlLWQxYzQtNDQ1
+        Mi1hMGY1LTkxZjkwMzU3ZjI0Yi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/d2edcb79-7c5d-44c6-bb6f-197e5d2436c6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/286802fe-d1c4-4452-a0f5-91f90357f24b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,7 +823,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1824,7 +836,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:08:41 GMT
+      - Wed, 07 Oct 2020 17:48:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1836,29 +848,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '391'
+      - '384'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJlZGNiNzktN2M1
-        ZC00NGM2LWJiNmYtMTk3ZTVkMjQzNmM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MDg6MzcuNzMwMzc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjg2ODAyZmUtZDFj
+        NC00NDUyLWEwZjUtOTFmOTAzNTdmMjRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6NDEuNjEzMzk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yMFQxOTowODozOS43ODc5
-        NDZaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjA4OjQxLjc0OTY0
-        OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
-        cnMvNDQ2OGEzZjAtMzg1Yy00MTUzLThjY2ItNTczOWRjMDA2YjBmLyIsInBh
+        ZWFudXAiLCJzdGFydGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODo0MS42OTc3
+        MjBaIiwiZmluaXNoZWRfYXQiOiIyMDIwLTEwLTA3VDE3OjQ4OjQxLjg1NDQy
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMWZkYzUxMzMtMzI1OS00M2I5LWFhZWMtZjFlOTAzOTgxNjQxLyIsInBh
         cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
         Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJDbGVhbiB1
         cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwi
-        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6ODMsImRvbmUiOjgzLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFj
-        dHMiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIsInN0YXRlIjoiY29tcGxl
-        dGVkIiwidG90YWwiOjEwMywiZG9uZSI6MTAzLCJzdWZmaXgiOm51bGx9XSwi
-        Y3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVj
-        b3JkIjpbXX0=
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0aWZhY3Rz
+        IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjo1LCJkb25lIjo1LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:41 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:41 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
@@ -1399,101 +1399,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 23 Jun 2020 18:57:00 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoxNjA3fQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:31 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/ce0c655f-51c0-4e6b-9ce9-553beb4dbe92/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9jZTBjNjU1Zi01
-        MWMwLTRlNmItOWNlOS01NTNiZWI0ZGJlOTIvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMC0wOC0yMFQxOTowODozMS43OTY5NjBaIiwic2l6ZSI6MTYwN30=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:31 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/ce0c655f-51c0-4e6b-9ce9-553beb4dbe92/
     body:
@@ -1691,62 +1596,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:32 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWY1MTI0NzIxM2IwYzRm
-        YjExMzY3ZDAxNWVkMzM2MmZlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3Qtc3JwbTAxLTEu
-        MC0xLnNyYy5ycG0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1m
-        NTEyNDcyMTNiMGM0ZmIxMTM2N2QwMTVlZDMzNjJmZQ0KQ29udGVudC1EaXNw
-        b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJhcnRpZmFjdCINCg0KL3B1bHAv
-        YXBpL3YzL2FydGlmYWN0cy9kNjcwOWM5ZS1mN2I2LTRmYzYtYTZhNS05YTky
-        NjM3Yzg4N2MvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZjUx
-        MjQ3MjEzYjBjNGZiMTEzNjdkMDE1ZWQzMzYyZmUtLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-f51247213b0c4fb11367d015ed3362fe
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '393'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:08:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0Y2Q0NDIxLTk3MzgtNDQx
-        MS1hMDQ2LTk4MjJhMmUyZDhiZi8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:08:32 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/34cd4421-9738-4411-a046-9822a2e2d8bf/
     body:
@@ -1909,4 +1758,515 @@ http_interactions:
         Yy05ZjA2MzVkZDAwZWYvIl19
     http_version: 
   recorded_at: Thu, 20 Aug 2020 19:08:33 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoxNjA3fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/72d2c491-ff2f-4ed0-bb63-9ac1d62e7b1a/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy83MmQyYzQ5MS1m
+        ZjJmLTRlZDAtYmI2My05YWMxZDYyZTdiMWEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODozOS4wMzk0MDJaIiwic2l6ZSI6MTYwN30=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/72d2c491-ff2f-4ed0-bb63-9ac1d62e7b1a/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LThjOWVlNGZmYjc0MmM3
+        YjVhYTcwMWJiN2Y0ZmRiODc5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMDEw
+        MDctMzAxODItMXZkdWthNCINCkNvbnRlbnQtTGVuZ3RoOiAxNjA3DQpDb250
+        ZW50LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1U
+        cmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCu2r7tsDAAABAAF0ZXN0LXNy
+        cG0wMS0xLjAtMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAQAFAAAAAAAAAAAAAAAAAAAAAI6t6AEAAAAAAAAA
+        BQAAAFQAAAA+AAAABwAAAEQAAAAQAAABDQAAAAYAAAAAAAAAAQAAA+gAAAAE
+        AAAALAAAAAEAAAPsAAAABwAAADAAAAAQAAAD7wAAAAQAAABAAAAAAWMyOTcx
+        M2Q4YWJiMjYwNDU2OTMxMTgwYWY3YTk3NjllMmY5MmI0MDYAAAAAAAAFL38a
+        0aLocnOKGkxnVcNc+RwAAAG8AAAAPgAAAAf///+wAAAAEAAAAACOregBAAAA
+        AAAAACgAAAGkAAAAPwAAAAcAAAGUAAAAEAAAAGQAAAAIAAAAAAAAAAEAAAPo
+        AAAABgAAAAIAAAABAAAD6QAAAAYAAAAOAAAAAQAAA+oAAAAGAAAAEgAAAAEA
+        AAPsAAAACQAAABQAAAABAAAD7QAAAAkAAAA1AAAAAQAAA+4AAAAEAAAATAAA
+        AAEAAAPvAAAABgAAAFAAAAABAAAD8QAAAAQAAABcAAAAAQAAA/YAAAAGAAAA
+        YAAAAAEAAAP4AAAACQAAAGYAAAABAAAD/QAAAAYAAAB+AAAAAQAAA/4AAAAG
+        AAAAhAAAAAEAAAQEAAAABAAAAIwAAAABAAAEBgAAAAMAAACQAAAAAQAABAkA
+        AAADAAAAkgAAAAEAAAQKAAAABAAAAJQAAAABAAAECwAAAAgAAACYAAAAAQAA
+        BAwAAAAIAAAA2QAAAAEAAAQNAAAABAAAANwAAAABAAAEDwAAAAgAAADgAAAA
+        AQAABBAAAAAIAAAA6QAAAAEAAAQVAAAABAAAAPQAAAABAAAEGAAAAAQAAAD4
+        AAAAAgAABBkAAAAIAAABAAAAAAIAAAQaAAAACAAAATAAAAACAAAEKAAAAAYA
+        AAFAAAAAAQAABEEAAAAIAAABRgAAAAEAAARGAAAABgAAAU0AAAABAAAERwAA
+        AAQAAAFkAAAAAQAABEgAAAAEAAABaAAAAAEAAARJAAAACAAAAWwAAAABAAAE
+        XAAAAAQAAAFwAAAAAQAABF0AAAAIAAABdAAAAAEAAAReAAAACAAAAYMAAAAB
+        AAAEZAAAAAYAAAGEAAAAAQAABGUAAAAGAAABiQAAAAEAAARmAAAABgAAAY4A
+        AAABAAATkwAAAAQAAAGQAAAAAUMAdGVzdC1zcnBtMDEAMS4wADEARHVtbXkg
+        UGFja2FnZSB0byBwcm92aWRlIHRvbWNhdDUAClRoaXMgaXMgYSB0ZXN0IHJw
+        bQAAAABPWg7jbG9jYWxob3N0AAAAAAAAwEdQTHYyAFN5c3RlbSBFbnZpcm9u
+        bWVudC9CYXNlAGxpbnV4AG5vYXJjaAAAAAAAwIG0AABPWg7VNTEyOWJhZmNj
+        NDBjNjExNDJjM2NhNWJiZGM5MzQ3OTFjZWI2NTBhNGFmYmJiNDk4MmE0ZDRm
+        MWMxZGZhNzc5YgAAAAAAAAAgcGtpbGFtYmkAcGtpbGFtYmkAAAD/////AQAA
+        CgEAAApycG1saWIoRmlsZURpZ2VzdHMpAHJwbWxpYihDb21wcmVzc2VkRmls
+        ZU5hbWVzKQA0LjYuMC0xADMuMC40LTEANC45LjAAbm9hcmNoAGxvY2FsaG9z
+        dCAxMzMxMzAyMTE1AAAAAAD9AQAINA4AAAAAAAAAAHRlc3Qtc3JwbS5zcGVj
+        AABjcGlvAGd6aXAAOQAAAAAIAAAAPwAAAAf///2AAAAAEB+LCAAAAAAAAgON
+        kFFLwzAQx32+T3F98NF50ZaNvm04hlBkdMP3LL26YJOUJC3s25uq9UEU9ieQ
+        X5Jf7uBoSUsSRLR6zIlpAnHK6e+IvC0kcVN8HdX3ddvM7//8a2eIHOJd8L1Z
+        hJ7VTcphMEb6S4lPCS64l+pdvjFGh713o24mNErGAl6k4RJ/KpCAV/ZBO1ui
+        WBDU3LEMyRCw827oSzxcQmSDWztq76xhG+83yYBKK7aTudtX4wNsBt01a6/O
+        JVon0w5w23BQXvcxVQc4nnXAtORnc0y9k9HqjgMA0Dy/a3Kt9zunGY71+rna
+        1lmWTbP7AE2AuiO8AQAADQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBv
+        c3QtOGM5ZWU0ZmZiNzQyYzdiNWFhNzAxYmI3ZjRmZGI4NzktLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-8c9ee4ffb742c7b5aa701bb7f4fdb879
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-1606/1607
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1929'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy83MmQyYzQ5MS1m
+        ZjJmLTRlZDAtYmI2My05YWMxZDYyZTdiMWEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMC0xMC0wN1QxNzo0ODozOS4wMzk0MDJaIiwic2l6ZSI6MTYwN30=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/uploads/72d2c491-ff2f-4ed0-bb63-9ac1d62e7b1a/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1NGNjNDcxM2ZlNzA0ZGZjN2E0ZmQ1YjM5OGY4MzRjZWI2
+        YTY5MmY1M2IwYzZhZWZhZjg5ZDg4NDE3YjRjNTFkIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzOGQzMzQ4LTExMjYtNDhi
+        Yi1iZTg2LTc3NjU4ODg5NDJjNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/838d3348-1126-48bb-be86-7765888942c7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM4ZDMzNDgtMTEy
+        Ni00OGJiLWJlODYtNzc2NTg4ODk0MmM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzkuMTE3OTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        c3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzkuMjcwMjM1WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozOS4zMjQ5NjNaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzL2YzNzg5
+        ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy83M2JhODRiNi1jMjQ2LTQ2M2QtOTlhYy0y
+        NDc2ODUzZWMzZDAvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsi
+        L3B1bHAvYXBpL3YzL3VwbG9hZHMvNzJkMmM0OTEtZmYyZi00ZWQwLWJiNjMt
+        OWFjMWQ2MmU3YjFhLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRlYjNjMzgwMjMzODMz
+        M2Y4ZmQ5N2MyZGEyZGVjYjQ3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3Qtc3JwbTAxLTEu
+        MC0xLnNyYy5ycG0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1k
+        ZWIzYzM4MDIzMzgzMzNmOGZkOTdjMmRhMmRlY2I0Nw0KQ29udGVudC1EaXNw
+        b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJhcnRpZmFjdCINCg0KL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy83M2JhODRiNi1jMjQ2LTQ2M2QtOTlhYy0yNDc2
+        ODUzZWMzZDAvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZGVi
+        M2MzODAyMzM4MzMzZjhmZDk3YzJkYTJkZWNiNDctLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-deb3c3802338333f8fd97c2da2decb47
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '393'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiNWI4N2I0LTA2ZjgtNDg1
+        NS04YjQ5LTlkNzQ1Y2U0NjU5Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/cb5b87b4-06f8-4855-8b49-9d745ce4659b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I1Yjg3YjQtMDZm
+        OC00ODU1LThiNDktOWQ3NDVjZTQ2NTliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzkuNDA2MTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6MzkuNTk0MTU0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODozOS43NTIyMTha
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2MyYmM5ZDky
+        LTI0Y2UtNDRlNi05YjIwLTdlYTIzNzA0MDkxZi8iXSwicmVzZXJ2ZWRfcmVz
+        b3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzczYmE4
+        NGI2LWMyNDYtNDYzZC05OWFjLTI0NzY4NTNlYzNkMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/d78160a1-3e79-4dd5-8529-3e7a297f2d2c/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzJiYzlkOTItMjRjZS00NGU2LTliMjAtN2VhMjM3MDQw
+        OTFmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5YjcyMTEzLTRmMTUtNDk3
+        OC1hOTVmLTM5ZWUzY2YxMDZlMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/09b72113-4f15-4978-a95f-39ee3cf106e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:40 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '356'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDliNzIxMTMtNGYx
+        NS00OTc4LWE5NWYtMzllZTNjZjEwNmUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTc6NDg6MzkuODM5NjU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTc6NDg6NDAu
+        MDA0ODcxWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNzo0ODo0MC4x
+        ODg5MDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
+        dXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q3
+        ODE2MGExLTNlNzktNGRkNS04NTI5LTNlN2EyOTdmMmQyYy92ZXJzaW9ucy8x
+        LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNzgxNjBhMS0zZTc5LTRkZDUtODUy
+        OS0zZTdhMjk3ZjJkMmMvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:40 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_list/list_with_pagination.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_list/list_with_pagination.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,159 +23,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:42 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:42 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -241,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -286,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +172,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -331,7 +203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +217,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -363,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -376,159 +248,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -549,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -563,17 +307,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -608,17 +352,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -639,7 +383,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -653,17 +397,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:27 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -698,17 +442,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:27 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -731,13 +475,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:28 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/526c2c8f-7e9c-4a1f-a905-fed1deab46ff/"
+      - "/pulp/api/v3/repositories/file/file/7aa09ed7-2c14-4f61-9665-af9fdd046d20/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -747,25 +491,25 @@ http_interactions:
       Content-Length:
       - '428'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS81MjZjMmM4Zi03ZTljLTRhMWYtYTkwNS1mZWQxZGVhYjQ2ZmYvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjoyOC4wODAyNzZaIiwi
+        ZmlsZS83YWEwOWVkNy0yYzE0LTRmNjEtOTY2NS1hZjlmZGQwNDZkMjAvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMDo0My41MjA0NThaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzUyNmMyYzhmLTdlOWMtNGExZi1hOTA1LWZlZDFkZWFiNDZmZi92
+        ZS9maWxlLzdhYTA5ZWQ3LTJjMTQtNGY2MS05NjY1LWFmOWZkZDA0NmQyMC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTI2YzJjOGYtN2U5Yy00YTFmLWE5
-        MDUtZmVkMWRlYWI0NmZmL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvN2FhMDllZDctMmMxNC00ZjYxLTk2
+        NjUtYWY5ZmRkMDQ2ZDIwL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRp
         b24iOm51bGwsInJlbW90ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -791,13 +535,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:28 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/4e4d0f00-b3ad-4201-9aa5-abadd901f1f3/"
+      - "/pulp/api/v3/remotes/file/file/2e5de72e-a565-4334-8aa0-0d883f3800f3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -807,32 +551,32 @@ http_interactions:
       Content-Length:
       - '466'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        NGU0ZDBmMDAtYjNhZC00MjAxLTlhYTUtYWJhZGQ5MDFmMWYzLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MjI6MjguMjE0MzI5WiIsIm5hbWUi
+        MmU1ZGU3MmUtYTU2NS00MzM0LThhYTAtMGQ4ODNmMzgwMGYzLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTA6NDMuNjUzMDg5WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUt
         bWFueS8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQiOm51bGwsImNsaWVudF9j
         ZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6
         dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJ1c2VybmFtZSI6bnVsbCwicGFzc3dv
-        cmQiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMC0wOC0yMFQxOToy
-        MjoyOC4yMTQzNDhaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjEwLCJwb2xp
+        cmQiOm51bGwsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMC0xMC0wN1QxNTox
+        MDo0My42NTMxMDdaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOjEwLCJwb2xp
         Y3kiOiJpbW1lZGlhdGUifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS81MjZjMmM4Zi03ZTljLTRhMWYtYTkwNS1mZWQxZGVh
-        YjQ2ZmYvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS83YWEwOWVkNy0yYzE0LTRmNjEtOTY2NS1hZjlmZGQw
+        NDZkMjAvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -851,7 +595,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:28 GMT
+      - Wed, 07 Oct 2020 15:10:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -865,17 +609,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlMTI4YzM4LWIxNGEtNGI5
-        Ni1iZjA5LTAzOTlhZDI4YmIyZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlMjI0Y2ExLWRiZTYtNGI3
+        Ni1hNDM5LWNlMmY4NmFlZDY1ZS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:43 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0e128c38-b14a-4b96-bf09-0399ad28bb2f/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/7e224ca1-dbe6-4b76-a439-ce2f86aed65e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -883,7 +627,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -896,7 +640,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:28 GMT
+      - Wed, 07 Oct 2020 15:10:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -908,32 +652,32 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '373'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGUxMjhjMzgtYjE0
-        YS00Yjk2LWJmMDktMDM5OWFkMjhiYjJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6MjguNDc1NDMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2UyMjRjYTEtZGJl
+        Ni00Yjc2LWE0MzktY2UyZjg2YWVkNjVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTA6NDMuOTQ3NDA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6MjguNjQ4NzI3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjoyOC43NDc5NjJa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTA6NDQuMTExMzE0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMDo0NC4yMDc5NTda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNGM1Mzg2
-        MTMtZjg1Ny00ZTJlLTlmYzUtM2E2N2Y2YmEyZmI0LyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNjVhYWVh
+        MzEtZWIxOS00ZmNlLTljZjQtMzg5MDI1ZTMzZjk1LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzUyNmMyYzhmLTdlOWMtNGExZi1hOTA1LWZlZDFkZWFiNDZm
-        Zi8iXX0=
+        ZmlsZS9maWxlLzdhYTA5ZWQ3LTJjMTQtNGY2MS05NjY1LWFmOWZkZDA0NmQy
+        MC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:44 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -941,7 +685,7 @@ http_interactions:
         bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJEZWZh
         dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInB1Ymxp
         Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        NGM1Mzg2MTMtZjg1Ny00ZTJlLTlmYzUtM2E2N2Y2YmEyZmI0LyJ9
+        NjVhYWVhMzEtZWIxOS00ZmNlLTljZjQtMzg5MDI1ZTMzZjk1LyJ9
     headers:
       Content-Type:
       - application/json
@@ -959,7 +703,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:29 GMT
+      - Wed, 07 Oct 2020 15:10:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -973,17 +717,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjMWY2YzViLTQxMGMtNDBl
-        OS1hOGZlLWEzNWI4ZjMyOTdmNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzMDcxNTc5LTVmZjgtNDE4
+        Yy1iNDMzLWM4OGFhZDZlNGNlNS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:29 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/1c1f6c5b-410c-40e9-a8fe-a35b8f3297f4/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/83071579-5ff8-418c-b433-c88aad6e4ce5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -991,7 +735,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1004,7 +748,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:29 GMT
+      - Wed, 07 Oct 2020 15:10:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1016,30 +760,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '346'
+      - '348'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMxZjZjNWItNDEw
-        Yy00MGU5LWE4ZmUtYTM1YjhmMzI5N2Y0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6MjkuMDAxNDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODMwNzE1NzktNWZm
+        OC00MThjLWI0MzMtYzg4YWFkNmU0Y2U1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTA6NDQuMzkxMDU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6MjkuMTgxMTEz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjoyOS41NzE1NzBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTA6NDQuNTMwOTg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMDo0NC43Nzk0OTBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2MyYWRj
-        M2M3LTU4ZTItNGIzOC1iYzQzLTJmYWM1MWI1MWQ0NC8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2FjNTVl
+        YWViLTQ5MWItNGM3NS1iOTI5LWZhMjY2YTkzMzk4ZS8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:29 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1060,7 +804,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:29 GMT
+      - Wed, 07 Oct 2020 15:10:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1072,28 +816,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '284'
+      - '288'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvYzJhZGMzYzctNThlMi00YjM4LWJjNDMtMmZhYzUxYjUxZDQ0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MjI6MjkuNTQ1NTg5WiIs
+        L2ZpbGUvYWM1NWVhZWItNDkxYi00Yzc1LWI5MjktZmEyNjZhOTMzOThlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTA6NDQuNzYzNDA4WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
-        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9u
-        L2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
-        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
-        cy9maWxlL2ZpbGUvNGM1Mzg2MTMtZjg1Ny00ZTJlLTlmYzUtM2E2N2Y2YmEy
-        ZmI0LyJ9
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2Fu
+        aXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJk
+        IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJs
+        aWNhdGlvbnMvZmlsZS9maWxlLzY1YWFlYTMxLWViMTktNGZjZS05Y2Y0LTM4
+        OTAyNWUzM2Y5NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:29 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:44 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/526c2c8f-7e9c-4a1f-a905-fed1deab46ff/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/7aa09ed7-2c14-4f61-9665-af9fdd046d20/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1116,7 +860,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:30 GMT
+      - Wed, 07 Oct 2020 15:10:45 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1130,17 +874,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhNjQ1MGM4LTA1ZjItNDA2
-        Yi04OWFhLTE5MjZkNjI4ZTgzOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhNjEyNmM1LTk2NjQtNGNk
+        NC05ODE5LWQxMjI4NmZlMzE1Yy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:45 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/4e4d0f00-b3ad-4201-9aa5-abadd901f1f3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/2e5de72e-a565-4334-8aa0-0d883f3800f3/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1166,7 +910,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:30 GMT
+      - Wed, 07 Oct 2020 15:10:45 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1180,24 +924,24 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwM2NjN2FjLTUwMDUtNDBi
-        NS05ZWZlLTdjNmNlNjllYmY0Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmZjhkODk2LTIzZjQtNDY4
+        ZS05OTI0LTg4ODgyODQ2MDdlZi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:45 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNGM1Mzg2
-        MTMtZjg1Ny00ZTJlLTlmYzUtM2E2N2Y2YmEyZmI0LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNjVhYWVh
+        MzEtZWIxOS00ZmNlLTljZjQtMzg5MDI1ZTMzZjk1LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1215,7 +959,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:30 GMT
+      - Wed, 07 Oct 2020 15:10:45 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1229,17 +973,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3Y2M0YzZkLWExYmQtNDc0
-        MC04MTY0LWYzOTlmYmRjMDBhMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiOGQ5Zjg2LWQzNTItNGFk
+        Mi1iNTlhLWIwODNmZTlmMTBlNi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:45 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f7cc4c6d-a1bd-4740-8164-f399fbdc00a2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/1b8d9f86-d352-4ad2-b59a-b083fe9f10e6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1247,7 +991,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1260,7 +1004,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:31 GMT
+      - Wed, 07 Oct 2020 15:10:45 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1272,36 +1016,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjdjYzRjNmQtYTFi
-        ZC00NzQwLTgxNjQtZjM5OWZiZGMwMGEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6MzAuMzE5NjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWI4ZDlmODYtZDM1
+        Mi00YWQyLWI1OWEtYjA4M2ZlOWYxMGU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTA6NDUuMzAyNjk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6MzAuNjc4NTE0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjozMS4wNTc3NTla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTA6NDUuNjMyMTc5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMDo0NS45MTM2MzFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:45 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNGM1Mzg2
-        MTMtZjg1Ny00ZTJlLTlmYzUtM2E2N2Y2YmEyZmI0LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNjVhYWVh
+        MzEtZWIxOS00ZmNlLTljZjQtMzg5MDI1ZTMzZjk1LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1319,7 +1063,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:31 GMT
+      - Wed, 07 Oct 2020 15:10:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1333,22 +1077,22 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkMWZiYjRhLTJmYmItNGI2
-        ZC1iMWNhLTc2Y2ZmZTAxZjk4Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmNTYxMWQxLWY0ZTctNDEw
+        Ni04ZDYzLWE0ODkwZjNjZDcwNS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:46 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/526c2c8f-7e9c-4a1f-a905-fed1deab46ff/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/7aa09ed7-2c14-4f61-9665-af9fdd046d20/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvNGU0
-        ZDBmMDAtYjNhZC00MjAxLTlhYTUtYWJhZGQ5MDFmMWYzLyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMmU1
+        ZGU3MmUtYTU2NS00MzM0LThhYTAtMGQ4ODNmMzgwMGYzLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1367,7 +1111,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:31 GMT
+      - Wed, 07 Oct 2020 15:10:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1381,17 +1125,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2MTRhM2ZkLWFiNDQtNDlk
-        Yy1iMGEyLWE1ODk3YzQyOTk0NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU4YTUzODVlLWJjMGEtNDQ3
+        Yi05ZGEyLTE1NTU0ZTNhOThkYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:10:46 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f614a3fd-ab44-49dc-b0a2-a5897c429944/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/58a5385e-bc0a-447b-9da2-15554e3a98dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1399,7 +1143,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1412,7 +1156,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:37 GMT
+      - Wed, 07 Oct 2020 15:11:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1424,53 +1168,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '536'
+      - '538'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjYxNGEzZmQtYWI0
-        NC00OWRjLWIwYTItYTU4OTdjNDI5OTQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6MzEuNTYwMTI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNThhNTM4NWUtYmMw
+        YS00NDdiLTlkYTItMTU1NTRlM2E5OGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTA6NDYuMzg4MTMwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjIyOjMx
-        Ljg0NTU0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6Mzcu
-        NjUyMzg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjEwOjQ2
+        LjYyMjU0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDQu
+        MDA3MzI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wOTUzOTc3NC1hZmE0LTQyYjctYWIxMS02NWRjYzc0NjIxNDUv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjoyNTAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
-        IjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0
-        aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNpbmcg
-        TWV0YWRhdGEgTGluZXMiLCJjb2RlIjoicGFyc2luZy5tZXRhZGF0YSIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjI1MCwiZG9uZSI6MjUwLCJzdWZm
-        aXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTI2YzJjOGYtN2U5Yy00YTFmLWE5
-        MDUtZmVkMWRlYWI0NmZmL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291
-        cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
-        L2ZpbGUvNTI2YzJjOGYtN2U5Yy00YTFmLWE5MDUtZmVkMWRlYWI0NmZmLyIs
-        Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS80ZTRkMGYwMC1iM2Fk
-        LTQyMDEtOWFhNS1hYmFkZDkwMWYxZjMvIl19
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
+        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjoyNTAsImRvbmUiOjI1MCwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJjb2RlIjoi
+        ZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6bnVsbCwiZG9uZSI6MjUwLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcu
+        Y29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjI1MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lh
+        dGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1
+        ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83YWEwOWVkNy0yYzE0LTRmNjEt
+        OTY2NS1hZjlmZGQwNDZkMjAvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVz
+        b3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2Zp
+        bGUvMmU1ZGU3MmUtYTU2NS00MzM0LThhYTAtMGQ4ODNmMzgwMGYzLyIsIi9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzdhYTA5ZWQ3LTJj
+        MTQtNGY2MS05NjY1LWFmOWZkZDA0NmQyMC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:37 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:04 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS81MjZjMmM4Zi03ZTljLTRhMWYtYTkwNS1mZWQxZGVh
-        YjQ2ZmYvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS83YWEwOWVkNy0yYzE0LTRmNjEtOTY2NS1hZjlmZGQw
+        NDZkMjAvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1489,7 +1233,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:37 GMT
+      - Wed, 07 Oct 2020 15:11:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1503,17 +1247,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1N2MxOTMyLTM4N2UtNDQ3
-        MS04ZGUxLTIyYWQ0NzdmZjlmMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkZGFmYWQxLTEzNzktNDE3
+        MC1hYTU0LTViYjg1YmQ1MmMyNC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:37 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/257c1932-387e-4471-8de1-22ad477ff9f1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9ddafad1-1379-4170-aa54-5bb85bd52c24/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1521,7 +1265,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1534,7 +1278,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:40 GMT
+      - Wed, 07 Oct 2020 15:11:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1546,39 +1290,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjU3YzE5MzItMzg3
-        ZS00NDcxLThkZTEtMjJhZDQ3N2ZmOWYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6MzcuODU0OTcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWRkYWZhZDEtMTM3
+        OS00MTcwLWFhNTQtNWJiODViZDUyYzI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDQuMjMxMjc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6MzguMDYyOTYx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0MC4zMDk4NDha
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDQuMzg0Njgx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNS40MzQ1OTla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMTYzM2Uw
-        NTAtYjFiOC00NDQ4LWFmNjctMGZiNTA2ZjJkMDU1LyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODc2M2Fi
+        OTQtNDcxNC00YTQ0LTg2NDktOTY3MDdmOGYyMTM0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzUyNmMyYzhmLTdlOWMtNGExZi1hOTA1LWZlZDFkZWFiNDZm
-        Zi8iXX0=
+        ZmlsZS9maWxlLzdhYTA5ZWQ3LTJjMTQtNGY2MS05NjY1LWFmOWZkZDA0NmQy
+        MC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:40 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:05 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMTYzM2Uw
-        NTAtYjFiOC00NDQ4LWFmNjctMGZiNTA2ZjJkMDU1LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODc2M2Fi
+        OTQtNDcxNC00YTQ0LTg2NDktOTY3MDdmOGYyMTM0LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1596,7 +1340,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:40 GMT
+      - Wed, 07 Oct 2020 15:11:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1610,17 +1354,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5Y2Q0MzZiLTFiZjEtNGZh
-        NS05YjFmLTEzN2JhYTg4YjhiYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3ZWEyZTMzLTk3NDItNDIz
+        OC1iNTFhLTYyODUzNzkzNDk0ZC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:40 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/99cd436b-1bf1-4fa5-9b1f-137baa88b8ba/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/97ea2e33-9742-4238-b51a-62853793494d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1628,7 +1372,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1641,7 +1385,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1653,36 +1397,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '318'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTljZDQzNmItMWJm
-        MS00ZmE1LTliMWYtMTM3YmFhODhiOGJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDAuNjUyODk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdlYTJlMzMtOTc0
+        Mi00MjM4LWI1MWEtNjI4NTM3OTM0OTRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDUuNjAwMzk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDAuODUxMzAz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0MS4xODc2MTFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDUuNzQ3NTQx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNi4wMDYyNzZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMTYzM2Uw
-        NTAtYjFiOC00NDQ4LWFmNjctMGZiNTA2ZjJkMDU1LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODc2M2Fi
+        OTQtNDcxNC00YTQ0LTg2NDktOTY3MDdmOGYyMTM0LyJ9
     headers:
       Content-Type:
       - application/json
@@ -1700,7 +1444,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1714,17 +1458,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA2MjYxNWQ4LWMxYjktNGFi
-        OS04ZDQxLWUyNjRiMjk0N2FmMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlZTRjY2E3LWFjM2EtNDhh
+        Mi1iZTU3LTA0ZDlkNzUyMjU1MC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1732,7 +1476,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1745,159 +1489,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1918,7 +1534,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1930,7 +1546,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '246'
     body:
@@ -1938,20 +1554,20 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzUyNmMyYzhmLTdlOWMtNGExZi1hOTA1LWZlZDFkZWFiNDZm
-        Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjIyOjI4LjA4MDI3
-        NloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNTI2YzJjOGYtN2U5Yy00YTFmLWE5MDUtZmVkMWRlYWI0
-        NmZmL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81MjZjMmM4Zi03ZTljLTRh
-        MWYtYTkwNS1mZWQxZGVhYjQ2ZmYvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
+        ZmlsZS9maWxlLzdhYTA5ZWQ3LTJjMTQtNGY2MS05NjY1LWFmOWZkZDA0NmQy
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjEwOjQzLjUyMDQ1
+        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvN2FhMDllZDctMmMxNC00ZjYxLTk2NjUtYWY5ZmRkMDQ2
+        ZDIwL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83YWEwOWVkNy0yYzE0LTRm
+        NjEtOTY2NS1hZjlmZGQwNDZkMjAvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
         YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
         cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/526c2c8f-7e9c-4a1f-a905-fed1deab46ff/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/7aa09ed7-2c14-4f61-9665-af9fdd046d20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1972,7 +1588,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1986,17 +1602,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1ZmMyMzc0LWZjYTQtNDU4
-        My1iYjE4LTExMDQ0ZWYyNzQ0OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhZjcyZWUyLWRiYjctNDA5
+        My1iYTRjLTg5NGQ2MDdlMzQ4Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2017,7 +1633,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2029,29 +1645,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '352'
+      - '351'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS80ZTRkMGYwMC1iM2FkLTQyMDEtOWFhNS1hYmFkZDkwMWYxZjMvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjoyOC4yMTQzMjlaIiwi
+        ZmlsZS8yZTVkZTcyZS1hNTY1LTQzMzQtOGFhMC0wZDg4M2YzODAwZjMvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMDo0My42NTMwODlaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
         ZV8xIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcv
         ZmlsZS1tYW55Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xp
         ZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJuYW1lIjpudWxsLCJw
-        YXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTA4LTIw
-        VDE5OjIyOjMwLjQ4NzIwNloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAs
+        YXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTEwLTA3
+        VDE1OjEwOjQ1LjQ5NzQ4OVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAs
         InBvbGljeSI6ImltbWVkaWF0ZSJ9XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/4e4d0f00-b3ad-4201-9aa5-abadd901f1f3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/2e5de72e-a565-4334-8aa0-0d883f3800f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2072,7 +1688,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2086,17 +1702,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlYzhhNGIxLTcyMWItNGYw
-        My05YmM2LTdlNmRhNzY1ODAzMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZhYjg3YWMxLTNhZjQtNGFk
+        Ni04MGUyLWUxNzZiMDZjZjNlMS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2117,7 +1733,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:41 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2129,29 +1745,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '314'
+      - '317'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS9jMmFkYzNjNy01OGUyLTRiMzgtYmM0My0yZmFjNTFiNTFk
-        NDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjoyOS41NDU1
-        ODlaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9kZXZlbDIuYmFs
-        bW9yYS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6
-        YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6
-        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
-        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
-        YXRpb25zL2ZpbGUvZmlsZS8xNjMzZTA1MC1iMWI4LTQ0NDgtYWY2Ny0wZmI1
-        MDZmMmQwNTUvIn1dfQ==
+        L2ZpbGUvZmlsZS9hYzU1ZWFlYi00OTFiLTRjNzUtYjkyOS1mYTI2NmE5MzM5
+        OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMDo0NC43NjM0
+        MDhaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRf
+        T3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODc2M2FiOTQtNDcxNC00YTQ0LTg2
+        NDktOTY3MDdmOGYyMTM0LyJ9XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2172,7 +1788,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2186,17 +1802,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5NDQyZWQxLWUyYTEtNGEx
-        Ni04ZWVlLTk2NjY2NDc1ODAyYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBmZmVkMzJkLWNjYmItNDRi
+        Yy05NTgwLTBhNzlkNmJhYTA2Zi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2217,7 +1833,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2229,29 +1845,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '314'
+      - '317'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS9jMmFkYzNjNy01OGUyLTRiMzgtYmM0My0yZmFjNTFiNTFk
-        NDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjoyOS41NDU1
-        ODlaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9kZXZlbDIuYmFs
-        bW9yYS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6
-        YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6
-        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
-        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
-        YXRpb25zL2ZpbGUvZmlsZS8xNjMzZTA1MC1iMWI4LTQ0NDgtYWY2Ny0wZmI1
-        MDZmMmQwNTUvIn1dfQ==
+        L2ZpbGUvZmlsZS9hYzU1ZWFlYi00OTFiLTRjNzUtYjkyOS1mYTI2NmE5MzM5
+        OGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMDo0NC43NjM0
+        MDhaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRf
+        T3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODc2M2FiOTQtNDcxNC00YTQ0LTg2
+        NDktOTY3MDdmOGYyMTM0LyJ9XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/c2adc3c7-58e2-4b38-bc43-2fac51b51d44/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ac55eaeb-491b-4c75-b929-fa266a93398e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2272,7 +1888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2286,17 +1902,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZjgyZTdiLTc3ZmItNDc0
-        Ny04ZTI0LTY4YTQwMDgwZDlhZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliNDRjMmNkLTkyNGUtNDhm
+        MS04Yjk2LTFmNTVmY2I0ODc1My8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/85fc2374-fca4-4583-bb18-11044ef27449/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9af72ee2-dbb7-4093-ba4c-894d607e3486/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2304,7 +1920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2317,7 +1933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2329,30 +1945,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '342'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODVmYzIzNzQtZmNh
-        NC00NTgzLWJiMTgtMTEwNDRlZjI3NDQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDEuNjU3NjM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWFmNzJlZTItZGJi
+        Ny00MDkzLWJhNGMtODk0ZDYwN2UzNDg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDYuMzU0NTc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDEuOTg5MzQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0Mi4yMTg2MDJa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDYuNjEwMTMz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNi44MDgxMDVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzUyNmMyYzhmLTdlOWMtNGExZi1h
-        OTA1LWZlZDFkZWFiNDZmZi8iXX0=
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzdhYTA5ZWQ3LTJjMTQtNGY2MS05
+        NjY1LWFmOWZkZDA0NmQyMC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/fec8a4b1-721b-4f03-9bc6-7e6da7658032/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/6ab87ac1-3af4-4ad6-80e2-e176b06cf3e1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2360,7 +1976,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2373,7 +1989,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2385,30 +2001,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '341'
+      - '339'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVjOGE0YjEtNzIx
-        Yi00ZjAzLTliYzYtN2U2ZGE3NjU4MDMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDEuNzkxNDM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmFiODdhYzEtM2Fm
+        NC00YWQ2LTgwZTItZTE3NmIwNmNmM2UxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDYuNDY1OTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDIuNDk1OTIw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0Mi41NjE4Mjla
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDYuOTAyMDA0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNi45OTY4MTBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS80ZTRkMGYwMC1iM2FkLTQyMDEtOWFhNS1h
-        YmFkZDkwMWYxZjMvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS8yZTVkZTcyZS1hNTY1LTQzMzQtOGFhMC0w
+        ZDg4M2YzODAwZjMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/09442ed1-e2a1-4a16-8eee-96666475802c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/0ffed32d-ccbb-44bc-9580-0a79d6baa06f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2416,7 +2032,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2429,7 +2045,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:42 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2441,29 +2057,29 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '313'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDk0NDJlZDEtZTJh
-        MS00YTE2LThlZWUtOTY2NjY0NzU4MDJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDIuMDIyODEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGZmZWQzMmQtY2Ni
+        Yi00NGJjLTk1ODAtMGE3OWQ2YmFhMDZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDYuNjQ0MTY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDIuNjc5MDk2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0Mi43NzI1MDNa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDcuMzIyODU1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNy4zNjM2MzRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/90f82e7b-77fb-4747-8e24-68a40080d9ae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9b44c2cd-924e-48f1-8b96-1f55fcb48753/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2471,7 +2087,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2484,7 +2100,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2496,49 +2112,49 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '664'
+      - '665'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBmODJlN2ItNzdm
-        Yi00NzQ3LThlMjQtNjhhNDAwODBkOWFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDIuMjY3MTgzWiIsInN0YXRlIjoiZmFpbGVkIiwi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWI0NGMyY2QtOTI0
+        ZS00OGYxLThiOTYtMWY1NWZjYjQ4NzUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDYuODI1Nzg1WiIsInN0YXRlIjoiZmFpbGVkIiwi
         bmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVsZXRl
-        Iiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDMuMDcxMDQyWiIs
-        ImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0My4xMDMxOThaIiwi
-        ZXJyb3IiOnsidHJhY2ViYWNrIjoiICBGaWxlIFwiL3Vzci9sb2NhbC9saWIv
-        cHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcnEvd29ya2VyLnB5XCIsIGxpbmUg
-        ODgzLCBpbiBwZXJmb3JtX2pvYlxuICAgIHJ2ID0gam9iLnBlcmZvcm0oKVxu
-        ICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHl0aG9uMy42L3NpdGUtcGFja2Fn
-        ZXMvcnEvam9iLnB5XCIsIGxpbmUgNjU3LCBpbiBwZXJmb3JtXG4gICAgc2Vs
-        Zi5fcmVzdWx0ID0gc2VsZi5fZXhlY3V0ZSgpXG4gIEZpbGUgXCIvdXNyL2xv
-        Y2FsL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9ycS9qb2IucHlcIiwg
-        bGluZSA2NjMsIGluIF9leGVjdXRlXG4gICAgcmV0dXJuIHNlbGYuZnVuYygq
-        c2VsZi5hcmdzLCAqKnNlbGYua3dhcmdzKVxuICBGaWxlIFwiL3Vzci9sb2Nh
-        bC9saWIvcHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcHVscGNvcmUvYXBwL3Rh
-        c2tzL2Jhc2UucHlcIiwgbGluZSA5MCwgaW4gZ2VuZXJhbF9kZWxldGVcbiAg
-        ICBpbnN0YW5jZSA9IHNlcmlhbGl6ZXJfY2xhc3MuTWV0YS5tb2RlbC5vYmpl
-        Y3RzLmdldChwaz1pbnN0YW5jZV9pZCkuY2FzdCgpXG4gIEZpbGUgXCIvdXNy
-        L2xvY2FsL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFuZ28vZGIv
-        bW9kZWxzL21hbmFnZXIucHlcIiwgbGluZSA4MiwgaW4gbWFuYWdlcl9tZXRo
-        b2RcbiAgICByZXR1cm4gZ2V0YXR0cihzZWxmLmdldF9xdWVyeXNldCgpLCBu
-        YW1lKSgqYXJncywgKiprd2FyZ3MpXG4gIEZpbGUgXCIvdXNyL2xvY2FsL2xp
-        Yi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFuZ28vZGIvbW9kZWxzL3F1
-        ZXJ5LnB5XCIsIGxpbmUgNDA4LCBpbiBnZXRcbiAgICBzZWxmLm1vZGVsLl9t
-        ZXRhLm9iamVjdF9uYW1lXG4iLCJkZXNjcmlwdGlvbiI6IkZpbGVEaXN0cmli
-        dXRpb24gbWF0Y2hpbmcgcXVlcnkgZG9lcyBub3QgZXhpc3QuIn0sIndvcmtl
-        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzEyNDMxOTY4LWNhNTMtNDJmZi1h
-        OWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRf
-        dGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRz
-        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
-        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+        Iiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDcuNTYwMDY5WiIs
+        ImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowNy41OTEzODhaIiwi
+        ZXJyb3IiOnsidHJhY2ViYWNrIjoiICBGaWxlIFwiL3Vzci9saWIvcHl0aG9u
+        My42L3NpdGUtcGFja2FnZXMvcnEvd29ya2VyLnB5XCIsIGxpbmUgODgzLCBp
+        biBwZXJmb3JtX2pvYlxuICAgIHJ2ID0gam9iLnBlcmZvcm0oKVxuICBGaWxl
+        IFwiL3Vzci9saWIvcHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcnEvam9iLnB5
+        XCIsIGxpbmUgNjU3LCBpbiBwZXJmb3JtXG4gICAgc2VsZi5fcmVzdWx0ID0g
+        c2VsZi5fZXhlY3V0ZSgpXG4gIEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYv
+        c2l0ZS1wYWNrYWdlcy9ycS9qb2IucHlcIiwgbGluZSA2NjMsIGluIF9leGVj
+        dXRlXG4gICAgcmV0dXJuIHNlbGYuZnVuYygqc2VsZi5hcmdzLCAqKnNlbGYu
+        a3dhcmdzKVxuICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHl0aG9uMy42L3Np
+        dGUtcGFja2FnZXMvcHVscGNvcmUvYXBwL3Rhc2tzL2Jhc2UucHlcIiwgbGlu
+        ZSA5MCwgaW4gZ2VuZXJhbF9kZWxldGVcbiAgICBpbnN0YW5jZSA9IHNlcmlh
+        bGl6ZXJfY2xhc3MuTWV0YS5tb2RlbC5vYmplY3RzLmdldChwaz1pbnN0YW5j
+        ZV9pZCkuY2FzdCgpXG4gIEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYvc2l0
+        ZS1wYWNrYWdlcy9kamFuZ28vZGIvbW9kZWxzL21hbmFnZXIucHlcIiwgbGlu
+        ZSA4MiwgaW4gbWFuYWdlcl9tZXRob2RcbiAgICByZXR1cm4gZ2V0YXR0cihz
+        ZWxmLmdldF9xdWVyeXNldCgpLCBuYW1lKSgqYXJncywgKiprd2FyZ3MpXG4g
+        IEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFu
+        Z28vZGIvbW9kZWxzL3F1ZXJ5LnB5XCIsIGxpbmUgNDA4LCBpbiBnZXRcbiAg
+        ICBzZWxmLm1vZGVsLl9tZXRhLm9iamVjdF9uYW1lXG4iLCJkZXNjcmlwdGlv
+        biI6IkZpbGVEaXN0cmlidXRpb24gbWF0Y2hpbmcgcXVlcnkgZG9lcyBub3Qg
+        ZXhpc3QuIn0sIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA5NTM5
+        Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJy
+        ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0
+        aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2546,7 +2162,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -2559,159 +2175,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2732,7 +2220,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2746,17 +2234,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2777,7 +2265,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2791,17 +2279,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2822,7 +2310,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2836,17 +2324,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2867,7 +2355,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2881,17 +2369,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:07 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2914,13 +2402,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/cc75c0cc-b336-450a-ab52-c541dc4adf17/"
+      - "/pulp/api/v3/repositories/file/file/608c3b14-9670-467f-858b-d80e8db95ad0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -2930,25 +2418,25 @@ http_interactions:
       Content-Length:
       - '428'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS9jYzc1YzBjYy1iMzM2LTQ1MGEtYWI1Mi1jNTQxZGM0YWRmMTcvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjo0My41MjI5MjlaIiwi
+        ZmlsZS82MDhjM2IxNC05NjcwLTQ2N2YtODU4Yi1kODBlOGRiOTVhZDAvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTowNy45OTMwMzZaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlL2NjNzVjMGNjLWIzMzYtNDUwYS1hYjUyLWM1NDFkYzRhZGYxNy92
+        ZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04NThiLWQ4MGU4ZGI5NWFkMC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvY2M3NWMwY2MtYjMzNi00NTBhLWFi
-        NTItYzU0MWRjNGFkZjE3L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNjA4YzNiMTQtOTY3MC00NjdmLTg1
+        OGItZDgwZThkYjk1YWQwL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRp
         b24iOm51bGwsInJlbW90ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:08 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2975,13 +2463,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/34336a99-554c-45c5-96d8-a24ac45e3a17/"
+      - "/pulp/api/v3/remotes/file/file/9b5d3910-f681-4923-98bf-482dbe43a17f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -2991,32 +2479,32 @@ http_interactions:
       Content-Length:
       - '490'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MzQzMzZhOTktNTU0Yy00NWM1LTk2ZDgtYTI0YWM0NWUzYTE3LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MjI6NDMuNjIxMzIxWiIsIm5hbWUi
+        OWI1ZDM5MTAtZjY4MS00OTIzLTk4YmYtNDgyZGJlNDNhMTdmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MDguMDg5NDYxWiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
         InVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxlLm9yZy9wdWxwL3B1
         bHAvZGVtb19yZXBvcy90ZXN0X2ZpbGVfcmVwby8vUFVMUF9NQU5JRkVTVCIs
         ImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5
         IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxs
         LCJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjo0My42MjEzMzhaIiwiZG93bmxv
+        cGRhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTowOC4wODk0ODJaIiwiZG93bmxv
         YWRfY29uY3VycmVuY3kiOjEwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:08 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS9jYzc1YzBjYy1iMzM2LTQ1MGEtYWI1Mi1jNTQxZGM0
-        YWRmMTcvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS82MDhjM2IxNC05NjcwLTQ2N2YtODU4Yi1kODBlOGRi
+        OTVhZDAvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -3035,7 +2523,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:43 GMT
+      - Wed, 07 Oct 2020 15:11:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3049,17 +2537,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1MjQ3Y2E1LTAxMGItNGJj
-        NS04ZDg4LTZkYTk5ZDg5ZTZjMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxOWE3MTRiLTc1M2YtNDc4
+        Mi1hYmNlLTBlNzc5YzMxZTAxZi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:08 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/e5247ca5-010b-4bc5-8d88-6da99d89e6c1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/b19a714b-753f-4782-abce-0e779c31e01f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3067,7 +2555,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3080,7 +2568,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:44 GMT
+      - Wed, 07 Oct 2020 15:11:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3092,32 +2580,32 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '372'
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTUyNDdjYTUtMDEw
-        Yi00YmM1LThkODgtNmRhOTlkODllNmMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDMuODcyNzg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjE5YTcxNGItNzUz
+        Zi00NzgyLWFiY2UtMGU3NzljMzFlMDFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDguMzMwMDgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDQuMDE3MjU0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0NC4xMjEzMDZa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDguNDkxMjgy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowOC41ODEzNzZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWUwZjQ4
-        MWYtMTY1My00M2I0LTk2MjUtZTU0ODhhODAwMGVkLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjIwNTMz
+        Y2UtZWQ3ZS00NTU5LWExMjAtMWE1YzcwODFmNjJjLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2NjNzVjMGNjLWIzMzYtNDUwYS1hYjUyLWM1NDFkYzRhZGYx
-        Ny8iXX0=
+        ZmlsZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04NThiLWQ4MGU4ZGI5NWFk
+        MC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:44 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:08 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3125,7 +2613,7 @@ http_interactions:
         bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJEZWZh
         dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInB1Ymxp
         Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MWUwZjQ4MWYtMTY1My00M2I0LTk2MjUtZTU0ODhhODAwMGVkLyJ9
+        MjIwNTMzY2UtZWQ3ZS00NTU5LWExMjAtMWE1YzcwODFmNjJjLyJ9
     headers:
       Content-Type:
       - application/json
@@ -3143,7 +2631,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:44 GMT
+      - Wed, 07 Oct 2020 15:11:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3157,17 +2645,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNzI5MGJiLWRkMDMtNDEx
-        Mi04YWE5LTgyNzExZjg4YTYwOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0OWZhOWJjLTUwNDktNGNm
+        Ny1iZDg4LTEwZTExYTA2NGY5Ny8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:44 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:08 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/5e7290bb-dd03-4112-8aa9-82711f88a608/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/949fa9bc-5049-4cf7-bd88-10e11a064f97/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3175,7 +2663,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3188,7 +2676,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:45 GMT
+      - Wed, 07 Oct 2020 15:11:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3200,30 +2688,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '348'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWU3MjkwYmItZGQw
-        My00MTEyLThhYTktODI3MTFmODhhNjA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDQuMzU0NDU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTQ5ZmE5YmMtNTA0
+        OS00Y2Y3LWJkODgtMTBlMTFhMDY0Zjk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDguNzQyODU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDQuNTE5MjI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0NC45NDg3NTBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MDguODkwODU4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTowOS4xNjcyMzha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzliZGM2
-        Zjc0LTE2ZmYtNDAwYi1iYTQ4LTc4NGViODk0MTg1My8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2Q0YWMy
+        MTk3LTk0YzQtNGVhMy05ZmI3LTI2OTgyY2M2ZjY5Yy8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9bdc6f74-16ff-400b-ba48-784eb8941853/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3244,7 +2732,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:45 GMT
+      - Wed, 07 Oct 2020 15:11:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3256,28 +2744,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '284'
+      - '289'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvOWJkYzZmNzQtMTZmZi00MDBiLWJhNDgtNzg0ZWI4OTQxODUzLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MjI6NDQuOTMxMzU3WiIs
+        L2ZpbGUvZDRhYzIxOTctOTRjNC00ZWEzLTlmYjctMjY5ODJjYzZmNjljLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MDkuMTUzMjIxWiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
-        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9u
-        L2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
-        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
-        cy9maWxlL2ZpbGUvMWUwZjQ4MWYtMTY1My00M2I0LTk2MjUtZTU0ODhhODAw
-        MGVkLyJ9
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2Fu
+        aXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJk
+        IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJs
+        aWNhdGlvbnMvZmlsZS9maWxlLzIyMDUzM2NlLWVkN2UtNDU1OS1hMTIwLTFh
+        NWM3MDgxZjYyYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:09 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/cc75c0cc-b336-450a-ab52-c541dc4adf17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/608c3b14-9670-467f-858b-d80e8db95ad0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3300,7 +2788,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:45 GMT
+      - Wed, 07 Oct 2020 15:11:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3314,17 +2802,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyYzE5NWEwLTU0YzctNDY2
-        Ni04NWZhLWI3YThlODhkZDUwZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxMTJhZTQxLWM5MDYtNDRj
+        Yi05MDRjLTUyMzFiOWE4NjYwZC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:09 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/34336a99-554c-45c5-96d8-a24ac45e3a17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/9b5d3910-f681-4923-98bf-482dbe43a17f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3351,7 +2839,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:45 GMT
+      - Wed, 07 Oct 2020 15:11:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3365,24 +2853,24 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyNzI0MzM4LTU4NmYtNDQx
-        Yy05YWZiLTk4NzBiMGFhZWI5Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MjNiNzgzLTI1ZGItNDI0
+        YS05MzZjLWIzYTBmZTFiNDA1Yy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:09 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9bdc6f74-16ff-400b-ba48-784eb8941853/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWUwZjQ4
-        MWYtMTY1My00M2I0LTk2MjUtZTU0ODhhODAwMGVkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjIwNTMz
+        Y2UtZWQ3ZS00NTU5LWExMjAtMWE1YzcwODFmNjJjLyJ9
     headers:
       Content-Type:
       - application/json
@@ -3400,7 +2888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:45 GMT
+      - Wed, 07 Oct 2020 15:11:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3414,17 +2902,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1ZDQ2NWMxLWM2NzAtNGQ0
-        ZC04ZDhkLTIzOGVhNGMxZDBiYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5OWJkMGM5LTY3YmEtNDg1
+        Ni04NTU3LTIxN2Y0ZGZkYWY5Ny8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/75d465c1-c670-4d4d-8d8d-238ea4c1d0bb/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/199bd0c9-67ba-4856-8557-217f4dfdaf97/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3432,7 +2920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3445,7 +2933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:46 GMT
+      - Wed, 07 Oct 2020 15:11:10 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3457,36 +2945,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '317'
+      - '318'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzVkNDY1YzEtYzY3
-        MC00ZDRkLThkOGQtMjM4ZWE0YzFkMGJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDUuNjI1NzAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTk5YmQwYzktNjdi
+        YS00ODU2LTg1NTctMjE3ZjRkZmRhZjk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MDkuNzU4Njk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDYuMTk1NjEz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo0Ni43MzE3OTFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTAuMDg4MjA1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxMC4zMzYxODBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:46 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:10 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9bdc6f74-16ff-400b-ba48-784eb8941853/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMWUwZjQ4
-        MWYtMTY1My00M2I0LTk2MjUtZTU0ODhhODAwMGVkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjIwNTMz
+        Y2UtZWQ3ZS00NTU5LWExMjAtMWE1YzcwODFmNjJjLyJ9
     headers:
       Content-Type:
       - application/json
@@ -3504,7 +2992,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:47 GMT
+      - Wed, 07 Oct 2020 15:11:10 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3518,22 +3006,22 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4YTI3NDNmLTRiMjAtNDJi
-        ZC05OWNiLWNjMWQwZGQ2MjlmZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZhOGQ1NzI3LWQxZDEtNDU0
+        ZC1hYWQ1LTFjODFkMTA5NzY0NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:10 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/cc75c0cc-b336-450a-ab52-c541dc4adf17/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/608c3b14-9670-467f-858b-d80e8db95ad0/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMzQz
-        MzZhOTktNTU0Yy00NWM1LTk2ZDgtYTI0YWM0NWUzYTE3LyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOWI1
+        ZDM5MTAtZjY4MS00OTIzLTk4YmYtNDgyZGJlNDNhMTdmLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -3552,7 +3040,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:47 GMT
+      - Wed, 07 Oct 2020 15:11:10 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3566,17 +3054,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ODgwZDJiLTFkMjItNDUw
-        NS05ZjBlLWZlMjI2YzUzZDE4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiOGU0Mzk3LTlkMzctNDdm
+        ZC1hOTkyLTFkODM4MjhjNjQyYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:10 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/69880d2b-1d22-4505-9f0e-fe226c53d18e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/fb8e4397-9d37-47fd-a992-1d83828c642c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3584,7 +3072,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3597,7 +3085,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:50 GMT
+      - Wed, 07 Oct 2020 15:11:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3609,53 +3097,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '532'
+      - '539'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjk4ODBkMmItMWQy
-        Mi00NTA1LTlmMGUtZmUyMjZjNTNkMThlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NDcuNzUwNTAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI4ZTQzOTctOWQz
+        Ny00N2ZkLWE5OTItMWQ4MzgyOGM2NDJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTAuNzkyOTc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjIyOjQ4
-        LjMxMzIwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NDku
-        ODExNTM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjExOjEx
+        LjA3MzE0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTEu
+        ODY1Nzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy9mMzc4OWU1MS01ZjQ2LTRlMzEtYmMyMy04ODE5ZWExYzAyMDcv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
-        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
+        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
+        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvY2M3NWMwY2MtYjMzNi00NTBhLWFiNTItYzU0
-        MWRjNGFkZjE3L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzM0MzM2
-        YTk5LTU1NGMtNDVjNS05NmQ4LWEyNGFjNDVlM2ExNy8iLCIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9jYzc1YzBjYy1iMzM2LTQ1MGEt
-        YWI1Mi1jNTQxZGM0YWRmMTcvIl19
+        aXRvcmllcy9maWxlL2ZpbGUvNjA4YzNiMTQtOTY3MC00NjdmLTg1OGItZDgw
+        ZThkYjk1YWQwL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        NjA4YzNiMTQtOTY3MC00NjdmLTg1OGItZDgwZThkYjk1YWQwLyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS85YjVkMzkxMC1mNjgxLTQ5MjMt
+        OThiZi00ODJkYmU0M2ExN2YvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:12 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS9jYzc1YzBjYy1iMzM2LTQ1MGEtYWI1Mi1jNTQxZGM0
-        YWRmMTcvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS82MDhjM2IxNC05NjcwLTQ2N2YtODU4Yi1kODBlOGRi
+        OTVhZDAvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -3674,7 +3162,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:50 GMT
+      - Wed, 07 Oct 2020 15:11:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3688,17 +3176,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0N2E2NGE5LTM2NTktNGUx
-        Mi1hYThkLTM2NmU5OGQ1ZjViMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3OWFkN2FjLWU1NjMtNGE3
+        MS04YmM3LWEzYjE4NWRjZWY0Yy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:12 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/247a64a9-3659-4e12-aa8d-366e98d5f5b2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/479ad7ac-e563-4a71-8bc7-a3b185dcef4c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3706,7 +3194,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3719,7 +3207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:50 GMT
+      - Wed, 07 Oct 2020 15:11:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3731,39 +3219,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '372'
+      - '375'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ3YTY0YTktMzY1
-        OS00ZTEyLWFhOGQtMzY2ZTk4ZDVmNWIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NTAuMTgxMDgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDc5YWQ3YWMtZTU2
+        My00YTcxLThiYzctYTNiMTg1ZGNlZjRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTIuMTI3NzA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NTAuMzQzMDUz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo1MC40NTg1MDBa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTIuMzAzMDc3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxMi40MDYyNzFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWE2MGM0
-        YjMtNjNmMi00ZGEyLTk1MTMtZjZjZWE2MWFiZTJkLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjQ0YzJi
+        YzktNmFlMS00MTMxLWEwMjEtNzc2NTRjYmQwNWExLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2NjNzVjMGNjLWIzMzYtNDUwYS1hYjUyLWM1NDFkYzRhZGYx
-        Ny8iXX0=
+        ZmlsZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04NThiLWQ4MGU4ZGI5NWFk
+        MC8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:12 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9bdc6f74-16ff-400b-ba48-784eb8941853/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWE2MGM0
-        YjMtNjNmMi00ZGEyLTk1MTMtZjZjZWE2MWFiZTJkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjQ0YzJi
+        YzktNmFlMS00MTMxLWEwMjEtNzc2NTRjYmQwNWExLyJ9
     headers:
       Content-Type:
       - application/json
@@ -3781,7 +3269,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:50 GMT
+      - Wed, 07 Oct 2020 15:11:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3795,17 +3283,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxNmYyZWI4LWIxYTctNGNk
-        My1hZGMzLWI5ZThhYjZhMjhjNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlNmI5NTRmLTFlM2MtNGZh
+        Ny1hYzMxLTM4NzU1NWE3NjQ0OS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:12 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f16f2eb8-b1a7-4cd3-adc3-b9e8ab6a28c6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/0e6b954f-1e3c-4fa7-ac31-387555a76449/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3813,7 +3301,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3826,7 +3314,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:51 GMT
+      - Wed, 07 Oct 2020 15:11:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3838,36 +3326,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '317'
+      - '315'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjE2ZjJlYjgtYjFh
-        Ny00Y2QzLWFkYzMtYjllOGFiNmEyOGM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MjI6NTAuNzI5NTM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGU2Yjk1NGYtMWUz
+        Yy00ZmE3LWFjMzEtMzg3NTU1YTc2NDQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTIuNTgxNzY0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MjI6NTEuMDY3MjI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToyMjo1MS40ODMzOTZa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTIuNzIwMDkw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxMi45NzQxOTZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:51 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:12 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/9bdc6f74-16ff-400b-ba48-784eb8941853/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWE2MGM0
-        YjMtNjNmMi00ZGEyLTk1MTMtZjZjZWE2MWFiZTJkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjQ0YzJi
+        YzktNmFlMS00MTMxLWEwMjEtNzc2NTRjYmQwNWExLyJ9
     headers:
       Content-Type:
       - application/json
@@ -3885,7 +3373,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:51 GMT
+      - Wed, 07 Oct 2020 15:11:13 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3899,17 +3387,107 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwNmYxYzFlLWIwZDEtNGZm
-        My1hNzlmLWYzNjk3NThiYzdkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1ZjFkMThhLWE5NjUtNDE5
+        OS05NzEyLTA0NzJlZWM5YjNiZi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:51 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.3.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:13 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:13 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3930,7 +3508,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:51 GMT
+      - Wed, 07 Oct 2020 15:11:13 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3942,39 +3520,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '347'
+      - '248'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlL2NjNzVjMGNjLWIzMzYtNDUwYS1hYjUyLWM1NDFkYzRhZGYx
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjIyOjQzLjUyMjky
-        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvY2M3NWMwY2MtYjMzNi00NTBhLWFiNTItYzU0MWRjNGFk
-        ZjE3L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9jYzc1YzBjYy1iMzM2LTQ1
-        MGEtYWI1Mi1jNTQxZGM0YWRmMTcvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
+        ZmlsZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04NThiLWQ4MGU4ZGI5NWFk
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjA3Ljk5MzAz
+        NloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNjA4YzNiMTQtOTY3MC00NjdmLTg1OGItZDgwZThkYjk1
+        YWQwL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82MDhjM2IxNC05NjcwLTQ2
+        N2YtODU4Yi1kODBlOGRiOTVhZDAvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
         YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
-        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNWZmYTU5Mzct
-        YjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNpb25zLyIsImxhdGVz
-        dF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
-        bGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQwYTItYjkzNy1iZjQxYTYzZjQ1ZTgv
-        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVibGlzaGVkIExpYnJhcnkgYW5kIGRl
-        diB2aWV3LTcwMDk3MzQ1My05MDkwNTgzNDciLCJkZXNjcmlwdGlvbiI6IlB1
-        Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYgdmlldy03MDA5NzM0NTMtOTA5MDU4
-        MzQ3IiwicmVtb3RlIjpudWxsfV19
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:51 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3982,7 +3549,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3995,82 +3562,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:51 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '367'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZjQyZGYzZS0zMjMxLTRlM2EtYWQ4OC05YWU0ZWUxNDRmMDYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToyMjoxNy4zNjcwMzha
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZjQyZGYzZS0zMjMxLTRlM2EtYWQ4OC05YWU0ZWUxNDRmMDYv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZjQyZGYzZS0zMjMxLTRlM2EtYWQ4
-        OC05YWU0ZWUxNDRmMDYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzAzMjJmM2RmLWFlZTEtNGY3MC04ZGU1LTUwNGVlOTYyNWRjZC8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjIyOjE2LjM0MzI2M1oiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzAzMjJmM2RmLWFlZTEtNGY3MC04ZGU1LTUwNGVlOTYyNWRjZC92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzAzMjJmM2RmLWFlZTEtNGY3MC04ZGU1LTUwNGVl
-        OTYyNWRjZC92ZXJzaW9ucy8xLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:51 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:22:51 GMT
+      - Wed, 07 Oct 2020 15:11:13 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -4084,17 +3576,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:51 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4102,7 +3594,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -4115,7 +3607,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:22:52 GMT
+      - Wed, 07 Oct 2020 15:11:13 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -4129,12 +3621,12 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:22:52 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:13 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/delete_orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/delete_orphan_repository_versions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -35,147 +80,73 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '3076'
+      - '248'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04NThiLWQ4MGU4ZGI5NWFk
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjA3Ljk5MzAz
+        NloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNjA4YzNiMTQtOTY3MC00NjdmLTg1OGItZDgwZThkYjk1
+        YWQwL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82MDhjM2IxNC05NjcwLTQ2
+        N2YtODU4Yi1kODBlOGRiOTVhZDAvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/608c3b14-9670-467f-858b-d80e8db95ad0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyZTc5ODM3LTM4ZjktNDk2
+        Yy05YjRhLTBlYWJjN2MwYzUwZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,187 +167,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
+      - Wed, 07 Oct 2020 15:11:15 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -388,147 +179,75 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '3076'
+      - '362'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS85YjVkMzkxMC1mNjgxLTQ5MjMtOThiZi00ODJkYmU0M2ExN2YvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTowOC4wODk0NjFaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
+        ZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFwZW9wbGUub3JnL3B1
+        bHAvcHVscC9kZW1vX3JlcG9zL3Rlc3RfZmlsZV9yZXBvLy9QVUxQX01BTklG
+        RVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVu
+        dF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwi
+        Om51bGwsInVzZXJuYW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjA5LjkyOTQ3OVoiLCJk
+        b3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+        XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/9b5d3910-f681-4923-98bf-482dbe43a17f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzOTU0OWMyLWVkM2UtNGIw
+        My1hMTQxLWM0YTJmYWUyMzBiNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -549,7 +268,62 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '318'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS9kNGFjMjE5Ny05NGM0LTRlYTMtOWZiNy0yNjk4MmNjNmY2
+        OWMvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTowOS4xNTMy
+        MjFaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRf
+        T3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMjQ0YzJiYzktNmFlMS00MTMxLWEw
+        MjEtNzc2NTRjYmQwNWExLyJ9XX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -557,23 +331,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlMGY4ZDI2LTZmY2YtNGI5
+        ZC1iN2RlLTFmMzI4MjJmNDExMy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +368,347 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:21 GMT
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS9kNGFjMjE5Ny05NGM0LTRlYTMtOWZiNy0yNjk4MmNjNmY2
+        OWMvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTowOS4xNTMy
+        MjFaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRf
+        T3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/d4ac2197-94c4-4ea3-9fb7-26982cc6f69c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0YzVjMWQ4LWVjMmEtNGRi
+        Ni1iZGViLWJmNWMyOWQwODcwYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/d2e79837-38f9-496c-9b4a-0eabc7c0c50d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '342'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJlNzk4MzctMzhm
+        OS00OTZjLTliNGEtMGVhYmM3YzBjNTBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTUuMDg2Mzk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTUuMjEyNzAx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxNS4zNjM3MzRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzYwOGMzYjE0LTk2NzAtNDY3Zi04
+        NThiLWQ4MGU4ZGI5NWFkMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/139549c2-ed3e-4b03-a141-c4a2fae230b7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:15 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '340'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTM5NTQ5YzItZWQz
+        ZS00YjAzLWExNDEtYzRhMmZhZTIzMGI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTUuMTkxMTczWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTUuNDIzMDI3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxNS41MDgzNTla
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL2ZpbGUvZmlsZS85YjVkMzkxMC1mNjgxLTQ5MjMtOThiZi00
+        ODJkYmU0M2ExN2YvIl19
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/7e0f8d26-6fcf-4b9d-b7de-1f32822f4113/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2UwZjhkMjYtNmZj
+        Zi00YjlkLWI3ZGUtMWYzMjgyMmY0MTEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTUuMzc4OTMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTUuODk1Mzkw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxNS45NTI2Njda
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/f4c5c1d8-ec2a-4db6-bdeb-bf5c29d0870a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '664'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjRjNWMxZDgtZWMy
+        YS00ZGI2LWJkZWItYmY1YzI5ZDA4NzBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTUuNTg0MDA0WiIsInN0YXRlIjoiZmFpbGVkIiwi
+        bmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVsZXRl
+        Iiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTYuMTIyNTY5WiIs
+        ImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxNi4xNTE5MDNaIiwi
+        ZXJyb3IiOnsidHJhY2ViYWNrIjoiICBGaWxlIFwiL3Vzci9saWIvcHl0aG9u
+        My42L3NpdGUtcGFja2FnZXMvcnEvd29ya2VyLnB5XCIsIGxpbmUgODgzLCBp
+        biBwZXJmb3JtX2pvYlxuICAgIHJ2ID0gam9iLnBlcmZvcm0oKVxuICBGaWxl
+        IFwiL3Vzci9saWIvcHl0aG9uMy42L3NpdGUtcGFja2FnZXMvcnEvam9iLnB5
+        XCIsIGxpbmUgNjU3LCBpbiBwZXJmb3JtXG4gICAgc2VsZi5fcmVzdWx0ID0g
+        c2VsZi5fZXhlY3V0ZSgpXG4gIEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYv
+        c2l0ZS1wYWNrYWdlcy9ycS9qb2IucHlcIiwgbGluZSA2NjMsIGluIF9leGVj
+        dXRlXG4gICAgcmV0dXJuIHNlbGYuZnVuYygqc2VsZi5hcmdzLCAqKnNlbGYu
+        a3dhcmdzKVxuICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHl0aG9uMy42L3Np
+        dGUtcGFja2FnZXMvcHVscGNvcmUvYXBwL3Rhc2tzL2Jhc2UucHlcIiwgbGlu
+        ZSA5MCwgaW4gZ2VuZXJhbF9kZWxldGVcbiAgICBpbnN0YW5jZSA9IHNlcmlh
+        bGl6ZXJfY2xhc3MuTWV0YS5tb2RlbC5vYmplY3RzLmdldChwaz1pbnN0YW5j
+        ZV9pZCkuY2FzdCgpXG4gIEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYvc2l0
+        ZS1wYWNrYWdlcy9kamFuZ28vZGIvbW9kZWxzL21hbmFnZXIucHlcIiwgbGlu
+        ZSA4MiwgaW4gbWFuYWdlcl9tZXRob2RcbiAgICByZXR1cm4gZ2V0YXR0cihz
+        ZWxmLmdldF9xdWVyeXNldCgpLCBuYW1lKSgqYXJncywgKiprd2FyZ3MpXG4g
+        IEZpbGUgXCIvdXNyL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9kamFu
+        Z28vZGIvbW9kZWxzL3F1ZXJ5LnB5XCIsIGxpbmUgNDA4LCBpbiBnZXRcbiAg
+        ICBzZWxmLm1vZGVsLl9tZXRhLm9iamVjdF9uYW1lXG4iLCJkZXNjcmlwdGlv
+        biI6IkZpbGVEaXN0cmlidXRpb24gbWF0Y2hpbmcgcXVlcnkgZG9lcyBub3Qg
+        ZXhpc3QuIn0sIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA5NTM5
+        Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJlbnRfdGFz
+        ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJy
+        ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0
+        aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -608,17 +722,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:21 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -639,7 +753,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -653,17 +767,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,7 +798,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -698,17 +812,107 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:16 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -731,13 +935,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/"
+      - "/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -747,25 +951,25 @@ http_interactions:
       Content-Length:
       - '428'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS80MGY2MmMyNi0zMmY3LTQ0MzAtOGIxZi1iYTg5NTM2NDg1MjcvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoyMi4zMDQ3MzlaIiwi
+        ZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMToxNi42MjkwODJaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUyNy92
+        ZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjViNi92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThi
-        MWYtYmE4OTUzNjQ4NTI3L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThk
+        NDItMjA5Njk4M2I2NWI2L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRp
         b24iOm51bGwsInJlbW90ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -791,13 +995,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/9b39adad-d8e0-4859-811c-fc815d0be3e3/"
+      - "/pulp/api/v3/remotes/file/file/3d6110fc-0900-45de-8da9-747bd82f6f9b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -807,26 +1011,26 @@ http_interactions:
       Content-Length:
       - '462'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        OWIzOWFkYWQtZDhlMC00ODU5LTgxMWMtZmM4MTVkMGJlM2UzLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTY6MjIuNDEwMjM3WiIsIm5hbWUi
+        M2Q2MTEwZmMtMDkwMC00NWRlLThkYTktNzQ3YmQ4MmY2ZjliLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MTYuNzE4MjE4WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVl
         LCJwcm94eV91cmwiOm51bGwsInVzZXJuYW1lIjpudWxsLCJwYXNzd29yZCI6
-        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjIy
-        LjQxMDI1NFoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
+        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjE2
+        LjcxODIzNloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
         ImltbWVkaWF0ZSJ9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:16 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/
     body:
       encoding: UTF-8
       base64_string: |
@@ -849,7 +1053,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -863,17 +1067,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliNzUxOTJiLTBhOTQtNDIw
-        NC1hNzdmLTg4YmU4NWFlZDY4My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxYmJmMmUyLTA0ZmYtNGM5
+        My04Y2FkLWM3YjdmNjA0ODk2MC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:17 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/9b39adad-d8e0-4859-811c-fc815d0be3e3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/3d6110fc-0900-45de-8da9-747bd82f6f9b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -899,7 +1103,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:22 GMT
+      - Wed, 07 Oct 2020 15:11:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -913,17 +1117,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5Y2FjY2UxLTAzYTktNDcx
-        YS1iZmZmLTgxMGQ0N2ZhZTRlYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ2NWM0ZjQ1LTk0YWQtNDFi
+        OC05MmE4LWVhYTM2ZjNmOTliMy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:22 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:17 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -948,7 +1152,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:23 GMT
+      - Wed, 07 Oct 2020 15:11:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -962,17 +1166,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RhM2UxYTNhLTRiNTEtNDY1
-        OC05MTBmLTY4M2NiNWE4MmMwOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhZThiNGI4LTc2MWUtNDA3
+        OS05NzU4LWY1NDVlNjlmNGFjNi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:23 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:17 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/da3e1a3a-4b51-4658-910f-683cb5a82c08/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/bae8b4b8-761e-4079-9758-f545e69f4ac6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -980,7 +1184,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +1197,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:23 GMT
+      - Wed, 07 Oct 2020 15:11:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1005,30 +1209,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '347'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGEzZTFhM2EtNGI1
-        MS00NjU4LTkxMGYtNjgzY2I1YTgyYzA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjIuOTUxNTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmFlOGI0YjgtNzYx
+        ZS00MDc5LTk3NTgtZjU0NWU2OWY0YWM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTcuMjA2NTQzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MjMuMzEyNDg4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjoyMy42MDE1Nzla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTcuNTg1NzYz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxNy43NzE0ODda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzg1YzI0
-        NTc5LWZlNzktNDk2ZC1iNGEyLWRiZDVmYjEyNGZhZS8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzE1Yzk3
+        ZDcyLTg3YjMtNDQyYi1iNmEwLWYxMTYyN2RjNTk5NC8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:23 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:17 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1049,7 +1253,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:23 GMT
+      - Wed, 07 Oct 2020 15:11:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1061,31 +1265,31 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '252'
+      - '257'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvODVjMjQ1NzktZmU3OS00OTZkLWI0YTItZGJkNWZiMTI0ZmFlLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTY6MjMuNTgzNjA4WiIs
+        L2ZpbGUvMTVjOTdkNzItODdiMy00NDJiLWI2YTAtZjExNjI3ZGM1OTk0LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MTcuNzU3NzUzWiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
-        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9u
-        L2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
-        bGVfMSIsInB1YmxpY2F0aW9uIjpudWxsfQ==
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2Fu
+        aXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJk
+        IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:23 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:17 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOWIz
-        OWFkYWQtZDhlMC00ODU5LTgxMWMtZmM4MTVkMGJlM2UzLyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvM2Q2
+        MTEwZmMtMDkwMC00NWRlLThkYTktNzQ3YmQ4MmY2ZjliLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1104,7 +1308,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:24 GMT
+      - Wed, 07 Oct 2020 15:11:18 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1118,17 +1322,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwYWYyZDlkLTRhMGEtNDg1
-        NS1hMDM4LTJiYTA0NzNjN2FiYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5YmJlOTlkLTJmYWUtNDc3
+        MC05OWUzLWFlZTA4NmM5OTkwYi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:24 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:18 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/90af2d9d-4a0a-4855-a038-2ba0473c7aba/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/19bbe99d-2fae-4770-99e3-aee086c9990b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1136,7 +1340,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,7 +1353,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:25 GMT
+      - Wed, 07 Oct 2020 15:11:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1161,53 +1365,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '531'
+      - '536'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBhZjJkOWQtNGEw
-        YS00ODU1LWEwMzgtMmJhMDQ3M2M3YWJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjQuMDA4NTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTliYmU5OWQtMmZh
+        ZS00NzcwLTk5ZTMtYWVlMDg2Yzk5OTBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTguMTczNjUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjE2OjI0
-        LjE4ODI2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MjQu
-        OTU5MzA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjExOjE4
+        LjMzNzQ5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTku
+        NTkxOTY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wOTUzOTc3NC1hZmE0LTQyYjctYWIxMS02NWRjYzc0NjIxNDUv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
-        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
+        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
+        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4
-        OTUzNjQ4NTI3L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aXRvcmllcy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5
+        Njk4M2I2NWI2L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        NDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4NTI3LyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS85YjM5YWRhZC1kOGUwLTQ4NTkt
-        ODExYy1mYzgxNWQwYmUzZTMvIl19
+        ZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2NWI2LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8zZDYxMTBmYy0wOTAwLTQ1ZGUt
+        OGRhOS03NDdiZDgyZjZmOWIvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:25 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:19 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0MzAtOGIxZi1iYTg5NTM2
-        NDg1MjcvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3Y2QtOGQ0Mi0yMDk2OTgz
+        YjY1YjYvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1226,7 +1430,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:25 GMT
+      - Wed, 07 Oct 2020 15:11:19 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1240,17 +1444,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1YTM5NDkzLTBmYmUtNGRm
-        ZC05OGNkLTE3ZjA4YjczNWZlMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNmRlNzIzLTY2NDctNGMz
+        Yy05NzRhLTFkNjhhZGZiNmNkYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:25 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:19 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b5a39493-0fbe-4dfd-98cd-17f08b735fe1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/5e6de723-6647-4c3c-974a-1d68adfb6cdc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1258,7 +1462,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1271,7 +1475,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:25 GMT
+      - Wed, 07 Oct 2020 15:11:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1283,39 +1487,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '372'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjVhMzk0OTMtMGZi
-        ZS00ZGZkLTk4Y2QtMTdmMDhiNzM1ZmUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjUuMTQxMjExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWU2ZGU3MjMtNjY0
+        Ny00YzNjLTk3NGEtMWQ2OGFkZmI2Y2RjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MTkuNzY0NzMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MjUuMzI3MTIy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjoyNS40Mjc3NDVa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MTkuODk0MDc3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToxOS45OTc2NjBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWMzOTAy
-        YjQtODI1NC00YTVhLTk4YmQtYmVhZDFmZDdmZjkzLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWVhZWVh
+        ODMtNzUyNS00ZGE0LWFlZTAtY2JmOWUyM2RhMjFlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny8iXX0=
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:25 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:20 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWMzOTAy
-        YjQtODI1NC00YTVhLTk4YmQtYmVhZDFmZDdmZjkzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWVhZWVh
+        ODMtNzUyNS00ZGE0LWFlZTAtY2JmOWUyM2RhMjFlLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1333,7 +1537,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:25 GMT
+      - Wed, 07 Oct 2020 15:11:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1347,17 +1551,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYjljZmM1LTM4OWYtNDhl
-        Yi04NDk4LTUyM2UzNDI4ZjBmNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3MDJiZTQyLWFkMzEtNDBh
+        NC1iZGQ0LWMzMzM0NmFhNWNjZS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:25 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:20 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/bfb9cfc5-389f-48eb-8498-523e3428f0f4/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/f702be42-ad31-40a4-bdd4-c33346aa5cce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1365,7 +1569,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1378,7 +1582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:26 GMT
+      - Wed, 07 Oct 2020 15:11:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1390,36 +1594,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '317'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZiOWNmYzUtMzg5
-        Zi00OGViLTg0OTgtNTIzZTM0MjhmMGY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjUuNjA3MDczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjcwMmJlNDItYWQz
+        MS00MGE0LWJkZDQtYzMzMzQ2YWE1Y2NlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjAuMTc3MTU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MjUuNzc5ODY5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjoyNi4xMzQzODla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjAuMzM2NjIw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyMC41OTg2OTVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:26 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:20 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWMzOTAy
-        YjQtODI1NC00YTVhLTk4YmQtYmVhZDFmZDdmZjkzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWVhZWVh
+        ODMtNzUyNS00ZGE0LWFlZTAtY2JmOWUyM2RhMjFlLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1437,7 +1641,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:26 GMT
+      - Wed, 07 Oct 2020 15:11:20 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1451,17 +1655,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3ZmIyOWI1LTVkMDgtNDYz
-        My1hYTA1LTY2NGVhYWVkZjNlNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4NTcwYzI1LWQ3ZDktNDM5
+        Yy05ZTYwLTRkNjJhYjEyYWJkNS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:26 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:20 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1484,7 +1688,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:26 GMT
+      - Wed, 07 Oct 2020 15:11:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1498,17 +1702,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyN2Q3ZDJjLWQyZDEtNGYz
-        OS1iMTc3LWMzZTUxNWMzNjNkZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2MjM0NTIzLTIxNzYtNDY1
+        Yy1iNjgyLTIzNzYwZjY3NTg4NC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:26 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:21 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/9b39adad-d8e0-4859-811c-fc815d0be3e3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/3d6110fc-0900-45de-8da9-747bd82f6f9b/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1534,7 +1738,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:26 GMT
+      - Wed, 07 Oct 2020 15:11:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1548,24 +1752,24 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmZjQ1ZDA0LWQ5M2MtNGI5
-        YS05OGM5LTA1ZTY2ZTdmYjAwMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwNTM2ZjQ4LTNjNTctNDBi
+        ZS05MmE2LWM1ODFlMmMxYzQzYS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:26 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:21 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWMzOTAy
-        YjQtODI1NC00YTVhLTk4YmQtYmVhZDFmZDdmZjkzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWVhZWVh
+        ODMtNzUyNS00ZGE0LWFlZTAtY2JmOWUyM2RhMjFlLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1583,7 +1787,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:26 GMT
+      - Wed, 07 Oct 2020 15:11:21 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1597,17 +1801,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyY2NmODNiLWIwNGUtNGY4
-        ZC1hOWZiLWUyNDRhNjY3MTFkYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2NmZiYmI0LTE5ZDgtNGI5
+        MS04MDlhLWM4NDAxNjQ0ODhiYS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:26 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:21 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/22ccf83b-b04e-4f8d-a9fb-e244a66711da/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/766fbbb4-19d8-4b91-809a-c840164488ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1615,7 +1819,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1628,7 +1832,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:28 GMT
+      - Wed, 07 Oct 2020 15:11:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1640,36 +1844,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '319'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjJjY2Y4M2ItYjA0
-        ZS00ZjhkLWE5ZmItZTI0NGE2NjcxMWRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjYuOTQ1NjI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzY2ZmJiYjQtMTlk
+        OC00YjkxLTgwOWEtYzg0MDE2NDQ4OGJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjEuMjY1NTE0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MjcuNjM1ODEy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjoyOC4wNDI4Nzla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjEuNzIwMDE4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyMi4wMDg4MTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:22 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWMzOTAy
-        YjQtODI1NC00YTVhLTk4YmQtYmVhZDFmZDdmZjkzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWVhZWVh
+        ODMtNzUyNS00ZGE0LWFlZTAtY2JmOWUyM2RhMjFlLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1687,7 +1891,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:28 GMT
+      - Wed, 07 Oct 2020 15:11:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1701,22 +1905,22 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2NDU3MjVlLTgzZmUtNDgz
-        MC1iYWIzLTE1MWI5ZGI1YjBlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwYmFjOWZlLTRkNzktNDlm
+        MS1iOGQzLWQ0NTI5MmIxZWQzYS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:22 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOWIz
-        OWFkYWQtZDhlMC00ODU5LTgxMWMtZmM4MTVkMGJlM2UzLyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvM2Q2
+        MTEwZmMtMDkwMC00NWRlLThkYTktNzQ3YmQ4MmY2ZjliLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1735,7 +1939,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:28 GMT
+      - Wed, 07 Oct 2020 15:11:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1749,17 +1953,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4YzFmYjI2LTBjMWItNGIy
-        Yi1hNTJkLTBlZTZlZDg4MDIyMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0YzIyYjVhLTAyY2EtNDUx
+        NS05MmUzLTQyM2M5MDcxN2IxNy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:28 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:22 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/48c1fb26-0c1b-4b2b-a52d-0ee6ed880221/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/94c22b5a-02ca-4515-92e3-423c90717b17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1767,7 +1971,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1780,7 +1984,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:29 GMT
+      - Wed, 07 Oct 2020 15:11:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1792,53 +1996,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '530'
+      - '538'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDhjMWZiMjYtMGMx
-        Yi00YjJiLWE1MmQtMGVlNmVkODgwMjIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MjguNzcyNTIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTRjMjJiNWEtMDJj
+        YS00NTE1LTkyZTMtNDIzYzkwNzE3YjE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjIuNDQ0MjU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjE2OjI5
-        LjAwOTgxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6Mjku
-        ODQ1NTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjExOjIy
+        LjY5NTEzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjQu
+        MDQ0MDM1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wOTUzOTc3NC1hZmE0LTQyYjctYWIxMS02NWRjYzc0NjIxNDUv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
-        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
-        YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
-        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IlBh
+        cnNpbmcgTWV0YWRhdGEgTGluZXMiLCJjb2RlIjoicGFyc2luZy5tZXRhZGF0
+        YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3Rz
+        IiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3Nv
+        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        bnVsbCwiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1B
+        c3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29u
+        dGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUi
+        OjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgTWV0
+        YWRhdGEiLCJjb2RlIjoiZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4
-        OTUzNjQ4NTI3L3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        aXRvcmllcy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5
+        Njk4M2I2NWI2L3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
         ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        NDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4NTI3LyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS85YjM5YWRhZC1kOGUwLTQ4NTkt
-        ODExYy1mYzgxNWQwYmUzZTMvIl19
+        ZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2NWI2LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8zZDYxMTBmYy0wOTAwLTQ1ZGUt
+        OGRhOS03NDdiZDgyZjZmOWIvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:29 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:24 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0MzAtOGIxZi1iYTg5NTM2
-        NDg1MjcvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3Y2QtOGQ0Mi0yMDk2OTgz
+        YjY1YjYvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1857,7 +2061,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:30 GMT
+      - Wed, 07 Oct 2020 15:11:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1871,17 +2075,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhMTA3NTAyLTYyYzktNDY3
-        ZC1iNjUzLTI0Yjc1MTk1MDBkZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUxNjg0NTg4LTM3YzAtNDI3
+        Yy1iNWRkLWRhNjJjNjNmZTQxMy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/ea107502-62c9-467d-b653-24b7519500dd/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/51684588-37c0-427c-b5dd-da62c63fe413/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1889,7 +2093,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1902,7 +2106,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:30 GMT
+      - Wed, 07 Oct 2020 15:11:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1914,39 +2118,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '374'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWExMDc1MDItNjJj
-        OS00NjdkLWI2NTMtMjRiNzUxOTUwMGRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzAuMDcwOTU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTE2ODQ1ODgtMzdj
+        MC00MjdjLWI1ZGQtZGE2MmM2M2ZlNDEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjQuMzA4ODk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzAuMjU5MTMw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozMC40MjM0Mjda
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjQuNDg0OTU5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyNC41ODYzMjRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODRlMjI1
-        YWQtY2EyNC00NzNkLWE3ZDQtNTNiOGY4YjJlODBkLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOWZjNGIx
+        NWItZTE1OC00ZTg4LTkzMTEtMDc2OGQ0YjUxNmVkLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny8iXX0=
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:24 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODRlMjI1
-        YWQtY2EyNC00NzNkLWE3ZDQtNTNiOGY4YjJlODBkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOWZjNGIx
+        NWItZTE1OC00ZTg4LTkzMTEtMDc2OGQ0YjUxNmVkLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1964,7 +2168,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:30 GMT
+      - Wed, 07 Oct 2020 15:11:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1978,17 +2182,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0YTA2NTEzLTJjMWYtNDVi
-        Ni04MmIzLTE1OWEyNTA4MDAwNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiNGNmYmM4LTE2YzYtNDY1
+        NS1hMWVhLWY2MWU5YmQyNjU3Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:30 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f4a06513-2c1f-45b6-82b3-159a25080004/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/3b4cfbc8-16c6-4655-a1ea-f61e9bd26576/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1996,7 +2200,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2009,7 +2213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:31 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2021,36 +2225,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '318'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjRhMDY1MTMtMmMx
-        Zi00NWI2LTgyYjMtMTU5YTI1MDgwMDA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzAuNzQwNDY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2I0Y2ZiYzgtMTZj
+        Ni00NjU1LWExZWEtZjYxZTliZDI2NTc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjQuNzI5ODg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzAuOTcwMzQx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozMS40ODkzNzJa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjQuODgwNjgz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyNS4xMjMzNzVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODRlMjI1
-        YWQtY2EyNC00NzNkLWE3ZDQtNTNiOGY4YjJlODBkLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOWZjNGIx
+        NWItZTE1OC00ZTg4LTkzMTEtMDc2OGQ0YjUxNmVkLyJ9
     headers:
       Content-Type:
       - application/json
@@ -2068,7 +2272,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:31 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2082,17 +2286,107 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiMmRjZjMzLTUyNTEtNDg4
-        Mi04OTEyLWVkZjk4OTc4Njc2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3NzA1NWMyLTdkMWQtNDRk
+        NS05MmUzLWVjZGUyMWI5Njg3Zi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.3.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:25 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:25 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2113,7 +2407,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:31 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2125,39 +2419,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '347'
+      - '247'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjIyLjMwNDcz
-        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4
-        NTI3L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0
-        MzAtOGIxZi1iYTg5NTM2NDg1MjcvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjE2LjYyOTA4
+        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2
+        NWI2L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3
+        Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
         YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
-        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNWZmYTU5Mzct
-        YjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNpb25zLyIsImxhdGVz
-        dF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
-        bGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQwYTItYjkzNy1iZjQxYTYzZjQ1ZTgv
-        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVibGlzaGVkIExpYnJhcnkgYW5kIGRl
-        diB2aWV3LTcwMDk3MzQ1My05MDkwNTgzNDciLCJkZXNjcmlwdGlvbiI6IlB1
-        Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYgdmlldy03MDA5NzM0NTMtOTA5MDU4
-        MzQ3IiwicmVtb3RlIjpudWxsfV19
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:31 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2178,7 +2461,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2190,7 +2473,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '322'
     body:
@@ -2198,45 +2481,45 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MTY6MjkuMDYyMjc5WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6
+        MTE6MjIuNzU3MzgzWiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
         LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
         dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
         cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJh
-        ODk1MzY0ODUyNy92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
+        c2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIw
+        OTY5ODNiNjViNi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
         bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
         aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0
-        MzAtOGIxZi1iYTg5NTM2NDg1MjcvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3
+        Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
         OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
         L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjct
-        NDQzMC04YjFmLWJhODk1MzY0ODUyNy92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDct
+        NDdjZC04ZDQyLTIwOTY5ODNiNjViNi92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        NDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4NTI3L3ZlcnNpb25z
-        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoyNC4yMzY2
-        NTFaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        ZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2NWI2L3ZlcnNpb25z
+        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMToxOC4zODI2
+        ODVaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
         c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhy
         ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
         b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4NTI3
+        aWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2NWI2
         L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
         LmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
         dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThi
-        MWYtYmE4OTUzNjQ4NTI3L3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80MGY2MmMy
-        Ni0zMmY3LTQ0MzAtOGIxZi1iYTg5NTM2NDg1MjcvdmVyc2lvbnMvMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjIyLjMxMTQzMloiLCJu
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThk
+        NDItMjA5Njk4M2I2NWI2L3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mYTdhZWI1
+        YS1kNzQ3LTQ3Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvdmVyc2lvbnMvMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjE2LjYzMzIyOFoiLCJu
         dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
         Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2244,7 +2527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2257,317 +2540,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '367'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoxNC4yNjg4Mzla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3
-        Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMS8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjEzLjA5MzA2OFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4
-        ZWQ1OTgwMS92ZXJzaW9ucy8xLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/37a0b7de-09d0-4603-af76-ed67b7ffbf57/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '306'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjE5LjM5MjUwN1oiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2
-        MDMtYWY3Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMC8iLCJjb250ZW50X3N1
-        bW1hcnkiOnsiYWRkZWQiOnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vMzdhMGI3ZGUtMDlkMC00NjAzLWFmNzYtZWQ2N2I3ZmZiZjU3
-        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJycG0u
-        cGFja2FnZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMt
-        YWY3Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdk
-        ZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjE0LjI3NDAxMloiLCJu
-        dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/18ef5587-9eea-430a-a8b1-be0a8ed59801/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '319'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOGVmNTU4Ny05ZWVhLTQzMGEtYThiMS1iZTBhOGVkNTk4MDEv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjE1LjI3OTI1MVoiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJj
-        b3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZp
-        c29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIx
-        LWJlMGE4ZWQ1OTgwMS92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJj
-        b3VudCI6MzIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
-        a2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMThlZjU1ODctOWVlYS00MzBhLWE4YjEt
-        YmUwYThlZDU5ODAxL3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJl
-        c2VudCI6eyJycG0uYWR2aXNvcnkiOnsiY291bnQiOjQsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOGVm
-        NTU4Ny05ZWVhLTQzMGEtYThiMS1iZTBhOGVkNTk4MDEvdmVyc2lvbnMvMS8i
-        fSwicnBtLnBhY2thZ2UiOnsiY291bnQiOjMyLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE4ZWY1NTg3LTll
-        ZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS92ZXJzaW9ucy8xLyJ9fX19LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTY6MTMuMTAx
-        MDgzWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50
-        X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6
-        e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2581,17 +2554,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2599,7 +2572,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2612,91 +2585,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '227'
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/versions/1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2717,7 +2630,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:32 GMT
+      - Wed, 07 Oct 2020 15:11:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2731,107 +2644,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjNzY2NjllLWVmNmUtNDAz
-        Yi1hYzNiLWZjMDE5NDA0MzhlMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4MGU4NDRmLTkyZTYtNDEx
+        ZC05ODM3LWQyOTY3MDU1ZmE3NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:32 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/37a0b7de-09d0-4603-af76-ed67b7ffbf57/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:33 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0ZTAwMjFkLTc3NjctNDQ4
-        NC05M2JmLWJiNGNlM2Y2ZDcyZS8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:33 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/18ef5587-9eea-430a-a8b1-be0a8ed59801/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:33 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4NjU3N2M1LTIwZmEtNDU4
-        ZC04MTZiLTcwNTkyNDg0NDRjMi8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:33 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:25 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/6c76669e-ef6e-403b-ac3b-fc01940438e2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/980e844f-92e6-411d-9837-d2967055fa75/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2839,7 +2662,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2852,7 +2675,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:33 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2864,86 +2687,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '342'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmM3NjY2OWUtZWY2
-        ZS00MDNiLWFjM2ItZmMwMTk0MDQzOGUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzIuOTA2OTQzWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZV92ZXJzaW9uIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzMu
-        MTAwNTcwWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozMy4z
-        NDQ2NzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8i
-        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
-        dXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjct
-        NDQzMC04YjFmLWJhODk1MzY0ODUyNy8iXX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:33 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b4e0021d-7767-4484-93bf-bb4ce3f6d72e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:33 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '343'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjRlMDAyMWQtNzc2
-        Ny00NDg0LTkzYmYtYmI0Y2UzZjZkNzJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzMuMDA2MDkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTgwZTg0NGYtOTJl
+        Ni00MTFkLTk4MzctZDI5NjcwNTVmYTc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjUuNzA3NDU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZV92ZXJzaW9uIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzMu
-        MzcwMDc4WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozMy41
-        MzgzODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8i
+        ZV92ZXJzaW9uIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjUu
+        ODcyMDA5WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyNS45
+        OTE3MTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
         dXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2
-        MDMtYWY3Ni1lZDY3YjdmZmJmNTcvIl19
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDct
+        NDdjZC04ZDQyLTIwOTY5ODNiNjViNi8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:33 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/d86577c5-20fa-458d-816b-7059248444c2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2951,7 +2718,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2964,42 +2731,76 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '343'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg2NTc3YzUtMjBm
-        YS00NThkLTgxNmItNzA1OTI0ODQ0NGMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzMuMTE3MTA0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZV92ZXJzaW9uIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzMu
-        OTk2MDM4WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozNC4x
-        ODk0NjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8i
-        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNv
-        dXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xOGVmNTU4Ny05ZWVhLTQz
-        MGEtYThiMS1iZTBhOGVkNTk4MDEvIl19
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:26 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3020,7 +2821,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3032,39 +2833,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '347'
+      - '247'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjIyLjMwNDcz
-        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4
-        NTI3L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0
-        MzAtOGIxZi1iYTg5NTM2NDg1MjcvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjE2LjYyOTA4
+        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2
+        NWI2L3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3
+        Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
         YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
-        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNWZmYTU5Mzct
-        YjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNpb25zLyIsImxhdGVz
-        dF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
-        bGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQwYTItYjkzNy1iZjQxYTYzZjQ1ZTgv
-        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVibGlzaGVkIExpYnJhcnkgYW5kIGRl
-        diB2aWV3LTcwMDk3MzQ1My05MDkwNTgzNDciLCJkZXNjcmlwdGlvbiI6IlB1
-        Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYgdmlldy03MDA5NzM0NTMtOTA5MDU4
-        MzQ3IiwicmVtb3RlIjpudWxsfV19
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3085,7 +2875,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3097,7 +2887,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '298'
     body:
@@ -3105,33 +2895,33 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJhODk1MzY0ODUy
-        Ny92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MTY6MjkuMDYyMjc5WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
+        ZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIwOTY5ODNiNjVi
+        Ni92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6
+        MTE6MjIuNzU3MzgzWiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
         LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
         dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
         cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04YjFmLWJh
-        ODk1MzY0ODUyNy92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
+        c2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04ZDQyLTIw
+        OTY5ODNiNjViNi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
         bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
         aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80MGY2MmMyNi0zMmY3LTQ0
-        MzAtOGIxZi1iYTg5NTM2NDg1MjcvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mYTdhZWI1YS1kNzQ3LTQ3
+        Y2QtOGQ0Mi0yMDk2OTgzYjY1YjYvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
         OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
         L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjct
-        NDQzMC04YjFmLWJhODk1MzY0ODUyNy92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDct
+        NDdjZC04ZDQyLTIwOTY5ODNiNjViNi92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        NDBmNjJjMjYtMzJmNy00NDMwLThiMWYtYmE4OTUzNjQ4NTI3L3ZlcnNpb25z
-        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoyMi4zMTE0
-        MzJaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        ZmE3YWViNWEtZDc0Ny00N2NkLThkNDItMjA5Njk4M2I2NWI2L3ZlcnNpb25z
+        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMToxNi42MzMy
+        MjhaIiwibnVtYmVyIjowLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
         c3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7
         fX19XX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3139,7 +2929,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3152,282 +2942,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '367'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoxNC4yNjg4Mzla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3
-        Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjEzLjA5MzA2OFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4
-        ZWQ1OTgwMS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/37a0b7de-09d0-4603-af76-ed67b7ffbf57/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjE0LjI3NDAxMloiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/18ef5587-9eea-430a-a8b1-be0a8ed59801/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOGVmNTU4Ny05ZWVhLTQzMGEtYThiMS1iZTBhOGVkNTk4MDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjEzLjEwMTA4M1oiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:34 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:34 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3441,17 +2956,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3459,7 +2974,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -3472,91 +2987,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '251'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '227'
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/9b39adad-d8e0-4859-811c-fc815d0be3e3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/3d6110fc-0900-45de-8da9-747bd82f6f9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3577,7 +3032,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3591,17 +3046,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhYzE1NjJjLTg4NzQtNGNi
-        My04NDFkLTIwZjMzZWYwNDVhMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmMjUzNjE5LTRjNDItNDkz
+        OS1hMDEzLTA3ZGQ4ZGU2MDhkYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3ac1562c-8874-4cb3-841d-20f33ef045a2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/5f253619-4c42-4939-a013-07dd8de608dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3609,7 +3064,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3622,7 +3077,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3634,30 +3089,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '339'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2FjMTU2MmMtODg3
-        NC00Y2IzLTg0MWQtMjBmMzNlZjA0NWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzUuNDIyMjcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWYyNTM2MTktNGM0
+        Mi00OTM5LWEwMTMtMDdkZDhkZTYwOGRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjYuNTQ3NDAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzUuNjY3MTY0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozNS43NjM4OTJa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjYuNjkxODM1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyNi43NTU2MDla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS85YjM5YWRhZC1kOGUwLTQ4NTktODExYy1m
-        YzgxNWQwYmUzZTMvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS8zZDYxMTBmYy0wOTAwLTQ1ZGUtOGRhOS03
+        NDdiZDgyZjZmOWIvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/85c24579-fe79-496d-b4a2-dbd5fb124fae/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/15c97d72-87b3-442b-b6a0-f11627dc5994/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3678,7 +3133,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:35 GMT
+      - Wed, 07 Oct 2020 15:11:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3692,17 +3147,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzYWU3NzNmLTZjNWUtNDQx
-        Ni04M2ViLWRhN2VlNDc3MmI4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MmYwZmY0LTkwYTItNDRm
+        NS1iY2Y5LTZhN2M2NWQ1YjdlYS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:35 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:26 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/40f62c26-32f7-4430-8b1f-ba8953648527/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/fa7aeb5a-d747-47cd-8d42-2096983b65b6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3723,7 +3178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:36 GMT
+      - Wed, 07 Oct 2020 15:11:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3737,17 +3192,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhNGFlZTE1LTdiYjYtNGFk
-        My05MmRiLWY4ZDQ2YjBkNDVhYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyNjNmNzFmLWU2OTMtNDg3
+        Ny1iYmJjLTllZGQ4ZTVmNDIzOC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:36 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/0a4aee15-7bb6-4ad3-92db-f8d46b0d45aa/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/2263f71f-e693-4877-bbbc-9edd8e5f4238/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3755,7 +3210,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3768,7 +3223,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:36 GMT
+      - Wed, 07 Oct 2020 15:11:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -3780,25 +3235,25 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '342'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGE0YWVlMTUtN2Ji
-        Ni00YWQzLTkyZGItZjhkNDZiMGQ0NWFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzYuMDAyMzk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI2M2Y3MWYtZTY5
+        My00ODc3LWJiYmMtOWVkZDhlNWY0MjM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjYuOTU4MjAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6MzYuNDAzMjI3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjozNi42NDk4Nzla
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MjcuMzAwMTkz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMToyNy40Mjc2OTla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzQwZjYyYzI2LTMyZjctNDQzMC04
-        YjFmLWJhODk1MzY0ODUyNy8iXX0=
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ZhN2FlYjVhLWQ3NDctNDdjZC04
+        ZDQyLTIwOTY5ODNiNjViNi8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:36 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:27 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/orphan_repository_versions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,159 +23,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -196,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -210,17 +82,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -241,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -255,17 +127,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -286,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -300,17 +172,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -331,7 +203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -345,17 +217,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -363,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.0.1/ruby
+      - OpenAPI-Generator/1.0.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -376,159 +248,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '3076'
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtL2ZlZmJmODJhLWJhOGUtNDkyMC05NjljLTZjMzlm
-        YTdhZTdlYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjA2OjEx
-        Ljk5NTIzNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
-        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
-        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
-        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
-        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
-        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
-        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
-        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
-        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
-        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
-        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
-        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
-        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
-        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
-        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
-        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
-        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
-        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
-        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
-        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
-        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
-        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
-        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
-        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
-        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
-        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
-        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
-        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
-        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
-        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
-        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
-        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
-        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
-        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
-        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
-        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
-        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
-        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
-        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
-        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
-        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
-        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
-        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
-        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
-        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
-        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
-        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
-        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
-        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
-        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
-        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
-        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
-        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
-        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
-        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
-        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
-        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
-        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
-        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
-        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
-        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
-        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
-        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
-        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
-        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
-        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
-        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
-        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
-        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
-        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
-        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
-        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
-        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
-        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
-        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
-        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
-        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
-        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
-        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
-        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
-        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
-        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
-        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
-        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
-        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
-        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
-        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
-        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
-        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
-        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
-        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
-        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
-        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
-        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
-        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
-        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
-        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
-        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
-        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
-        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
-        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
-        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
-        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
-        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
-        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
-        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
-        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
-        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
-        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
-        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
-        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
-        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
-        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
-        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
-        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
-        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
-        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
-        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
-        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
-        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
-        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
-        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -549,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -563,17 +307,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -608,17 +352,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -639,7 +383,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:38 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -653,17 +397,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:38 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,7 +428,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -698,17 +442,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:28 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -731,13 +475,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/"
+      - "/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -747,25 +491,25 @@ http_interactions:
       Content-Length:
       - '428'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wZTU2MzNjYy01ZGQ5LTQ4ODUtYmJkNy1hMWMxNjdlYmY3MzIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjozOS4yMDU0NTFaIiwi
+        ZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2OTItODhiYy0yMGNiMDgyMzA4OGEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMToyOS4xMzYwMjNaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWExYzE2N2ViZjczMi92
+        ZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIwY2IwODIzMDg4YS92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJi
-        ZDctYTFjMTY3ZWJmNzMyL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4
+        YmMtMjBjYjA4MjMwODhhL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRp
         b24iOm51bGwsInJlbW90ZSI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:29 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -791,13 +535,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/f500c346-1b00-4d6e-bb00-3c03518175ab/"
+      - "/pulp/api/v3/remotes/file/file/0bd11d3a-9ecc-42dd-978e-1c6c68e42fd2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -807,26 +551,26 @@ http_interactions:
       Content-Length:
       - '462'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ZjUwMGMzNDYtMWIwMC00ZDZlLWJiMDAtM2MwMzUxODE3NWFiLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTY6MzkuMzI3OTY3WiIsIm5hbWUi
+        MGJkMTFkM2EtOWVjYy00MmRkLTk3OGUtMWM2YzY4ZTQyZmQyLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MjkuMjI3OTY5WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVl
         LCJwcm94eV91cmwiOm51bGwsInVzZXJuYW1lIjpudWxsLCJwYXNzd29yZCI6
-        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjM5
-        LjMyODAxMVoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
+        bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjI5
+        LjIyNzk4N1oiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6MTAsInBvbGljeSI6
         ImltbWVkaWF0ZSJ9
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:29 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -849,7 +593,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -863,17 +607,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5OTgzOWZkLWZjMGItNDkw
-        NS05ZGQ5LWVhZjk3ZWVkMTcyNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3MjhhYjFlLTA1OTQtNDcw
+        OS04N2RlLWRlOThmYjhiNzI2Yi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:29 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/f500c346-1b00-4d6e-bb00-3c03518175ab/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/0bd11d3a-9ecc-42dd-978e-1c6c68e42fd2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -899,7 +643,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -913,17 +657,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmZGUxOTJkLWRjMTktNDVh
-        Mi05OTExLWY1ZmExNTY5MzBhMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlNTU4OGQ3LWEzN2ItNGYy
+        Ny1iNzgwLTRjY2VlZGJkNjQwNy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:29 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -948,7 +692,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:39 GMT
+      - Wed, 07 Oct 2020 15:11:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -962,17 +706,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmMjg1MWNiLTY0Y2ItNDNi
-        Yi1iNDU5LWNmZTZiMWMzNDk5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiNDA1NjI0LWE0MmYtNDJh
+        Ny1iMTI5LWE4OGEwOGQ2MzViYy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:39 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:29 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/df2851cb-64cb-43bb-b459-cfe6b1c34999/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/1b405624-a42f-42a7-b129-a88a08d635bc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -980,7 +724,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +737,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:40 GMT
+      - Wed, 07 Oct 2020 15:11:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1005,30 +749,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '348'
+      - '350'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGYyODUxY2ItNjRj
-        Yi00M2JiLWI0NTktY2ZlNmIxYzM0OTk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6MzkuODUwMTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWI0MDU2MjQtYTQy
+        Zi00MmE3LWIxMjktYTg4YTA4ZDYzNWJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MjkuNzAxMzIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDAuMzE5OTcx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0MC41NjMyODla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzAuMDk4NDAw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozMC4yOTk2MDha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2RiNWUx
-        ODNlLTI3MWMtNDNiYy04Yjc5LTQ3YjUwMjVkNTQ4Yy8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2VmODY1
+        NGRmLTc1MDYtNDU4MC05OTY5LWYzMTQxYjRlODhjZS8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:40 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:30 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1049,7 +793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:40 GMT
+      - Wed, 07 Oct 2020 15:11:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1061,31 +805,31 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '253'
+      - '257'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvZGI1ZTE4M2UtMjcxYy00M2JjLThiNzktNDdiNTAyNWQ1NDhjLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6MTY6NDAuNTQ0ODUxWiIs
+        L2ZpbGUvZWY4NjU0ZGYtNzUwNi00NTgwLTk5NjktZjMxNDFiNGU4OGNlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6MTE6MzAuMjg0NTQ1WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
-        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9u
-        L2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGws
-        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
-        bGVfMSIsInB1YmxpY2F0aW9uIjpudWxsfQ==
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJodHRwOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2Fu
+        aXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJk
+        IjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:40 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:30 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZjUw
-        MGMzNDYtMWIwMC00ZDZlLWJiMDAtM2MwMzUxODE3NWFiLyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMGJk
+        MTFkM2EtOWVjYy00MmRkLTk3OGUtMWM2YzY4ZTQyZmQyLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1104,7 +848,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:41 GMT
+      - Wed, 07 Oct 2020 15:11:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1118,17 +862,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiOTA2NTk0LTNhYWUtNGFi
-        Ni05MWYyLTZkZmQ4N2Y0ODM3ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2MmY3MWY0LWUyNGEtNDc3
+        ZS04MTMwLWM1MWI0N2E5MjAyMy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:30 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/cb906594-3aae-4ab6-91f2-6dfd87f4837e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/862f71f4-e24a-477e-8130-c51b47a92023/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1136,7 +880,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,7 +893,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:41 GMT
+      - Wed, 07 Oct 2020 15:11:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1161,53 +905,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '533'
+      - '537'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I5MDY1OTQtM2Fh
-        ZS00YWI2LTkxZjItNmRmZDg3ZjQ4MzdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDEuMDU3MjMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODYyZjcxZjQtZTI0
+        YS00NzdlLTgxMzAtYzUxYjQ3YTkyMDIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzAuNjQzOTU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjE2OjQx
-        LjI2ODg3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDEu
-        Nzc4ODA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMGUzZTYyZi1jOTc2LTRjN2EtYjEzNS0zODE2NDg5NDQ4MDUv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjExOjMw
+        LjgwNTE4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzEu
+        NTEzNjM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy9mMzc4OWU1MS01ZjQ2LTRlMzEtYmMyMy04ODE5ZWExYzAyMDcv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
-        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
+        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
+        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFj
-        MTY3ZWJmNzMyL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        MGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFjMTY3ZWJmNzMyLyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9mNTAwYzM0Ni0xYjAwLTRkNmUt
-        YmIwMC0zYzAzNTE4MTc1YWIvIl19
+        aXRvcmllcy9maWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4YmMtMjBj
+        YjA4MjMwODhhL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzBiZDEx
+        ZDNhLTllY2MtNDJkZC05NzhlLTFjNmM2OGU0MmZkMi8iLCIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2OTIt
+        ODhiYy0yMGNiMDgyMzA4OGEvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:41 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:31 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS8wZTU2MzNjYy01ZGQ5LTQ4ODUtYmJkNy1hMWMxNjdl
-        YmY3MzIvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2OTItODhiYy0yMGNiMDgy
+        MzA4OGEvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1226,7 +970,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:42 GMT
+      - Wed, 07 Oct 2020 15:11:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1240,17 +984,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1ZGJlZGE1LTI1OTgtNDU1
-        My05N2FhLTQyNmNkZjQ1NzY4Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyODEzY2VjLWE2NDktNGQ0
+        My04YjY2LWQ4NTk4YTNhMjNmMy8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:31 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/c5dbeda5-2598-4553-97aa-426cdf45768c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/32813cec-a649-4d43-8b66-d8598a3a23f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1258,7 +1002,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1271,7 +1015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:42 GMT
+      - Wed, 07 Oct 2020 15:11:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1283,39 +1027,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '372'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzVkYmVkYTUtMjU5
-        OC00NTUzLTk3YWEtNDI2Y2RmNDU3NjhjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDIuMDE5MzQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzI4MTNjZWMtYTY0
+        OS00ZDQzLThiNjYtZDg1OThhM2EyM2YzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzEuNjkxODAzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDIuMjE3MDU4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0Mi4zNjMzNTha
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzEuODM2OTcz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozMS45NDA0Nzha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMmJjMDg3
-        NDEtZTNhNS00YjBiLWIzZmUtMjY3ZDUyNjU4NTc3LyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNzgyZjQ0
+        NmMtZWJiNS00YTMzLTliYTItNTBiNTQ4MDY0MzczLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWExYzE2N2ViZjcz
-        Mi8iXX0=
+        ZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIwY2IwODIzMDg4
+        YS8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:32 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMmJjMDg3
-        NDEtZTNhNS00YjBiLWIzZmUtMjY3ZDUyNjU4NTc3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNzgyZjQ0
+        NmMtZWJiNS00YTMzLTliYTItNTBiNTQ4MDY0MzczLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1333,7 +1077,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:42 GMT
+      - Wed, 07 Oct 2020 15:11:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1347,17 +1091,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5NGEyZjUxLTQyNjItNDE3
-        NS1iYWY3LTNmYTkyZTU3ZDZhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzMDZhMzZiLTBjZGItNDgz
+        Ni1hYTQ2LTE3OGJhNWE2YjA3YS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:42 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:32 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/494a2f51-4262-4175-baf7-3fa92e57d6ad/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/8306a36b-0cdb-4836-aa46-178ba5a6b07a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1365,7 +1109,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1378,7 +1122,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:43 GMT
+      - Wed, 07 Oct 2020 15:11:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1390,36 +1134,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '315'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDk0YTJmNTEtNDI2
-        Mi00MTc1LWJhZjctM2ZhOTJlNTdkNmFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDIuNTQzMDg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODMwNmEzNmItMGNk
+        Yi00ODM2LWFhNDYtMTc4YmE1YTZiMDdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzIuMTQzNjczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDIuNzMyMzQ0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0My4xMzcwNzFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzIuMzEwNjI3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozMi41NTMxMDVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:32 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMmJjMDg3
-        NDEtZTNhNS00YjBiLWIzZmUtMjY3ZDUyNjU4NTc3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNzgyZjQ0
+        NmMtZWJiNS00YTMzLTliYTItNTBiNTQ4MDY0MzczLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1437,7 +1181,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:43 GMT
+      - Wed, 07 Oct 2020 15:11:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1451,17 +1195,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1YmRlYTg3LWU2ZmQtNDVk
-        Zi1hNjE4LTAxZjZkMTMyODgzMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0ZDE4ZmY1LWVjY2QtNDdh
+        Zi1hNGI0LThiY2VhZWZmNDFjOC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:32 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1484,7 +1228,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:43 GMT
+      - Wed, 07 Oct 2020 15:11:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1498,17 +1242,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiZWY0ZDdjLTQxNDctNDcy
-        Yy05ZDIxLWViZWY0NzY2MTA4OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjNjM4NTJmLTRhNWMtNDE5
+        Yy05MjdjLWZiNzM2Nzk0ODgwOC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:43 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:33 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/f500c346-1b00-4d6e-bb00-3c03518175ab/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/0bd11d3a-9ecc-42dd-978e-1c6c68e42fd2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1534,7 +1278,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:44 GMT
+      - Wed, 07 Oct 2020 15:11:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1548,24 +1292,24 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViMjE1NWU1LTFlZTYtNDJj
-        ZC1hMzc2LWU0ZTc0ZDJmYWNlZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmYzlhZDIzLTlmNjAtNDg2
+        MC05ZmVhLWRmZTI1MDZkMTMzZi8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:44 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:33 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMmJjMDg3
-        NDEtZTNhNS00YjBiLWIzZmUtMjY3ZDUyNjU4NTc3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNzgyZjQ0
+        NmMtZWJiNS00YTMzLTliYTItNTBiNTQ4MDY0MzczLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1583,7 +1327,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:44 GMT
+      - Wed, 07 Oct 2020 15:11:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1597,17 +1341,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyMGM2ZGFhLThmOGItNDc0
-        ZS1hNzViLTQ4MGU2OTZiY2M4Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MWU2NWQ3LWM0ZGYtNDQ0
+        Ny05MzZiLTY5OTM0MmZmOTcwMC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:44 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:33 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/720c6daa-8f8b-474e-a75b-480e696bcc8f/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/251e65d7-c4df-4447-936b-699342ff9700/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1615,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1628,7 +1372,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:45 GMT
+      - Wed, 07 Oct 2020 15:11:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1640,36 +1384,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '316'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzIwYzZkYWEtOGY4
-        Yi00NzRlLWE3NWItNDgwZTY5NmJjYzhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDQuMjE4MjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjUxZTY1ZDctYzRk
+        Zi00NDQ3LTkzNmItNjk5MzQyZmY5NzAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzMuMjIxNDA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDQuOTQ2OTI1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0NS4zNjMwMTJa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzMuODgwMTYx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozNC4xNTUxMzda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:34 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMmJjMDg3
-        NDEtZTNhNS00YjBiLWIzZmUtMjY3ZDUyNjU4NTc3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNzgyZjQ0
+        NmMtZWJiNS00YTMzLTliYTItNTBiNTQ4MDY0MzczLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1687,7 +1431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:45 GMT
+      - Wed, 07 Oct 2020 15:11:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1701,22 +1445,22 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzNDMyZTBjLWRiMDgtNGI1
-        MC1iYmI0LThlY2QzMDA1NzkxOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1ZTlmZjE3LTQ1MTgtNDc2
+        Ni05M2E0LWU3ZTZiMmY5YWY0MS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:45 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:34 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZjUw
-        MGMzNDYtMWIwMC00ZDZlLWJiMDAtM2MwMzUxODE3NWFiLyIsIm1pcnJvciI6
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMGJk
+        MTFkM2EtOWVjYy00MmRkLTk3OGUtMWM2YzY4ZTQyZmQyLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1735,7 +1479,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:46 GMT
+      - Wed, 07 Oct 2020 15:11:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1749,17 +1493,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjMjljNjQ3LWM1ZjEtNDIx
-        OS1iNWRjLTNiZWRkYjU2YTFhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwMGFmNzI0LWY4YTUtNGU4
+        My04ZmU4LWRhNjg4NjdkN2YzMC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:46 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:34 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/2c29c647-c5f1-4219-b5dc-3beddb56a1ad/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/f00af724-f8a5-4e83-8fe8-da68867d7f30/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1767,7 +1511,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1780,7 +1524,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:47 GMT
+      - Wed, 07 Oct 2020 15:11:35 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1792,53 +1536,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '531'
+      - '534'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmMyOWM2NDctYzVm
-        MS00MjE5LWI1ZGMtM2JlZGRiNTZhMWFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDUuOTYzMTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjAwYWY3MjQtZjhh
+        NS00ZTgzLThmZTgtZGE2ODg2N2Q3ZjMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzQuNjEzMzE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
-        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA4LTIwVDE5OjE2OjQ2
-        LjI4NjYzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDYu
-        OTYzMTEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
-        d29ya2Vycy8xMjQzMTk2OC1jYTUzLTQyZmYtYTljMy00MGQ2YWIxM2Y1NmMv
+        eW5jaHJvbml6ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTEwLTA3VDE1OjExOjM0
+        Ljg1NTMxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzUu
+        NzkyODk1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy9mMzc4OWU1MS01ZjQ2LTRlMzEtYmMyMy04ODE5ZWExYzAyMDcv
         IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
         cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkRv
         d25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6ImRvd25sb2FkaW5nLm1ldGFk
         YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
-        dGFkYXRhIExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRh
+        IExpbmVzIiwiY29kZSI6InBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJkb3du
+        bG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFz
+        c29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVu
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51
         bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFj
-        MTY3ZWJmNzMyL3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        MGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFjMTY3ZWJmNzMyLyIsIi9wdWxw
-        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9mNTAwYzM0Ni0xYjAwLTRkNmUt
-        YmIwMC0zYzAzNTE4MTc1YWIvIl19
+        aXRvcmllcy9maWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4YmMtMjBj
+        YjA4MjMwODhhL3ZlcnNpb25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzBiZDEx
+        ZDNhLTllY2MtNDJkZC05NzhlLTFjNmM2OGU0MmZkMi8iLCIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2OTIt
+        ODhiYy0yMGNiMDgyMzA4OGEvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:35 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/file/file/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/publications/file/file/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS8wZTU2MzNjYy01ZGQ5LTQ4ODUtYmJkNy1hMWMxNjdl
-        YmY3MzIvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2OTItODhiYy0yMGNiMDgy
+        MzA4OGEvdmVyc2lvbnMvMi8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -1857,7 +1601,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:47 GMT
+      - Wed, 07 Oct 2020 15:11:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1871,17 +1615,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0YmNlNTA5LWRkNDMtNGIy
-        Zi1hZDhmLTc1ZWY3NTFmOTE3ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliMTEwODYwLTBmOTAtNDdk
+        Yy04OGVmLTcwODE0NjAwNjE4Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b4bce509-dd43-4b2f-ad8f-75ef751f917e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/9b110860-0f90-47dc-88ef-708146006186/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1889,7 +1633,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1902,7 +1646,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:47 GMT
+      - Wed, 07 Oct 2020 15:11:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1914,39 +1658,39 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '371'
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjRiY2U1MDktZGQ0
-        My00YjJmLWFkOGYtNzVlZjc1MWY5MTdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDcuMjA5NDQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWIxMTA4NjAtMGY5
+        MC00N2RjLTg4ZWYtNzA4MTQ2MDA2MTg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzUuOTk2MzgxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDcuMzg3ODQ0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0Ny40OTk5NjZa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzYuMTg5OTY5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozNi4yOTk2ODla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        LzA5NTM5Nzc0LWFmYTQtNDJiNy1hYjExLTY1ZGNjNzQ2MjE0NS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOTZkMzk5
-        YzYtZDBhZC00OTBmLThjYzItMGE0YzUwYjBmNmQzLyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZmJmNWE0
+        N2QtNjg2MS00ZjZmLWE4MTktNDIyYzFmNjBkODViLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWExYzE2N2ViZjcz
-        Mi8iXX0=
+        ZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIwY2IwODIzMDg4
+        YS8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:36 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOTZkMzk5
-        YzYtZDBhZC00OTBmLThjYzItMGE0YzUwYjBmNmQzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZmJmNWE0
+        N2QtNjg2MS00ZjZmLWE4MTktNDIyYzFmNjBkODViLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1964,7 +1708,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:47 GMT
+      - Wed, 07 Oct 2020 15:11:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1978,17 +1722,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1NDJlNzdhLTA4YzAtNGI3
-        Yy04OTI3LTczNjAyM2IzMGNmNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5MGRjMjY2LTZiNTgtNGVh
+        ZC1iMGE1LTY3NjE2OTU1MzA4NS8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:47 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/d542e77a-08c0-4b7c-8927-736023b30cf5/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/690dc266-6b58-4ead-b0a5-676169553085/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1996,7 +1740,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2009,7 +1753,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:48 GMT
+      - Wed, 07 Oct 2020 15:11:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2021,36 +1765,36 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
       - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDU0MmU3N2EtMDhj
-        MC00YjdjLTg5MjctNzM2MDIzYjMwY2Y1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDcuNzI1MTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjkwZGMyNjYtNmI1
+        OC00ZWFkLWIwYTUtNjc2MTY5NTUzMDg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzYuNDM1MzE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDcuOTQ4MTA2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0OC4yOTAyNzVa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzYuNTkzNTg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozNi44MjQ4ODBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:48 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:36 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvOTZkMzk5
-        YzYtZDBhZC00OTBmLThjYzItMGE0YzUwYjBmNmQzLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZmJmNWE0
+        N2QtNjg2MS00ZjZmLWE4MTktNDIyYzFmNjBkODViLyJ9
     headers:
       Content-Type:
       - application/json
@@ -2068,7 +1812,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:48 GMT
+      - Wed, 07 Oct 2020 15:11:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2082,17 +1826,17 @@ http_interactions:
       Content-Length:
       - '67'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFkMzMyZWY4LWVkZDQtNDdl
-        Yy1iMzIxLWU1NjdkNDdhYmM1Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0YmU3ZWZlLTliMGMtNDY5
+        MS1iODg3LWIzYTM0ZmJkYjVmZC8ifQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:48 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2100,7 +1844,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
+      - OpenAPI-Generator/0.3.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2113,426 +1857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:48 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '347'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWExYzE2N2ViZjcz
-        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjM5LjIwNTQ1
-        MVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFjMTY3ZWJm
-        NzMyL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wZTU2MzNjYy01ZGQ5LTQ4
-        ODUtYmJkNy1hMWMxNjdlYmY3MzIvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
-        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
-        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVmZmE1OTM3LWI4
-        ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVlOC8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIwLTA4LTIwVDE5OjA3OjU3LjkwNzA3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNWZmYTU5Mzct
-        YjhlNS00MGEyLWI5MzctYmY0MWE2M2Y0NWU4L3ZlcnNpb25zLyIsImxhdGVz
-        dF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
-        bGUvZmlsZS81ZmZhNTkzNy1iOGU1LTQwYTItYjkzNy1iZjQxYTYzZjQ1ZTgv
-        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUHVibGlzaGVkIExpYnJhcnkgYW5kIGRl
-        diB2aWV3LTcwMDk3MzQ1My05MDkwNTgzNDciLCJkZXNjcmlwdGlvbiI6IlB1
-        Ymxpc2hlZCBMaWJyYXJ5IGFuZCBkZXYgdmlldy03MDA5NzM0NTMtOTA5MDU4
-        MzQ3IiwicmVtb3RlIjpudWxsfV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:48 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:48 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '323'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWExYzE2N2ViZjcz
-        Mi92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MTY6NDYuMzU1MTI3WiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
-        dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1iYmQ3LWEx
-        YzE2N2ViZjczMi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
-        bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
-        aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wZTU2MzNjYy01ZGQ5LTQ4
-        ODUtYmJkNy1hMWMxNjdlYmY3MzIvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
-        OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzBlNTYzM2NjLTVkZDkt
-        NDg4NS1iYmQ3LWExYzE2N2ViZjczMi92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        MGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFjMTY3ZWJmNzMyL3ZlcnNpb25z
-        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjo0MS4zMzA0
-        NTRaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
-        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
-        aWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJiZDctYTFjMTY3ZWJmNzMy
-        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
-        LmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMGU1NjMzY2MtNWRkOS00ODg1LWJi
-        ZDctYTFjMTY3ZWJmNzMyL3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wZTU2MzNj
-        Yy01ZGQ5LTQ4ODUtYmJkNy1hMWMxNjdlYmY3MzIvdmVyc2lvbnMvMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjM5LjIxMjM1NloiLCJu
-        dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:48 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/5ffa5937-b8e5-40a2-b937-bf41a63f45e8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:48 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '222'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzVmZmE1OTM3LWI4ZTUtNDBhMi1iOTM3LWJmNDFhNjNmNDVl
-        OC92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjBUMTk6
-        MDc6NTcuOTEyMjUwWiIsIm51bWJlciI6MCwiYmFzZV92ZXJzaW9uIjpudWxs
-        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwi
-        cHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:48 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '367'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOToxNjoxNC4yNjg4Mzla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3
-        Ni1lZDY3YjdmZmJmNTcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRlc2Ny
-        aXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdf
-        c2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9LHsi
-        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2OjEzLjA5MzA2OFoiLCJ2ZXJz
-        aW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4ZWQ1OTgwMS92ZXJzaW9u
-        cy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzE4ZWY1NTg3LTllZWEtNDMwYS1hOGIxLWJlMGE4
-        ZWQ1OTgwMS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZW1vdGUiOm51bGwsIm1ldGFkYXRhX3NpZ25p
-        bmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
-        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4OjE1LjgwMzQ2OVoiLCJ2
-        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgwYmRmYThhZTcwMC92ZXJz
-        aW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzExNmM2YWJiLTdiMDEtNDIwYy05M2EzLTgw
-        YmRmYThhZTcwMC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ6b28tMTUxNjgiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsLCJtZXRhZGF0YV9zaWdu
-        aW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjow
-        fV19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/37a0b7de-09d0-4603-af76-ed67b7ffbf57/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zN2EwYjdkZS0wOWQwLTQ2MDMtYWY3Ni1lZDY3YjdmZmJmNTcv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjE0LjI3NDAxMloiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/18ef5587-9eea-430a-a8b1-be0a8ed59801/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '223'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xOGVmNTU4Ny05ZWVhLTQzMGEtYThiMS1iZTBhOGVkNTk4MDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE5OjE2
-        OjEzLjEwMTA4M1oiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/116c6abb-7b01-420c-93a3-80bdfa8ae700/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '224'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMTZjNmFiYi03YjAxLTQyMGMtOTNhMy04MGJkZmE4YWU3MDAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTIwVDE1OjE4
-        OjE1LjgxMTM2NVoiLCJudW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwi
-        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInBy
-        ZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.3.0.dev01597697504/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
+      - Wed, 07 Oct 2020 15:11:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2546,17 +1871,17 @@ http_interactions:
       Content-Length:
       - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2564,7 +1889,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/2.0.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2577,7 +1902,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
+      - Wed, 07 Oct 2020 15:11:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2589,29 +1959,28 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '251'
+      - '246'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0yMFQxOTow
-        ODoyNi4yMjQ4NjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkx
-        LTQxOWEtYjc4Ni0zZTY1OGFkYmE5Y2MvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
-        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY29udGFp
-        bmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0zZTY1OGFk
-        YmE5Y2MvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
-        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZW1vdGUiOm51bGx9XX0=
+        ZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIwY2IwODIzMDg4
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjI5LjEzNjAy
+        M1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4YmMtMjBjYjA4MjMw
+        ODhhL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2
+        OTItODhiYy0yMGNiMDgyMzA4OGEvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
+        cmlwdGlvbiI6bnVsbCwicmVtb3RlIjpudWxsfV19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/d9c3bae4-8091-419a-b786-3e658adba9cc/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2619,7 +1988,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0/ruby
+      - OpenAPI-Generator/1.2.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2632,7 +2001,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
+      - Wed, 07 Oct 2020 15:11:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2644,69 +2013,53 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '227'
+      - '322'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9kOWMzYmFlNC04MDkxLTQxOWEtYjc4Ni0z
-        ZTY1OGFkYmE5Y2MvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIw
-        LTA4LTIwVDE5OjA4OjI2LjIyOTU3N1oiLCJudW1iZXIiOjAsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
-        b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        ZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIwY2IwODIzMDg4
+        YS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjAtMTAtMDdUMTU6
+        MTE6MzQuOTE2NTczWiIsIm51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxs
+        LCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNv
+        dW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxl
+        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04OGJjLTIw
+        Y2IwODIzMDg4YS92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6eyJmaWxlLmZp
+        bGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0vcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mMzk0ZDVjOS04ZGEzLTQ2
+        OTItODhiYy0yMGNiMDgyMzA4OGEvdmVyc2lvbnMvMi8ifX0sInByZXNlbnQi
+        OnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2YzOTRkNWM5LThkYTMt
+        NDY5Mi04OGJjLTIwY2IwODIzMDg4YS92ZXJzaW9ucy8yLyJ9fX19LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        ZjM5NGQ1YzktOGRhMy00NjkyLTg4YmMtMjBjYjA4MjMwODhhL3ZlcnNpb25z
+        LzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMC0xMC0wN1QxNToxMTozMC44NTI2
+        OTZaIiwibnVtYmVyIjoxLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4YmMtMjBjYjA4MjMwODhh
+        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
+        LmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvZjM5NGQ1YzktOGRhMy00NjkyLTg4
+        YmMtMjBjYjA4MjMwODhhL3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9mMzk0ZDVj
+        OS04ZGEzLTQ2OTItODhiYy0yMGNiMDgyMzA4OGEvdmVyc2lvbnMvMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTEwLTA3VDE1OjExOjI5LjE0MTQzNFoiLCJu
+        dW1iZXIiOjAsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
+        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/f500c346-1b00-4d6e-bb00-3c03518175ab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5MDkwODRhLWZkZjEtNDJj
-        OS04ZWIxLWYzM2JlOWI5NzNkMS8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f909084a-fdf1-42c9-8eb1-f33be9b973d1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2714,7 +2067,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2727,63 +2080,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:49 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '337'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjkwOTA4NGEtZmRm
-        MS00MmM5LThlYjEtZjMzYmU5Yjk3M2QxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NDkuNjMxMzYyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NDkuODE2MTA1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo0OS44ODc1NTZa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEwZTNlNjJmLWM5NzYtNGM3YS1iMTM1LTM4MTY0ODk0NDgwNS8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS9mNTAwYzM0Ni0xYjAwLTRkNmUtYmIwMC0z
-        YzAzNTE4MTc1YWIvIl19
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:49 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/db5e183e-271c-43bc-8b79-47b5025d548c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:50 GMT
+      - Wed, 07 Oct 2020 15:11:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2791,68 +2088,23 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5ZmMyMTMwLTRlNmItNDM3
-        MS1iYzc3LWRlMzhkMGY1ZDY1ZS8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:50 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/0e5633cc-5dd9-4885-bbd7-a1c167ebf732/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 20 Aug 2020 19:16:50 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxODY0YTBlLWQzOTItNDc5
-        ZC1hN2JlLTQ1ZDRkZTgzYWMxYy8ifQ==
-    http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/21864a0e-d392-479d-a7be-45d4de83ac1c/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2860,7 +2112,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/2.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2873,7 +2125,97 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 20 Aug 2020 19:16:50 GMT
+      - Wed, 07 Oct 2020 15:11:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/remotes/file/file/0bd11d3a-9ecc-42dd-978e-1c6c68e42fd2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzNjgyYzIyLTE4ZWMtNDRl
+        MS1hMmJmLTZlZjA0NjVlNWU0My8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/e3682c22-18ec-44e1-a2bf-6ef0465e5e43/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2885,25 +2227,171 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjE4NjRhMGUtZDM5
-        Mi00NzlkLWE3YmUtNDVkNGRlODNhYzFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjBUMTk6MTY6NTAuMTI1MTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTM2ODJjMjItMThl
+        Yy00NGUxLWEyYmYtNmVmMDQ2NWU1ZTQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzcuNTkxMDcxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjBUMTk6MTY6NTAuNDYxMDI3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yMFQxOToxNjo1MC42OTI1NDFa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzcuNzM5OTQ1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozNy43OTM4NDRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzEyNDMxOTY4LWNhNTMtNDJmZi1hOWMzLTQwZDZhYjEzZjU2Yy8iLCJwYXJl
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzBlNTYzM2NjLTVkZDktNDg4NS1i
-        YmQ3LWExYzE2N2ViZjczMi8iXX0=
+        My9yZW1vdGVzL2ZpbGUvZmlsZS8wYmQxMWQzYS05ZWNjLTQyZGQtOTc4ZS0x
+        YzZjNjhlNDJmZDIvIl19
     http_version: 
-  recorded_at: Thu, 20 Aug 2020 19:16:50 GMT
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/distributions/file/file/ef8654df-7506-4580-9969-f3141b4e88ce/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExOTYwYmU2LWQ2MWItNDRl
+        MC1iZTM1LTgyNzBkODBmNDlhYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:37 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/repositories/file/file/f394d5c9-8da3-4692-88bc-20cb0823088a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5MzcyZTYwLTEwOGQtNDc2
+        My1iNjA2LWRjZWQ3Yzk4ZTBhMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v3/tasks/39372e60-108d-4763-b606-dced7c98e0a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 15:11:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.example.com
+      Content-Length:
+      - '339'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkzNzJlNjAtMTA4
+        ZC00NzYzLWI2MDYtZGNlZDdjOThlMGExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMTAtMDdUMTU6MTE6MzguMDEyMTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMTAtMDdUMTU6MTE6MzguMjczODkw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0xMC0wN1QxNToxMTozOC40MjQwMjVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2YzNzg5ZTUxLTVmNDYtNGUzMS1iYzIzLTg4MTllYTFjMDIwNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2YzOTRkNWM5LThkYTMtNDY5Mi04
+        OGJjLTIwY2IwODIzMDg4YS8iXX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 15:11:38 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,10 +44,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -55,7 +55,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -66,7 +66,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,10 +89,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -100,7 +100,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,10 +134,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -145,7 +145,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -156,7 +156,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,10 +179,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -190,7 +190,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -201,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -224,10 +224,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -235,7 +235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -246,7 +246,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,10 +269,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -291,7 +291,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -314,10 +314,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -325,7 +325,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -336,7 +336,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:08 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -359,10 +359,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:08 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -381,7 +381,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -403,10 +403,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -414,7 +414,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -425,7 +425,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -447,10 +447,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -458,7 +458,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -469,7 +469,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -493,10 +493,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -515,7 +515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -539,10 +539,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +550,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -561,7 +561,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -583,10 +583,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +594,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -605,7 +605,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -627,10 +627,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -649,7 +649,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -672,10 +672,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +683,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -694,7 +694,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:09 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -717,10 +717,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:09 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -728,7 +728,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -739,7 +739,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -761,10 +761,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -772,7 +772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -783,7 +783,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -805,10 +805,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -816,7 +816,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -827,7 +827,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -849,10 +849,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -860,7 +860,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -871,7 +871,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -893,10 +893,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -904,7 +904,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -915,7 +915,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -937,10 +937,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -948,7 +948,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -959,7 +959,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -981,10 +981,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -992,7 +992,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1003,7 +1003,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1026,10 +1026,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1048,7 +1048,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1071,10 +1071,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1093,7 +1093,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:10 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1118,10 +1118,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:10 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1129,7 +1129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1140,7 +1140,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1165,10 +1165,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1187,7 +1187,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1213,10 +1213,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1235,7 +1235,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1261,10 +1261,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1272,7 +1272,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1283,7 +1283,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1309,10 +1309,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1320,7 +1320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1331,7 +1331,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1357,10 +1357,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1368,7 +1368,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1379,7 +1379,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1401,10 +1401,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1412,7 +1412,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1423,7 +1423,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -1445,10 +1445,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1456,7 +1456,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1493,10 +1493,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1515,7 +1515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:11 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1541,10 +1541,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:11 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1552,7 +1552,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1563,7 +1563,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:12 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1589,10 +1589,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1600,7 +1600,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1611,7 +1611,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:12 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1637,10 +1637,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1648,7 +1648,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1659,7 +1659,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:12 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1685,10 +1685,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1696,7 +1696,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1707,7 +1707,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:12 GMT
+      - Wed, 07 Oct 2020 17:48:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -1733,10 +1733,106 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:12 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:46 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '569'
+      Etag:
+      - '"8e505e45d07d7353d9dcdadab7199016"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNf
+        RGViXzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RlYl8xLz9kZXRh
+        aWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29k
+        ZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3Np
+        dG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Rl
+        Yl8xIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
+        cmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X0RlYl8xIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJhY2siOiBudWxs
+        LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:46 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '569'
+      Etag:
+      - '"8e505e45d07d7353d9dcdadab7199016"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNf
+        RGViXzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RlYl8xLz9kZXRh
+        aWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29k
+        ZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3Np
+        dG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Rl
+        Yl8xIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
+        cmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X0RlYl8xIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJhY2siOiBudWxs
+        LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1747,10 +1843,10 @@ http_interactions:
         L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
         X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
         X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwicHJveHlfcG9ydCI6ODAsInBy
-        b3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVsbCwic3Ns
-        X2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3Ns
-        X2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
+        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwic3NsX2NsaWVudF9jZXJ0Ijpu
+        dWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGws
+        InByb3h5X3BvcnQiOjgwLCJwcm94eV91c2VybmFtZSI6bnVsbCwicHJveHlf
+        cGFzc3dvcmQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
         cG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
         eXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0
         aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdf
@@ -1770,7 +1866,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1783,7 +1879,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:13 GMT
+      - Wed, 07 Oct 2020 17:48:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -1800,14 +1896,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgwZjliMDJlNTMwNzU0YzkxOWI2In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmN2YwMjIzOWY3NDFlODgzZDQ0In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:13 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1815,7 +1911,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1826,15 +1922,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:13 GMT
+      - Wed, 07 Oct 2020 17:48:47 GMT
       Server:
       - Apache
       Etag:
-      - '"0c3d75f7b1ab9788591e15dd2c271d09-gzip"'
+      - '"dc7dce7962aaa07435b125ae10619a7d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '639'
+      - '638'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1843,61 +1939,61 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDowNToxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMC0wN1QxNzo0ODo0N1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgwZjliMDJlNTMwNzU0YzkxOWJhIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmN2YwMjIzOWY3NDFlODgzZDQ4In0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MDU6MTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDg6NDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MGY5YjAyZTUzMDc1NGM5MTliOSJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4M2Q0NyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjEzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MGY5YjAyZTUzMDc1NGM5
-        MTliOCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4
+        M2Q0NiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjEzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODBm
-        OWIwMmU1MzA3NTRjOTE5YjcifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY3
+        ZjAyMjM5Zjc0MWU4ODNkNDUifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
         Oi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b28i
         LCAicHJveHlfcG9ydCI6IDgwLCAiZG93bmxvYWRfcG9saWN5IjogImltbWVk
         aWF0ZSIsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJwcm94eV9ob3N0Ijog
         Imh0dHA6Ly91cmxfMSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWV9LCAiaWQi
         OiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAw
-        LCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MGY5YjAyZTUzMDc1NGM5MTliNiJ9
+        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4M2Q0NCJ9
         LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFf
         MTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRv
         cmFfMTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:13 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1905,7 +2001,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1916,7 +2012,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:13 GMT
+      - Wed, 07 Oct 2020 17:48:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -1927,14 +2023,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E2MTE4ZmI0LTQ1N2UtNDE1NC1iZmFlLWE4MTFkNjQxZTkyZi8iLCAi
-        dGFza19pZCI6ICJhNjExOGZiNC00NTdlLTQxNTQtYmZhZS1hODExZDY0MWU5
-        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRmMGMxYzFjLWJmMmMtNGNiYy1hZTMyLWVjY2I1YjgzZjM0YS8iLCAi
+        dGFza19pZCI6ICI0ZjBjMWMxYy1iZjJjLTRjYmMtYWUzMi1lY2NiNWI4M2Yz
+        NGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:14 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/a6118fb4-457e-4154-bfae-a811d641e92f/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f0c1c1c-bf2c-4cbc-ae32-eccb5b83f34a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1942,7 +2038,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1953,15 +2049,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:14 GMT
+      - Wed, 07 Oct 2020 17:48:47 GMT
       Server:
       - Apache
       Etag:
-      - '"b85576129866839ea0c4d4d60e730c03-gzip"'
+      - '"8c74689e73d73bcc68b1c9fc52c79c98-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '358'
+      - '362'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1969,20 +2065,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNjExOGZiNC00NTdlLTQxNTQtYmZhZS1hODExZDY0MWU5
-        MmYvIiwgInRhc2tfaWQiOiAiYTYxMThmYjQtNDU3ZS00MTU0LWJmYWUtYTgx
-        MWQ2NDFlOTJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80ZjBjMWMxYy1iZjJjLTRjYmMtYWUzMi1lY2NiNWI4M2Yz
+        NGEvIiwgInRhc2tfaWQiOiAiNGYwYzFjMWMtYmYyYy00Y2JjLWFlMzItZWNj
+        YjViODNmMzRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjA1OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjE0WiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ4OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgw
-        ZmFmZGJjY2E5ZjM4OTU3YTkwIn0sICJpZCI6ICI1ZWFjODBmYWZkYmNjYTlm
-        Mzg5NTdhOTAifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjdmMTI5NzNmOGNkZTJhNTczZCJ9LCAiaWQiOiAi
+        NWY3ZGZmN2YxMjk3M2Y4Y2RlMmE1NzNkIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:14 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,10 +44,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -55,7 +55,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -66,7 +66,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,10 +89,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -100,7 +100,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,10 +134,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -145,7 +145,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -156,7 +156,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,10 +179,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -190,7 +190,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -201,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -224,10 +224,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -235,7 +235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -246,7 +246,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,10 +269,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -291,7 +291,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:16 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -314,10 +314,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:16 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -325,7 +325,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -336,7 +336,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -359,10 +359,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -381,7 +381,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -403,10 +403,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -414,7 +414,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -425,7 +425,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -447,10 +447,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -458,7 +458,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -469,7 +469,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -493,10 +493,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -515,7 +515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -539,10 +539,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +550,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -561,7 +561,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -583,10 +583,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +594,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -605,7 +605,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -627,10 +627,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -649,7 +649,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -672,10 +672,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +683,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -694,7 +694,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:17 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -717,10 +717,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:17 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -728,7 +728,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -739,7 +739,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -761,10 +761,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -772,7 +772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -783,7 +783,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -805,10 +805,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -816,7 +816,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -827,7 +827,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -849,10 +849,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -860,7 +860,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -871,7 +871,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -893,10 +893,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -904,7 +904,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -915,7 +915,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -937,10 +937,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -948,7 +948,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -959,7 +959,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -981,10 +981,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -992,7 +992,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1003,7 +1003,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1026,10 +1026,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:18 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1048,7 +1048,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:18 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1071,10 +1071,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1093,7 +1093,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1118,10 +1118,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1129,7 +1129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1140,7 +1140,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1165,10 +1165,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1187,7 +1187,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1213,10 +1213,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1235,7 +1235,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1261,10 +1261,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1272,7 +1272,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1283,7 +1283,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1309,10 +1309,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1320,7 +1320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1331,7 +1331,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1357,10 +1357,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1368,7 +1368,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1379,7 +1379,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1401,10 +1401,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:19 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1412,7 +1412,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1423,7 +1423,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:19 GMT
+      - Wed, 07 Oct 2020 17:48:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -1445,10 +1445,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1456,7 +1456,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1493,10 +1493,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1515,7 +1515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1541,10 +1541,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1552,7 +1552,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1563,7 +1563,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1589,10 +1589,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1600,7 +1600,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1611,7 +1611,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1637,10 +1637,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1648,7 +1648,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1659,7 +1659,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1685,10 +1685,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1696,7 +1696,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1707,7 +1707,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:20 GMT
+      - Wed, 07 Oct 2020 17:48:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -1733,10 +1733,106 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:52 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '569'
+      Etag:
+      - '"8e505e45d07d7353d9dcdadab7199016"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNf
+        RGViXzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RlYl8xLz9kZXRh
+        aWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29k
+        ZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3Np
+        dG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Rl
+        Yl8xIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
+        cmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X0RlYl8xIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJhY2siOiBudWxs
+        LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:48:52 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '569'
+      Etag:
+      - '"8e505e45d07d7353d9dcdadab7199016"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNf
+        RGViXzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RlYl8xLz9kZXRh
+        aWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29k
+        ZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3Np
+        dG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Rl
+        Yl8xIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
+        cmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X0RlYl8xIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJhY2siOiBudWxs
+        LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1747,10 +1843,10 @@ http_interactions:
         L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
         X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
         X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwicHJveHlfcG9ydCI6ODAsInBy
-        b3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVsbCwic3Ns
-        X2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3Ns
-        X2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
+        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwic3NsX2NsaWVudF9jZXJ0Ijpu
+        dWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGws
+        InByb3h5X3BvcnQiOjgwLCJwcm94eV91c2VybmFtZSI6bnVsbCwicHJveHlf
+        cGFzc3dvcmQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
         cG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
         eXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0
         aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdf
@@ -1770,7 +1866,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1783,7 +1879,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:21 GMT
+      - Wed, 07 Oct 2020 17:48:53 GMT
       Server:
       - Apache
       Content-Length:
@@ -1800,14 +1896,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFiMDJlNTMwNzU0YzkxOWJiIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmODUwMjIzOWY3MzY0MTMxYjBlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:53 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1817,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1830,7 +1926,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:21 GMT
+      - Wed, 07 Oct 2020 17:48:53 GMT
       Server:
       - Apache
       Content-Length:
@@ -1841,14 +1937,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FlOWJiYWY1LTM3NjMtNDY0Yi1iNjcxLTU2ZDMzZTExN2I3YS8iLCAi
-        dGFza19pZCI6ICJhZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzk3OTM3Zjc2LTRhYzItNGMxYi1iOTIwLWYwM2JiZmNmOTNiZC8iLCAi
+        dGFza19pZCI6ICI5NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1856,7 +1952,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1867,15 +1963,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1883,16 +1979,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1904,42 +2000,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1947,7 +2043,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1958,15 +2054,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1974,16 +2070,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1995,42 +2091,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2038,7 +2134,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2049,15 +2145,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2065,16 +2161,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2086,42 +2182,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2129,7 +2225,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2140,15 +2236,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2156,16 +2252,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2177,42 +2273,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2220,7 +2316,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2231,15 +2327,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2247,16 +2343,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2268,42 +2364,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2311,7 +2407,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2322,15 +2418,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2338,16 +2434,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2359,42 +2455,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2402,7 +2498,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2413,15 +2509,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2429,16 +2525,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
+        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
+        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
+        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
+        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2450,42 +2546,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
+        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/70023aa1-971d-45e2-8fe2-c7e0a192e0f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2493,7 +2589,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2504,288 +2600,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
+      - '"8b4bf2767f520ef7aa25604661e2142a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:05:22 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '715'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ae9bbaf5-3763-464b-b671-56d33e117b7a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:05:22 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b56352ae403072cef78e56ee5cc77278-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '715'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTliYmFmNS0zNzYzLTQ2NGItYjY3MS01NmQzM2UxMTdi
-        N2EvIiwgInRhc2tfaWQiOiAiYWU5YmJhZjUtMzc2My00NjRiLWI2NzEtNTZk
-        MzNlMTE3YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJmOTgzZmQtMzkxYS00Zjk5LTk2NDctYzM4NjA2ZGI4
-        OTUwLyIsICJ0YXNrX2lkIjogImYyZjk4M2ZkLTM5MWEtNGY5OS05NjQ3LWMz
-        ODYwNmRiODk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MTAyYjAyZTUzNDNkMGUxMjNlYiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMDFmZGJjY2E5ZjM4OTU3YmNjIn0sICJpZCI6ICI1ZWFjODEwMWZk
-        YmNjYTlmMzg5NTdiY2MifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f2f983fd-391a-4f99-9647-c38606db8950/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:05:22 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"a4c5bcf0b76ef85d1923141ee414b476-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1350'
+      - '1360'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2793,199 +2616,199 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mMmY5ODNmZC0zOTFhLTRmOTktOTY0Ny1jMzg2
-        MDZkYjg5NTAvIiwgInRhc2tfaWQiOiAiZjJmOTgzZmQtMzkxYS00Zjk5LTk2
-        NDctYzM4NjA2ZGI4OTUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83MDAyM2FhMS05NzFkLTQ1ZTItOGZlMi1jN2Uw
+        YTE5MmUwZjgvIiwgInRhc2tfaWQiOiAiNzAwMjNhYTEtOTcxZC00NWUyLThm
+        ZTItYzdlMGExOTJlMGY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDowNToyMloiLCAi
+        bWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1NFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhZjFhNjFhZC00M2U5LTRkMzUtOTE2Yi0zYjc4MjZi
-        YzQyMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI1NThhMmZiNy1iNjI3LTQyZGQtOGYyZC0yYzM0ZWJj
+        NjRlOWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMzk0ZmExNTYtMWIyYy00ZGU4LTg3ZWYtNTc5MzY5Yjc3NTk1Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
+        aWQiOiAiZGZhZTMwOWQtYzI3Yi00Y2EwLWFhMzctNmVmYjM4MDg0OTBjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
-        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YmZmZmMyZS00MWFkLTQwMDktOWYx
-        OS0wMTRjNjkzYzVjNjkiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWNhOWZjMy04NmI4LTQ5MzMtOWVi
+        Mi1jOWRkYzIzZTZhZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZTUwZDJlYzMtNDg1MS00MGIxLWJjN2EtNWZiOWMyZThlY2QwIiwgIm51bV9w
+        MjcxOTFhOGYtN2MwNy00YTU2LWJhYjAtYWQ2MDdkNDEwZTc3IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjdmNGM2NjhkLThkOGYtNDg1MS1hNDUzLWUx
-        ODBiYzczYmQ4OSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImVjNTAwMzczLWEwMGItNDRkMC1iMGFmLTYz
+        Yjg5MzMxYTU3YyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3NmY3
-        YzE1LTQwOWYtNDFlMS1hZTMzLTM4NmYyMjJhMWJjNiIsICJudW1fcHJvY2Vz
-        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAwYjg1
+        Yzk4LTE3MDctNGRlOS05Mzc5LWNhNzU5ZGZhZWY1YSIsICJudW1fcHJvY2Vz
+        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
-        ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1ZjQ5NmM4NS03ZDA3LTQ2ZGUtOTViZC02YzJj
-        ODkxZTA1NjEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
-        IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
-        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
+        OiAwLCAic3RlcF9pZCI6ICJhYzhhZmE4YS1jYTNhLTQ0ZGUtYmE1Yi03OTBi
+        Y2NmNTk3ODQiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
+        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMWFk
-        MWEyMS1mN2ZhLTQ4MDEtYTUyMC1hZjdhMzM1MWIwMjEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NjA1
+        M2Y3ZC01Yjc5LTQ1OTQtODdhZi00NzY1NzhiMmI0MTIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTM5YjUwZC05OTM5
-        LTQ2ZjUtOTFmOC1hMzY1Y2IxN2Y5N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YWMxYjUzMC01NjRi
+        LTRhYjctODhjMy1hYzY0ZGRmMDQwZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhNDViZmNlYy01Yjk0LTQ4MzctODRiOC04
-        ZGVkZDliNDg5NjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIxYTNiYWQzYi0wYjMwLTQ2ZWEtYTY2Ny1j
+        YzA0Y2I2YTRhYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIwM2Q5OGM2Mi1mYmQ2LTQwNzItOGE1ZC03N2Y5N2NiZWJj
-        NTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI5MzkxNjI2My03NzAxLTQ4MzYtODViNS04OTUyYzlhZmJl
+        N2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MTU1ZTliYi1m
-        ODlhLTQ5NTAtOGQyNS0yMzAyNTQyM2FjMzkiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjI5MmNlMS1i
+        MTg4LTQxNGItYjE3Zi0zN2M2ODYwM2I3N2MiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2N2MxMDA0Yi0yMGRiLTRiZDEt
-        ODU0OS04OWJmNmRkZGJmYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MzE4YjU1Mi1iMmE5LTRjZmIt
+        ODlmMy1hYjEwMTRjZDc0NzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImRkOTRkYWM4LTdmM2EtNDdlNC04YjUx
-        LTVhODE2MWYyZDk1MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
-        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIyWiIsICJfbnMi
-        OiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MDU6MjJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmli
-        dXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5Ijog
-        eyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklT
-        SEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
-        ICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMi
-        OiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hF
-        RCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwg
-        ImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQ
-        UEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNWVhYzgxMDJiMDJlNTM0M2QwZTEyM2VjIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmMWE2MWFk
-        LTQzZTktNGQzNS05MTZiLTNiNzgyNmJjNDIyYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOTRmYTE1Ni0xYjJjLTRk
-        ZTgtODdlZi01NzkzNjliNzc1OTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAx
-        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjRiZmZmYzJlLTQxYWQtNDAwOS05ZjE5LTAxNGM2OTNjNWM2OSIsICJudW1f
-        cHJvY2Vzc2VkIjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAi
-        ZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNTBkMmVjMy00ODUxLTQwYjEtYmM3
-        YS01ZmI5YzJlOGVjZDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogNiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Y0
-        YzY2OGQtOGQ4Zi00ODUxLWE0NTMtZTE4MGJjNzNiZDg5IiwgIm51bV9wcm9j
-        ZXNzZWQiOiA2fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
-        LCAiaXRlbXNfdG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMzc2ZjdjMTUtNDA5Zi00MWUxLWFlMzMtMzg2
-        ZjIyMmExYmM2IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
-        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVmNDk2
-        Yzg1LTdkMDctNDZkZS05NWJkLTZjMmM4OTFlMDU2MSIsICJudW1fcHJvY2Vz
-        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImQxYWQxYTIxLWY3ZmEtNDgwMS1hNTIwLWFm
-        N2EzMzUxYjAyMSIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImIxMzliNTBkLTk5MzktNDZmNS05MWY4LWEzNjVjYjE3Zjk3
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0
-        NWJmY2VjLTViOTQtNDgzNy04NGI4LThkZWRkOWI0ODk2OCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAzZDk4YzYyLWZi
-        ZDYtNDA3Mi04YTVkLTc3Zjk3Y2JlYmM1NSIsICJudW1fcHJvY2Vzc2VkIjog
-        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQxNTVlOWJiLWY4OWEtNDk1MC04ZDI1LTIzMDI1NDIz
-        YWMzOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
-        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjY3YzEwMDRiLTIwZGItNGJkMS04NTQ5LTg5YmY2ZGRkYmZiYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
-        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjFhODg4NDVhLWNkMjQtNGRiNi1iYTUx
+        LWJhZDEwMzM2NTliYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0ODo1NFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
+        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
+        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
+        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
+        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
+        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
+        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
+        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
+        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjg2MDIyMzlmMDU3
+        ZjhhNDNkZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1NThhMmZiNy1iNjI3LTQyZGQtOGYyZC0yYzM0ZWJjNjRlOWUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZGQ5NGRhYzgtN2YzYS00N2U0LThiNTEtNWE4MTYxZjJkOTUzIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MTAyZmRiY2NhOWYzODk1N2U3MSJ9LCAiaWQiOiAiNWVhYzgx
-        MDJmZGJjY2E5ZjM4OTU3ZTcxIn0=
+        ZGZhZTMwOWQtYzI3Yi00Y2EwLWFhMzctNmVmYjM4MDg0OTBjIiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIwYWNhOWZjMy04NmI4LTQ5MzMtOWViMi1jOWRk
+        YzIzZTZhZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
+        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjcxOTFh
+        OGYtN2MwNy00YTU2LWJhYjAtYWQ2MDdkNDEwZTc3IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVjNTAwMzczLWEwMGItNDRkMC1iMGFmLTYzYjg5MzMx
+        YTU3YyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
+        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAwYjg1Yzk4LTE3
+        MDctNGRlOS05Mzc5LWNhNzU5ZGZhZWY1YSIsICJudW1fcHJvY2Vzc2VkIjog
+        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
+        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhYzhhZmE4YS1jYTNhLTQ0ZGUtYmE1Yi03OTBiY2NmNTk3
+        ODQiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
+        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NjA1M2Y3ZC01
+        Yjc5LTQ1OTQtODdhZi00NzY1NzhiMmI0MTIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
+        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YWMxYjUzMC01NjRiLTRhYjct
+        ODhjMy1hYzY0ZGRmMDQwZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxYTNiYWQzYi0wYjMwLTQ2ZWEtYTY2Ny1jYzA0Y2I2
+        YTRhYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
+        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5MzkxNjI2My03NzAxLTQ4MzYtODViNS04OTUyYzlhZmJlN2EiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
+        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjI5MmNlMS1iMTg4LTQx
+        NGItYjE3Zi0zN2M2ODYwM2I3N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3MzE4YjU1Mi1iMmE5LTRjZmItODlmMy1h
+        YjEwMTRjZDc0NzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
+        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjFhODg4NDVhLWNkMjQtNGRiNi1iYTUxLWJhZDEw
+        MzM2NTliYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NjEyOTczZjhjZGUyYTViMjgi
+        fSwgImlkIjogIjVmN2RmZjg2MTI5NzNmOGNkZTJhNWIyOCJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2993,7 +2816,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3004,15 +2827,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:22 GMT
+      - Wed, 07 Oct 2020 17:48:54 GMT
       Server:
       - Apache
       Etag:
-      - '"ce43daee645d94cc92516c358bfe447f-gzip"'
+      - '"06c4fac0ce70fe006433e996235788bd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '810'
+      - '828'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3021,68 +2844,69 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MDU6MjFa
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDg6NTNa
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4
-        MTAxYjAyZTUzMDc1NGM5MTliZiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        Zjg1MDIyMzlmNzM2NDEzMWIxMiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIxWiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjUzWiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODEwMWIwMmU1
-        MzA3NTRjOTE5YmUifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5
+        ZjczNjQxMzFiMTEifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDIwLTA1LTAxVDIwOjA1OjIyWiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODEwMWIwMmU1MzA3NTRjOTE5
-        YmQifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5ZjczNjQxMzFi
+        MTAifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0wNS0wMVQy
-        MDowNToyMloiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0ODo1NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
-        ImRpc3RyaWJ1dGlvbiI6IDEsICJtb2R1bGVtZCI6IDYsICJycG0iOiAxOCwg
-        Inl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAyfSwgIl9ucyI6ICJyZXBvcyIs
-        ICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDowNToyMVoiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0ZXJz
-        L3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImlt
-        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJp
-        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAyMC0wNS0wMVQyMDow
-        NToyMloiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
-        Mjc4MzM0NSwgInJlcG9tZF9jaGVja3N1bSI6ICIyOTFhZjNkN2M2ZGNlZTQ1
-        YWM1ODdmYWEwYTIxZjdjNzI2NGMxNTZhYzQ4MDY3YjkxODFmMzk1ZDVlMjVi
-        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgxMDFiMDJlNTMwNzU0Yzkx
-        OWJjIn0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvbGliL3B1
-        bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwgInByb3h5X3BvcnQi
-        OiA4MCwgImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUiLCAicmVtb3Zl
-        X21pc3NpbmciOiB0cnVlLCAicHJveHlfaG9zdCI6ICJodHRwOi8vdXJsXzEi
-        LCAic3NsX3ZhbGlkYXRpb24iOiB0cnVlfSwgImlkIjogInl1bV9pbXBvcnRl
-        ciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMzksICJfaWQiOiB7IiRv
-        aWQiOiAiNWVhYzgxMDFiMDJlNTMwNzU0YzkxOWJiIn0sICJ0b3RhbF9yZXBv
-        c2l0b3J5X3VuaXRzIjogMzksICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
+        InBhY2thZ2VfZW52aXJvbm1lbnQiOiAxLCAiZGlzdHJpYnV0aW9uIjogMSwg
+        Im1vZHVsZW1kIjogNiwgInJwbSI6IDE5LCAieXVtX3JlcG9fbWV0YWRhdGFf
+        ZmlsZSI6IDF9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEw
+        LTA3VDE3OjQ4OjUzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        dG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJf
+        bnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
+        dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3Rfc3luYyI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJzY3JhdGNocGFk
+        IjogeyJyZXBvbWRfcmV2aXNpb24iOiAxNTg4MTU4MDM4LCAicmVwb21kX2No
+        ZWNrc3VtIjogImRjNDc0YjM2NTQ0YmVjYmExNzc5NWJiMjUxMDE0NTNlMjVi
+        NDBmY2Q0ODExZmE1OTQ2ODYzMzRlZWFiZDVmMDkifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZjdkZmY4NTAyMjM5ZjczNjQxMzFiMGYifSwgImNvbmZpZyI6IHsi
+        ZmVlZCI6ICJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVz
+        dF9yZXBvcy96b28iLCAicHJveHlfcG9ydCI6IDgwLCAiZG93bmxvYWRfcG9s
+        aWN5IjogImltbWVkaWF0ZSIsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJw
+        cm94eV9ob3N0IjogImh0dHA6Ly91cmxfMSIsICJzc2xfdmFsaWRhdGlvbiI6
+        IHRydWV9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9y
+        ZWRfdW5pdHMiOiA0MCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5
+        ZjczNjQxMzFiMGUifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiA0MCwg
+        ImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVw
+        b3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3090,7 +2914,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3101,7 +2925,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:23 GMT
+      - Wed, 07 Oct 2020 17:48:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -3112,14 +2936,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBhMzg4ZWYyLTk3ZjctNGFiMS1hZjg3LTA2NTUyMTliMzI5Mi8iLCAi
-        dGFza19pZCI6ICIwYTM4OGVmMi05N2Y3LTRhYjEtYWY4Ny0wNjU1MjE5YjMy
-        OTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2RkNWRmZDA0LTY2MWYtNDg2NC1iNTI5LTJiYjY1YzZmMGI0Mi8iLCAi
+        dGFza19pZCI6ICJkZDVkZmQwNC02NjFmLTQ4NjQtYjUyOS0yYmI2NWM2ZjBi
+        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:55 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/0a388ef2-97f7-4ab1-af87-0655219b3292/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/dd5dfd04-661f-4864-b529-2bb65c6f0b42/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3127,7 +2951,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3138,15 +2962,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:23 GMT
+      - Wed, 07 Oct 2020 17:48:55 GMT
       Server:
       - Apache
       Etag:
-      - '"7a5c18822d993cbfdffa64d3b48e82d7-gzip"'
+      - '"6d037848d827049f98ac09c026c2db1e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '358'
+      - '365'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3154,20 +2978,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wYTM4OGVmMi05N2Y3LTRhYjEtYWY4Ny0wNjU1MjE5YjMy
-        OTIvIiwgInRhc2tfaWQiOiAiMGEzODhlZjItOTdmNy00YWIxLWFmODctMDY1
-        NTIxOWIzMjkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kZDVkZmQwNC02NjFmLTQ4NjQtYjUyOS0yYmI2NWM2ZjBi
+        NDIvIiwgInRhc2tfaWQiOiAiZGQ1ZGZkMDQtNjYxZi00ODY0LWI1MjktMmJi
+        NjVjNmYwYjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjA1OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjIzWiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ4OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgx
-        MDNmZGJjY2E5ZjM4OTU3ZmNlIn0sICJpZCI6ICI1ZWFjODEwM2ZkYmNjYTlm
-        Mzg5NTdmY2UifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjg3MTI5NzNmOGNkZTJhNWM2YSJ9LCAiaWQiOiAi
+        NWY3ZGZmODcxMjk3M2Y4Y2RlMmE1YzZhIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:29 GMT
+      - Wed, 07 Oct 2020 17:48:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:29 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:29 GMT
+      - Wed, 07 Oct 2020 17:48:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:29 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -121,7 +121,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -134,7 +134,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:30 GMT
+      - Wed, 07 Oct 2020 17:48:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,15 +150,15 @@ http_interactions:
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
         OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
         Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWVh
-        YzgxMGFiMDJlNTMwNzUzYTk4NTRlIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3
+        ZGZmODkwMjIzOWY3MzY0MTMxYjEzIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -166,7 +166,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -177,15 +177,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:30 GMT
+      - Wed, 07 Oct 2020 17:48:57 GMT
       Server:
       - Apache
       Etag:
-      - '"a3195e9667010b7a21dfd9b597725cc6-gzip"'
+      - '"f8396a01a48335f51f58cca5a109b928-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '672'
+      - '674'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -194,37 +194,37 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
         eyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3Rf
-        dXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjMwWiIsICJfaHJlZiI6ICIv
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU3WiIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0L2Rpc3RyaWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NF9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWVhYzgxMGFiMDJlNTMwNzUzYTk4NTUxIn0sICJjb25maWci
+        IiRvaWQiOiAiNWY3ZGZmODkwMjIzOWY3MzY0MTMxYjE2In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1y
         aGVsXzZfeDg2XzY0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
         NF9jbG9uZSJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
-        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MDU6MzBaIiwg
+        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDg6NTdaIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlk
         LXJoZWxfNl94ODZfNjQvZGlzdHJpYnV0b3JzL3B1bHAtdXVpZC1yaGVsXzZf
         eDg2XzY0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
         c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MTBhYjAyZTUzMDc1M2E5ODU1MCJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjg5MDIyMzlmNzM2NDEzMWIxNSJ9LCAiY29uZmlnIjog
         eyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0
         cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
         eS9yaGVsXzZfbGFiZWwifSwgImlkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0In0sIHsicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
-        ICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDowNTozMFoiLCAiX2hy
+        ICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0ODo1N1oiLCAiX2hy
         ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
         bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1
         dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9
         LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZWFjODEwYWIwMmU1MzA3NTNhOTg1NTIifSwgImNvbmZpZyI6IHsiaHR0
+        ICI1ZjdkZmY4OTAyMjM5ZjczNjQxMzFiMTcifSwgImNvbmZpZyI6IHsiaHR0
         cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24v
         bGlicmFyeS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6
         ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBu
@@ -232,29 +232,29 @@ http_interactions:
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
         OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
         IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjA1OjMwWiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        ICIyMDIwLTEwLTA3VDE3OjQ4OjU3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
         djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2ltcG9y
         dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
         ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTBhYjAyZTUz
-        MDc1M2E5ODU0ZiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
+        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg5MDIyMzlm
+        NzM2NDEzMWIxNCJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
         LnJlZGhhdC5jb20vZm9vL2JhciIsICJzc2xfY2FfY2VydCI6ICJjYV9jZXJ0
         IiwgInNzbF9jbGllbnRfY2VydCI6ICJyZXBvX2NlcnQiLCAicmVtb3ZlX21p
         c3NpbmciOiB0cnVlLCAicHJveHlfaG9zdCI6ICIiLCAic3NsX3ZhbGlkYXRp
         b24iOiB0cnVlLCAic3NsX2NsaWVudF9rZXkiOiAicmVwb19rZXkiLCAiZG93
         bmxvYWRfcG9saWN5IjogIm9uX2RlbWFuZCIsICJ0eXBlX3NraXBfbGlzdCI6
         IFsicnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
-        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTBhYjAy
-        ZTUzMDc1M2E5ODU0ZSJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
+        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg5MDIy
+        MzlmNzM2NDEzMWIxMyJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
         ICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0LyJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +262,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -273,7 +273,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:30 GMT
+      - Wed, 07 Oct 2020 17:48:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -284,14 +284,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzEzOTg4NzA3LTgzYjYtNGQyOS1iM2U5LWYyNzNmNTdhNmNmMy8iLCAi
-        dGFza19pZCI6ICIxMzk4ODcwNy04M2I2LTRkMjktYjNlOS1mMjczZjU3YTZj
-        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzExZTA1YWNjLTYxMTQtNGM0Ny1hMTI0LTkwMmFhOTBhYWM4Ny8iLCAi
+        dGFza19pZCI6ICIxMWUwNWFjYy02MTE0LTRjNDctYTEyNC05MDJhYTkwYWFj
+        ODcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:58 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/13988707-83b6-4d29-b3e9-f273f57a6cf3/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/11e05acc-6114-4c47-a124-902aa90aac87/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -299,7 +299,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -310,15 +310,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:30 GMT
+      - Wed, 07 Oct 2020 17:48:58 GMT
       Server:
       - Apache
       Etag:
-      - '"65d5a44a0b57bbf2c3f2847071b584ae-gzip"'
+      - '"f7c6cf51f25be76f530137c81f3e4da7-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '366'
+      - '371'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -326,20 +326,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMzk4ODcwNy04M2I2LTRkMjktYjNlOS1mMjczZjU3YTZj
-        ZjMvIiwgInRhc2tfaWQiOiAiMTM5ODg3MDctODNiNi00ZDI5LWIzZTktZjI3
-        M2Y1N2E2Y2YzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aS92Mi90YXNrcy8xMWUwNWFjYy02MTE0LTRjNDctYTEyNC05MDJhYTkwYWFj
+        ODcvIiwgInRhc2tfaWQiOiAiMTFlMDVhY2MtNjExNC00YzQ3LWExMjQtOTAy
+        YWE5MGFhYzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
         aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
-        bmlzaF90aW1lIjogIjIwMjAtMDUtMDFUMjA6MDU6MzBaIiwgIl9ucyI6ICJ0
-        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMDUtMDFUMjA6MDU6
-        MzBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
+        bmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6NThaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6
+        NThaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
         ICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZWFjODEwYWZkYmNjYTlmMzg5NTgwNWMifSwgImlkIjogIjVl
-        YWM4MTBhZmRiY2NhOWYzODk1ODA1YyJ9
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGExMjk3M2Y4Y2RlMmE1
+        ZDY2In0sICJpZCI6ICI1ZjdkZmY4YTEyOTczZjhjZGUyYTVkNjYifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:58 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:32 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:32 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:32 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:32 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -120,7 +120,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -133,7 +133,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:33 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,14 +150,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMGRiMDJlNTMwNzU0YzkxOWMwIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmODgwMjIzOWY3NDFlODgzZDQ5In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:33 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -176,11 +176,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:33 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Etag:
-      - '"43962a150d0ff9b122a934c3aee9658b-gzip"'
+      - '"13b2ed60c47e60f360432069a74c8915-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -193,61 +193,61 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDowNTozM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMC0wN1QxNzo0ODo1NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgxMGRiMDJlNTMwNzU0YzkxOWM0In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmODgwMjIzOWY3NDFlODgzZDRkIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MDU6MzNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDg6NTZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MTBkYjAyZTUzMDc1NGM5MTljMyJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4M2Q0YyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjMzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTBkYjAyZTUzMDc1NGM5
-        MTljMiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4
+        M2Q0YiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjMzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODEw
-        ZGIwMmU1MzA3NTRjOTE5YzEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
+        ODAyMjM5Zjc0MWU4ODNkNGEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJiYXNpY19hdXRoX3Bhc3N3b3JkIjogIioqKioq
         IiwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgInByb3h5X2hvc3QiOiAiIiwg
         InNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgImJhc2ljX2F1dGhfdXNlcm5hbWUi
         OiAicm9vdCIsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVtYW5kIiwgInR5
         cGVfc2tpcF9saXN0IjogWyJkcnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVy
         In1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MTBkYjAyZTUzMDc1NGM5MTljMCJ9LCAidG90YWxfcmVwb3Np
+        IjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4M2Q0OSJ9LCAidG90YWxfcmVwb3Np
         dG9yeV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:33 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -255,7 +255,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -266,7 +266,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:33 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -277,14 +277,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNkODdjMWIyLTkyOGEtNGM0Yi05Y2VhLWMxNGYzZjVkMDU5NC8iLCAi
-        dGFza19pZCI6ICIzZDg3YzFiMi05MjhhLTRjNGItOWNlYS1jMTRmM2Y1ZDA1
-        OTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzdlYWViODU4LThmODYtNDlkYy05Njc0LTE5OWU3N2JmZjA5Ny8iLCAi
+        dGFza19pZCI6ICI3ZWFlYjg1OC04Zjg2LTQ5ZGMtOTY3NC0xOTllNzdiZmYw
+        OTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:33 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/3d87c1b2-928a-4c4b-9cea-c14f3f5d0594/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7eaeb858-8f86-49dc-9674-199e77bff097/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -292,7 +292,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -303,15 +303,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:33 GMT
+      - Wed, 07 Oct 2020 17:48:56 GMT
       Server:
       - Apache
       Etag:
-      - '"dd51c2bc0824ae834776d27f10ee54f7-gzip"'
+      - '"6a72652789e28d406005352d69af3e9c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '357'
+      - '363'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -319,20 +319,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZDg3YzFiMi05MjhhLTRjNGItOWNlYS1jMTRmM2Y1ZDA1
-        OTQvIiwgInRhc2tfaWQiOiAiM2Q4N2MxYjItOTI4YS00YzRiLTljZWEtYzE0
-        ZjNmNWQwNTk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83ZWFlYjg1OC04Zjg2LTQ5ZGMtOTY3NC0xOTllNzdiZmYw
+        OTcvIiwgInRhc2tfaWQiOiAiN2VhZWI4NTgtOGY4Ni00OWRjLTk2NzQtMTk5
+        ZTc3YmZmMDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjA1OjMzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjMzWiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ4OjU2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgx
-        MGRmZGJjY2E5ZjM4OTU4MGQ3In0sICJpZCI6ICI1ZWFjODEwZGZkYmNjYTlm
-        Mzg5NTgwZDcifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjg4MTI5NzNmOGNkZTJhNWNlNSJ9LCAiaWQiOiAi
+        NWY3ZGZmODgxMjk3M2Y4Y2RlMmE1Y2U1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:33 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:35 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:35 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -119,7 +119,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -132,7 +132,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -149,14 +149,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM1In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -164,7 +164,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -175,15 +175,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Etag:
-      - '"9cc5b69c25d283a39e4cbd476908970d-gzip"'
+      - '"43109e57874bc8392eb66501c49cbc8c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '607'
+      - '606'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -192,59 +192,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDowNTozNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMC0wN1QxNzo0ODo1OVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM5In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MDU6MzZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDg6NTlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MTEwYjAyZTUzMDc1NGM5MTljOCJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjM2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU5WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTEwYjAyZTUzMDc1NGM5
-        MTljNyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEz
+        MWIxYSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjM2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU5WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODEx
-        MGIwMmU1MzA3NTRjOTE5YzYifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
+        YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM1In0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -252,7 +252,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -263,7 +263,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -274,14 +274,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk1NzU0NGNmLTk0NzEtNGQxMi05YTgwLTEzOTM0ZWZhMGE3YS8iLCAi
-        dGFza19pZCI6ICI5NTc1NDRjZi05NDcxLTRkMTItOWE4MC0xMzkzNGVmYTBh
-        N2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Y4MDdiZmZiLWJjYjctNDA3ZC04ODE0LWNiNTIxZjk1ZDZmZC8iLCAi
+        dGFza19pZCI6ICJmODA3YmZmYi1iY2I3LTQwN2QtODgxNC1jYjUyMWY5NWQ2
+        ZmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/957544cf-9471-4d12-9a80-13934efa0a7a/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/f807bffb-bcb7-407d-8814-cb521f95d6fd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -289,7 +289,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -300,15 +300,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Etag:
-      - '"7e39265e290b50dcdc86454cfbbb4f7d-gzip"'
+      - '"262fccff0bc4ad7aa12de47973053b8b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '380'
+      - '384'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -316,26 +316,27 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfZGVsZXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy85NTc1NDRjZi05NDcxLTRkMTItOWE4
-        MC0xMzkzNGVmYTBhN2EvIiwgInRhc2tfaWQiOiAiOTU3NTQ0Y2YtOTQ3MS00
-        ZDEyLTlhODAtMTM5MzRlZmEwYTdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9mODA3YmZmYi1iY2I3LTQwN2QtODgx
+        NC1jYjUyMWY5NWQ2ZmQvIiwgInRhc2tfaWQiOiAiZjgwN2JmZmItYmNiNy00
+        MDdkLTg4MTQtY2I1MjFmOTVkNmZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpyZW1vdmVfZGlzdHJpYnV0b3Ii
-        XSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDUtMDFUMjA6MDU6MzZaIiwgIl9u
-        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMDUtMDFU
-        MjA6MDU6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        XSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6NTlaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTAtMDdU
+        MTc6NDg6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
         IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1ZWFjODExMGZkYmNjYTlmMzg5NTgxNWIifSwgImlk
-        IjogIjVlYWM4MTEwZmRiY2NhOWYzODk1ODE1YiJ9
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1r
+        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIxMjk3M2Y4
+        Y2RlMmE1ZGYyIn0sICJpZCI6ICI1ZjdkZmY4YjEyOTczZjhjZGUyYTVkZjIi
+        fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -343,7 +344,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -354,15 +355,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:36 GMT
+      - Wed, 07 Oct 2020 17:48:59 GMT
       Server:
       - Apache
       Etag:
-      - '"ac5cec60f196975ac33651938c483923-gzip"'
+      - '"e10ad21fe97fbea40f8010b515a47c18-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '569'
+      - '571'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -371,49 +372,49 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDowNTozNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMC0wN1QxNzo0ODo1OVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM5In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MDU6MzZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDg6NTlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MTEwYjAyZTUzMDc1NGM5MTljOCJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
         IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
         bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
         cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAx
-        VDIwOjA1OjM2WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3
+        VDE3OjQ4OjU5WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
         c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZWFjODExMGIwMmU1MzA3NTRjOTE5YzYifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
         IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
         Y3kiOiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5
         dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM1In0sICJ0
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0
         b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny8ifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:36 GMT
+  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
 - request:
     method: put
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -423,7 +424,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -436,7 +437,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -447,14 +448,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUzODZkNDVmLWVmYWUtNDNjNy04YjdmLWIzNzcwZjFkYjBhMS8iLCAi
-        dGFza19pZCI6ICI1Mzg2ZDQ1Zi1lZmFlLTQzYzctOGI3Zi1iMzc3MGYxZGIw
-        YTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzE1YmM4MGFlLTI0MTgtNDg4ZS04ODI4LWYzYzc1MGJlYWU5NC8iLCAi
+        dGFza19pZCI6ICIxNWJjODBhZS0yNDE4LTQ4OGUtODgyOC1mM2M3NTBiZWFl
+        OTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: put
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -469,7 +470,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -482,7 +483,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -493,14 +494,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RmNzBhODQ1LWIyZWItNGJlZS1iZGM2LWQwY2RhYzUwZDk0MS8iLCAi
-        dGFza19pZCI6ICJkZjcwYTg0NS1iMmViLTRiZWUtYmRjNi1kMGNkYWM1MGQ5
-        NDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I1OWIyNjI4LWIzOWQtNDYyOC1hZDQ4LTJhZTY0NTY2YTAxMS8iLCAi
+        dGFza19pZCI6ICJiNTliMjYyOC1iMzlkLTQ2MjgtYWQ0OC0yYWU2NDU2NmEw
+        MTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
     body:
       encoding: UTF-8
       base64_string: |
@@ -514,7 +515,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -527,7 +528,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -540,21 +541,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAy
-        MC0wNS0wMVQyMDowNTozN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
+        MC0xMC0wN1QxNzo0OTowMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
         cG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8i
         LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
         IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRv
         ciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAi
         X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZWFjODExMWIwMmU1MzA3NTRjOTE5Y2EifSwgImNvbmZpZyI6IHsicHJvdGVj
+        ZjdkZmY4YzAyMjM5ZjczNjUxZTYxYWMifSwgImNvbmZpZyI6IHsicHJvdGVj
         dGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
         Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
         dHBzIjogdHJ1ZX0sICJpZCI6ICJGZWRvcmFfMTcifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: put
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
     body:
       encoding: UTF-8
       base64_string: |
@@ -564,7 +565,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -577,7 +578,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -588,14 +589,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYwNGEwZDI4LTNlNTktNGQ2My1iN2YxLTk0MWJjYjM0OWNjYi8iLCAi
-        dGFza19pZCI6ICI2MDRhMGQyOC0zZTU5LTRkNjMtYjdmMS05NDFiY2IzNDlj
-        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q2MzAyZmI0LWZiNTktNGNjOC1iOWE0LWQ3YmIxNzJjNDU3MC8iLCAi
+        dGFza19pZCI6ICJkNjMwMmZiNC1mYjU5LTRjYzgtYjlhNC1kN2JiMTcyYzQ1
+        NzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: put
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
     body:
       encoding: UTF-8
       base64_string: |
@@ -606,7 +607,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -619,7 +620,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -630,14 +631,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzVhYjNhZmQ0LWRlYTUtNGViNi1hNzMwLTllMjBlMjY2MzAxMy8iLCAi
-        dGFza19pZCI6ICI1YWIzYWZkNC1kZWE1LTRlYjYtYTczMC05ZTIwZTI2NjMw
-        MTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzNiODAwODBlLWIwYTUtNDdmNi1iOGVhLWFkZjE4NTViYWQ4Mi8iLCAi
+        dGFza19pZCI6ICIzYjgwMDgwZS1iMGE1LTQ3ZjYtYjhlYS1hZGYxODU1YmFk
+        ODIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/5386d45f-efae-43c7-8b7f-b3770f1db0a1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/15bc80ae-2418-488e-8828-f3c750beae94/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -645,7 +646,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -656,15 +657,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Etag:
-      - '"28e49c2d1897e8bc74d1402cb35bb4b0-gzip"'
+      - '"2a40ebcd5f4891e2d13edea50970e903-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '557'
+      - '564'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -672,36 +673,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTM4NmQ0NWYtZWZh
-        ZS00M2M3LThiN2YtYjM3NzBmMWRiMGExLyIsICJ0YXNrX2lkIjogIjUzODZk
-        NDVmLWVmYWUtNDNjNy04YjdmLWIzNzcwZjFkYjBhMSIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMTViYzgwYWUtMjQx
+        OC00ODhlLTg4MjgtZjNjNzUwYmVhZTk0LyIsICJ0YXNrX2lkIjogIjE1YmM4
+        MGFlLTI0MTgtNDg4ZS04ODI4LWYzYzc1MGJlYWU5NCIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6cmVwb3NpdG9yeV9p
         bXBvcnRlcjp5dW1faW1wb3J0ZXIiLCAicHVscDphY3Rpb246dXBkYXRlX2lt
-        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjM3
+        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAw
         WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIw
-        LTA1LTAxVDIwOjA1OjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTEwLTA3VDE3OjQ5OjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
-        b3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MDU6Mzda
-        IiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9y
-        dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
-        ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTEwYjAyZTUz
-        MDc1NGM5MTljNiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9teXJl
-        cG8uY29tIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNz
-        aW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQiLCAi
-        cHJveHlfaG9zdCI6ICIifSwgImlkIjogInl1bV9pbXBvcnRlciJ9LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTExZmRiY2NhOWYz
-        ODk1ODE5MCJ9LCAiaWQiOiAiNWVhYzgxMTFmZGJjY2E5ZjM4OTU4MTkwIn0=
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
+        ZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
+        bnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIw
+        LTEwLTA3VDE3OjQ5OjAwWiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAi
+        cmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
+        b3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3lu
+        YyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVl
+        ZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRy
+        dWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3ki
+        OiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1f
+        aW1wb3J0ZXIifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZjdkZmY4YzEyOTczZjhjZGUyYTVlMjYifSwgImlkIjogIjVmN2RmZjhjMTI5
+        NzNmOGNkZTJhNWUyNiJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/df70a845-b2eb-4bee-bdc6-d0cdac50d941/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/b59b2628-b39d-4628-ad48-2ae64566a011/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -709,7 +711,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -720,15 +722,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:00 GMT
       Server:
       - Apache
       Etag:
-      - '"a0bd387a75882527373d1a19c34bb91c-gzip"'
+      - '"1ab3ce5cfb298193a9b1107a4a60ddd5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '557'
+      - '564'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -736,36 +738,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGY3MGE4NDUtYjJl
-        Yi00YmVlLWJkYzYtZDBjZGFjNTBkOTQxLyIsICJ0YXNrX2lkIjogImRmNzBh
-        ODQ1LWIyZWItNGJlZS1iZGM2LWQwY2RhYzUwZDk0MSIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjU5YjI2MjgtYjM5
+        ZC00NjI4LWFkNDgtMmFlNjQ1NjZhMDExLyIsICJ0YXNrX2lkIjogImI1OWIy
+        NjI4LWIzOWQtNDYyOC1hZDQ4LTJhZTY0NTY2YTAxMSIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6cmVwb3NpdG9yeV9p
         bXBvcnRlcjp5dW1faW1wb3J0ZXIiLCAicHVscDphY3Rpb246dXBkYXRlX2lt
-        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjM3
+        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAw
         WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIw
-        LTA1LTAxVDIwOjA1OjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTEwLTA3VDE3OjQ5OjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
-        b3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MDU6Mzda
-        IiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9y
-        dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
-        ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTEwYjAyZTUz
-        MDc1NGM5MTljNiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9teXJl
-        cG8uY29tIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNz
-        aW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQiLCAi
-        cHJveHlfaG9zdCI6ICIifSwgImlkIjogInl1bV9pbXBvcnRlciJ9LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTExZmRiY2NhOWYz
-        ODk1ODFhNiJ9LCAiaWQiOiAiNWVhYzgxMTFmZGJjY2E5ZjM4OTU4MWE2In0=
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
+        ZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
+        bnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIw
+        LTEwLTA3VDE3OjQ5OjAwWiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAi
+        cmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
+        b3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3lu
+        YyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVl
+        ZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRy
+        dWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3ki
+        OiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1f
+        aW1wb3J0ZXIifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZjdkZmY4YzEyOTczZjhjZGUyYTVlM2EifSwgImlkIjogIjVmN2RmZjhjMTI5
+        NzNmOGNkZTJhNWUzYSJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/604a0d28-3e59-4d63-b7f1-941bcb349ccb/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d6302fb4-fb59-4cc8-b9a4-d7bb172c4570/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -773,7 +776,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -784,15 +787,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:01 GMT
       Server:
       - Apache
       Etag:
-      - '"dcba7f5ff25f258f8e6583d4e0217fa3-gzip"'
+      - '"2b73dc5fc03c5da4f54cd8a9f4471fd5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '523'
+      - '529'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -800,36 +803,36 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy82MDRhMGQyOC0zZTU5LTRkNjMtYjdm
-        MS05NDFiY2IzNDljY2IvIiwgInRhc2tfaWQiOiAiNjA0YTBkMjgtM2U1OS00
-        ZDYzLWI3ZjEtOTQxYmNiMzQ5Y2NiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9kNjMwMmZiNC1mYjU5LTRjYzgtYjlh
+        NC1kN2JiMTcyYzQ1NzAvIiwgInRhc2tfaWQiOiAiZDYzMDJmYjQtZmI1OS00
+        Y2M4LWI5YTQtZDdiYjE3MmM0NTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OkZlZG9yYV8xN19jbG9uZSIsICJwdWxwOmFjdGlvbjp1cGRhdGVfZGlzdHJp
-        YnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDUtMDFUMjA6MDU6Mzda
+        YnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDk6MDBa
         IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
-        MDUtMDFUMjA6MDU6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        MTAtMDdUMTc6NDk6MDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
         X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
-        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDowNTozN1oi
-        LCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJp
-        YnV0b3JzL0ZlZG9yYV8xN19jbG9uZS8iLCAibGFzdF9vdmVycmlkZV9jb25m
-        aWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90
-        eXBlX2lkIjogInl1bV9jbG9uZV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
-        c2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rp
-        c3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJlNTMw
-        NzU0YzkxOWM4In0sICJjb25maWciOiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1
-        dG9yX2lkIjogIkZlZG9yYV8xNyJ9LCAiaWQiOiAiRmVkb3JhXzE3X2Nsb25l
-        In0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgxMTFm
-        ZGJjY2E5ZjM4OTU4MWM2In0sICJpZCI6ICI1ZWFjODExMWZkYmNjYTlmMzg5
-        NTgxYzYifQ==
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2Vu
+        dG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAt
+        MTAtMDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3JpZXMv
+        RmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUvIiwgImxh
+        c3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0
+        b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30s
+        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjog
+        IjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjogeyJkZXN0
+        aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwgImlkIjog
+        IkZlZG9yYV8xN19jbG9uZSJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjhjMTI5NzNmOGNkZTJhNWU1NiJ9LCAiaWQiOiAiNWY3
+        ZGZmOGMxMjk3M2Y4Y2RlMmE1ZTU2In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:01 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/5ab3afd4-dea5-4eb6-a730-9e20e2663013/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3b80080e-b0a5-47f6-b8ea-adf1855bad82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -837,7 +840,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -848,15 +851,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:01 GMT
       Server:
       - Apache
       Etag:
-      - '"9fd05d916f4493110f297de3434e6999-gzip"'
+      - '"036da54d2ad5e7df675fd4714295782e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '551'
+      - '558'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -864,37 +867,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy81YWIzYWZkNC1kZWE1LTRlYjYtYTcz
-        MC05ZTIwZTI2NjMwMTMvIiwgInRhc2tfaWQiOiAiNWFiM2FmZDQtZGVhNS00
-        ZWI2LWE3MzAtOWUyMGUyNjYzMDEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8zYjgwMDgwZS1iMGE1LTQ3ZjYtYjhl
+        YS1hZGYxODU1YmFkODIvIiwgInRhc2tfaWQiOiAiM2I4MDA4MGUtYjBhNS00
+        N2Y2LWI4ZWEtYWRmMTg1NWJhZDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OmV4cG9ydF9kaXN0cmlidXRvciIsICJwdWxwOmFjdGlvbjp1cGRhdGVfZGlz
-        dHJpYnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMDUtMDFUMjA6MDU6
-        MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MjAtMDUtMDFUMjA6MDU6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        dHJpYnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDk6
+        MDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MjAtMTAtMDdUMTc6NDk6MDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
-        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDowNToz
-        N1oiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlz
-        dHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlk
-        ZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmli
-        dXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1
-        Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBv
-        X2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJl
-        NTMwNzU0YzkxOWM5In0sICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJl
-        bGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3Jh
-        XzE3X2xhYmVsIiwgImh0dHBzIjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rp
-        c3RyaWJ1dG9yIn0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgxMTFmZGJjY2E5ZjM4OTU4MWQ3In0sICJpZCI6ICI1ZWFjODExMWZk
-        YmNjYTlmMzg5NTgxZDcifQ==
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3Jp
+        ZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3Iv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJp
+        YnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjog
+        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
+        IjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYyJ9LCAiY29uZmlnIjogeyJo
+        dHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlv
+        bi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwg
+        ImlkIjogImV4cG9ydF9kaXN0cmlidXRvciJ9LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjhjMTI5NzNmOGNkZTJhNWU2MyJ9LCAi
+        aWQiOiAiNWY3ZGZmOGMxMjk3M2Y4Y2RlMmE1ZTYzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:01 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -902,7 +905,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -913,15 +916,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:37 GMT
+      - Wed, 07 Oct 2020 17:49:02 GMT
       Server:
       - Apache
       Etag:
-      - '"648b5805a32b3cc59d8b6bf0beed4736-gzip"'
+      - '"37f5aeb8230b8d01d27657acc52731d6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '609'
+      - '612'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -930,59 +933,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDowNTozN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMC0wN1QxNzo0OTowMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM5In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MDU6MzdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MTEwYjAyZTUzMDc1NGM5MTljOCJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjM3WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MTExYjAyZTUzMDc1NGM5
-        MTljYSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjhjMDIyMzlmNzM2NTFl
+        NjFhYyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjA1OjM3WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODEx
-        MGIwMmU1MzA3NTRjOTE5YzYifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
+        YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgxMTBiMDJlNTMwNzU0YzkxOWM1In0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:37 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -990,7 +993,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1001,7 +1004,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:38 GMT
+      - Wed, 07 Oct 2020 17:49:02 GMT
       Server:
       - Apache
       Content-Length:
@@ -1012,14 +1015,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzFiNjU2NzNmLTZlNTUtNDk3Zi1iOWNkLTA4Nzg0YjVlODRmZS8iLCAi
-        dGFza19pZCI6ICIxYjY1NjczZi02ZTU1LTQ5N2YtYjljZC0wODc4NGI1ZTg0
-        ZmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzIyNzY2YmRlLTQ0YmItNDRhNi1iZTYyLTUyMTk5MDVlNWU0MS8iLCAi
+        dGFza19pZCI6ICIyMjc2NmJkZS00NGJiLTQ0YTYtYmU2Mi01MjE5OTA1ZTVl
+        NDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:38 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/1b65673f-6e55-497f-b9cd-08784b5e84fe/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/22766bde-44bb-44a6-be62-5219905e5e41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1027,7 +1030,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1038,15 +1041,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:05:38 GMT
+      - Wed, 07 Oct 2020 17:49:02 GMT
       Server:
       - Apache
       Etag:
-      - '"2402ffda0cf3aaf766efadd5dce758c9-gzip"'
+      - '"8a4e5703fc150c066687ac8f8215e805-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '359'
+      - '364'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1054,20 +1057,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xYjY1NjczZi02ZTU1LTQ5N2YtYjljZC0wODc4NGI1ZTg0
-        ZmUvIiwgInRhc2tfaWQiOiAiMWI2NTY3M2YtNmU1NS00OTdmLWI5Y2QtMDg3
-        ODRiNWU4NGZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yMjc2NmJkZS00NGJiLTQ0YTYtYmU2Mi01MjE5OTA1ZTVl
+        NDEvIiwgInRhc2tfaWQiOiAiMjI3NjZiZGUtNDRiYi00NGE2LWJlNjItNTIx
+        OTkwNWU1ZTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjA1OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjA1OjM4WiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ5OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgx
-        MTJmZGJjY2E5ZjM4OTU4MjM5In0sICJpZCI6ICI1ZWFjODExMmZkYmNjYTlm
-        Mzg5NTgyMzkifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjhlMTI5NzNmOGNkZTJhNWVkYyJ9LCAiaWQiOiAi
+        NWY3ZGZmOGUxMjk3M2Y4Y2RlMmE1ZWRjIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:05:38 GMT
+  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:52 GMT
+      - Wed, 07 Oct 2020 17:47:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:36 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:52 GMT
+      - Wed, 07 Oct 2020 17:47:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:36 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:52 GMT
+      - Wed, 07 Oct 2020 17:47:37 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWYwZTNkMjAwNmM3MWEwYTQxOTA4OGViIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmMzkwMjIzOWY3NDFlODgzZDFmIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:37 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:52 GMT
+      - Wed, 07 Oct 2020 17:47:37 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE5YTI1YzdmLTQ5NWQtNGI5NS1iODQ3LTZmZWZkOTk0NjRlNi8iLCAi
-        dGFza19pZCI6ICIxOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FmMGJlY2YxLWNjNWItNDgwYS1iYWIzLWZkZmNiOTgzYjhjNC8iLCAi
+        dGFza19pZCI6ICJhZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:37 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,64 +231,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -296,7 +295,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -307,15 +306,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -323,64 +322,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -388,7 +386,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -399,15 +397,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -415,64 +413,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -480,7 +477,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -491,15 +488,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -507,64 +504,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -572,7 +568,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -583,15 +579,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -599,64 +595,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -664,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -675,15 +670,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -691,64 +686,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -756,7 +750,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -767,15 +761,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -783,64 +777,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -848,7 +841,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -859,15 +852,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -875,64 +868,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/19a25c7f-495d-4b95-b847-6fefd99464e6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -940,7 +932,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -951,15 +943,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7ba91e2e7102e03beef68935f4688c43-gzip"'
+      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '731'
+      - '715'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -967,64 +959,63 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWEyNWM3Zi00OTVkLTRiOTUtYjg0Ny02ZmVmZDk5NDY0
-        ZTYvIiwgInRhc2tfaWQiOiAiMTlhMjVjN2YtNDk1ZC00Yjk1LWI4NDctNmZl
-        ZmQ5OTQ2NGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
+        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
+        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzdkMzM5OWMtYmU0Mi00MjUwLWEyMjAtNzY0NDFlMmEz
-        YmZkLyIsICJ0YXNrX2lkIjogImM3ZDMzOTljLWJlNDItNDI1MC1hMjIwLTc2
-        NDQxZTJhM2JmZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDUsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
+        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
+        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA1LCAicnBtX2RvbmUiOiA1LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAyOTE4NSwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZjBlM2QyMjA2YzcxYTBi
-        ZDBkNzM0ZGEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAyOTE4NSwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA1LCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDUsICJycG1fZG9uZSI6IDUsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MDBmNjg4NzRiMDNmMzY3YjcifSwgImlkIjogIjVmMGUzZDIwMGY2ODg3NGIw
-        M2YzNjdiNyJ9
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
+        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/c7d3399c-be42-4250-a220-76441e2a3bfd/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d35f3b19-617d-4cea-b9c6-470eaa9f622a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1032,7 +1023,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1043,15 +1034,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Etag:
-      - '"cbeb5b1d4f7b7a9a18f295ecdc09c9d0-gzip"'
+      - '"1aadfbcd6185458e03963e61ae5089dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1360'
+      - '1347'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1059,200 +1050,199 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jN2QzMzk5Yy1iZTQyLTQyNTAtYTIyMC03NjQ0
-        MWUyYTNiZmQvIiwgInRhc2tfaWQiOiAiYzdkMzM5OWMtYmU0Mi00MjUwLWEy
-        MjAtNzY0NDFlMmEzYmZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9kMzVmM2IxOS02MTdkLTRjZWEtYjljNi00NzBl
+        YWE5ZjYyMmEvIiwgInRhc2tfaWQiOiAiZDM1ZjNiMTktNjE3ZC00Y2VhLWI5
+        YzYtNDcwZWFhOWY2MjJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxNzo1NFoiLCAi
+        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0MFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyNDMxN2NmMS01OTExLTQ5MDMtYWVmZS00N2RhYjM1
-        YjRiNTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIxNTQ1YmYwYS1mM2NhLTQ4YjYtYWY3Zi04YWJkN2Rk
+        YWZjNzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMWU4YWIzMTMtZjY1ZC00Mjc4LWE4MmMtYjMwZjA2MWM5M2NhIiwg
+        aWQiOiAiMDJlM2ZjOTgtYmYwZS00NDMyLWFmOTctMDVmMjE0NTM0ZGMxIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOTY4YjcwNC1iYTE1LTRmZTMtODJm
-        MC05MWUxOTljODQxMDQiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDYyZDhhNS1iZTBhLTQ3YTYtYjFk
+        Yy02NzliMmJjOTU4YzkiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZmZlMzIxMjgtNDFhNy00OGMxLThmOTUtODBjNWM2ZmFlOGQ0IiwgIm51bV9w
+        MzBlN2M3ZjMtZGU1Ni00NDQ2LTg1ZGYtZjU1NGI5Njc3MmE1IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjA1ZTAzMjk0LTkwOWEtNGQ1YS1hNjk5LWI4
-        ZWQyNzM4YmJmNCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjNmNmU5MDVhLTMwY2YtNGY3Ny05ZjkxLTdl
+        Y2I0YWJiNTJiYyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3N2Zh
-        ZDM1LTIyYWItNGUwOC04M2ZkLWJlZmExYzFiMDcxMCIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiZTM2
+        YTUxLTE3NmMtNDI2Mi05ZTJmLTZlZTA1YjA4ZTI3NyIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwOTQ3ZTFlYS03YzY5LTQ1YmQtOGNkZC02MjBm
-        NjBhYTdlMGIiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI0OWU2ZmE4OS0yOGFjLTRiNWQtODZiNS0yZGY5
+        NzAxZWNjMzkiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMjhh
-        ZGViZC01NzhlLTQyODUtYjkyMC03YjkwNGEzZGFiYzEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Mjhl
+        NWZmOS0xZDU0LTQwYTItYTQxOC01OTRjN2U5N2Q1OTgiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZjE5YTllZi1kNjQ4
-        LTQ5NGItYjI5NC1kYmRmYWUwNzUyYTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTAwOTJhMi05ZmI1
+        LTQzNzMtOTAxOS0xMWI5NjMxOWYzNmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NzEyZGM2Zi02N2I1LTRjN2UtYmU4ZC02
-        Mzg0NTgyZTc1YTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjYjI2ZWU0ZS1kZjE3LTQ4NDItOWQ5MS00
+        YTEwZWJhMzU4YWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkNjhiYzJiNS00MmI5LTQwODUtYTBlNi1mMTJiMmZiZDlj
-        YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIyMTNlYTUzNi1iZGIxLTRiMDUtYWFkYS1lOTY5N2JhNmEx
+        NmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYTlkMzk1MS01
-        ODdkLTRjYTgtYmI2ZC02YzUxMDcwN2ZkMmEiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYWU5ZTNkNi02
+        NjFjLTRhMTktYTZmMS1jNzlkNmI2ZWM4MzMiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkOGY2ZWZiMy04MGM4LTQzNGMt
-        ODJjYi0xNzA5ZjlkOGU1NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNDhjODQyOC03YjMzLTQ5OGUt
+        YjFhMy00NzFhZDM0YzkzNDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImIyN2Q5NzQ1LTkwNDgtNDFhYy05OWEx
-        LWE3ZTZmZTg5MWRkMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
-        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
-        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6
-        ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTRa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
-        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
-        dGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxp
-        emVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3Jl
-        cG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQiLCAi
-        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
-        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
-        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNWYw
-        ZTNkMjIwNmM3MWEwYmQwZDczNGRiIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjI0MzE3Y2YxLTU5MTEtNDkwMy1hZWZl
-        LTQ3ZGFiMzViNGI1NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxZThhYjMxMy1mNjVkLTQyNzgtYTgyYy1iMzBmMDYx
-        YzkzY2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MTksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
-        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5NjhiNzA0LWJhMTUt
-        NGZlMy04MmYwLTkxZTE5OWM4NDEwNCIsICJudW1fcHJvY2Vzc2VkIjogMTl9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjRiMTA5YzRlLTI2ZDQtNGU3MS1hMDk1
+        LTQzY2Q5Njc3YjE0NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo0MFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
+        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
+        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
+        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
+        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
+        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
+        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
+        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
+        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjNjMDIyMzlmMDU3
+        ZjhhNDM1MCIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmZmUzMjEyOC00MWE3LTQ4YzEtOGY5NS04MGM1YzZmYWU4ZDQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogNiwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
-        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDVlMDMyOTQtOTA5YS00ZDVh
-        LWE2OTktYjhlZDI3MzhiYmY0IiwgIm51bV9wcm9jZXNzZWQiOiA2fSwgeyJu
-        dW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1v
-        ZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwi
-        OiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYjc3ZmFkMzUtMjJhYi00ZTA4LTgzZmQtYmVmYTFjMWIwNzEwIiwgIm51
-        bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjog
-        ImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogNCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA5NDdlMWVhLTdjNjktNDViZC04
-        Y2RkLTYyMGY2MGFhN2UwYiIsICJudW1fcHJvY2Vzc2VkIjogNH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRh
-        ZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImYyOGFkZWJkLTU3OGUtNDI4NS1iOTIwLTdiOTA0YTNkYWJjMSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6
-        ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJmMTlh
-        OWVmLWQ2NDgtNDk0Yi1iMjk0LWRiZGZhZTA3NTJhMyIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
-        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
-        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ3MTJkYzZmLTY3YjUtNGM3
-        ZS1iZThkLTYzODQ1ODJlNzVhMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
-        IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImQ2OGJjMmI1LTQyYjktNDA4NS1hMGU2LWYx
-        MmIyZmJkOWNjNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJh
-        OWQzOTUxLTU4N2QtNGNhOC1iYjZkLTZjNTEwNzA3ZmQyYSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
-        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        cF9pZCI6ICIxNTQ1YmYwYS1mM2NhLTQ4YjYtYWY3Zi04YWJkN2RkYWZjNzki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MDJlM2ZjOTgtYmYwZS00NDMyLWFmOTctMDVmMjE0NTM0ZGMxIiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxMDYyZDhhNS1iZTBhLTQ3YTYtYjFkYy02Nzli
+        MmJjOTU4YzkiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
+        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzBlN2M3
+        ZjMtZGU1Ni00NDQ2LTg1ZGYtZjU1NGI5Njc3MmE1IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNmNmU5MDVhLTMwY2YtNGY3Ny05ZjkxLTdlY2I0YWJi
+        NTJiYyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
+        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
         IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ4ZjZlZmIzLTgw
-        YzgtNDM0Yy04MmNiLTE3MDlmOWQ4ZTU2YyIsICJudW1fcHJvY2Vzc2VkIjog
-        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
-        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
-        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjI3ZDk3NDUtOTA0OC00
-        MWFjLTk5YTEtYTdlNmZlODkxZGQxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDIyMGY2
-        ODg3NGIwM2YzNzNmNSJ9LCAiaWQiOiAiNWYwZTNkMjIwZjY4ODc0YjAzZjM3
-        M2Y1In0=
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiZTM2YTUxLTE3
+        NmMtNDI2Mi05ZTJmLTZlZTA1YjA4ZTI3NyIsICJudW1fcHJvY2Vzc2VkIjog
+        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
+        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0OWU2ZmE4OS0yOGFjLTRiNWQtODZiNS0yZGY5NzAxZWNj
+        MzkiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
+        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MjhlNWZmOS0x
+        ZDU0LTQwYTItYTQxOC01OTRjN2U5N2Q1OTgiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
+        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTAwOTJhMi05ZmI1LTQzNzMt
+        OTAxOS0xMWI5NjMxOWYzNmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJjYjI2ZWU0ZS1kZjE3LTQ4NDItOWQ5MS00YTEwZWJh
+        MzU4YWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
+        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIyMTNlYTUzNi1iZGIxLTRiMDUtYWFkYS1lOTY5N2JhNmExNmEiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
+        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYWU5ZTNkNi02NjFjLTRh
+        MTktYTZmMS1jNzlkNmI2ZWM4MzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjNDhjODQyOC03YjMzLTQ5OGUtYjFhMy00
+        NzFhZDM0YzkzNDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
+        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjRiMTA5YzRlLTI2ZDQtNGU3MS1hMDk1LTQzY2Q5
+        Njc3YjE0NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYzEyOTczZjhjZGUyYTQwYzAi
+        fSwgImlkIjogIjVmN2RmZjNjMTI5NzNmOGNkZTJhNDBjMCJ9
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1278,7 +1268,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1291,7 +1281,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:54 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -1308,14 +1298,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWYwZTNkMjIwNmM3MWEwYTQxOTA4OGYwIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI0In0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1327,7 +1317,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1340,281 +1330,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:40 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2181'
+      - '2168'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjgu
-        c3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
-        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
-        MTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        aXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
-        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAwMzVhYzQwLTUyMjQtNDFl
-        ZS1iZDRiLWVhMzM2MDc4OGI3YyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
-        YXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwMDM1YWM0MC01
-        MjI0LTQxZWUtYmQ0Yi1lYTMzNjA3ODhiN2MiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmMGUzZDIxMGY2ODg3NGIwM2YzNjg2OCJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        c291cmNlcnBtIjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUi
-        OiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYz
-        MjY4NTliOGQ4YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5
-        OWYiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4i
-        LCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjog
-        ZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjog
-        IjEiLCAiX2lkIjogIjAzODExNjVlLWY1YzctNDZmMC1iMjA5LWQwMWEyZTgw
-        NTQzZiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA3
-        LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVh
-        dGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJycG0iLCAidW5pdF9pZCI6ICIwMzgxMTY1ZS1mNWM3LTQ2ZjAtYjIwOS1k
-        MDFhMmU4MDU0M2YiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDIxMGY2ODg3
-        NGIwM2YzNjhhZSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1
-        Y2stMC42LTEuc3JjLnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0i
-        OiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2Jj
-        YmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiBkdWNrIiwgImZpbGVuYW1lIjogImR1Y2stMC42LTEubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgImlz
-        X21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAi
-        cmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIwYWMwYWI0Yi0xMzRjLTQ3MjYtYjlm
-        NS0wMTQ2ZmYzMTIxMDIiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMGFjMGFiNGItMTM0Yy00
-        NzI2LWI5ZjUtMDE0NmZmMzEyMTAyIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBl
-        M2QyMTBmNjg4NzRiMDNmMzY3ZmYifX0sIHsibWV0YWRhdGEiOiB7InNvdXJj
-        ZXJwbSI6ICJrYW5nYXJvby0wLjMtMS5zcmMucnBtIiwgIm5hbWUiOiAia2Fu
-        Z2Fyb28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3
-        MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJz
-        dW1tYXJ5IjogImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwg
-        ImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogdHJ1
-        ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIs
-        ICJfaWQiOiAiMWIwZjAyOTMtZDJjMS00MDI1LThkMzQtOTQ5ZTRiYTQwYWQw
-        IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRU
-        MjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJw
-        bSIsICJ1bml0X2lkIjogIjFiMGYwMjkzLWQyYzEtNDAyNS04ZDM0LTk0OWU0
-        YmE0MGFkMCIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEwZjY4ODc0YjAz
-        ZjM2ODE2In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAidHJvdXQt
-        MC4xMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJ0cm91dCIsICJjaGVja3N1bSI6
-        ICJhZWE5MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJh
-        MjczMDkzOWQ1N2ZjODQyNjAyZTE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHRyb3V0IiwgImZpbGVuYW1lIjogInRyb3V0LTAuMTItMS5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjEyIiwg
-        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
-        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiMjgyNmNmNzYtMjllMS00ODQ4
-        LTlmNzUtZGRhYTg1M2JkODAwIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjI4MjZjZjc2LTI5
-        ZTEtNDg0OC05Zjc1LWRkYWE4NTNiZDgwMCIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWYwZTNkMjEwZjY4ODc0YjAzZjM2OGNkIn19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFj
-        YWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFm
-        MyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIs
-        ICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjog
-        ZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjog
-        IjAuOCIsICJfaWQiOiAiMzIzZjEyNzktYTI4Ni00YmJiLTlmYTYtYTBiOTMz
-        ZjE4ZTBlIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAt
-        MDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNy
-        ZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSIsICJ1bml0X2lkIjogIjMyM2YxMjc5LWEyODYtNGJiYi05ZmE2
-        LWEwYjkzM2YxOGUwZSIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEwZjY4
-        ODc0YjAzZjM2ODBkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAi
-        d2FscnVzLTUuMjEtMS5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNo
-        ZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4
-        OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAic3VtbWFyeSI6ICJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1
-        cy01LjIxLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiNS4yMSIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiM2NhNTUwZDQt
-        ZWUwNy00YmE1LTg1YTAtZmE0M2VlYzNiMGFlIiwgImFyY2giOiAibm9hcmNo
-        In0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzox
-        Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjNj
-        YTU1MGQ0LWVlMDctNGJhNS04NWEwLWZhNDNlZWMzYjBhZSIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWYwZTNkMjEwZjY4ODc0YjAzZjM2ODg4In19LCB7Im1ldGFk
-        YXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0i
-        LCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJm
-        ODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2
-        MWRkYzI3YjU4OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJt
-        YWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21v
-        ZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJl
-        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2NkMDE3NTUtYjJlZC00MmRkLWEyYWUt
-        MGQ1NzViNTEyOTY5IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90
-        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjNjZDAxNzU1LWIyZWQtNDJk
-        ZC1hMmFlLTBkNTc1YjUxMjk2OSIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNk
-        MjEwZjY4ODc0YjAzZjM2ODhmIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
-        cG0iOiAiZHVjay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJj
-        aGVja3N1bSI6ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
-        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAi
-        UXVhY2sgbGlrZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjog
-        ImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC43IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlw
-        ZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0Mjg0NmRh
-        Ny03MTA3LTRiY2EtOTVlNi01ZjdjNGVhN2M3MDEiLCAiYXJjaCI6ICJub2Fy
-        Y2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIz
-        OjE3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
-        NDI4NDZkYTctNzEwNy00YmNhLTk1ZTYtNWY3YzRlYTdjNzAxIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY4MjgifX0sIHsibWV0
-        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJtb25rZXktMC4zLTAuOC5zcmMucnBt
-        IiwgIm5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEy
-        OGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRk
-        ZTg1MDFkYjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbW9u
-        a2V5IiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFy
-        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
-        IjogIjAuOCIsICJfaWQiOiAiNTMwNGY2OWMtYzA2YS00MDA3LTgzZTUtYjI4
-        Mjk2NzNiZjkzIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSIsICJ1bml0X2lkIjogIjUzMDRmNjljLWMwNmEtNDAwNy04
-        M2U1LWIyODI5NjczYmY5MyIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEw
-        ZjY4ODc0YjAzZjM2ODU2In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0i
-        OiAid2FscnVzLTAuNzEtMS5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwg
-        ImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEzOWI5
-        MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAic3VtbWFyeSI6
-        ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndh
-        bHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC43MSIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5
-        cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNjQ4Zjdj
-        OTItNTQ0Ni00NDY1LTlhZTktNzBlNDRjYmUxMjVmIiwgImFyY2giOiAibm9h
-        cmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQy
-        MzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjog
-        IjY0OGY3YzkyLTU0NDYtNDQ2NS05YWU5LTcwZTQ0Y2JlMTI1ZiIsICJfaWQi
-        OiB7IiRvaWQiOiAiNWYwZTNkMjEwZjY4ODc0YjAzZjM2ODM2In19LCB7Im1l
-        dGFkYXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMi0xLnNyYy5y
-        cG0iLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiOGQzMTk5
-        MDVlZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4
-        N2I2ZjUxYWIzYjY1YSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3Ig
-        YXJtYWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4yLTEubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlz
-        X21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
-        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNzYyMGNmZjgtM2JkNC00ODg0LTk1
-        N2ItMmJlMWNjOGQzYzRmIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
-        IjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5p
-        dF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjc2MjBjZmY4LTNiZDQt
-        NDg4NC05NTdiLTJiZTFjYzhkM2M0ZiIsICJfaWQiOiB7IiRvaWQiOiAiNWYw
-        ZTNkMjEwZjY4ODc0YjAzZjM2ODljIn19LCB7Im1ldGFkYXRhIjogeyJzb3Vy
-        Y2VycG0iOiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9u
-        IiwgImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZj
-        ZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFy
-        eSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5
-        cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI3ODBm
-        NTJjNi1lYjc0LTRhYjEtOGNjNy1hNmUxY2VlZGFlZGMiLCAiYXJjaCI6ICJu
-        b2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0
-        VDIzOjE3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
-        OiAiNzgwZjUyYzYtZWI3NC00YWIxLThjYzctYTZlMWNlZWRhZWRjIiwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY4NDgifX0sIHsi
-        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5zcmMu
-        cnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFm
-        ZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1
-        ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3Ig
-        ZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19t
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
+        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
+        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
+        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
+        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
+        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjNiMTI5NzNmOGNkZTJhM2VhMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291
+        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
+        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
+        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
+        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
+        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
+        NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
+        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
+        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmEz
+        ZTY4In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
+        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
+        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
+        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
+        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
+        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
+        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
+        IjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U4OCJ9fSwgeyJtZXRhZGF0YSI6
+        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
+        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
+        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
+        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
+        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
+        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNi
+        MTI5NzNmOGNkZTJhM2UxMiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
+        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
+        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U1
+        NiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
+        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
+        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
+        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
+        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90
+        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
+        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
+        M2IxMjk3M2Y4Y2RlMmEzZTQzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
+        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
+        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
+        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
+        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
+        MTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
+        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U1ZiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
+        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
+        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
+        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
+        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
+        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
+        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAi
+        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
+        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZTdmIn19LCB7Im1ldGFkYXRhIjog
+        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
+        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
+        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
+        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
+        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQi
+        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
+        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTcz
+        ZjhjZGUyYTNlMzYifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
+        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
+        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
+        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
+        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
+        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
+        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlOWEifX0sIHsibWV0YWRh
+        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
+        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
+        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
+        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
+        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
+        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNi
+        MTI5NzNmOGNkZTJhM2U3MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
+        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
+        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U5
+        MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
+        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
+        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
+        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
         b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjg3OGUwOGU2LWIwMmEtNDI0MS04M2Vi
-        LTMzNjhhOGI0ZDUxNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4NzhlMDhlNi1iMDJhLTQy
-        NDEtODNlYi0zMzY4YThiNGQ1MTUiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUz
-        ZDIxMGY2ODg3NGIwM2YzNjhiYiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
-        cnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxy
-        dXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZj
-        N2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1t
-        YXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUi
-        OiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6
-        ICJiNjJiOWM1MS02NDZkLTRjMjQtYTY5OS0wOWQwMjlmYWUwNDciLCAiYXJj
-        aCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1
-        M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIw
-        LTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
-        aXRfaWQiOiAiYjYyYjljNTEtNjQ2ZC00YzI0LWE2OTktMDlkMDI5ZmFlMDQ3
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY4N2Ui
-        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjIt
-        MS5zcmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAi
-        ODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1
-        YTliZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
-        a2FnZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjIt
-        MS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIi
-        LCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImJkNTUxNzQ0LWJhYmEtNDcz
-        NS04YmYyLTM0YzA1ODY0M2EwZSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
-        YXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiZDU1MTc0NC1i
-        YWJhLTQ3MzUtOGJmMi0zNGMwNTg2NDNhMGUiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmMGUzZDIxMGY2ODg3NGIwM2YzNjg1ZiJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        c291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1
-        N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0
-        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCAi
-        ZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFs
-        c2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiZGYyMGZiOTktNDdlOC00NDY5LTg1MTgtZGZkZDg4Njc4
-        OWQwIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDct
-        MTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImRmMjBmYjk5LTQ3ZTgtNDQ2OS04NTE4LWRm
-        ZGQ4ODY3ODlkMCIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEwZjY4ODc0
-        YjAzZjM2ODNmIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAic3F1
-        aXJyZWwtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAic3F1aXJyZWwiLCAi
-        Y2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNk
-        MDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIsICJzdW1tYXJ5Ijog
-        IkEgZHVtbXkgcGFja2FnZSBvZiBzcXVpcnJlbCIsICJmaWxlbmFtZSI6ICJz
-        cXVpcnJlbC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
-        ZWMyY2IzODAtMjg3ZC00ODg0LTg4OTEtZjhlODU4ZjU1YWE4IiwgImFyY2gi
-        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0w
-        Ny0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0
-        X2lkIjogImVjMmNiMzgwLTI4N2QtNDg4NC04ODkxLWY4ZTg1OGY1NWFhOCIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEwZjY4ODc0YjAzZjM2ODFmIn19
-        LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQy
-        MmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBk
-        ZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
-        Z2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
-        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJmMDI0NWRkOC0yY2Y2LTQx
-        ZGQtYjA0OC04ZGEyZDI5MTU2NmEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjAyNDVkZDgt
-        MmNmNi00MWRkLWIwNDgtOGRhMmQyOTE1NjZhIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY4NzEifX1d
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
+        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
+        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        ZjNiMTI5NzNmOGNkZTJhM2UxYiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
+        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
+        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2UyZCJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
+        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
+        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
+        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
+        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
+        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlMDUifX0sIHsibWV0YWRhdGEiOiB7
+        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
+        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
+        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
+        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVf
+        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
+        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEy
+        OTczZjhjZGUyYTNkZmIifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
+        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
+        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
+        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
+        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
+        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
+        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZGYyIn19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
+        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
+        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
+        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
+        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4
+        Y2RlMmEzZTRkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
+        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
+        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
+        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
+        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
+        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
+        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlMjQifX1d
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1626,7 +1616,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1639,7 +1629,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -1652,10 +1642,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1665,7 +1655,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1678,144 +1668,144 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1318'
+      - '1315'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFhY2QwOWVk
-        NGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5
-        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwgImFydGlm
-        YWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
-        OiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5NWZkOThi
-        OWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVkIjogMTU5
-        NDY3MjYwNCwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
-        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBlciI6IFsi
-        d2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1bGUiLCAi
-        ZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMs
-        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiYzBmZmVl
-        NDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6
-        IFtdLCAiX2lkIjogIjM3MDJmNzNmLTcyMjEtNDUzZi04ZmI5LTVlODMyMjU2
-        NmZhYyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6ICJBIG1v
-        ZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0
-        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzNzAyZjczZi03
-        MjIxLTQ1M2YtOGZiOS01ZTgzMjI1NjZmYWMiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmMGUzZDIxMGY2ODg3NGIwM2YzNjk1YiJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        X3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMv
-        bW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3OTdhMDdhODRmZDNm
-        NTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAibmFtZSI6ICJrYW5n
-        YXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImthbmdhcm9v
-        LTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJlODIwZTA4YzA1YWE3
-        MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgyNDI3OWUzNmM5YTcy
-        ZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTk0NjcyNjA0LCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVs
-        dCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkthbmdhcm9vIDAuMiBt
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
+        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
+        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
+        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
         b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
         OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjU2YzYyM2E0LWFlMjYtNDMwMy1iZDM2
-        LWY1MGQ2NmE4YjQ0MyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAuMiBwYWNrYWdlIn0s
-        ICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQi
-        OiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1
-        M1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAi
-        NTZjNjIzYTQtYWUyNi00MzAzLWJkMzYtZjUwZDY2YThiNDQzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY5MmQifX0sIHsibWV0
-        YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250
-        ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRlNGUzNWM2N2FiMDhk
-        MjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIwYzM4MmNlIiwgIm5h
-        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImR1
-        Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjogImRkNjIxYzA1OGNk
-        ZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODczZDg1NmI3OTBhN2Y3
-        MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1OTQ2NzI2MDQsICJfY29u
-        dGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZh
-        dWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNyBtb2R1bGUi
-        LCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MzAyMzMx
-        MDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiZGVh
-        ZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2ll
-        cyI6IFtdLCAiX2lkIjogImExMTRjZGI0LTQ3MjgtNGJhOC04YjMyLTFkMDdj
-        NDdjNWMyOCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlvbiI6ICJB
-        IG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2UifSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0
-        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJhMTE0Y2RiNC00
-        NzI4LTRiYTgtOGIzMi0xZDA3YzQ3YzVjMjgiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmMGUzZDIxMGY2ODg3NGIwM2YzNjkzYiJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        X3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMv
-        bW9kdWxlbWQvMWIvMmYwMDM5NjRiYjY0MjFkZTc0Mjc3ZGIxOWM5Y2E4ZDMz
-        M2FiYTk2MzkzOTEwYzc4MGU1NzAwZGM4YTgzYTMiLCAibmFtZSI6ICJkdWNr
-        IiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsiZHVjay0wOjAuNi0x
-        Lm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiNmJkOWQ5MDljOTI3MDU3MWI4MTFl
-        NTAyNzA5ZWE3YjU2MTUwZDQ0YTJiNGIzNGNmZDI1ZTUyYTgxYzViZmNlNyIs
-        ICJfbGFzdF91cGRhdGVkIjogMTU5NDY3MjYwNCwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbImR1
-        Y2siXX0sICJzdW1tYXJ5IjogIkR1Y2sgMC42IG1vZHVsZSIsICJkb3dubG9h
-        ZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwgInB1bHBf
-        dXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJf
-        bnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJf
-        aWQiOiAiYTNhY2RkZTQtOWUxZi00Nzc1LTg2ZTEtNzQwOTNkY2MyZjA5Iiwg
-        ImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZv
-        ciB0aGUgZHVjayAwLjYgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTA3
-        LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVh
-        dGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogImEzYWNkZGU0LTllMWYtNDc3NS04
-        NmUxLTc0MDkzZGNjMmYwOSIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEw
-        ZjY4ODc0YjAzZjM2OTQ0In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
-        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83
-        OC82ODcyN2JjYzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNk
-        NTU1NmJjZGNlYTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0
-        cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjMtMS5u
-        b2FyY2giXSwgImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2NzdjNGJh
-        YWNmMDA1ZWM5ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNmZGUiLCAi
-        X2xhc3RfdXBkYXRlZCI6IDE1OTQ2NzI2MDQsICJfY29udGVudF90eXBlX2lk
-        IjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5n
-        YXJvbyJdfSwgInN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVsZSIsICJk
-        b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQwNywg
-        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
-        ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
-        W10sICJfaWQiOiAiYTdiMzM4NjEtMmJiZC00YWUzLWI1OGItNDI5MDQwMWRl
-        MmE1IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
-        dWxlIGZvciB0aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0
-        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJhN2IzMzg2MS0y
-        YmJkLTRhZTMtYjU4Yi00MjkwNDAxZGUyYTUiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmMGUzZDIxMGY2ODg3NGIwM2YzNjkyNCJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        X3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMv
-        bW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5YTM2NmY4
-        MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6ICJ3YWxy
-        dXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMt
-        MDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1MGU1M2M1
-        ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3ZDgwMjhh
-        MDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTk0NjcyNjA0LCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVs
-        dCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4yMSBtb2R1
-        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDQx
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
+        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
+        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y0ZCJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
+        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
+        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
+        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
+        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
+        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
+        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
+        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
+        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
+        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
+        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
+        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
+        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y1YiJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
+        bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
+        ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
+        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
+        OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
+        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
+        bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
+        aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
+        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
+        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
+        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
+        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNm
+        MmQifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
+        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
+        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
+        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
+        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
+        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
+        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
+        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
+        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
+        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
+        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
+        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
+        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y0NCJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
+        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
+        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
+        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
+        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
+        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
+        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
+        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
+        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
+        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
+        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
+        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNm
+        MzcifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
+        Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
+        ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
+        ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
+        Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
+        NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
+        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
+        LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
+        ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
+        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
         NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
-        ZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogImZlYjQzODliLTgwZTctNGFjZi1hMDU0LWZh
-        YTQ0Yzk0MTM3NCIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
-        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmZWI0
-        Mzg5Yi04MGU3LTRhY2YtYTA1NC1mYWE0NGM5NDEzNzQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmMGUzZDIxMGY2ODg3NGIwM2YzNjk1MSJ9fV0=
+        YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
+        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
+        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
+        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
+        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y2NCJ9fV0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1825,7 +1815,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1838,7 +1828,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -1851,10 +1841,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1864,7 +1854,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1877,42 +1867,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1960'
+      - '1950'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
         W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAy
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6ICJ1
-        bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2Vz
-        dGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBb
-        eyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2pl
-        Y3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZp
-        bGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
-        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAi
-        c2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjog
-        IiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xh
-        c3RfdXBkYXRlZCI6IDE1OTQ3Njg2NzMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
+        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
+        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
+        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
+        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
+        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
+        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
+        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
+        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
+        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
+        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
+        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NTksICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
         IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
         aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjBlNjRiNDQ2LTkxMjItNDJkZi04MzEzLWNiNzg4YTI2NGQxMyJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMGU2
-        NGI0NDYtOTEyMi00MmRmLTgzMTMtY2I3ODhhMjY0ZDEzIiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRiMDNmMzY5YWIifX0sIHsibWV0YWRh
+        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
+        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
+        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTQwNDUifX0sIHsibWV0YWRh
         dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
         aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
         X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
@@ -1927,97 +1928,86 @@ http_interactions:
         IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
         ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
         dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTU5NDc2ODY3MywgInJl
+        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg1OSwgInJl
         c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
         Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
-        bGVhc2UiOiAiMSIsICJfaWQiOiAiMGU4ZjBkZGUtZTc2YS00MWY4LThhZTMt
-        MjkyMTg2NDc4MTRlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6
-        NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
-        LCAidW5pdF9pZCI6ICIwZThmMGRkZS1lNzZhLTQxZjgtOGFlMy0yOTIxODY0
-        NzgxNGUiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDIxMGY2ODg3NGIwM2Yz
-        NjliYSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgtMDEtMjcg
-        MTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
+        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
+        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
+        MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
+        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
+        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJh
+        NDAwZCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
+        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
         ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
         bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
-        MDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0LmNvbSIsICJzZXZl
-        cml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJvb19FcnJhdHVtIiwg
-        Il9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJv
-        b3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50Iiwg
-        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3
-        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVjayIsICJzdW0iOiBu
-        dWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gucnBtIiwgImVw
-        b2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJlbGVhc2UiOiAiMSIs
-        ICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0wIiwg
-        Im1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjog
-        IjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAi
-        ZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn0sIHsicGFja2Fn
-        ZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIs
-        ICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6
-        ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwg
-        InZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwgIm1vZHVsZSI6IHsi
-        Y29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIwMTgwNzMwMjIz
-        NDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAi
-        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFi
-        bGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVUQyIsICJk
-        ZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlwdGlv
-        biIsICJfbGFzdF91cGRhdGVkIjogMTU5NDc2ODY3MywgInJlc3RhcnRfc3Vn
-        Z2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIi
-        LCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiNDc0Njg2NmItNzI2Zi00ZjNkLThkODUtMzM1MWZlMDA1
-        MjQ0In0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQy
-        MzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9p
-        ZCI6ICI0NzQ2ODY2Yi03MjZmLTRmM2QtOGQ4NS0zMzUxZmUwMDUyNDQiLCAi
-        X2lkIjogeyIkb2lkIjogIjVmMGUzZDIxMGY2ODg3NGIwM2YzNjlkZCJ9fSwg
-        eyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEi
-        LCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBb
-        XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDEi
-        LCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5Ijog
-        IiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2Vy
-        cmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBm
-        YWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAic3Rh
-        dHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6
-        ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1OTQ3Njg2NzMs
-        ICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIs
-        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
-        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjdjODVmOGQ3LWU1ZDYtNDhkMC05
-        Yjg0LWYxMzE5MWZhZjkzMiJ9LCAidXBkYXRlZCI6ICIyMDIwLTA3LTE0VDIz
-        OjE3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
-        IjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJh
-        dHVtIiwgInVuaXRfaWQiOiAiN2M4NWY4ZDctZTVkNi00OGQwLTliODQtZjEz
-        MTkxZmFmOTMyIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4NzRi
-        MDNmMzY5ODgifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEyLTAx
-        LTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJy
-        ZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJI
-        RUEtMjAxMDowMTExIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIs
-        ICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVwbGljYXRlZCBwYWNrYWdl
-        IGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjog
-        IjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1
-        cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0
-        cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImxpb24iLCAi
-        c3VtIjogbnVsbCwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifSwgeyJzcmMiOiAiaHR0cDov
-        L3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50Iiwg
-        InN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJy
-        ZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAi
-        Y29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFi
-        bGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRHVwbGljYXRl
-        IE9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTU5NDc2
-        ODY3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
+        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
+        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
+        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
+        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
+        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
+        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
+        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
+        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
+        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
+        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
+        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODU5
+        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
+        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
+        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
+        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
+        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4
+        Y2RlMmE0MDJiIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
+        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
+        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
+        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
+        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
+        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
+        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
+        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
+        IjogMTYwMjA5Mjg1OSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
+        dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
+        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
+        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90
+        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
+        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjNiMTI5NzNmOGNkZTJhM2ZiOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
+        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
+        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
+        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
+        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
+        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
+        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
+        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
+        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
+        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
+        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
+        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg1OSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
         OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODYzYTMwZTMtYWViOS00
-        YTU2LWJiNDctNmQyMjBmOTBlODM1In0sICJ1cGRhdGVkIjogIjIwMjAtMDct
-        MTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NjNhMzBlMy1hZWI5LTRhNTYtYmI0
-        Ny02ZDIyMGY5MGU4MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDIxMGY2
-        ODg3NGIwM2YzNjljOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
+        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
+        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
+        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5
+        NzNmOGNkZTJhM2ZmMiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
         MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
         ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
         dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
@@ -2074,7 +2064,7 @@ http_interactions:
         b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
         dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
         bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
-        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE1OTQ3Njg2NzMsICJy
+        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NTksICJy
         ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
         aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
         b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
@@ -2085,18 +2075,18 @@ http_interactions:
         dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
         ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
         YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
-        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImJlZDY2NTU0LTA5MjYtNGU4
-        OS1hOTBhLWUzYjcyZmUxN2ZjNyJ9LCAidXBkYXRlZCI6ICIyMDIwLTA3LTE0
-        VDIzOjE3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMDctMTRUMjM6MTc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiYmVkNjY1NTQtMDkyNi00ZTg5LWE5MGEt
-        ZTNiNzJmZTE3ZmM3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMTBmNjg4
-        NzRiMDNmMzY5OWMifX1d
+        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
+        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
+        VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
+        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTcz
+        ZjhjZGUyYTNmZDgifX1d
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2106,7 +2096,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2119,7 +2109,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2132,10 +2122,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2145,7 +2135,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2158,13 +2148,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '521'
+      - '519'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2174,19 +2164,19 @@ http_interactions:
         b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
         X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
         YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
-        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE1OTQ3Njg2NzMsICJv
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
         cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
         OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
         cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
         ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
-        YmlyZCIsICJfaWQiOiAiNzYxMTI2ODMtYWEzYS00MTJlLWIwNzAtMjE1Mjdk
-        Y2UxNDMyIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0wNy0xNFQy
-        MzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjc2MTEyNjgzLWFhM2EtNDEyZS1i
-        MDcwLTIxNTI3ZGNlMTQzMiIsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjEw
-        ZjY4ODc0YjAzZjM2OWVjIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
+        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
+        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2Ix
+        Mjk3M2Y4Y2RlMmE0MDYxIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
         cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
         ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
         ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
@@ -2194,24 +2184,24 @@ http_interactions:
         LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
         XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
         InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
-        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTk0
-        NzY4NjczLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
+        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
         YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
         ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
         YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
-        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOTY1Y2Y4ZGQtN2M1MS00MWFj
-        LTlkMzAtNTk3Njc0ODQ0NTk3IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
+        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
         Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
-        MjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUzWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjk2NWNmOGRk
-        LTdjNTEtNDFhYy05ZDMwLTU5NzY3NDg0NDU5NyIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWYwZTNkMjEwZjY4ODc0YjAzZjM2OWY3In19XQ==
+        MjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
+        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmE0MDZkIn19XQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2221,7 +2211,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2234,7 +2224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2247,10 +2237,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2260,7 +2250,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2273,13 +2263,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '403'
+      - '405'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2293,22 +2283,22 @@ http_interactions:
         Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
         b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
         ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNTk0NzY4NjcyLCAiX2NvbnRlbnRfdHlwZV9p
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODU4LCAiX2NvbnRlbnRfdHlwZV9p
         ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
         cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
         eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiZThkYWI4Y2MtODAxOS00Njg1LWEwYWQtOGE2OWMw
-        NjkwYjYxIn0sICJ1cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTJaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNy0x
-        NFQyMzoxNzo1MloiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOGRhYjhjYy04MDE5LTQ2ODUtYTBh
-        ZC04YTY5YzA2OTBiNjEiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDIwMGY2
-        ODg3NGIwM2YzNjdlMCJ9fV0=
+        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
+        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzhaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
+        N1QxNzo0NzozOFoiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
+        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNhMTI5
+        NzNmOGNkZTJhM2RjNSJ9fV0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2318,7 +2308,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2331,7 +2321,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2344,10 +2334,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2359,7 +2349,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2372,7 +2362,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2385,10 +2375,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2398,7 +2388,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2411,7 +2401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Vary:
@@ -2437,45 +2427,45 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU5NDc2
-        ODY3MywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg1OSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImQ5NGZkZmIzLTQ3
-        MjUtNDM2Mi1hMjJiLTM3MDVkZDkxZjYzMSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMDctMTRUMjM6MTc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0wNy0xNFQyMzoxNzo1M1oiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImQ5NGZkZmIzLTQ3
-        MjUtNDM2Mi1hMjJiLTM3MDVkZDkxZjYzMSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWYwZTNkMjEwZjY4ODc0YjAzZjM2OTEzIn19XQ==
+        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZWY3In19XQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJ0cm91dC0wLjEyLTEubm9hcmNoLnJw
-        bSIsImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsImFybWFkaWxsby0w
-        LjEtMS5ub2FyY2gucnBtIiwibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwibGlvbi0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwid2FscnVz
-        LTAuMy0wLjgubm9hcmNoLnJwbSIsImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwiY2hlZXRhaC0w
-        LjMtMC44Lm5vYXJjaC5ycG0iXX19fSwiZmllbGRzIjp7InVuaXQiOlsibmFt
+        OnsiJGluIjpbImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCJ3YWxydXMt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJsaW9uLTAuMy0w
+        Ljgubm9hcmNoLnJwbSIsIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJj
+        aGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsImdpcmFmZmUtMC4zLTAuOC5u
+        b2FyY2gucnBtIiwicGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJhcm1h
+        ZGlsbG8tMC4yLTEubm9hcmNoLnJwbSIsInRyb3V0LTAuMTItMS5ub2FyY2gu
+        cnBtIiwiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwiYXJtYWRpbGxv
+        LTAuMS0xLm5vYXJjaC5ycG0iXX19fSwiZmllbGRzIjp7InVuaXQiOlsibmFt
         ZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwiY2hlY2tz
         dW10eXBlIiwiY2hlY2tzdW0iXX19LCJvdmVycmlkZV9jb25maWciOnt9fQ==
     headers:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2488,7 +2478,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2499,14 +2489,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc2YTc2YjU1LWNhOWEtNDAzMi05MjczLTNjNDhlZDMyNmE3ZS8iLCAi
-        dGFza19pZCI6ICI3NmE3NmI1NS1jYTlhLTQwMzItOTI3My0zYzQ4ZWQzMjZh
-        N2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzliODk4NGM1LWZlNmItNDNkNS1hYTI3LTVjMDUzNTc3NmNjYi8iLCAi
+        dGFza19pZCI6ICI5Yjg5ODRjNS1mZTZiLTQzZDUtYWEyNy01YzA1MzU3NzZj
+        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2517,7 +2507,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2530,7 +2520,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2541,14 +2531,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYzOWExN2YwLWM5NTMtNDM1Ny1iNzlmLTMwZjY4NTkyZGQxMi8iLCAi
-        dGFza19pZCI6ICI2MzlhMTdmMC1jOTUzLTQzNTctYjc5Zi0zMGY2ODU5MmRk
-        MTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzU2NWEyZmVlLTg1N2EtNGVjZS1hMWQ5LTE3NzU1MTYxNDlkNi8iLCAi
+        dGFza19pZCI6ICI1NjVhMmZlZS04NTdhLTRlY2UtYTFkOS0xNzc1NTE2MTQ5
+        ZDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2558,7 +2548,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2571,7 +2561,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2582,14 +2572,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JhZmZmMmZjLWJmMmYtNDFkZi1hNDA1LTAyYzQ5MTc1YjE5Ny8iLCAi
-        dGFza19pZCI6ICJiYWZmZjJmYy1iZjJmLTQxZGYtYTQwNS0wMmM0OTE3NWIx
-        OTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2M0YWE1NDU2LWYxNmEtNGZjOC04MWQwLWJjMDIzODZiNjE4NS8iLCAi
+        dGFza19pZCI6ICJjNGFhNTQ1Ni1mMTZhLTRmYzgtODFkMC1iYzAyMzg2YjYx
+        ODUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2599,7 +2589,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2612,7 +2602,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2623,14 +2613,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2QzODFkOWYxLWE0YjAtNDM3YS04M2I4LWEyNDQ3ZTNjZTUwNS8iLCAi
-        dGFza19pZCI6ICJkMzgxZDlmMS1hNGIwLTQzN2EtODNiOC1hMjQ0N2UzY2U1
-        MDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzlhYTg5NjE0LWY4NWEtNDllZS1hMDc2LTcwYmI0ZTU4YWIwMC8iLCAi
+        dGFza19pZCI6ICI5YWE4OTYxNC1mODVhLTQ5ZWUtYTA3Ni03MGJiNGU1OGFi
+        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2640,7 +2630,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2653,7 +2643,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2664,14 +2654,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JiZDE1M2RiLWU0NjQtNDRlMi05MDk1LTUzMmYzYTNmODAzNy8iLCAi
-        dGFza19pZCI6ICJiYmQxNTNkYi1lNDY0LTQ0ZTItOTA5NS01MzJmM2EzZjgw
-        MzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2NmYTU4ZjFjLWZiM2QtNDhhYy1hMTBlLTAzMjViNmVmMjQ4MC8iLCAi
+        dGFza19pZCI6ICJjZmE1OGYxYy1mYjNkLTQ4YWMtYTEwZS0wMzI1YjZlZjI0
+        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2682,7 +2672,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2695,7 +2685,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2706,14 +2696,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E0Nzg4MTcwLTk1YmMtNDg1Ni1iNTBkLWNkZGQzYzc2ZmNlNy8iLCAi
-        dGFza19pZCI6ICJhNDc4ODE3MC05NWJjLTQ4NTYtYjUwZC1jZGRkM2M3NmZj
-        ZTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQzNjhiZDljLTRkM2MtNGRlMC1iNGZiLTQ5NmM2OGI3OWUyNi8iLCAi
+        dGFza19pZCI6ICI0MzY4YmQ5Yy00ZDNjLTRkZTAtYjRmYi00OTZjNjhiNzll
+        MjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2724,7 +2714,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2737,7 +2727,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -2748,14 +2738,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzEwYzY2MzAwLWQ4MTYtNDA2Ny05ZDA5LTE0Y2U0NWVjMTk5Yi8iLCAi
-        dGFza19pZCI6ICIxMGM2NjMwMC1kODE2LTQwNjctOWQwOS0xNGNlNDVlYzE5
-        OWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI5YmI1OTdkLWE2NzktNDA5NC05NTc1LWZmYmExMzhlMzA2Zi8iLCAi
+        dGFza19pZCI6ICIyOWJiNTk3ZC1hNjc5LTQwOTQtOTU3NS1mZmJhMTM4ZTMw
+        NmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2765,7 +2755,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2778,7 +2768,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -2789,14 +2779,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M3MDQ1YzFjLTBkMDgtNDAwMS04MWFlLTE0N2ZiY2U2ZWYwNi8iLCAi
-        dGFza19pZCI6ICJjNzA0NWMxYy0wZDA4LTQwMDEtODFhZS0xNDdmYmNlNmVm
-        MDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FiN2Y0MDE2LTc1ODQtNDI4OC1iYTExLTE4YjJhMmM3ODU1Mi8iLCAi
+        dGFza19pZCI6ICJhYjdmNDAxNi03NTg0LTQyODgtYmExMS0xOGIyYTJjNzg1
+        NTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2806,7 +2796,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2819,7 +2809,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -2830,14 +2820,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBhMGM3NDdlLWI0N2ItNGU2NS1hNTNlLWRlN2I5MjQ2MWY3Ny8iLCAi
-        dGFza19pZCI6ICIwYTBjNzQ3ZS1iNDdiLTRlNjUtYTUzZS1kZTdiOTI0NjFm
-        NzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc0Y2Q0ZTU1LWJkMTktNDRkMS1iOTRjLWU5YmYyZTFiYjczMi8iLCAi
+        dGFza19pZCI6ICI3NGNkNGU1NS1iZDE5LTQ0ZDEtYjk0Yy1lOWJmMmUxYmI3
+        MzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2847,7 +2837,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2860,7 +2850,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -2871,14 +2861,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJjMTM5ZmI5LTc2NmQtNDA5YS1hNjMyLTA3ZWZiMzcwMTY0ZS8iLCAi
-        dGFza19pZCI6ICIyYzEzOWZiOS03NjZkLTQwOWEtYTYzMi0wN2VmYjM3MDE2
-        NGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRmNDIzNTVjLWI1MzctNDZmOS05ZjI2LTJiNzYxMGUxMmFhMy8iLCAi
+        dGFza19pZCI6ICI0ZjQyMzU1Yy1iNTM3LTQ2ZjktOWYyNi0yYjc2MTBlMTJh
+        YTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/76a76b55-ca9a-4032-9273-3c48ed326a7e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9b8984c5-fe6b-43d5-aa27-5c0535776ccb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2886,7 +2876,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2897,15 +2887,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Etag:
-      - '"ed176f644248dcbde77f8ba0c4f3a1e9-gzip"'
+      - '"bf50bbc4e43f2ce60ea9be9f846d0d18-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1176'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2913,206 +2903,206 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83NmE3NmI1
-        NS1jYTlhLTQwMzItOTI3My0zYzQ4ZWQzMjZhN2UvIiwgInRhc2tfaWQiOiAi
-        NzZhNzZiNTUtY2E5YS00MDMyLTkyNzMtM2M0OGVkMzI2YTdlIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85Yjg5ODRj
+        NS1mZTZiLTQzZDUtYWEyNy01YzA1MzU3NzZjY2IvIiwgInRhc2tfaWQiOiAi
+        OWI4OTg0YzUtZmU2Yi00M2Q1LWFhMjctNWMwNTM1Nzc2Y2NiIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQxWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQx
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJh
-        YmY2OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhk
-        MDU4OWU2ZjNkOGQxZmYzOTlmIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsi
-        c2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAibGlv
-        biIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2
-        Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
-        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
-        X2tleSI6IHsibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQw
-        YmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJk
-        YmI3ZDY1ZmIzNjhkYWUiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
-        MyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
-        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNp
-        Z25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBo
-        YW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2Ni
-        M2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIs
-        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJh
-        ZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0NjgyN2M0OGYyZDI5YjdjNmU5
-        YmJhODk4YTYxZGRjMjdiNTg5IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsi
-        c2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxl
-        cGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4
-        YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIs
-        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
-        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
-        MTBmZDZlNDg2MzViZTY5NCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsi
-        c2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAibW9u
-        a2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJjN2NjYzU2MzJl
-        M2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFkYjEiLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIs
-        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThk
-        NmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFk
-        ZWM3ZmI2MjFhNDYxZGZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
-        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
-        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
-        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJhcm1h
-        ZGlsbG8iLCAiY2hlY2tzdW0iOiAiOGQzMTk5MDVlZWRiNWE1MjQ3ZTNhMzUy
-        NTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2ZjUxYWIzYjY1YSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIs
-        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogInRyb3V0IiwgImNoZWNrc3VtIjogImFlYTkx
-        ZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2MTc1MWExYmEyNzMwOTM5
-        ZDU3ZmM4NDI2MDJlMTQiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
-        MTIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
-        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
-        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZ2lyYWZm
-        ZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3
-        YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0IiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
-        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
-        X2tleSI6IHsibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3
-        NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNj
-        ZGUxYzBhZTg3OGExN2QyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
-        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
-        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV0sICJ1
-        bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMzBmNjg4NzRiMDNmMzc1
-        YzMifSwgImlkIjogIjVmMGUzZDIzMGY2ODg3NGIwM2YzNzVjMyJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/639a17f0-c953-4357-b79f-30f68592dd12/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"0da93b6f2c5cbd4539843dfbfdd11ce1-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '958'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MzlhMTdm
-        MC1jOTUzLTQzNTctYjc5Zi0zMGY2ODU5MmRkMTIvIiwgInRhc2tfaWQiOiAi
-        NjM5YTE3ZjAtYzk1My00MzU3LWI3OWYtMzBmNjg1OTJkZDEyIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250ZXh0Ijog
-        ImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwgImFyY2gi
-        OiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAi
-        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
-        IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIwMywgImFy
-        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIw
-        LjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9rZXkiOiB7
-        ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjMz
-        MTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwgInN0cmVh
-        bSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19r
-        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNo
-        ZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEzOWI5MTc2
-        N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAi
-        bm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQi
-        OiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7
-        Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYwYWQ2Nzgz
-        MjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0
-        NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAicmVsZWFz
-        ZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0
+        NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZm
+        Mzk5ZiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgInJlbGVh
+        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
+        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0i
+        OiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1
+        ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsICJlcG9jaCI6ICIwIiwgInZlcnNp
+        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
+        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
+        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
+        OiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2Fl
+        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNo
+        YTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51
+        bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1
+        bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1
+        ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
+        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3
+        Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRi
+        MSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
         aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
-        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tz
-        dW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
+        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tz
+        dW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNm
+        NjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
         aCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJw
-        bSJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZl
-        cnNpb24iOiAyMDE4MDcwNDExMTcxOSwgImFyY2giOiAibm9hcmNoIiwgIm5h
-        bWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAi
-        bW9kdWxlbWQifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6
-        IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJj
-        MGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2
-        MTAzY2U0Y2M4IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAi
-        cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
-        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
-        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNo
-        ZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4
-        OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAi
-        bm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQi
-        OiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYi
-        LCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJub2FyY2gi
-        LCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9p
+        bSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1l
+        IjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2
+        ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5
+        NCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
+        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
+        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
+        c3VtIjogImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJk
+        MjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
+        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJjOTgx
+        OWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2MWRm
+        ZCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
+        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
+        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
+        c3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2NGU4
+        MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
+        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJ0cm91dCIsICJjaGVja3N1bSI6ICJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
+        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjEyIiwgInJlbGVhc2Ui
+        OiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
+        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0i
+        OiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNl
+        MzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIsICJlcG9jaCI6ICIwIiwgInZlcnNp
+        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
+        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
+        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
+        OiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVmMTNkNzg0
+        ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdk
+        MiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
+        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0Mjk4In0sICJpZCI6ICI1
+        ZjdkZmYzZDEyOTczZjhjZGUyYTQyOTgifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/565a2fee-857a-4ece-a1d9-1775516149d6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:42 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"dfe895d5c43ed72eab1ff5c17b8251f4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '960'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81NjVhMmZl
+        ZS04NTdhLTRlY2UtYTFkOS0xNzc1NTE2MTQ5ZDYvIiwgInRhc2tfaWQiOiAi
+        NTY1YTJmZWUtODU3YS00ZWNlLWExZDktMTc3NTUxNjE0OWQ2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQx
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
+        ZXJzaW9uIjogMjAxODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJu
+        YW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9k
+        dWxlbWQifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIs
+        ICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIs
+        ICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9p
         ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
-        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFyY2giOiAi
-        eDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIn0s
-        ICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXkiOiBudWxs
-        LCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5
-        NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3
-        Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAi
-        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjMwZjY4ODc0YjAzZjM3
-        NWQyIn0sICJpZCI6ICI1ZjBlM2QyMzBmNjg4NzRiMDNmMzc1ZDIifQ==
+        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAi
+        bm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlw
+        ZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgz
+        M2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5
+        YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNr
+        IiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNl
+        ZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
+        ZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tl
+        eSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVhNGM4
+        OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2Qw
+        OTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
+        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9r
+        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
+        NzA0MTExNzE5LCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJrYW5nYXJv
+        byIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
+        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndh
+        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
+        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
+        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUz
+        M2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0
+        OGI3N2UwMTg5OGU3YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1
+        LjIxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
+        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVu
+        aXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAy
+        MDE4MDczMDIyMzQwNywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2Fu
+        Z2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQi
+        fSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
+        aW9uIjogMjAxODA3MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1l
+        IjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
+        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZl
+        NmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3
+        NGJjNyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVh
+        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9z
+        aWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjNkMTI5NzNmOGNkZTJhNDJhOSJ9LCAiaWQiOiAi
+        NWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MmE5In0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/bafff2fc-bf2f-41df-a405-02c49175b197/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c4aa5456-f16a-4fc8-81d0-bc02386b6185/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3120,7 +3110,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3131,15 +3121,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:55 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Etag:
-      - '"75f4440a6d2559992f581e23ba901c6e-gzip"'
+      - '"2951977b4ab3b12f6d71e437f78fcaa8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '431'
+      - '427'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3147,28 +3137,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iYWZmZjJm
-        Yy1iZjJmLTQxZGYtYTQwNS0wMmM0OTE3NWIxOTcvIiwgInRhc2tfaWQiOiAi
-        YmFmZmYyZmMtYmYyZi00MWRmLWE0MDUtMDJjNDkxNzViMTk3IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jNGFhNTQ1
+        Ni1mMTZhLTRmYzgtODFkMC1iYzAyMzg2YjYxODUvIiwgInRhc2tfaWQiOiAi
+        YzRhYTU0NTYtZjE2YS00ZmM4LTgxZDAtYmMwMjM4NmI2MTg1IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
-        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWYwZTNkMjMwZjY4ODc0YjAzZjM3NWU0In0sICJpZCI6ICI1ZjBlM2Qy
-        MzBmNjg4NzRiMDNmMzc1ZTQifQ==
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNkMTI5
+        NzNmOGNkZTJhNDJiYiJ9LCAiaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0
+        MmJiIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/d381d9f1-a4b0-437a-83b8-a2447e3ce505/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9aa89614-f85a-49ee-a076-70bb4e58ab00/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3176,7 +3166,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3187,15 +3177,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:56 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Etag:
-      - '"74a1e26ffb5ca9782b1419981c2a6c9a-gzip"'
+      - '"75806a3e736dc5cf89f5cd0f5846f1a1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '514'
+      - '510'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3203,404 +3193,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kMzgxZDlm
-        MS1hNGIwLTQzN2EtODNiOC1hMjQ0N2UzY2U1MDUvIiwgInRhc2tfaWQiOiAi
-        ZDM4MWQ5ZjEtYTRiMC00MzdhLTgzYjgtYTI0NDdlM2NlNTA1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YWE4OTYx
+        NC1mODVhLTQ5ZWUtYTA3Ni03MGJiNGU1OGFiMDAvIiwgInRhc2tfaWQiOiAi
+        OWFhODk2MTQtZjg1YS00OWVlLWEwNzYtNzBiYjRlNThhYjAwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
-        TExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
-        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9
-        LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjog
-        IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJyYXR1
-        bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
-        MDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
-        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVfaWQiOiAi
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
         ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
-        MjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1bml0c19m
-        YWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMzBmNjg4NzRiMDNmMzc1ZmEifSwg
-        ImlkIjogIjVmMGUzZDIzMGY2ODg3NGIwM2YzNzVmYSJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:56 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/bbd153db-e464-44e2-9095-532f3a3f8037/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:56 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d40a8142b38e8feefd6b15a7e44c1f77-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '489'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iYmQxNTNk
-        Yi1lNDY0LTQ0ZTItOTA5NS01MzJmM2EzZjgwMzcvIiwgInRhc2tfaWQiOiAi
-        YmJkMTUzZGItZTQ2NC00NGUyLTkwOTUtNTMyZjNhM2Y4MDM3IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIs
-        ICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9
-        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJpcmQifSwg
-        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
-        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVf
-        aWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWYwZTNkMjMwZjY4ODc0YjAzZjM3NjI2In0sICJpZCI6
-        ICI1ZjBlM2QyMzBmNjg4NzRiMDNmMzc2MjYifQ==
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:56 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a4788170-95bc-4856-b50d-cddd3c76fce7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:57 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"7e6ab3ccc4f8c4a768581ef95140ca82-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '480'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNDc4ODE3
-        MC05NWJjLTQ4NTYtYjUwZC1jZGRkM2M3NmZjZTcvIiwgInRhc2tfaWQiOiAi
-        YTQ3ODgxNzAtOTViYy00ODU2LWI1MGQtY2RkZDNjNzZmY2U3IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNr
-        YWdlX2Vudmlyb25tZW50In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
-        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2Vudmly
-        b25tZW50In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZjBlM2QyMzBmNjg4NzRiMDNmMzc2M2UifSwgImlkIjogIjVmMGUzZDIzMGY2
-        ODg3NGIwM2YzNzYzZSJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:57 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/10c66300-d816-4067-9d09-14ce45ec199b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:57 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"52d2989f751b4d00ab8b781c2e93519d-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '480'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMGM2NjMw
-        MC1kODE2LTQwNjctOWQwOS0xNGNlNDVlYzE5OWIvIiwgInRhc2tfaWQiOiAi
-        MTBjNjYzMDAtZDgxNi00MDY3LTlkMDktMTRjZTQ1ZWMxOTliIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dLCAidW5pdHNfZmFpbGVk
-        X3NpZ25hdHVyZV9maWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlw
-        ZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dfSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMzBmNjg4NzRiMDNmMzc2
-        NWMifSwgImlkIjogIjVmMGUzZDIzMGY2ODg3NGIwM2YzNzY1YyJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:57 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/c7045c1c-0d08-4001-81ae-147fbce6ef06/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:58 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"f110015800747455b078541ac9298dbe-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '513'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jNzA0NWMx
-        Yy0wZDA4LTQwMDEtODFhZS0xNDdmYmNlNmVmMDYvIiwgInRhc2tfaWQiOiAi
-        YzcwNDVjMWMtMGQwOC00MDAxLTgxYWUtMTQ3ZmJjZTZlZjA2IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJpYW50Ijog
-        IlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6ICJ4ODZf
-        NjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQtMTYteDg2
-        XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9pZCI6ICJk
-        aXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
-        ciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBl
-        M2QyMzBmNjg4NzRiMDNmMzc2N2EifSwgImlkIjogIjVmMGUzZDIzMGY2ODg3
-        NGIwM2YzNzY3YSJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:58 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/0a0c747e-b47b-4e65-a53e-de7b92461f77/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:58 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"99b73976d0e666a18ea7c63c27132d99-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '506'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYTBjNzQ3
-        ZS1iNDdiLTRlNjUtYTUzZS1kZTdiOTI0NjFmNzcvIiwgInRhc2tfaWQiOiAi
-        MGEwYzc0N2UtYjQ3Yi00ZTY1LWE1M2UtZGU3YjkyNDYxZjc3IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9pZCI6ICJt
-        b2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQiOiAibW9k
-        dWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIz
-        X3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
-        ZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
-        IjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
-        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        bmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
-        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
-        In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2Qy
-        MzBmNjg4NzRiMDNmMzc2YTAifSwgImlkIjogIjVmMGUzZDIzMGY2ODg3NGIw
-        M2YzNzZhMCJ9
-    http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:58 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/2c139fb9-766d-409a-a632-07efb370164e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 14 Jul 2020 23:17:59 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"9d10bb458d4e732501ab90cb03f00f2e-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '431'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yYzEzOWZi
-        OS03NjZkLTQwOWEtYTYzMi0wN2VmYjM3MDE2NGUvIiwgInRhc2tfaWQiOiAi
-        MmMxMzlmYjktNzY2ZC00MDlhLWE2MzItMDdlZmIzNzAxNjRlIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
+        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
+        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
+        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
         ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWYwZTNkMjMwZjY4ODc0YjAzZjM3NmI2In0sICJpZCI6ICI1ZjBlM2Qy
-        MzBmNjg4NzRiMDNmMzc2YjYifQ==
+        OiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MmQ0In0sICJpZCI6ICI1ZjdkZmYz
+        ZDEyOTczZjhjZGUyYTQyZDQifQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/cfa58f1c-fb3d-48ac-a10e-0325b6ef2480/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3608,7 +3231,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3619,15 +3242,380 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:59 GMT
+      - Wed, 07 Oct 2020 17:47:42 GMT
       Server:
       - Apache
       Etag:
-      - '"43909ff7605db3e009ee60258cd6c12d-gzip"'
+      - '"1304ab44f3b6a411f594fad2176ae5a3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '812'
+      - '482'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZmE1OGYx
+        Yy1mYjNkLTQ4YWMtYTEwZS0wMzI1YjZlZjI0ODAvIiwgInRhc2tfaWQiOiAi
+        Y2ZhNThmMWMtZmIzZC00OGFjLWExMGUtMDMyNWI2ZWYyNDgwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
+        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
+        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
+        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
+        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjNkMTI5NzNmOGNkZTJhNDJmNSJ9LCAiaWQiOiAiNWY3ZGZmM2QxMjk3
+        M2Y4Y2RlMmE0MmY1In0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4368bd9c-4d3c-4de0-b4fb-496c68b79e26/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:43 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"263f9e943b0ea17c2efdb6dfba0197c5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '472'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80MzY4YmQ5
+        Yy00ZDNjLTRkZTAtYjRmYi00OTZjNjhiNzllMjYvIiwgInRhc2tfaWQiOiAi
+        NDM2OGJkOWMtNGQzYy00ZGUwLWI0ZmItNDk2YzY4Yjc5ZTI2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
+        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
+        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
+        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4
+        Y2RlMmE0MzI3In0sICJpZCI6ICI1ZjdkZmYzZDEyOTczZjhjZGUyYTQzMjci
+        fQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/29bb597d-a679-4094-9575-ffba138e306f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:43 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7d5b5220a2c0c6ead1bb8a96ab543b17-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '473'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yOWJiNTk3
+        ZC1hNjc5LTQwOTQtOTU3NS1mZmJhMTM4ZTMwNmYvIiwgInRhc2tfaWQiOiAi
+        MjliYjU5N2QtYTY3OS00MDk0LTk1NzUtZmZiYTEzOGUzMDZmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
+        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
+        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MzQ3In0sICJpZCI6ICI1
+        ZjdkZmYzZDEyOTczZjhjZGUyYTQzNDcifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/ab7f4016-7584-4288-ba11-18b2a2c78552/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f596d1e453752f663907294207cf4cff-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '510'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hYjdmNDAx
+        Ni03NTg0LTQyODgtYmExMS0xOGIyYTJjNzg1NTIvIiwgInRhc2tfaWQiOiAi
+        YWI3ZjQwMTYtNzU4NC00Mjg4LWJhMTEtMThiMmEyYzc4NTUyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
+        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
+        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
+        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
+        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2Rl
+        MmE0MzYxIn0sICJpZCI6ICI1ZjdkZmYzZTEyOTczZjhjZGUyYTQzNjEifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/74cd4e55-bd19-44d1-b94c-e9bf2e1bb732/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"01a22bc79e3927a38e18a2353bf08de8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83NGNkNGU1
+        NS1iZDE5LTQ0ZDEtYjk0Yy1lOWJmMmUxYmI3MzIvIiwgInRhc2tfaWQiOiAi
+        NzRjZDRlNTUtYmQxOS00NGQxLWI5NGMtZTliZjJlMWJiNzMyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
+        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
+        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
+        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
+        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
+        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2RlMmE0
+        MzhhIn0sICJpZCI6ICI1ZjdkZmYzZTEyOTczZjhjZGUyYTQzOGEifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f42355c-b537-46f9-9f26-2b7610e12aa3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:45 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d41874b4e3d00fd8ff959eca5e30df91-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '427'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZjQyMzU1
+        Yy1iNTM3LTQ2ZjktOWYyNi0yYjc2MTBlMTJhYTMvIiwgInRhc2tfaWQiOiAi
+        NGY0MjM1NWMtYjUzNy00NmY5LTlmMjYtMmI3NjEwZTEyYWEzIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNlMTI5
+        NzNmOGNkZTJhNDM5ZCJ9LCAiaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2RlMmE0
+        MzlkIn0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:45 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"760f39eb8bcc094373dfa35b9b738b51-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '811'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3636,68 +3624,68 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTJa
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzda
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmMGUz
-        ZDIwMDZjNzFhMGE0MTkwODhlZiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        ZjM5MDIyMzlmNzQxZTg4M2QyMyJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjUyWiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM3WiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMDA2Yzcx
-        YTBhNDE5MDg4ZWUifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzOTAyMjM5
+        Zjc0MWU4ODNkMjIifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAyMC0wNy0xNFQyMzoxNzo1MloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAyMC0xMC0wN1QxNzo0NzozN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMDA2YzcxYTBhNDE5MDg4
-        ZWQifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNk
+        MjEifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0wNy0xNFQy
-        MzoxNzo1NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo0MFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         InBhY2thZ2VfZW52aXJvbm1lbnQiOiAxLCAiZGlzdHJpYnV0aW9uIjogMSwg
         Im1vZHVsZW1kIjogNiwgInJwbSI6IDE5LCAieXVtX3JlcG9fbWV0YWRhdGFf
         ZmlsZSI6IDF9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA3
-        LTE0VDIzOjE3OjUyWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEw
+        LTA3VDE3OjQ3OjM3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
         dG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJf
         bnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
         dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3Rfc3luYyI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIsICJzY3JhdGNocGFk
+        c3Rfc3luYyI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJzY3JhdGNocGFk
         IjogeyJyZXBvbWRfcmV2aXNpb24iOiAxNTg4MTU4MDM4LCAicmVwb21kX2No
         ZWNrc3VtIjogImRjNDc0YjM2NTQ0YmVjYmExNzc5NWJiMjUxMDE0NTNlMjVi
         NDBmY2Q0ODExZmE1OTQ2ODYzMzRlZWFiZDVmMDkifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZjBlM2QyMDA2YzcxYTBhNDE5MDg4ZWMifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNkMjAifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVz
         dF9yZXBvcy96b28iLCAic3NsX3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3Zl
         X21pc3NpbmciOiB0cnVlLCAiZG93bmxvYWRfcG9saWN5IjogIm9uX2RlbWFu
         ZCIsICJwcm94eV9ob3N0IjogIiJ9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1d
-        LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAzNCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjBlM2QyMDA2YzcxYTBhNDE5MDg4ZWIifSwgInRvdGFsX3JlcG9zaXRv
+        LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAzOSwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNkMWYifSwgInRvdGFsX3JlcG9zaXRv
         cnlfdW5pdHMiOiA0MCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3705,7 +3693,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3716,15 +3704,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:59 GMT
+      - Wed, 07 Oct 2020 17:47:45 GMT
       Server:
       - Apache
       Etag:
-      - '"da93fffe38acb338d5d637e3005e29ed-gzip"'
+      - '"59a5dbcec414cf44e829b3a41ceb7944-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '646'
+      - '636'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3733,60 +3721,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDctMTRUMjM6MTc6NTVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjBlM2QyMzA2YzcxYTBhNDE5MDg4ZjQifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZjdkZmYzYzAyMjM5Zjc0MWU4ODNkMjgifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDctMTRUMjM6MTc6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWYwZTNkMjIwNmM3MWEwYTQxOTA4OGYzIn0sICJjb25maWci
+        IiRvaWQiOiAiNWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI3In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDctMTRUMjM6MTc6NTRaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZjBlM2QyMjA2YzcxYTBhNDE5MDg4ZjIifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYzAyMjM5Zjc0MWU4ODNkMjYifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMDct
-        MTRUMjM6MTc6NTZaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NDJaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJlcnJhdHVt
         IjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQiOiA2LCAicGFj
         a2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24iOiAxLCAicnBt
         IjogMTksICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIjogMX0sICJfbnMiOiAi
         cmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICIzX3ZpZXcxIiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTA3LTE0VDIzOjE3OjU0WiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvaW1wb3J0
         ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwg
         ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3Zl
         cnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiBudWxsLCAic2NyYXRj
-        aHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjIwNmM3MWEw
-        YTQxOTA4OGYxIn0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRl
-        ciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMzMsICJfaWQiOiB7IiRv
-        aWQiOiAiNWYwZTNkMjIwNmM3MWEwYTQxOTA4OGYwIn0sICJ0b3RhbF9yZXBv
+        aHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2MwMjIzOWY3
+        NDFlODgzZDI1In0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRl
+        ciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMzgsICJfaWQiOiB7IiRv
+        aWQiOiAiNWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI0In0sICJ0b3RhbF9yZXBv
         c2l0b3J5X3VuaXRzIjogMzksICJpZCI6ICIzX3ZpZXcxIiwgIl9ocmVmIjog
         Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8ifQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3794,7 +3782,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3805,7 +3793,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:17:59 GMT
+      - Wed, 07 Oct 2020 17:47:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -3816,14 +3804,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzczMzhjZDdkLTI4MWQtNDI0OC05ZDVkLWU0OGIxZWEyM2FkYS8iLCAi
-        dGFza19pZCI6ICI3MzM4Y2Q3ZC0yODFkLTQyNDgtOWQ1ZC1lNDhiMWVhMjNh
-        ZGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FmYzUzZjlmLTFkOTQtNDM5OS05NTM1LWY4MWQ4ODdiZWJlZC8iLCAi
+        dGFza19pZCI6ICJhZmM1M2Y5Zi0xZDk0LTQzOTktOTUzNS1mODFkODg3YmVi
+        ZWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:17:59 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7338cd7d-281d-4248-9d5d-e48b1ea23ada/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/afc53f9f-1d94-4399-9535-f81d887bebed/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3831,7 +3819,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3842,15 +3830,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:18:00 GMT
+      - Wed, 07 Oct 2020 17:47:46 GMT
       Server:
       - Apache
       Etag:
-      - '"3ee4d6a835929074716273aa2c1c275d-gzip"'
+      - '"b217f959be6293b43f12e2a1e008c4ee-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '375'
+      - '364'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3858,25 +3846,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MzM4Y2Q3ZC0yODFkLTQyNDgtOWQ1ZC1lNDhiMWVhMjNh
-        ZGEvIiwgInRhc2tfaWQiOiAiNzMzOGNkN2QtMjgxZC00MjQ4LTlkNWQtZTQ4
-        YjFlYTIzYWRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hZmM1M2Y5Zi0xZDk0LTQzOTktOTUzNS1mODFkODg3YmVi
+        ZWQvIiwgInRhc2tfaWQiOiAiYWZjNTNmOWYtMWQ5NC00Mzk5LTk1MzUtZjgx
+        ZDg4N2JlYmVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA3LTE0VDIzOjE4OjAwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA3LTE0VDIzOjE3OjU5WiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ3OjQ2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
-        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWYwZTNkMjcwZjY4ODc0YjAzZjM3
-        ODVmIn0sICJpZCI6ICI1ZjBlM2QyNzBmNjg4NzRiMDNmMzc4NWYifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjQyMTI5NzNmOGNkZTJhNDU3MCJ9LCAiaWQiOiAi
+        NWY3ZGZmNDIxMjk3M2Y4Y2RlMmE0NTcwIn0=
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:18:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3884,7 +3872,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3895,7 +3883,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:18:00 GMT
+      - Wed, 07 Oct 2020 17:47:46 GMT
       Server:
       - Apache
       Content-Length:
@@ -3906,14 +3894,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY3ZDk1OWFmLWMxMTYtNGNiZC04ZTNmLTkxYmZhNTJhNGZkNS8iLCAi
-        dGFza19pZCI6ICI2N2Q5NTlhZi1jMTE2LTRjYmQtOGUzZi05MWJmYTUyYTRm
-        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc2MWFhNjMyLTA1YjUtNGVlMi04MmQyLTM2MGU3NzE5ODdkYy8iLCAi
+        dGFza19pZCI6ICI3NjFhYTYzMi0wNWI1LTRlZTItODJkMi0zNjBlNzcxOTg3
+        ZGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:18:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/67d959af-c116-4cbd-8e3f-91bfa52a4fd5/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/761aa632-05b5-4ee2-82d2-360e771987dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3921,7 +3909,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3932,15 +3920,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Jul 2020 23:18:00 GMT
+      - Wed, 07 Oct 2020 17:47:46 GMT
       Server:
       - Apache
       Etag:
-      - '"72b70d96d09a5009a1a09bdfc6182bd8-gzip"'
+      - '"357a0b8ab01871b054d06caf3a95fb23-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '368'
+      - '362'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3948,20 +3936,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82N2Q5NTlhZi1jMTE2LTRjYmQtOGUzZi05MWJmYTUyYTRm
-        ZDUvIiwgInRhc2tfaWQiOiAiNjdkOTU5YWYtYzExNi00Y2JkLThlM2YtOTFi
-        ZmE1MmE0ZmQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy83NjFhYTYzMi0wNWI1LTRlZTItODJkMi0zNjBlNzcxOTg3
+        ZGMvIiwgInRhc2tfaWQiOiAiNzYxYWE2MzItMDViNS00ZWUyLTgyZDItMzYw
+        ZTc3MTk4N2RjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNy0xNFQyMzoxODowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNy0xNFQyMzoxODowMFoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0NloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIi
-        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0
-        YWJsZS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVmMGUzZDI4MGY2ODg3NGIwM2YzNzhh
-        ZSJ9LCAiaWQiOiAiNWYwZTNkMjgwZjY4ODc0YjAzZjM3OGFlIn0=
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0MjEyOTczZjhjZGUyYTQ1YzUifSwgImlkIjogIjVm
+        N2RmZjQyMTI5NzNmOGNkZTJhNDVjNSJ9
     http_version: 
-  recorded_at: Tue, 14 Jul 2020 23:18:00 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:20 GMT
+      - Wed, 07 Oct 2020 17:47:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:20 GMT
+      - Wed, 07 Oct 2020 17:47:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:20 GMT
+      - Wed, 07 Oct 2020 17:47:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNiMDJlNTMwNzUzYTk4NTZiIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmNDMwMjIzOWY3MzY1MWU2MThlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:20 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:20 GMT
+      - Wed, 07 Oct 2020 17:47:47 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE4OWRjNmIxLTdkMjgtNGUyNC04NjFkLTEwYjJhM2ZmMjQ2ZS8iLCAi
-        dGFza19pZCI6ICIxODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzNlNzlhNmE2LWMzNjktNGVmYy04OWMwLWUwODRjZjcxYzVkYi8iLCAi
+        dGFza19pZCI6ICIzZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:21 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:22 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,16 +231,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -252,42 +252,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,7 +295,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -306,15 +306,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:22 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -322,16 +322,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -343,42 +343,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:22 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -397,15 +397,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -413,16 +413,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -434,42 +434,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -477,7 +477,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -488,15 +488,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -504,16 +504,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -525,42 +525,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +568,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -579,15 +579,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -595,16 +595,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -616,42 +616,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -659,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -670,15 +670,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -686,16 +686,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -707,42 +707,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -750,7 +750,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -761,15 +761,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -777,16 +777,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
+        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
+        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
+        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
+        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -798,42 +798,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
+        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3f4236e1-f96d-4baf-b333-f8b42b3c4700/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +841,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -852,197 +852,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
+      - '"e6439452f261e64e89aef34cb9012364-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '714'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/189dc6b1-7d28-4e24-861d-10b2a3ff246e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:23 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"15f468242fecad1edb4a441a1f25c42a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '714'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODlkYzZiMS03ZDI4LTRlMjQtODYxZC0xMGIyYTNmZjI0
-        NmUvIiwgInRhc2tfaWQiOiAiMTg5ZGM2YjEtN2QyOC00ZTI0LTg2MWQtMTBi
-        MmEzZmYyNDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI4NmE1OGItZTY0My00MjI2LWE2ZTgtYTU5ZjA0MTBh
-        MzUzLyIsICJ0YXNrX2lkIjogIjUyODZhNThiLWU2NDMtNDIyNi1hNmU4LWE1
-        OWYwNDEwYTM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjJlYjAyZTUzNDNkMGUxMjUyOCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmNmZGJjY2E5ZjM4OTVhZmVmIn0sICJpZCI6ICI1ZWFjODIyY2Zk
-        YmNjYTlmMzg5NWFmZWYifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/5286a58b-e643-4226-a6e8-a59f0410a353/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:23 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"0370b1c973e005fed7ba101cec9ee204-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1359'
+      - '1364'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1050,199 +868,199 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81Mjg2YTU4Yi1lNjQzLTQyMjYtYTZlOC1hNTlm
-        MDQxMGEzNTMvIiwgInRhc2tfaWQiOiAiNTI4NmE1OGItZTY0My00MjI2LWE2
-        ZTgtYTU5ZjA0MTBhMzUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8zZjQyMzZlMS1mOTZkLTRiYWYtYjMzMy1mOGI0
+        MmIzYzQ3MDAvIiwgInRhc2tfaWQiOiAiM2Y0MjM2ZTEtZjk2ZC00YmFmLWIz
+        MzMtZjhiNDJiM2M0NzAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAi
+        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmMTMxNzU1OS03YzYxLTRjZTQtODFkOS1mNzFiODVk
-        NDllMjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI1Y2EwYWFiMC0yN2MwLTQ1MDUtYTIxZS01ZWVjYWM3
+        N2ZhZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTI3NWVkOTUtMDU3MC00MjMzLTg3ODQtYzA2NGI4YzBkYjkzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
+        aWQiOiAiNDY4ZDA4NzctYjFkNi00ZThlLTljNjItOTI4MzNiOGQzYjY5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
-        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYzc4OGY1Ni1iYWViLTQ5NjAtOTk0
-        MC1jNDYxNjdhMzdhNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTFiNjVlZi03NmJjLTQ0YTMtODkw
+        Ni1hNzRkNDE2OWE4NWUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        OTVhMDI4YTUtODk2YS00ZDI1LTkzNTgtNmUzNzczZmEwOTVhIiwgIm51bV9w
+        MmRjYjVlMmQtYTY2OS00YjhiLWJkYTUtZmQ5NDQ2ODMyZDc0IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImM2NDJhMDQwLTMxOTYtNDRjOS1iMWY3LWFh
-        ODJiYjE2ZTFiNSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImRhYTM5ZDFiLWEwNjktNDYwNC04NmQyLTQy
+        ZTU0NjM1ZGYwMCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1M2Ex
-        ZTllLTg5ZjMtNGZmNy05YmYzLTM2OGNhYTQ3ZjdjMSIsICJudW1fcHJvY2Vz
-        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5Yzk5
+        MmE5LTFmYzEtNDRmOC04OTFmLTUwYjFlMmFiMTg0YSIsICJudW1fcHJvY2Vz
+        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
-        ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkZThmMWVhYS03OTkzLTQyMDMtOGI1MS0xYjcx
-        NTU5ZjE3YmQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
-        IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
-        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
+        OiAwLCAic3RlcF9pZCI6ICIwODVhZjQ4ZS02NDBlLTQ5ODItYjA5ZS02OWU3
+        NTVmZGFjMjYiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
+        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MWY3
-        NWEzMS0zZGY5LTRiMmUtYjBjYi1mYWVmMDhiZjVjNWYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTc2
+        MDYzMC0wMDExLTQ1MzktODJhYi0yZDA5NGYwYWM2NTkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDYyMDA3NC02Yjhj
-        LTQzMGMtYThiZC1lMWVhOTRhNTkwY2UiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMmQ0N2JiNC1jMmMz
+        LTRkM2UtOTM2YS00MTkxMjdkZWVhMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwYzI1MWUyNy01ZTRkLTQxNWUtYmNiOC01
-        MTg4OGU2NTU4MWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MjllOTBiYy1hMDMzLTQ3MzctODYwMC03
+        YThjYWRhZTdjY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5YWEyOWFlZi03OGMzLTRkZDgtYmQ3OS1jODNkZmY1OWVk
-        YTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJmOTg5N2YzOS0wY2I5LTQ1OGYtYTc3Yy1mNmI5NDk2Yzlk
+        YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MDFhZWZlMC00
-        NGMzLTQyNTAtODc5Zi0xZGU1ZmNjY2M0YTQiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWI4NmEyMS05
+        MjY4LTQwMzEtOTM2Yy1kMWJhNmM0ODRhM2YiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYjhmZDVlOS03ZmVkLTQ1ODUt
-        YTQ0Zi02Zjg5YjNhNjAzNDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTUwMDhkMS0zZGI4LTRkZjkt
+        OTBjOS0yZGNlMjEzNTJiMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA1ODhlMTlkLWIwMTUtNGQ2MS1hZjU1
-        LWQ0MjA1NWNlOTFmYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
-        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIyWiIsICJfbnMi
-        OiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmli
-        dXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5Ijog
-        eyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklT
-        SEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
-        ICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMi
-        OiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hF
-        RCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwg
-        ImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQ
-        UEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNWVhYzgyMmZiMDJlNTM0M2QwZTEyNTI5IiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYxMzE3NTU5
-        LTdjNjEtNGNlNC04MWQ5LWY3MWI4NWQ0OWUyNyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMjc1ZWQ5NS0wNTcwLTQy
-        MzMtODc4NC1jMDY0YjhjMGRiOTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAx
-        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBjNzg4ZjU2LWJhZWItNDk2MC05OTQwLWM0NjE2N2EzN2E1YSIsICJudW1f
-        cHJvY2Vzc2VkIjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAi
-        ZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NWEwMjhhNS04OTZhLTRkMjUtOTM1
-        OC02ZTM3NzNmYTA5NWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogNiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzY0
-        MmEwNDAtMzE5Ni00NGM5LWIxZjctYWE4MmJiMTZlMWI1IiwgIm51bV9wcm9j
-        ZXNzZWQiOiA2fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
-        LCAiaXRlbXNfdG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMDUzYTFlOWUtODlmMy00ZmY3LTliZjMtMzY4
-        Y2FhNDdmN2MxIiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
-        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRlOGYx
-        ZWFhLTc5OTMtNDIwMy04YjUxLTFiNzE1NTlmMTdiZCIsICJudW1fcHJvY2Vz
-        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjcxZjc1YTMxLTNkZjktNGIyZS1iMGNiLWZh
-        ZWYwOGJmNWM1ZiIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjEwNjIwMDc0LTZiOGMtNDMwYy1hOGJkLWUxZWE5NGE1OTBj
-        ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBj
-        MjUxZTI3LTVlNGQtNDE1ZS1iY2I4LTUxODg4ZTY1NTgxZCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlhYTI5YWVmLTc4
-        YzMtNGRkOC1iZDc5LWM4M2RmZjU5ZWRhMSIsICJudW1fcHJvY2Vzc2VkIjog
-        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjkwMWFlZmUwLTQ0YzMtNDI1MC04NzlmLTFkZTVmY2Nj
-        YzRhNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
-        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNiOGZkNWU5LTdmZWQtNDU4NS1hNDRmLTZmODliM2E2MDM0MyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
-        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZGU4ZWNkLWQ1ZTYtNDcxYy1iODhl
+        LTMwYWJjYmVlZGQ5MiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo0OFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
+        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
+        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
+        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
+        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
+        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
+        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
+        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
+        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjQ0MDIyMzlmMDU3
+        ZjhhNDM3ZiIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1Y2EwYWFiMC0yN2MwLTQ1MDUtYTIxZS01ZWVjYWM3N2ZhZGYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MDU4OGUxOWQtYjAxNS00ZDYxLWFmNTUtZDQyMDU1Y2U5MWZhIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MjJlZmRiY2NhOWYzODk1YjI4ZSJ9LCAiaWQiOiAiNWVhYzgy
-        MmVmZGJjY2E5ZjM4OTViMjhlIn0=
+        NDY4ZDA4NzctYjFkNi00ZThlLTljNjItOTI4MzNiOGQzYjY5IiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiMTFiNjVlZi03NmJjLTQ0YTMtODkwNi1hNzRk
+        NDE2OWE4NWUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
+        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmRjYjVl
+        MmQtYTY2OS00YjhiLWJkYTUtZmQ5NDQ2ODMyZDc0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImRhYTM5ZDFiLWEwNjktNDYwNC04NmQyLTQyZTU0NjM1
+        ZGYwMCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
+        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5Yzk5MmE5LTFm
+        YzEtNDRmOC04OTFmLTUwYjFlMmFiMTg0YSIsICJudW1fcHJvY2Vzc2VkIjog
+        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
+        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIwODVhZjQ4ZS02NDBlLTQ5ODItYjA5ZS02OWU3NTVmZGFj
+        MjYiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
+        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTc2MDYzMC0w
+        MDExLTQ1MzktODJhYi0yZDA5NGYwYWM2NTkiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
+        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMmQ0N2JiNC1jMmMzLTRkM2Ut
+        OTM2YS00MTkxMjdkZWVhMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI4MjllOTBiYy1hMDMzLTQ3MzctODYwMC03YThjYWRh
+        ZTdjY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
+        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJmOTg5N2YzOS0wY2I5LTQ1OGYtYTc3Yy1mNmI5NDk2YzlkYjAiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
+        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWI4NmEyMS05MjY4LTQw
+        MzEtOTM2Yy1kMWJhNmM0ODRhM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZTUwMDhkMS0zZGI4LTRkZjktOTBjOS0y
+        ZGNlMjEzNTJiMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
+        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImM3ZGU4ZWNkLWQ1ZTYtNDcxYy1iODhlLTMwYWJj
+        YmVlZGQ5MiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ4ZWEi
+        fSwgImlkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDhlYSJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:23 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1268,7 +1086,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1281,7 +1099,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:23 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Content-Length:
@@ -1298,14 +1116,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmZiMDJlNTMwNzUzYTk4NTcwIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWY3ZGZmNDQwMjIzOWY3MzY1MWU2MTkzIn0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1317,7 +1135,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1330,268 +1148,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:48 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2080'
+      - '2166'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtNS4yMS0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNzQ1MzNm
-        YmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhi
-        NzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
-        ZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTUuMjEtMS5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgImlzX21v
-        ZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIxIiwgIl9pZCI6ICIxYzc1MTA3NS02MGY2LTQxYTQtOGM1NC01
-        YTVhY2Y5ZWI1ZWEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMWM3NTEwNzUtNjBmNi00MWE0
-        LThjNTQtNWE1YWNmOWViNWVhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIy
-        ZGZkYmNjYTlmMzg5NWIwZGQifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJlbGVw
-        aGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdj
-        YjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgImZpbGVu
-        YW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwg
-        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44Iiwg
-        Il9pZCI6ICI0MDVmM2NhNS00ZjJjLTRlY2EtYjZjZi1hZDE3OGUwMzY3NTIi
-        LCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5cGVfaWQiOiAicnBt
-        IiwgInVuaXRfaWQiOiAiNDA1ZjNjYTUtNGYyYy00ZWNhLWI2Y2YtYWQxNzhl
-        MDM2NzUyIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZGZkYmNjYTlmMzg5
-        NWIwNGMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWlu
-        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tz
-        dW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQy
-        ZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVt
-        bXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4t
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjQwZGZlN2My
-        LTdkMjctNDU1MC04YTIxLTU0MTNkOTMwNGM4OSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6
-        MTA6MjFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0
-        MGRmZTdjMi03ZDI3LTQ1NTAtOGEyMS01NDEzZDkzMDRjODkiLCAiX2lkIjog
-        eyIkb2lkIjogIjVlYWM4MjJkZmRiY2NhOWYzODk1YjBiNCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJw
-        bSIsICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJk
-        ZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFj
-        MGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yg
-        c3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNf
-        bW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjRiY2U0MTNjLWYyNjctNGVjMC1h
-        MTVkLTk3YjE3NTk2NDYxZSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
-        ZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjFaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0YmNlNDEzYy1mMjY3
-        LTRlYzAtYTE1ZC05N2IxNzU5NjQ2MWUiLCAiX2lkIjogeyIkb2lkIjogIjVl
-        YWM4MjJkZmRiY2NhOWYzODk1YjA1ZSJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndh
-        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
-        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFt
-        ZSI6ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        IjY4ZWQ4NWE4LTlhZmYtNDhiZS04ODUzLThiYTcxMmFjN2Y0NCIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIx
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6MjFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI2OGVkODVhOC05YWZmLTQ4YmUtODg1My04YmE3MTJhYzdmNDQi
-        LCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjJkZmRiY2NhOWYzODk1YjA3MSJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4
-        ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZj
-        YjhlMmM4NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiBtb25rZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlz
-        X21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
-        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI5NjkwNTIzZi0xNzY5LTQ0ZDEt
-        ODg1Mi1lYzI1YzRjMTZlYjAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0
-        ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1
-        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOTY5MDUyM2YtMTc2
-        OS00NGQxLTg4NTItZWMyNWM0YzE2ZWIwIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZWFjODIyZGZkYmNjYTlmMzg5NWIwYTIifX0sIHsibWV0YWRhdGEiOiB7InNv
-        dXJjZXJwbSI6ICJrYW5nYXJvby0wLjMtMS5zcmMucnBtIiwgIm5hbWUiOiAi
-        a2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNj
-        NDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIs
-        ICJzdW1tYXJ5IjogImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlh
-        IiwgImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjog
-        dHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiYTM5Mzg0Y2ItYzFlYi00NTI5LTk1NjQtZjczZjhkNDQ1
-        MGQ5IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MTA6MjFaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImEzOTM4NGNiLWMxZWItNDUyOS05NTY0LWY3
-        M2Y4ZDQ0NTBkOSIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmRmZGJjY2E5
-        ZjM4OTViMDU1In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiYXJt
-        YWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAi
-        Y2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4Mjdj
-        NDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsICJzdW1tYXJ5Ijog
-        IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsICJmaWxlbmFtZSI6ICJh
-        cm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50
-        X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTgy
-        YzAxZDYtYzM1NS00MmI1LTg3NWUtNDIxZTgyOWI4NGQ1IiwgImFyY2giOiAi
-        bm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjFaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDoyMVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lk
-        IjogImE4MmMwMWQ2LWMzNTUtNDJiNS04NzVlLTQyMWU4MjliODRkNSIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgyMmRmZGJjY2E5ZjM4OTViMDQzIn19LCB7
-        Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVjay0wLjYtMS5zcmMucnBt
-        IiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5NmYzNzg3NzUxOGEx
-        ZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdkMzhh
-        Nzc0YmM3IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2si
-        LCAiZmlsZW5hbWUiOiAiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjYiLCAiaXNfbW9kdWxhciI6IHRydWUs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAi
-        X2lkIjogImJhYWRjOGQ3LTdiZTMtNGZiNi05Yzg2LTc5M2Y2YTE2MGZiNiIs
-        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIw
-        OjEwOjIxWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
-        IjIwMjAtMDUtMDFUMjA6MTA6MjFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
-        LCAidW5pdF9pZCI6ICJiYWFkYzhkNy03YmUzLTRmYjYtOWM4Ni03OTNmNmEx
-        NjBmYjYiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjJkZmRiY2NhOWYzODk1
-        YjA5OSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxs
-        by0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
-        c3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2NGU4
-        MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3VtbWFyeSI6ICJGYWtl
-        IHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRp
-        bGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBl
-        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImJlYTdhNmNi
-        LTM2NDgtNDc2OC1iNzgzLWQ5YjJmN2YxNDkzNSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6
-        MTA6MjFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJi
-        ZWE3YTZjYi0zNjQ4LTQ3NjgtYjc4My1kOWIyZjdmMTQ5MzUiLCAiX2lkIjog
-        eyIkb2lkIjogIjVlYWM4MjJkZmRiY2NhOWYzODk1YjBkNCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0i
-        LCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2Uz
-        ZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIx
-        YTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxy
-        dXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJjMmYxMDhiYy0wMWY4LTRmMTYtYWM4MS00MjBi
-        MGEyOTZmNjEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        Y3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5cGVf
-        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzJmMTA4YmMtMDFmOC00ZjE2LWFj
-        ODEtNDIwYjBhMjk2ZjYxIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZGZk
-        YmNjYTlmMzg5NWIwY2EifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
-        ICJhcm1hZGlsbG8tMi4xLTEuc3JjLnJwbSIsICJuYW1lIjogImFybWFkaWxs
-        byIsICJjaGVja3N1bSI6ICJhYmY2OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4
-        ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNkOGQxZmYzOTlmIiwgInN1bW1h
-        cnkiOiAiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwgImZpbGVuYW1l
-        IjogImFybWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
-        LCAidmVyc2lvbiI6ICIyLjEiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2Nv
-        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
-        ICJjODhhNWNiMi04MjBhLTQ0OTktODZmMi1iNzYxOTJhNGMyODIiLCAiYXJj
-        aCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoy
-        MVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIw
-        LTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
-        aXRfaWQiOiAiYzg4YTVjYjItODIwYS00NDk5LTg2ZjItYjc2MTkyYTRjMjgy
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZGZkYmNjYTlmMzg5NWIwOTAi
-        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJjaGVldGFoLTAuMy0w
-        Ljguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAi
-        NDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4
-        MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
-        a2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0YWgtMC4zLTAu
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
+        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
+        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
+        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
+        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
+        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjQzMTI5NzNmOGNkZTJhNDczOCJ9fSwgeyJtZXRhZGF0YSI6IHsic291
+        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
+        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
+        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
+        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
+        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
+        NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
+        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
+        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0
+        NmZkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
+        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
+        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
+        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
         OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
         LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImQyODY1YmQwLTkxZjEt
-        NDc0MC1iZDk0LTQ5ODRjNWRhMTJmZSIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjFa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJkMjg2NWJk
-        MC05MWYxLTQ3NDAtYmQ5NC00OTg0YzVkYTEyZmUiLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MjJkZmRiY2NhOWYzODk1YjBiZCJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIsICJuYW1lIjog
-        ImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2Ez
-        YmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJz
-        dW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsICJm
-        aWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiZGVmNTk3YWUtOTQzYS00MTAzLTk1MWMtNmUxYTQwZmI0NTcyIiwgImFy
-        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6
-        MjFaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDoyMVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
-        bml0X2lkIjogImRlZjU5N2FlLTk0M2EtNDEwMy05NTFjLTZlMWE0MGZiNDU3
-        MiIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmRmZGJjY2E5ZjM4OTViMDY3
-        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlvbi0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAw
-        ZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2
-        NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVs
-        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
-        c2UiOiAiMC44IiwgIl9pZCI6ICJlZmZmMTllMS03Yzg2LTQxMzEtYWQ1MC03
-        MjNlZGYzN2ZhOTUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWZmZjE5ZTEtN2M4Ni00MTMx
-        LWFkNTAtNzIzZWRmMzdmYTk1IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIy
-        ZGZkYmNjYTlmMzg5NWIwODcifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiZWxlcGhh
-        bnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJl
-        ODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1t
-        YXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgZWxlcGhhbnQuIiwgImZpbGVuYW1l
-        IjogImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        ImYwZDZhNjY5LTZhN2UtNDhhOS05MmM3LTA3YjdiZjdkM2E5NyIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIx
+        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
+        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDda
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
+        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
+        IjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDcxZCJ9fSwgeyJtZXRhZGF0YSI6
+        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
+        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
+        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
+        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
+        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
+        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQz
+        MTI5NzNmOGNkZTJhNDZhNiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
+        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
+        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZl
+        YSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
+        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
+        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
+        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
+        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90
+        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
+        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
+        NDMxMjk3M2Y4Y2RlMmE0NmQ4In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
+        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
+        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
+        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
+        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3
         WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6MjFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICJmMGQ2YTY2OS02YTdlLTQ4YTktOTJjNy0wN2I3YmY3ZDNhOTci
-        LCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjJkZmRiY2NhOWYzODk1YjBlNiJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJm
-        MjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTVi
-        ODJkZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44
+        MTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
+        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZmNCJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
+        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
+        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
+        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
         Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
         ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZjk2NDdmZjgtZjVmMC00
-        ZTNhLTlkMGEtNWY2MTlhNDNjOGFhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjFaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImY5NjQ3ZmY4
-        LWY1ZjAtNGUzYS05ZDBhLTVmNjE5YTQzYzhhYSIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgyMmRmZGJjY2E5ZjM4OTViMDdlIn19LCB7Im1ldGFkYXRhIjog
-        eyJzb3VyY2VycG0iOiAia2FuZ2Fyb28tMC4yLTEuc3JjLnJwbSIsICJuYW1l
-        IjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgzM2FmNTk0YmMwYmEzMTI1
-        NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRj
-        YzgiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28i
-        LCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlzX21vZHVsYXIiOiB0
-        cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
-        IiwgIl9pZCI6ICJmYmFjZWM2Zi0xNzRiLTQ0ODEtOTRiMC1iOTY1ZDVhNWY4
-        ZTAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDoyMVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
-        ZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5cGVfaWQiOiAi
-        cnBtIiwgInVuaXRfaWQiOiAiZmJhY2VjNmYtMTc0Yi00NDgxLTk0YjAtYjk2
-        NWQ1YTVmOGUwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZGZkYmNjYTlm
-        Mzg5NWIwYWIifX1d
+        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
+        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
+        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAi
+        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
+        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NzE0In19LCB7Im1ldGFkYXRhIjog
+        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
+        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
+        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
+        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
+        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJ1bml0X3R5cGVfaWQi
+        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
+        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0MzEyOTcz
+        ZjhjZGUyYTQ2Y2MifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
+        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
+        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
+        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
+        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
+        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjQ3WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
+        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ3MmYifX0sIHsibWV0YWRh
+        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
+        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
+        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
+        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
+        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
+        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQz
+        MTI5NzNmOGNkZTJhNDcwOSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
+        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
+        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDcy
+        NiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
+        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
+        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
+        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
+        b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
+        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
+        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        ZjQzMTI5NzNmOGNkZTJhNDZhZiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
+        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
+        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZjMSJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
+        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
+        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
+        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
+        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
+        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ2OWQifX0sIHsibWV0YWRhdGEiOiB7
+        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
+        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
+        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
+        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJ1bml0X3R5cGVf
+        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
+        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0MzEy
+        OTczZjhjZGUyYTQ2OTEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
+        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
+        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
+        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
+        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
+        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
+        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0Njg2In19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
+        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
+        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
+        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
+        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDMxMjk3M2Y4
+        Y2RlMmE0NmUxIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
+        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
+        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
+        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
+        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
+        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
+        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ2YjgifX1d
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1603,7 +1434,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1616,7 +1447,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -1629,10 +1460,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1642,7 +1473,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1655,144 +1486,144 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1313'
+      - '1317'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzQxLzljMjZjYTAzMjJmMDQ1OGFi
-        NzRmNTg3NmUyOWEzNjZmODBjMmI0OTAyMGY2NjNhYmI5ZmY0YmJkY2JkNmNj
-        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIiwgImFydGlm
-        YWN0cyI6IFsid2FscnVzLTA6NS4yMS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
-        OiAiZmMwY2I5NTBlNTNjNWVhOTliMDNiY2FjNDI3MjVjNjAyOTVmMTQ4YWFh
-        ZGUxYTdjZTZjN2Q4MDI4YTA3M2I1OSIsICJfbGFzdF91cGRhdGVkIjogMTU4
-        ODE5NjE0NCwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
-        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdfSwgInN1bW1hcnkiOiAi
-        V2FscnVzIDUuMjEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVy
-        c2lvbiI6IDIwMTgwNzA0MTQ0MjAzLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1
-        bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIwMDBhODY4NS0w
-        ZGNkLTQ2OWItODE5My0xOTU5Y2NlMWZhOWQiLCAiYXJjaCI6ICJ4ODZfNjQi
-        LCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3YWxydXMgNS4y
-        MSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0w
-        NS0wMVQyMDoxMDoyMloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiMDAwYTg2ODUtMGRjZC00NjliLTgxOTMtMTk1OWNjZTFm
-        YTlkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZWZkYmNjYTlmMzg5NWIx
-        NWYifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
-        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
-        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
-        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
-        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
-        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgx
-        OTYxNDQsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
-        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
-        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjA5ZDMxOTZkLWRhNzUtNDNj
-        Yi04OTExLTU4MDZjNGJhMDdjOCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEw
-        OjIyWiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICIwOWQzMTk2ZC1kYTc1LTQzY2ItODkxMS01ODA2YzRiYTA3YzgiLCAiX2lk
-        IjogeyIkb2lkIjogIjVlYWM4MjJlZmRiY2NhOWYzODk1YjE0OCJ9fSwgeyJt
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
+        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
+        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
+        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
+        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
+        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
+        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdhNSJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
+        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
+        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
+        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
+        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
+        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
+        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
+        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
+        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
+        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
+        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
+        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
+        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdiMCJ9fSwgeyJt
         ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
         bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
         ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
         bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
         OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
         OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
-        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MTk2
-        MTQ0LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
         cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
         bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
         aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
         fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjEzMjBhZGNlLWNj
-        NTQtNDc2NC1hYjc3LWNhNDZjODVkMDUwYSIsICJhcmNoIjogIm5vYXJjaCIs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
+        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
         ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0w
-        NS0wMVQyMDoxMDoyMloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiMTMyMGFkY2UtY2M1NC00NzY0LWFiNzctY2E0NmM4NWQw
-        NTBhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZWZkYmNjYTlmMzg5NWIx
-        MzEifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
+        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ3
+        ODUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
+        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
+        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
+        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
+        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
+        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
+        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
+        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
+        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
+        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
+        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
+        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
+        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDc5OSJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
+        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
+        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
+        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
+        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
+        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
+        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
+        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
+        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
+        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
+        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
+        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ3
+        OGUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
         aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
         Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
         ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
         ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
         Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
         NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
-        IjogMTU4ODE5NjE0NCwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
+        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
         LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
         ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
         bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
         NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
         YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogIjI5NDkwOWE4LTk3OTEtNDU2Zi1hZmRkLWE5
-        ODdmMGEzM2Y4NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
+        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
+        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
         ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIyWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIyOTQ5
-        MDlhOC05NzkxLTQ1NmYtYWZkZC1hOTg3ZjBhMzNmODciLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjJlZmRiY2NhOWYzODk1YjE2OCJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
-        dW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3OTdhMDdh
-        ODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImth
-        bmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJlODIwZTA4
-        YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgyNDI3OWUz
-        NmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MTk2MTQ0LCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
-        ZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkthbmdhcm9v
-        IDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjU5NzYzMDAyLWI0MTAtNDU2
-        Yy05YmE0LWVlNjRmODMxODgyYyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAuMiBwYWNr
-        YWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDoyMloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
-        aWQiOiAiNTk3NjMwMDItYjQxMC00NTZjLTliYTQtZWU2NGY4MzE4ODJjIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZWZkYmNjYTlmMzg5NWIxM2UifX0s
-        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
-        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgxOTYxNDQs
-        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
-        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogImU1ZGI1MTk4LTljMjMtNDU2OC04ODJk
-        LWJkMmFiYzg1Njg4ZCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIyWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlNWRi
-        NTE5OC05YzIzLTQ1NjgtODgyZC1iZDJhYmM4NTY4OGQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjJlZmRiY2NhOWYzODk1YjE1MSJ9fV0=
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
+        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdiZSJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1802,7 +1633,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1815,7 +1646,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -1828,10 +1659,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1841,7 +1672,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1854,226 +1685,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1958'
+      - '1948'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
         W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYzODIy
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
+        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
+        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
+        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
+        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
+        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
+        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
+        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
+        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
+        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
+        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
+        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NjgsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
+        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
+        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
+        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ4OTAifX0sIHsibWV0YWRh
+        dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
+        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
+        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
+        YXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9t
+        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
+        dGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2
+        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
+        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
+        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
+        ImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRp
+        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
+        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
+        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg2OCwgInJl
+        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
+        Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
+        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
+        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
+        NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
+        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
+        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJh
+        NDg1NSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
+        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
+        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
+        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
+        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
+        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
+        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
+        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
+        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
+        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
+        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
+        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
+        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
+        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODY4
         LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
         LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIyZjVmOTI4NC1lNTUyLTRmZjgt
-        OTI4Yi1mYTcyNWE1ZjU2ZDgifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDoyMloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjEwOjIyWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjJmNWY5Mjg0LWU1NTItNGZmOC05MjhiLWZh
-        NzI1YTVmNTZkOCIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmVmZGJjY2E5
-        ZjM4OTViMWFiIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0w
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
+        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
+        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
+        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDQxMjk3M2Y4
+        Y2RlMmE0ODcxIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
         MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
         cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
         Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2Fn
-        ZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6
-        ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2Vj
-        dXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0
-        dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwg
-        InN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6
-        Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIs
-        ICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3Rh
-        YmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0
-        ZSBPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgz
-        NjM4MjIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50
-        IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5
-        IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjQyZTJhYTk2LWY3NDgt
-        NGE3MS1iZjAxLWNiNGYyNGYzMjNkZiJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1
-        LTAxVDIwOjEwOjIyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVh
-        dGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNDJlMmFhOTYtZjc0OC00YTcxLWJm
-        MDEtY2I0ZjI0ZjMyM2RmIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZWZk
-        YmNjYTlmMzg5NWIyMWIifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIy
-        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
-        c2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRF
-        TExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhh
-        dC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIs
-        ICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVi
-        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
-        a2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5m
-        ZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNl
-        IjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rp
-        b24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFz
-        dF91cGRhdGVkIjogMTU4ODM2MzgyMiwgInJlc3RhcnRfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRp
-        b24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiOTZkZWIxZjEtN2JlYS00NDIxLWJlOTItZWY0NjQyMGNjYjQ4In0sICJ1
-        cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI5NmRl
-        YjFmMS03YmVhLTQ0MjEtYmU5Mi1lZjQ2NDIwY2NiNDgiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjJlZmRiY2NhOWYzODk1YjFmZSJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dp
-        bl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBf
-        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
-        dHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6
-        ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRs
-        ZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0
-        dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2Vz
-        IjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAi
-        bmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAi
-        ZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJu
-        b2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIi
-        fV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogMTU4ODM2MzgyMiwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
+        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
+        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
+        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
+        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
+        IjogMTYwMjA5Mjg2OCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
         dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
-        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYmRjMTU4
-        YjYtMThmZi00Nzk2LWIyMDUtYmUzMDU1NDBkZGNiIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJiZGMxNThiNi0xOGZm
-        LTQ3OTYtYjIwNS1iZTMwNTU0MGRkY2IiLCAiX2lkIjogeyIkb2lkIjogIjVl
-        YWM4MjJlZmRiY2NhOWYzODk1YjFlMyJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8v
-        cmhuLnJlZGhhdC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAi
-        dHlwZSI6ICJzZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAx
-        MDowODU4In0sIHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5j
-        b20vYnVnemlsbGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjog
-        ImJ1Z3ppbGxhIiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAx
-        MC0wNDA1IGJ6aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2Rl
-        Y29tcHJlc3MifSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20v
-        c2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUi
-        OiAiY3ZlIiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZF
-        LTIwMTAtMDQwNSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29t
-        L3NlY3VyaXR5L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIs
-        ICJ0eXBlIjogIm90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1d
-        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
-        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIs
-        ICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        SW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJp
-        dHkgdXBkYXRlIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24i
-        OiAiMyIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNl
-        Y3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJi
-        emlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1s
-        aWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1
-        NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQi
-        XSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZf
-        NjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJy
-        ZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMi
-        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
-        cDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2
-        YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgy
-        ZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZf
-        MC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
-        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNy
-        YyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJi
-        emlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTcz
-        ZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVm
-        NTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZf
-        MC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
-        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNy
-        YyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJi
-        emlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTVi
-        N2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3
-        NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVs
-        Nl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEu
-        MC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9
-        LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFt
-        ZSI6ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBk
-        ODliYTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2
-        YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4
-        Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41Iiwg
-        InJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5h
-        bWUiOiAiY29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6
-        ICJmaW5hbCIsICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAi
-        ZGVzY3JpcHRpb24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBo
-        aWdoLXF1YWxpdHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3Ro
-        XG5saWJiejIgbGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVw
-        ZGF0ZSB0byB0YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgz
-        NjM4MjIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50
-        IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMi
-        LCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBt
-        YWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxl
-        dmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhp
-        cyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3Jr
-        LiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsg
-        dG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDov
-        L2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1h
-        cnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2Vj
-        dXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImMzMDNjMDg5
-        LTkxMmItNDAwMy05NjhlLWU4OGQ1YTc5ZWZmNyJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTA1LTAxVDIwOjEwOjIyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiYzMwM2MwODktOTEyYi00
-        MDAzLTk2OGUtZTg4ZDVhNzllZmY3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFj
-        ODIyZWZkYmNjYTlmMzg5NWIxYzUifX0sIHsibWV0YWRhdGEiOiB7Imlzc3Vl
-        ZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5IiwgInJlbG9naW5fc3VnZ2VzdGVk
-        IjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRh
-        dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6
-        ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwgImZyb20iOiAiZXJyYXRhQHJl
-        ZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1Y2tfS2Fu
-        Z2Fyb29fRXJyYXR1bSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJz
-        aW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6
-        ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
-        ImR1Y2siLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImR1Y2stMC43LTEu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjogIjAuNyIs
-        ICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJtb2R1bGUiOiB7ImNvbnRleHQiOiAiZGVhZGJl
-        ZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIzMzEwMiIsICJhcmNoIjogIm5v
-        YXJjaCIsICJuYW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInNob3J0
-        IjogIiJ9LCB7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVk
-        b3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdW0iOiBu
-        dWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4zLTEubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24t
-        MSIsICJtb2R1bGUiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lv
-        biI6ICIyMDE4MDczMDIyMzQwNyIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1l
-        IjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIn0sICJzaG9ydCI6ICIifV0s
-        ICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiMjAxOC0wNy0yMCAw
-        NjowMDowMSBVVEMiLCAiZGVzY3JpcHRpb24iOiAiRHVja19LYW5nYXJvX0Vy
-        cmF0dW0gZGVzY3JpcHRpb24iLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgzNjM4
-        MjIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
-        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
-        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImNmNTk1MTQ3LTg2NTEtNGJl
-        OC1hMDQzLTkzZGI1ZDVmNThmYSJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAx
-        VDIwOjEwOjIyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMDUtMDFUMjA6MTA6MjJaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiY2Y1OTUxNDctODY1MS00YmU4LWEwNDMt
-        OTNkYjVkNWY1OGZhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZWZkYmNj
-        YTlmMzg5NWIyM2EifX1d
+        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
+        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90
+        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
+        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjQ0MTI5NzNmOGNkZTJhNDgwMiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
+        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
+        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
+        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
+        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
+        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
+        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
+        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
+        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
+        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
+        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
+        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg2OCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
+        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
+        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
+        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
+        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5
+        NzNmOGNkZTJhNDgzYiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
+        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
+        ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
+        dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
+        ZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0s
+        IHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemls
+        bGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxh
+        IiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6
+        aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3Mi
+        fSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkv
+        ZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwg
+        ImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
+        NSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
+        L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjog
+        Im90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91
+        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
+        dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIsICJmcm9tIjog
+        InNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50
+        IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBkYXRl
+        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMyIsICJy
+        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
+        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAu
+        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
+        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
+        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
+        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
+        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDIt
+        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
+        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
+        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
+        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
+        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
+        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
+        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
+        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
+        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
+        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
+        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZl
+        bCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2Vj
+        NGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0s
+        ICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82
+        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
+        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
+        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
+        MiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5
+        OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0s
+        ICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
+        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29s
+        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
+        dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
+        bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
+        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NjgsICJy
+        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
+        aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
+        b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
+        YWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5
+        b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUg
+        aXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxz
+        IG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkg
+        dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
+        ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
+        YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
+        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
+        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
+        VDE3OjQ3OjQ4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
+        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTcz
+        ZjhjZGUyYTQ4MWMifX1d
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2083,7 +1914,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2096,7 +1927,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2109,10 +1940,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2122,7 +1953,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2135,57 +1966,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '442'
+      - '519'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE1ODgxOTYxNDQsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNWMwODAzNTgtODA4YS00
-        NTI3LWI4MzQtZDAyZmZjYWU0NjgyIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjIyWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjVjMDgw
-        MzU4LTgwOGEtNDUyNy1iODM0LWQwMmZmY2FlNDY4MiIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWVhYzgyMmVmZGJjY2E5ZjM4OTViMjRkIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNTg4MTk2MTQ0LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOGEz
-        N2JiMGQtYjI5ZC00NzQzLWIxMTgtNGZlODg5ZmJlYzg3IiwgImRpc3BsYXlf
-        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMloiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEw
-        OjIyWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogIjhhMzdiYjBkLWIyOWQtNDc0My1iMTE4LTRmZTg4OWZiZWM4NyIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmVmZGJjY2E5ZjM4OTViMjU5In19
-        XQ==
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJj
+        b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
+        YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
+        cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
+        OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
+        ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
+        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
+        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
+        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDQx
+        Mjk3M2Y4Y2RlMmE0OGEwIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
+        ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
+        ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
+        cnNlIiwgImthbmdhcm9vIiwgImxpb24iLCAibW91c2UiLCAic3F1aXJyZWwi
+        LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
+        XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
+        InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
+        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
+        YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
+        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
+        MjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
+        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNDQxMjk3M2Y4Y2RlMmE0OGFjIn19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2195,7 +2029,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2208,7 +2042,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2221,10 +2055,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2234,7 +2068,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2247,60 +2081,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '402'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvOWUvYjY2
-        NjBkZWYxMzNlNWI4NjdiYmVhMDgzNjEzYTY1YzQ5OGQ1OGFmMDFjMDBhZjU5
-        MjU5ZTg5OGVmMDkxYjEvNTY5YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIy
-        OGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJjNDA4ZjhkOTcxYi1zd2lkdGFncy54
-        bWwuZ3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjog
-        InN3aWR0YWdzIiwgImNoZWNrc3VtIjogIjU2OWMwYWMzMjQzMmEyMTMwODY3
-        OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3MWIi
-        LCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgzNjM4MjEsICJfY29udGVudF90eXBl
-        X2lkIjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiZG93bmxvYWRlZCI6
-        IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9ucyI6ICJ1bml0
-        c195dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImNoZWNrc3VtX3R5cGUiOiAi
-        c2hhMjU2IiwgIl9pZCI6ICIzZGEwNThmZS1jZmNjLTRhYmUtYjhkYS0xMTkz
-        YTM5NWNlNjIifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoi
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1
-        LTAxVDIwOjEwOjIxWiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0
-        YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogIjNkYTA1OGZlLWNmY2MtNGFiZS1i
-        OGRhLTExOTNhMzk1Y2U2MiIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmRm
-        ZGJjY2E5ZjM4OTViMDFkIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
-        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19t
-        ZXRhZGF0YV9maWxlL2I0LzVmM2E1OWVmNDE5ZTgzYjMwZGQwNWYyMmE1MWVh
-        MWVmZTMwNTdkYjZhNzQ3NDAwYWUzMThkNjU3NzcyYjFmLzBkMWViNzM4Njdj
-        NDU5Yjg2ZDE1OGNkYWQyNjYwMDJlNDU4ODE0MDUxZTM1NTI5OTcwNTNkMzU2
-        NzE0NGE3ZTItcHJvZHVjdGlkLmd6IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQx
-        ZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5
-        NzA1M2QzNTY3MTQ0YTdlMiIsICJfbGFzdF91cGRhdGVkIjogMTU4ODM2Mzgy
-        MSwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
-        IHt9LCAiX25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogIjViZjBhODQxLTY4
-        ODEtNGIwYy04Njk1LWRlMTRkZjMwOTc3NSJ9LCAidXBkYXRlZCI6ICIyMDIw
-        LTA1LTAxVDIwOjEwOjIxWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjFaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiNWJm
-        MGE4NDEtNjg4MS00YjBjLTg2OTUtZGUxNGRmMzA5Nzc1IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZWFjODIyZGZkYmNjYTlmMzg5NWIwMjQifX1d
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYjQvNWYz
+        YTU5ZWY0MTllODNiMzBkZDA1ZjIyYTUxZWExZWZlMzA1N2RiNmE3NDc0MDBh
+        ZTMxOGQ2NTc3NzJiMWYvYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUyNzc1YWEw
+        ZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMi1wcm9kdWN0aWQu
+        Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
+        b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
+        ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODY3LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
+        cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
+        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
+        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
+        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
+        N1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
+        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5
+        NzNmOGNkZTJhNDY2YyJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:24 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2310,7 +2126,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2323,7 +2139,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:24 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2336,10 +2152,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2351,7 +2167,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2364,7 +2180,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2377,10 +2193,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2390,7 +2206,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2403,13 +2219,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '532'
+      - '534'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2429,42 +2245,42 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU4ODM2
-        MzgyMSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg2NywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjU2NDhhM2ZlLTJj
-        YmYtNDQyYS1hY2FiLTMwY2VkN2ZmYTllNSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6MjFaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDoyMVoiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjU2NDhhM2ZlLTJj
-        YmYtNDQyYS1hY2FiLTMwY2VkN2ZmYTllNSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyMmRmZGJjY2E5ZjM4OTViMTI1In19XQ==
+        MjAtMTAtMDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmNDQxMjk3M2Y4Y2RlMmE0Nzc0In19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSJdfX19LCJm
-        aWVsZHMiOnsidW5pdCI6WyJuYW1lIiwiZXBvY2giLCJ2ZXJzaW9uIiwicmVs
-        ZWFzZSIsImFyY2giLCJjaGVja3N1bXR5cGUiLCJjaGVja3N1bSJdfX0sIm92
-        ZXJyaWRlX2NvbmZpZyI6e319
+        OnsiJGluIjpbImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iXX19fSwiZmll
+        bGRzIjp7InVuaXQiOlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVh
+        c2UiLCJhcmNoIiwiY2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19LCJvdmVy
+        cmlkZV9jb25maWciOnt9fQ==
     headers:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
-      - '243'
+      - '241'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2473,7 +2289,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2484,14 +2300,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUzZDgyN2EzLTk3ODAtNDc5ZS05M2E5LTlkMjQzY2FlMjE0NS8iLCAi
-        dGFza19pZCI6ICI1M2Q4MjdhMy05NzgwLTQ3OWUtOTNhOS05ZDI0M2NhZTIx
-        NDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2NjODY3OGY3LWZiY2QtNDU5Yy05MDVlLWU3YTQ2ZTVjY2MwNy8iLCAi
+        dGFza19pZCI6ICJjYzg2NzhmNy1mYmNkLTQ1OWMtOTA1ZS1lN2E0NmU1Y2Nj
+        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2502,7 +2318,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2515,7 +2331,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2526,14 +2342,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzhlZTUwZWE1LWJlNDgtNDZkZC04ZmFhLTUwYmM2YWNiZmZlMi8iLCAi
-        dGFza19pZCI6ICI4ZWU1MGVhNS1iZTQ4LTQ2ZGQtOGZhYS01MGJjNmFjYmZm
-        ZTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzkxOTQ2NjFkLTc3OWQtNDgwZi1hYTYzLTYwNGU2MGU0NjkwZC8iLCAi
+        dGFza19pZCI6ICI5MTk0NjYxZC03NzlkLTQ4MGYtYWE2My02MDRlNjBlNDY5
+        MGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2543,7 +2359,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2556,7 +2372,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2567,14 +2383,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNlNDA2MTU4LTIwM2UtNDFlYy1iODlkLTI3NzEzZmMxNTRkOS8iLCAi
-        dGFza19pZCI6ICIzZTQwNjE1OC0yMDNlLTQxZWMtYjg5ZC0yNzcxM2ZjMTU0
-        ZDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzgyMGM3NDQzLTU2ODAtNDgwOS04NzA1LTRiMWMyNGZjN2YwNi8iLCAi
+        dGFza19pZCI6ICI4MjBjNzQ0My01NjgwLTQ4MDktODcwNS00YjFjMjRmYzdm
+        MDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2584,7 +2400,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2597,7 +2413,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2608,14 +2424,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzM1NjlhYWE1LTIwMDAtNGU3Zi1iMTMzLWViNTE4NTAwODNiYi8iLCAi
-        dGFza19pZCI6ICIzNTY5YWFhNS0yMDAwLTRlN2YtYjEzMy1lYjUxODUwMDgz
-        YmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzdiZDQxNjYwLTE5OTMtNDA3NC05NzllLTY2OGZiYjJlNDIwNC8iLCAi
+        dGFza19pZCI6ICI3YmQ0MTY2MC0xOTkzLTQwNzQtOTc5ZS02NjhmYmIyZTQy
+        MDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2625,7 +2441,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2638,7 +2454,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2649,14 +2465,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2VjZGJkY2MxLTgzNDItNDBlNy1hN2QyLTc0ZjU3YjVkMzMwMS8iLCAi
-        dGFza19pZCI6ICJlY2RiZGNjMS04MzQyLTQwZTctYTdkMi03NGY1N2I1ZDMz
-        MDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I1ODZjN2RiLWNlMTktNDg4Yy1hYTg2LTM5M2Y2MDQxOTQxNC8iLCAi
+        dGFza19pZCI6ICJiNTg2YzdkYi1jZTE5LTQ4OGMtYWE4Ni0zOTNmNjA0MTk0
+        MTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2667,7 +2483,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2680,7 +2496,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2691,14 +2507,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2IxN2I0MGI3LWE5ZjctNDIyNy1iNzc4LTQ1N2FhZmNiNzIyMy8iLCAi
-        dGFza19pZCI6ICJiMTdiNDBiNy1hOWY3LTQyMjctYjc3OC00NTdhYWZjYjcy
-        MjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MyOWE3ZmZjLTQzMWYtNDU2MC04MDA5LWEyNGQ0ZjYwOWJmZC8iLCAi
+        dGFza19pZCI6ICJjMjlhN2ZmYy00MzFmLTQ1NjAtODAwOS1hMjRkNGY2MDli
+        ZmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2709,7 +2525,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2722,7 +2538,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2733,14 +2549,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JlMDUyMWMwLTFjOGMtNDdiYi1hY2RlLTMxZDM5Y2ZlNWQ3ZS8iLCAi
-        dGFza19pZCI6ICJiZTA1MjFjMC0xYzhjLTQ3YmItYWNkZS0zMWQzOWNmZTVk
-        N2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRmM2NjYTQ1LWIwNGEtNDdmMC05NzAwLTRmY2NiMmRmMTdiNS8iLCAi
+        dGFza19pZCI6ICI0ZjNjY2E0NS1iMDRhLTQ3ZjAtOTcwMC00ZmNjYjJkZjE3
+        YjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2750,7 +2566,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2763,7 +2579,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2774,14 +2590,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NlYmYzMzcyLTIyMTItNGM2Ni05OWNkLTc2NDcyZTE4MDgyMy8iLCAi
-        dGFza19pZCI6ICJjZWJmMzM3Mi0yMjEyLTRjNjYtOTljZC03NjQ3MmUxODA4
-        MjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzUxNjk0M2E3LTE1YWItNDc0Yi1hYTk4LTExZWI4NDMzZWJjYi8iLCAi
+        dGFza19pZCI6ICI1MTY5NDNhNy0xNWFiLTQ3NGItYWE5OC0xMWViODQzM2Vi
+        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2791,7 +2607,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2804,7 +2620,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2815,14 +2631,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg2YzkwNzcxLTRlOGYtNGE4YS1iNjIzLTczODkxMjYyYThiNi8iLCAi
-        dGFza19pZCI6ICI4NmM5MDc3MS00ZThmLTRhOGEtYjYyMy03Mzg5MTI2MmE4
-        YjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzVjMmI0YjJhLTlmMjQtNDFkOC05NmQ1LTk5NTVhYWIwZTdlMy8iLCAi
+        dGFza19pZCI6ICI1YzJiNGIyYS05ZjI0LTQxZDgtOTZkNS05OTU1YWFiMGU3
+        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2832,7 +2648,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2845,7 +2661,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Content-Length:
@@ -2856,14 +2672,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYzNmZiNjZlLTQzNGUtNDZjMi05Yzk2LTBmZDU4MjNiNjIyOC8iLCAi
-        dGFza19pZCI6ICI2MzZmYjY2ZS00MzRlLTQ2YzItOWM5Ni0wZmQ1ODIzYjYy
-        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzNlMGExMmQ1LTcyZmMtNGNlYi1hZjMxLWIxMGRkY2Q1M2Y5Yy8iLCAi
+        dGFza19pZCI6ICIzZTBhMTJkNS03MmZjLTRjZWItYWYzMS1iMTBkZGNkNTNm
+        OWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/53d827a3-9780-479e-93a9-9d243cae2145/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/cc8678f7-fbcd-459c-905e-e7a46e5ccc07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2871,7 +2687,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2882,15 +2698,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Etag:
-      - '"0661dbbf36a409ee4a0065fe84b8aef2-gzip"'
+      - '"5ca04ef41342600a9c752460816056c8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '555'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2898,33 +2714,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81M2Q4Mjdh
-        My05NzgwLTQ3OWUtOTNhOS05ZDI0M2NhZTIxNDUvIiwgInRhc2tfaWQiOiAi
-        NTNkODI3YTMtOTc4MC00NzllLTkzYTktOWQyNDNjYWUyMTQ1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jYzg2Nzhm
+        Ny1mYmNkLTQ1OWMtOTA1ZS1lN2E0NmU1Y2NjMDcvIiwgInRhc2tfaWQiOiAi
+        Y2M4Njc4ZjctZmJjZC00NTljLTkwNWUtZTdhNDZlNWNjYzA3IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdf
-        a2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50Iiwg
-        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
-        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
-        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
-        X2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
-        IjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4
-        MjMxZmRiY2NhOWYzODk1YjQ1MCJ9LCAiaWQiOiAiNWVhYzgyMzFmZGJjY2E5
-        ZjM4OTViNDUwIn0=
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzMzM1MWZkNmMyYTM4ZTVk
+        NDlhZWE3ODhhMmU4MzhlYWNkNjU0Y2Y2MWQ0NzZiYTViNjVkZTQzOWRkZDEy
+        NWI5IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
+        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWEwIn0sICJpZCI6ICI1
+        ZjdkZmY0NTEyOTczZjhjZGUyYTRhYTAifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/8ee50ea5-be48-46dd-8faa-50bc6acbffe2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9194661d-779d-480f-aa63-604e60e4690d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2932,7 +2748,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2943,15 +2759,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:25 GMT
+      - Wed, 07 Oct 2020 17:47:49 GMT
       Server:
       - Apache
       Etag:
-      - '"dbb69849a9c4079810585fa7dd77425e-gzip"'
+      - '"2f1aa97abf31e5aa53b8bd0bf7934509-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '946'
+      - '956'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2959,79 +2775,79 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84ZWU1MGVh
-        NS1iZTQ4LTQ2ZGQtOGZhYS01MGJjNmFjYmZmZTIvIiwgInRhc2tfaWQiOiAi
-        OGVlNTBlYTUtYmU0OC00NmRkLThmYWEtNTBiYzZhY2JmZmUyIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85MTk0NjYx
+        ZC03NzlkLTQ4MGYtYWE2My02MDRlNjBlNDY5MGQvIiwgInRhc2tfaWQiOiAi
+        OTE5NDY2MWQtNzc5ZC00ODBmLWFhNjMtNjA0ZTYwZTQ2OTBkIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcw
-        NDI0NDIwNSwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJz
-        dHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRf
-        a2V5IjogeyJjb250ZXh0IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4
-        MDcwNzE0NDIwMywgImFyY2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVz
-        IiwgInN0cmVhbSI6ICIwLjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0s
-        IHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lv
-        biI6IDIwMTgwNzMwMjMzMTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6
-        ICJkdWNrIiwgInN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1k
-        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
-        OiAid2FscnVzIiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNi
-        ZWUxYzYyNmEzOWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6
-        ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEy
-        NTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxs
-        LCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1
-        YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIx
-        YmY0YzIwOGUzZjY2YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjciLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsi
-        c2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2Fu
-        Z2Fyb28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3
-        MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIs
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
+        ZXJzaW9uIjogMjAxODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJu
+        YW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9k
+        dWxlbWQifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIs
+        ICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIs
+        ICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
+        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAi
+        bm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlw
+        ZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgz
+        M2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5
+        YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNr
+        IiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNl
+        ZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
+        ZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tl
+        eSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVhNGM4
+        OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2Qw
+        OTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
+        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9r
+        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
+        NzA0MTExNzE5LCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJrYW5nYXJv
+        byIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
+        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndh
+        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
+        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIs
         ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0Ijog
-        ImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDExMTcxOSwgImFyY2gi
-        OiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAi
-        fSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJzaWduaW5nX2tleSI6IG51
-        bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1
-        bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4
-        OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNo
-        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
-        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
-        OiAid2FscnVzIiwgImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2
-        MzYxY2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6
-        ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEy
-        NTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRl
-        eHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAi
-        YXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0i
-        OiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5Ijog
-        eyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0
-        NDIwMywgImFyY2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0
-        cmVhbSI6ICI1LjIxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2ln
-        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIs
-        ICJjaGVja3N1bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgx
-        YjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
-        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
-        aWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIi
-        OiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgy
-        MzFmZGJjY2E5ZjM4OTViNDVmIn0sICJpZCI6ICI1ZWFjODIzMWZkYmNjYTlm
-        Mzg5NWI0NWYifQ==
+        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUz
+        M2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0
+        OGI3N2UwMTg5OGU3YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1
+        LjIxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
+        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVu
+        aXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAy
+        MDE4MDczMDIyMzQwNywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2Fu
+        Z2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQi
+        fSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
+        aW9uIjogMjAxODA3MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1l
+        IjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
+        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZl
+        NmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3
+        NGJjNyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVh
+        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9z
+        aWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjQ1MTI5NzNmOGNkZTJhNGFiNiJ9LCAiaWQiOiAi
+        NWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWI2In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:25 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/3e406158-203e-41ec-b89d-27713fc154d9/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/820c7443-5680-4809-8705-4b1c24fc7f06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3039,7 +2855,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3050,15 +2866,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:26 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"55fafc6c6c5d4652a0f0eec05c523a0f-gzip"'
+      - '"cec6e053bbf27ab2ce6aa5dc0c5fd678-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '421'
+      - '427'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3066,27 +2882,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZTQwNjE1
-        OC0yMDNlLTQxZWMtYjg5ZC0yNzcxM2ZjMTU0ZDkvIiwgInRhc2tfaWQiOiAi
-        M2U0MDYxNTgtMjAzZS00MWVjLWI4OWQtMjc3MTNmYzE1NGQ5IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MjBjNzQ0
+        My01NjgwLTQ4MDktODcwNS00YjFjMjRmYzdmMDYvIiwgInRhc2tfaWQiOiAi
+        ODIwYzc0NDMtNTY4MC00ODA5LTg3MDUtNGIxYzI0ZmM3ZjA2IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI1
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMzFmZGJjY2E5ZjM4OTViNDc3In0s
-        ICJpZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI0NzcifQ==
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ1MTI5
+        NzNmOGNkZTJhNGFkNyJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
+        YWQ3In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:26 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/3569aaa5-2000-4e7f-b133-eb51850083bb/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7bd41660-1993-4074-979e-668fbb2e4204/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3094,7 +2911,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3105,15 +2922,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:26 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"122899ec805ba891e66ef60fea26d120-gzip"'
+      - '"d0d2172f83bd8679c94b1e8a16f20aa4-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '503'
+      - '510'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3121,37 +2938,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zNTY5YWFh
-        NS0yMDAwLTRlN2YtYjEzMy1lYjUxODUwMDgzYmIvIiwgInRhc2tfaWQiOiAi
-        MzU2OWFhYTUtMjAwMC00ZTdmLWIxMzMtZWI1MTg1MDA4M2JiIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YmQ0MTY2
+        MC0xOTkzLTQwNzQtOTc5ZS02NjhmYmIyZTQyMDQvIiwgInRhc2tfaWQiOiAi
+        N2JkNDE2NjAtMTk5My00MDc0LTk3OWUtNjY4ZmJiMmU0MjA0IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5In0sICJ0eXBlX2lk
-        IjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1S
-        SFNBLTIwMTA6MDg1OCJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5p
-        dF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5
-        cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
-        TExPLVJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
-        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
-        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
-        ICJLQVRFTExPLVJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0
-        dW0ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODIzMWZkYmNj
-        YTlmMzg5NWI0OGYifSwgImlkIjogIjVlYWM4MjMxZmRiY2NhOWYzODk1YjQ4
-        ZiJ9
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
+        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
+        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
+        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWU3In0sICJpZCI6ICI1ZjdkZmY0
+        NTEyOTczZjhjZGUyYTRhZTcifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:26 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/ecdbdcc1-8342-40e7-a7d2-74f57b5d3301/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/b586c7db-ce19-488c-aa86-393f60419414/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3159,7 +2976,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3170,128 +2987,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:26 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"2460ed51b322a836865469f5215cb93c-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lY2RiZGNj
-        MS04MzQyLTQwZTctYTdkMi03NGY1N2I1ZDMzMDEvIiwgInRhc2tfaWQiOiAi
-        ZWNkYmRjYzEtODM0Mi00MGU3LWE3ZDItNzRmNTdiNWQzMzAxIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlw
-        ZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9f
-        aWQiOiAiM192aWV3MSIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAi
-        cGFja2FnZV9ncm91cCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImlkIjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7
-        InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJt
-        YW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMzFmZGJjY2E5ZjM4
-        OTViNGE1In0sICJpZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI0YTUifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:26 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b17b40b7-a9f7-4227-b778-457aafcb7223/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:27 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"926e85be97e1c8b9068390f2e5c34a9a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '421'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iMTdiNDBi
-        Ny1hOWY3LTQyMjctYjc3OC00NTdhYWZjYjcyMjMvIiwgInRhc2tfaWQiOiAi
-        YjE3YjQwYjctYTlmNy00MjI3LWI3NzgtNDU3YWFmY2I3MjIzIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMzFmZGJjY2E5ZjM4OTViNGIyIn0s
-        ICJpZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI0YjIifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:27 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/be0521c0-1c8c-47bb-acde-31d39cfe5d7e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:27 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b843e5511828af505c7bd9819c0a0205-gzip"'
+      - '"8478664a8321789033e16a6c78de6294-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3303,36 +3003,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZTA1MjFj
-        MC0xYzhjLTQ3YmItYWNkZS0zMWQzOWNmZTVkN2UvIiwgInRhc2tfaWQiOiAi
-        YmUwNTIxYzAtMWM4Yy00N2JiLWFjZGUtMzFkMzljZmU1ZDdlIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iNTg2Yzdk
+        Yi1jZTE5LTQ4OGMtYWE4Ni0zOTNmNjA0MTk0MTQvIiwgInRhc2tfaWQiOiAi
+        YjU4NmM3ZGItY2UxOS00ODhjLWFhODYtMzkzZjYwNDE5NDE0IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1
-        Y3RpZCJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn0s
-        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJkYXRhX3R5
-        cGUiOiAic3dpZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRh
-        dGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjog
-        W3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRhdGFf
-        dHlwZSI6ICJzd2lkdGFncyJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRh
-        ZGF0YV9maWxlIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAi
-        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgyMzFmZGJjY2E5ZjM4OTViNGM2In0sICJp
-        ZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI0YzYifQ==
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
+        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
+        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
+        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
+        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjQ1MTI5NzNmOGNkZTJhNGIxZiJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3
+        M2Y4Y2RlMmE0YjFmIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:27 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/cebf3372-2212-4c66-99cd-76472e180823/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c29a7ffc-431f-4560-8009-a24d4f609bfd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3340,7 +3039,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3351,15 +3050,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:28 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"f995d064871fa74c4e9e73f5f316ca3b-gzip"'
+      - '"ef92b9281b5effa69aea08e423e5846c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '503'
+      - '473'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3367,31 +3066,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZWJmMzM3
-        Mi0yMjEyLTRjNjYtOTljZC03NjQ3MmUxODA4MjMvIiwgInRhc2tfaWQiOiAi
-        Y2ViZjMzNzItMjIxMi00YzY2LTk5Y2QtNzY0NzJlMTgwODIzIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jMjlhN2Zm
+        Yy00MzFmLTQ1NjAtODAwOS1hMjRkNGY2MDliZmQvIiwgInRhc2tfaWQiOiAi
+        YzI5YTdmZmMtNDMxZi00NTYwLTgwMDktYTI0ZDRmNjA5YmZkIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJ2YXJpYW50IjogIlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYi
-        LCAiYXJjaCI6ICJ4ODZfNjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVz
-        dFZhcmlhbnQtMTYteDg2XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9
-        LCAidHlwZV9pZCI6ICJkaXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRf
-        c2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI0ZWIifSwgImlkIjog
-        IjVlYWM4MjMxZmRiY2NhOWYzODk1YjRlYiJ9
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
+        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
+        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
+        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4
+        Y2RlMmE0YjQ0In0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiNDQi
+        fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:28 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/86c90771-4e8f-4a8a-b623-73891262a8b6/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f3cca45-b04a-47f0-9700-4fccb2df17b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3399,7 +3099,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3410,15 +3110,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:28 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"d4c1241e7455ccd0f472ca3fc8627e90-gzip"'
+      - '"82c0bc196554e798768c0248c08c46de-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '496'
+      - '473'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3426,39 +3126,158 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84NmM5MDc3
-        MS00ZThmLTRhOGEtYjYyMy03Mzg5MTI2MmE4YjYvIiwgInRhc2tfaWQiOiAi
-        ODZjOTA3NzEtNGU4Zi00YThhLWI2MjMtNzM4OTEyNjJhOGI2IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZjNjY2E0
+        NS1iMDRhLTQ3ZjAtOTcwMC00ZmNjYjJkZjE3YjUvIiwgInRhc2tfaWQiOiAi
+        NGYzY2NhNDUtYjA0YS00N2YwLTk3MDAtNGZjY2IyZGYxN2I1IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
+        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
+        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YjY2In0sICJpZCI6ICI1
+        ZjdkZmY0NTEyOTczZjhjZGUyYTRiNjYifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/516943a7-15ab-474b-aa98-11eb8433ebcb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7a1321605459ecc7b334c9d8d78d28f2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '509'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81MTY5NDNh
+        Ny0xNWFiLTQ3NGItYWE5OC0xMWViODQzM2ViY2IvIiwgInRhc2tfaWQiOiAi
+        NTE2OTQzYTctMTVhYi00NzRiLWFhOTgtMTFlYjg0MzNlYmNiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
+        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
+        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
+        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
+        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2Rl
+        MmE0Yjc0In0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiNzQifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/5c2b4b2a-9f24-41d8-96d5-9955aab0e7e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6f94b547708cbfb3e5810b60597117a9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YzJiNGIy
+        YS05ZjI0LTQxZDgtOTZkNS05OTU1YWFiMGU3ZTMvIiwgInRhc2tfaWQiOiAi
+        NWMyYjRiMmEtOWYyNC00MWQ4LTk2ZDUtOTk1NWFhYjBlN2UzIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
+        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
+        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
+        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
         LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwg
-        InR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6
-        IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlw
-        ZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9z
-        aWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgIm5hbWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAi
-        bW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAibmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1v
-        ZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgIm5hbWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1v
-        ZHVsZW1kX2RlZmF1bHRzIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI1MTYifSwgImlkIjogIjVl
-        YWM4MjMxZmRiY2NhOWYzODk1YjUxNiJ9
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
+        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
+        YmFiIn0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiYWIifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:28 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/636fb66e-434e-46c2-9c96-0fd5823b6228/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e0a12d5-72fc-4ceb-af31-b10ddcd53f9c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3466,7 +3285,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3477,15 +3296,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:29 GMT
+      - Wed, 07 Oct 2020 17:47:50 GMT
       Server:
       - Apache
       Etag:
-      - '"c0d6bfa2032d8d85fd1467c7354e3046-gzip"'
+      - '"c56c2d584e34b0105a272b6c8958bf89-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '421'
+      - '424'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3493,27 +3312,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MzZmYjY2
-        ZS00MzRlLTQ2YzItOWM5Ni0wZmQ1ODIzYjYyMjgvIiwgInRhc2tfaWQiOiAi
-        NjM2ZmI2NmUtNDM0ZS00NmMyLTljOTYtMGZkNTgyM2I2MjI4IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZTBhMTJk
+        NS03MmZjLTRjZWItYWYzMS1iMTBkZGNkNTNmOWMvIiwgInRhc2tfaWQiOiAi
+        M2UwYTEyZDUtNzJmYy00Y2ViLWFmMzEtYjEwZGRjZDUzZjljIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjI2
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMzFmZGJjY2E5ZjM4OTViNTJhIn0s
-        ICJpZCI6ICI1ZWFjODIzMWZkYmNjYTlmMzg5NWI1MmEifQ==
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ1MTI5
+        NzNmOGNkZTJhNGJjMyJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
+        YmMzIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:29 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3521,7 +3341,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3532,15 +3352,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:29 GMT
+      - Wed, 07 Oct 2020 17:47:51 GMT
       Server:
       - Apache
       Etag:
-      - '"7e6b93b599d7e45238608c518cb5728f-gzip"'
+      - '"6d160c2611b939595d9b75dde93d5e1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '634'
+      - '637'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3549,60 +3369,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6MjRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZWFjODIzMGIwMmU1MzA3NTNhOTg1NzQifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTcifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6MjNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWVhYzgyMzBiMDJlNTMwNzUzYTk4NTczIn0sICJjb25maWci
+        IiRvaWQiOiAiNWY3ZGZmNDQwMjIzOWY3MzY1MWU2MTk2In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6MjNaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZWFjODIyZmIwMmU1MzA3NTNhOTg1NzIifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTUifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MTA6MjZaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTBaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgIm1vZHVsZW1kIjog
-        NiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2LCAiZGlz
-        dHJpYnV0aW9uIjogMSwgInJwbSI6IDcsICJ5dW1fcmVwb19tZXRhZGF0YV9m
-        aWxlIjogMn0sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVw
-        b19pZCI6ICIzX3ZpZXcxIiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1LTAx
-        VDIwOjEwOjIzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
-        aWVzLzNfdmlldzEvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjog
-        InJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
-        cG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5
-        bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgyMmZiMDJlNTMwNzUzYTk4NTcxIn0sICJjb25maWciOiB7fSwg
-        ImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRz
-        IjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyMmZiMDJlNTMwNzUzYTk4
-        NTcwIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjcsICJpZCI6ICIz
-        X3ZpZXcxIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        M192aWV3MS8ifQ==
+        aXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJlcnJhdHVt
+        IjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQiOiA2LCAicGFj
+        a2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24iOiAxLCAicnBt
+        IjogNywgInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwgIl9ucyI6ICJy
+        ZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAi
+        bGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9pbXBvcnRl
+        cnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMiLCAi
+        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVy
+        cmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3JhdGNo
+        cGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5Zjcz
+        NjUxZTYxOTQifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9ydGVy
+        In1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAyNiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTMifSwgInRvdGFsX3JlcG9z
+        aXRvcnlfdW5pdHMiOiAyNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:29 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3610,7 +3430,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3621,7 +3441,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:30 GMT
+      - Wed, 07 Oct 2020 17:47:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -3632,14 +3452,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRiMzE5YmE1LWNiMGMtNDZhZi1hYzBjLWJiMGY5MjVhMWU2MS8iLCAi
-        dGFza19pZCI6ICI0YjMxOWJhNS1jYjBjLTQ2YWYtYWMwYy1iYjBmOTI1YTFl
-        NjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2JkZDVkMGE4LWUwODYtNGE5NC04MjVjLWY4ZjM1NDUwNzI4Ni8iLCAi
+        dGFza19pZCI6ICJiZGQ1ZDBhOC1lMDg2LTRhOTQtODI1Yy1mOGYzNTQ1MDcy
+        ODYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/4b319ba5-cb0c-46af-ac0c-bb0f925a1e61/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/bdd5d0a8-e086-4a94-825c-f8f354507286/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3647,7 +3467,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3658,15 +3478,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:30 GMT
+      - Wed, 07 Oct 2020 17:47:51 GMT
       Server:
       - Apache
       Etag:
-      - '"b79e0005e83ed311ab3c454e2990b44f-gzip"'
+      - '"b85a72a9ef1660479e6ff6997fca97e5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '357'
+      - '365'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3674,25 +3494,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YjMxOWJhNS1jYjBjLTQ2YWYtYWMwYy1iYjBmOTI1YTFl
-        NjEvIiwgInRhc2tfaWQiOiAiNGIzMTliYTUtY2IwYy00NmFmLWFjMGMtYmIw
-        ZjkyNWExZTYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9iZGQ1ZDBhOC1lMDg2LTRhOTQtODI1Yy1mOGYzNTQ1MDcy
+        ODYvIiwgInRhc2tfaWQiOiAiYmRkNWQwYTgtZTA4Ni00YTk0LTgyNWMtZjhm
+        MzU0NTA3Mjg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjEwOjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjMwWiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ3OjUxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUxWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgy
-        MzZmZGJjY2E5ZjM4OTViNmViIn0sICJpZCI6ICI1ZWFjODIzNmZkYmNjYTlm
-        Mzg5NWI2ZWIifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjQ3MTI5NzNmOGNkZTJhNGQyOCJ9LCAiaWQiOiAi
+        NWY3ZGZmNDcxMjk3M2Y4Y2RlMmE0ZDI4In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3700,7 +3520,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3711,7 +3531,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:30 GMT
+      - Wed, 07 Oct 2020 17:47:51 GMT
       Server:
       - Apache
       Content-Length:
@@ -3722,14 +3542,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JhZDliYzAzLTcyYjMtNDcyZi04NmVkLWQ2MjBlMTNlZjdlZS8iLCAi
-        dGFza19pZCI6ICJiYWQ5YmMwMy03MmIzLTQ3MmYtODZlZC1kNjIwZTEzZWY3
-        ZWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzllMTkzZTM2LTU3MjctNDZkMy05NmQyLWE1YjFmMjFlMmYxOS8iLCAi
+        dGFza19pZCI6ICI5ZTE5M2UzNi01NzI3LTQ2ZDMtOTZkMi1hNWIxZjIxZTJm
+        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/bad9bc03-72b3-472f-86ed-d620e13ef7ee/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9e193e36-5727-46d3-96d2-a5b1f21e2f19/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3737,7 +3557,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3748,15 +3568,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:30 GMT
+      - Wed, 07 Oct 2020 17:47:51 GMT
       Server:
       - Apache
       Etag:
-      - '"ca0db2db62c1290cab0b7c20372cf5e9-gzip"'
+      - '"80e777224f0f64b6bf521c8e888d2463-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '355'
+      - '361'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3764,20 +3584,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iYWQ5YmMwMy03MmIzLTQ3MmYtODZlZC1kNjIwZTEzZWY3
-        ZWUvIiwgInRhc2tfaWQiOiAiYmFkOWJjMDMtNzJiMy00NzJmLTg2ZWQtZDYy
-        MGUxM2VmN2VlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy85ZTE5M2UzNi01NzI3LTQ2ZDMtOTZkMi1hNWIxZjIxZTJm
+        MTkvIiwgInRhc2tfaWQiOiAiOWUxOTNlMzYtNTcyNy00NmQzLTk2ZDItYTVi
+        MWYyMWUyZjE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDozMFoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1MVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
-        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjM2
-        ZmRiY2NhOWYzODk1YjczOSJ9LCAiaWQiOiAiNWVhYzgyMzZmZGJjY2E5ZjM4
-        OTViNzM5In0=
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0NzEyOTczZjhjZGUyYTRkNzEifSwgImlkIjogIjVm
+        N2RmZjQ3MTI5NzNmOGNkZTJhNGQ3MSJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:30 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:45 GMT
+      - Wed, 07 Oct 2020 17:47:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:45 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:45 GMT
+      - Wed, 07 Oct 2020 17:47:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:45 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:45 GMT
+      - Wed, 07 Oct 2020 17:47:52 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDViMDJlNTMwNzUzYTk4NTg3In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWY3ZGZmNDgwMjIzOWY3MzY0MTMxYWZiIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:45 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:45 GMT
+      - Wed, 07 Oct 2020 17:47:53 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzMyMWU2ZmIxLTFkOTQtNDEzMi05OWVlLTI0ZDhjMjAzNmI5OS8iLCAi
-        dGFza19pZCI6ICIzMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MxOWI5NGNhLTYwN2ItNGQ4Ny1iMWQxLWVlMTQ0ZGZkZGZhNy8iLCAi
+        dGFza19pZCI6ICJjMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:45 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:53 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,16 +231,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -252,42 +252,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,7 +295,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -306,15 +306,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:53 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -322,16 +322,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -343,42 +343,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -397,15 +397,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:53 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -413,16 +413,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -434,42 +434,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -477,7 +477,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -488,15 +488,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:53 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -504,16 +504,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -525,42 +525,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +568,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -579,15 +579,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -595,16 +595,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -616,42 +616,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -659,7 +659,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -670,15 +670,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:47 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -686,16 +686,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -707,42 +707,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:47 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -750,7 +750,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -761,15 +761,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
+      - '710'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -777,16 +777,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
+        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
+        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
+        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
+        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -798,42 +798,42 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
+        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
+        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
+        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/321e6fb1-1d94-4132-99ee-24d8c2036b99/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d8656576-173f-4992-96b5-cb10e536c7ff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +841,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -852,106 +852,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Etag:
-      - '"f89a7c988f9eb40a9b65cf239829adfb-gzip"'
+      - '"7cf1933a74b9720d64e35d7debcea678-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '711'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjFlNmZiMS0xZDk0LTQxMzItOTllZS0yNGQ4YzIwMzZi
-        OTkvIiwgInRhc2tfaWQiOiAiMzIxZTZmYjEtMWQ5NC00MTMyLTk5ZWUtMjRk
-        OGMyMDM2Yjk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWI1NjFlODctYWQ2NS00MjU1LTk4MmMtNGRiNWQyNWEz
-        MzhlLyIsICJ0YXNrX2lkIjogIjliNTYxZTg3LWFkNjUtNDI1NS05ODJjLTRk
-        YjVkMjVhMzM4ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ1WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMDUtMDFU
-        MjA6MTA6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVlYWM4
-        MjQ3YjAyZTUzNDNkMGUxMjU4MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDVmZGJjY2E5ZjM4OTViZmEzIn0sICJpZCI6ICI1ZWFjODI0NWZk
-        YmNjYTlmMzg5NWJmYTMifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9b561e87-ad65-4255-982c-4db5d25a338e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:48 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"07e255171d00408a687426d9af89da94-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1361'
+      - '1364'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -959,199 +868,199 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85YjU2MWU4Ny1hZDY1LTQyNTUtOTgyYy00ZGI1
-        ZDI1YTMzOGUvIiwgInRhc2tfaWQiOiAiOWI1NjFlODctYWQ2NS00MjU1LTk4
-        MmMtNGRiNWQyNWEzMzhlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9kODY1NjU3Ni0xNzNmLTQ5OTItOTZiNS1jYjEw
+        ZTUzNmM3ZmYvIiwgInRhc2tfaWQiOiAiZDg2NTY1NzYtMTczZi00OTkyLTk2
+        YjUtY2IxMGU1MzZjN2ZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo0N1oiLCAi
+        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1YWU2Y2E5NC0wZTg5LTRlZjktOTQxNC04OTQzOWI1
-        YTBhYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIyMmVmZmY3OS1iOTljLTQ2ODYtOTcxMi05OGUzYWM4
+        MTM5ZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYmU2YWZlNzAtOTczNy00OWU3LWJhYzAtM2NmODJkODBkOWRlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
+        aWQiOiAiZjhjMmUwOTQtMmVlZi00MmMxLWEyYzYtOTQ0ZTEzOWFhMjdjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
-        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZjMzZDc5Ni02ZjM0LTQ2Y2UtYjY5
-        Zi1iNWMxN2VmNzVlNzIiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNDg5ZWNmZC03YjM5LTRlZGUtOWJj
+        My1mZjc0MzNkNjc3NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MTIzZjNhZDYtMzFmYi00MWRjLWExNTgtYjljNmUyMDUwZDhlIiwgIm51bV9w
+        MTY3YTA4MGYtZjJkNS00ZTEyLWI3NWMtYTU1NGExNDM1ZWIzIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjQ2N2ZhZGYwLTdhYjgtNDU1ZS05ZGYzLTQ4
-        YjcyOTRlMjUzNyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImUxMTg2MTY0LTI1MTAtNGJmYi04ODA0LWIz
+        NmZkZDIxYTY5ZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUwNjA2
-        N2Y0LTI2NzMtNGI1Mi1hOWNmLTNkMjI0NWM5YWQxNSIsICJudW1fcHJvY2Vz
-        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0MWVm
+        NjJjLTM3OWEtNDE1OS04ODBhLWZhZWFmZjgxOTM5ZiIsICJudW1fcHJvY2Vz
+        c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
-        ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmMzM3YmYyNi02ZjM4LTRmNjYtOGEwMC0yMWE3
-        YWU4OWU2ZjgiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
-        IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
-        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
+        OiAwLCAic3RlcF9pZCI6ICI0ZGM4MzdmZi0xOWExLTQwZTgtYjc1Ny1mYjA2
+        MzI5ZDQ5MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
+        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZWFk
-        OTk1Zi0wZjU5LTQzN2ItYTI1Ny01OTA3YTBjNjAzMWEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTNm
+        NWIwNC0wMGM0LTQzNWYtOTA3Ni0xNzFiZmMxZjliM2IiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNzFiNzYwMS0wM2Mz
-        LTQ0YjEtYjI2Mi0xOWExYzZhNzM1ZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYzg2Yzc0MC0xNGUy
+        LTQ5NjEtODM1My1mM2VhNWI5YjBiYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjYjUwOTE3ZS03YzUyLTRmZjUtOTc1OS1m
-        YzFmMGIxODAwM2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MmM2MmIyZC04NjM3LTQ2NGEtODE3NS0y
+        MGM1ODg2OWExYTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkZjgyNjAzMC0zNjY2LTQxYzItYmJmZS0yMTI3Yzg4OWMy
-        ZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIwZGU1ZWI1Mi00MTcxLTQ0ZmUtYmNjMy1jNTNjZTEyNmQ5
+        ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NTM1MGMwZS0z
-        OWVlLTQ5YzEtOWZiYy02NDUzNWQyZjJiYWYiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMjM1NzdlZi1i
+        ZTc4LTRmMjItOGMyYS1hMjk5NmM2Mjk1MjYiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YzE4MDBkNC05M2I2LTQzNjUt
-        OTE4Yy05NjUxZmE0Y2RkZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYzE5NzI5Ny0wNGIzLTQ0NzYt
+        YTFiMi0wZmU3YTdjMmZmYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YmM4MzA5LTVlZTItNGE3Ny05YWVi
-        LTE1ZjVjOTE1YTQzYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
-        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAic3RhcnRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ3WiIsICJfbnMi
-        OiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmli
-        dXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5Ijog
-        eyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklT
-        SEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
-        ICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMi
-        OiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hF
-        RCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwg
-        ImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQ
-        UEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNWVhYzgyNDhiMDJlNTM0M2QwZTEyNTgzIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVhZTZjYTk0
-        LTBlODktNGVmOS05NDE0LTg5NDM5YjVhMGFjMSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTZhZmU3MC05NzM3LTQ5
-        ZTctYmFjMC0zY2Y4MmQ4MGQ5ZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAx
-        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjJmMzNkNzk2LTZmMzQtNDZjZS1iNjlmLWI1YzE3ZWY3NWU3MiIsICJudW1f
-        cHJvY2Vzc2VkIjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAi
-        ZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMjNmM2FkNi0zMWZiLTQxZGMtYTE1
-        OC1iOWM2ZTIwNTBkOGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogNiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDY3
-        ZmFkZjAtN2FiOC00NTVlLTlkZjMtNDhiNzI5NGUyNTM3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiA2fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
-        LCAiaXRlbXNfdG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNTA2MDY3ZjQtMjY3My00YjUyLWE5Y2YtM2Qy
-        MjQ1YzlhZDE1IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
-        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYzMzdi
-        ZjI2LTZmMzgtNGY2Ni04YTAwLTIxYTdhZTg5ZTZmOCIsICJudW1fcHJvY2Vz
-        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImZlYWQ5OTVmLTBmNTktNDM3Yi1hMjU3LTU5
-        MDdhMGM2MDMxYSIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImI3MWI3NjAxLTAzYzMtNDRiMS1iMjYyLTE5YTFjNmE3MzVk
-        ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNi
-        NTA5MTdlLTdjNTItNGZmNS05NzU5LWZjMWYwYjE4MDAzYyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRmODI2MDMwLTM2
-        NjYtNDFjMi1iYmZlLTIxMjdjODg5YzJlOCIsICJudW1fcHJvY2Vzc2VkIjog
-        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjk1MzUwYzBlLTM5ZWUtNDljMS05ZmJjLTY0NTM1ZDJm
-        MmJhZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
-        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjVjMTgwMGQ0LTkzYjYtNDM2NS05MThjLTk2NTFmYTRjZGRlNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
-        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMzOGM4Njc1LWEyZmEtNDAyNi1hYmI2
+        LWRhMTMwZjdiYTEyNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo1M1oiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU0WiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
+        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
+        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
+        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
+        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
+        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
+        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
+        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
+        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjRhMDIyMzlmMDU3
+        ZjhhNDNhZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIyMmVmZmY3OS1iOTljLTQ2ODYtOTcxMi05OGUzYWM4MTM5ZWQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MThiYzgzMDktNWVlMi00YTc3LTlhZWItMTVmNWM5MTVhNDNiIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MjQ3ZmRiY2NhOWYzODk1YzI0MiJ9LCAiaWQiOiAiNWVhYzgy
-        NDdmZGJjY2E5ZjM4OTVjMjQyIn0=
+        ZjhjMmUwOTQtMmVlZi00MmMxLWEyYzYtOTQ0ZTEzOWFhMjdjIiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiNDg5ZWNmZC03YjM5LTRlZGUtOWJjMy1mZjc0
+        MzNkNjc3NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
+        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTY3YTA4
+        MGYtZjJkNS00ZTEyLWI3NWMtYTU1NGExNDM1ZWIzIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImUxMTg2MTY0LTI1MTAtNGJmYi04ODA0LWIzNmZkZDIx
+        YTY5ZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
+        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0MWVmNjJjLTM3
+        OWEtNDE1OS04ODBhLWZhZWFmZjgxOTM5ZiIsICJudW1fcHJvY2Vzc2VkIjog
+        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
+        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0ZGM4MzdmZi0xOWExLTQwZTgtYjc1Ny1mYjA2MzI5ZDQ5
+        MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
+        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTNmNWIwNC0w
+        MGM0LTQzNWYtOTA3Ni0xNzFiZmMxZjliM2IiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
+        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYzg2Yzc0MC0xNGUyLTQ5NjEt
+        ODM1My1mM2VhNWI5YjBiYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI4MmM2MmIyZC04NjM3LTQ2NGEtODE3NS0yMGM1ODg2
+        OWExYTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
+        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwZGU1ZWI1Mi00MTcxLTQ0ZmUtYmNjMy1jNTNjZTEyNmQ5ZDQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
+        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMjM1NzdlZi1iZTc4LTRm
+        MjItOGMyYS1hMjk5NmM2Mjk1MjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzE5NzI5Ny0wNGIzLTQ0NzYtYTFiMi0w
+        ZmU3YTdjMmZmYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
+        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjMzOGM4Njc1LWEyZmEtNDAyNi1hYmI2LWRhMTMw
+        ZjdiYTEyNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTUwOGIi
+        fSwgImlkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNTA4YiJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1177,7 +1086,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1190,7 +1099,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -1207,14 +1116,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDhiMDJlNTMwNzUzYTk4NThjIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWY3ZGZmNGEwMjIzOWY3NDFlODgzZDM1In0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1226,7 +1135,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1239,268 +1148,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2079'
+      - '2169'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtNS4yMS0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNzQ1MzNm
-        YmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4ZGZmOGQ2OTc4NWVjNDhi
-        NzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
-        ZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTUuMjEtMS5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgImlzX21v
-        ZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIxIiwgIl9pZCI6ICIxYzc1MTA3NS02MGY2LTQxYTQtOGM1NC01
-        YTVhY2Y5ZWI1ZWEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMWM3NTEwNzUtNjBmNi00MWE0
-        LThjNTQtNWE1YWNmOWViNWVhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0
-        NmZkYmNjYTlmMzg5NWMwOTEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJlbGVw
-        aGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdj
-        YjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgImZpbGVu
-        YW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwg
-        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44Iiwg
-        Il9pZCI6ICI0MDVmM2NhNS00ZjJjLTRlY2EtYjZjZi1hZDE3OGUwMzY3NTIi
-        LCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5cGVfaWQiOiAicnBt
-        IiwgInVuaXRfaWQiOiAiNDA1ZjNjYTUtNGYyYy00ZWNhLWI2Y2YtYWQxNzhl
-        MDM2NzUyIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlmMzg5
-        NWJmZjYifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWlu
-        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tz
-        dW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQy
-        ZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVt
-        bXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4t
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjQwZGZlN2My
-        LTdkMjctNDU1MC04YTIxLTU0MTNkOTMwNGM4OSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6
-        MTA6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0
-        MGRmZTdjMi03ZDI3LTQ1NTAtOGEyMS01NDEzZDkzMDRjODkiLCAiX2lkIjog
-        eyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzA2OCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJw
-        bSIsICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJk
-        ZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFj
-        MGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yg
-        c3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNf
-        bW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjRiY2U0MTNjLWYyNjctNGVjMC1h
-        MTVkLTk3YjE3NTk2NDYxZSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
-        ZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0YmNlNDEzYy1mMjY3
-        LTRlYzAtYTE1ZC05N2IxNzU5NjQ2MWUiLCAiX2lkIjogeyIkb2lkIjogIjVl
-        YWM4MjQ2ZmRiY2NhOWYzODk1YzAwZCJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndh
-        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
-        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFt
-        ZSI6ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        IjY4ZWQ4NWE4LTlhZmYtNDhiZS04ODUzLThiYTcxMmFjN2Y0NCIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI2OGVkODVhOC05YWZmLTQ4YmUtODg1My04YmE3MTJhYzdmNDQi
-        LCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzAxZiJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4
-        ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZj
-        YjhlMmM4NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiBtb25rZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlz
-        X21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
-        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI5NjkwNTIzZi0xNzY5LTQ0ZDEt
-        ODg1Mi1lYzI1YzRjMTZlYjAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0
-        ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1
-        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOTY5MDUyM2YtMTc2
-        OS00NGQxLTg4NTItZWMyNWM0YzE2ZWIwIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZWFjODI0NmZkYmNjYTlmMzg5NWMwNTEifX0sIHsibWV0YWRhdGEiOiB7InNv
-        dXJjZXJwbSI6ICJrYW5nYXJvby0wLjMtMS5zcmMucnBtIiwgIm5hbWUiOiAi
-        a2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNj
-        NDA3MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIs
-        ICJzdW1tYXJ5IjogImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlh
-        IiwgImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjog
-        dHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiYTM5Mzg0Y2ItYzFlYi00NTI5LTk1NjQtZjczZjhkNDQ1
-        MGQ5IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MTA6NDZaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImEzOTM4NGNiLWMxZWItNDUyOS05NTY0LWY3
-        M2Y4ZDQ0NTBkOSIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDZmZGJjY2E5
-        ZjM4OTVjMDA0In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiYXJt
-        YWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAi
-        Y2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4Mjdj
-        NDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsICJzdW1tYXJ5Ijog
-        IkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIsICJmaWxlbmFtZSI6ICJh
-        cm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50
-        X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTgy
-        YzAxZDYtYzM1NS00MmI1LTg3NWUtNDIxZTgyOWI4NGQ1IiwgImFyY2giOiAi
-        bm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lk
-        IjogImE4MmMwMWQ2LWMzNTUtNDJiNS04NzVlLTQyMWU4MjliODRkNSIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgyNDZmZGJjY2E5ZjM4OTViZmVkIn19LCB7
-        Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVjay0wLjYtMS5zcmMucnBt
-        IiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5NmYzNzg3NzUxOGEx
-        ZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdkMzhh
-        Nzc0YmM3IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2si
-        LCAiZmlsZW5hbWUiOiAiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjYiLCAiaXNfbW9kdWxhciI6IHRydWUs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAi
-        X2lkIjogImJhYWRjOGQ3LTdiZTMtNGZiNi05Yzg2LTc5M2Y2YTE2MGZiNiIs
-        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIw
-        OjEwOjQ2WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
-        IjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
-        LCAidW5pdF9pZCI6ICJiYWFkYzhkNy03YmUzLTRmYjYtOWM4Ni03OTNmNmEx
-        NjBmYjYiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1
-        YzA0OCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxs
-        by0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
-        c3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2NGU4
-        MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3VtbWFyeSI6ICJGYWtl
-        IHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRp
-        bGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBl
-        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImJlYTdhNmNi
-        LTM2NDgtNDc2OC1iNzgzLWQ5YjJmN2YxNDkzNSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6
-        MTA6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJi
-        ZWE3YTZjYi0zNjQ4LTQ3NjgtYjc4My1kOWIyZjdmMTQ5MzUiLCAiX2lkIjog
-        eyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzA4OCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0i
-        LCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2Uz
-        ZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIx
-        YTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxy
-        dXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJjMmYxMDhiYy0wMWY4LTRmMTYtYWM4MS00MjBi
-        MGEyOTZmNjEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        Y3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5cGVf
-        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzJmMTA4YmMtMDFmOC00ZjE2LWFj
-        ODEtNDIwYjBhMjk2ZjYxIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZk
-        YmNjYTlmMzg5NWMwN2IifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
-        ICJhcm1hZGlsbG8tMi4xLTEuc3JjLnJwbSIsICJuYW1lIjogImFybWFkaWxs
-        byIsICJjaGVja3N1bSI6ICJhYmY2OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4
-        ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNkOGQxZmYzOTlmIiwgInN1bW1h
-        cnkiOiAiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwgImZpbGVuYW1l
-        IjogImFybWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
-        LCAidmVyc2lvbiI6ICIyLjEiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2Nv
-        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
-        ICJjODhhNWNiMi04MjBhLTQ0OTktODZmMi1iNzYxOTJhNGMyODIiLCAiYXJj
-        aCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0
-        NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIw
-        LTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
-        aXRfaWQiOiAiYzg4YTVjYjItODIwYS00NDk5LTg2ZjItYjc2MTkyYTRjMjgy
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlmMzg5NWMwM2Yi
-        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJjaGVldGFoLTAuMy0w
-        Ljguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAi
-        NDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4
-        MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
-        a2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0YWgtMC4zLTAu
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
+        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
+        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
+        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
+        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
+        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjQ5MTI5NzNmOGNkZTJhNGVkOSJ9fSwgeyJtZXRhZGF0YSI6IHsic291
+        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
+        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
+        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
+        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
+        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
+        NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
+        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
+        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0
+        ZTllIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
+        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
+        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
+        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
         OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
         LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImQyODY1YmQwLTkxZjEt
-        NDc0MC1iZDk0LTQ5ODRjNWRhMTJmZSIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJkMjg2NWJk
-        MC05MWYxLTQ3NDAtYmQ5NC00OTg0YzVkYTEyZmUiLCAiX2lkIjogeyIkb2lk
-        IjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzA3MSJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIsICJuYW1lIjog
-        ImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2Ez
-        YmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJz
-        dW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsICJm
-        aWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiZGVmNTk3YWUtOTQzYS00MTAzLTk1MWMtNmUxYTQwZmI0NTcyIiwgImFy
-        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6
-        NDZaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
-        bml0X2lkIjogImRlZjU5N2FlLTk0M2EtNDEwMy05NTFjLTZlMWE0MGZiNDU3
-        MiIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDZmZGJjY2E5ZjM4OTVjMDE2
-        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlvbi0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAw
-        ZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2
-        NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVs
-        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
-        c2UiOiAiMC44IiwgIl9pZCI6ICJlZmZmMTllMS03Yzg2LTQxMzEtYWQ1MC03
-        MjNlZGYzN2ZhOTUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWZmZjE5ZTEtN2M4Ni00MTMx
-        LWFkNTAtNzIzZWRmMzdmYTk1IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0
-        NmZkYmNjYTlmMzg5NWMwMzYifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiZWxlcGhh
-        bnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJl
-        ODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1t
-        YXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgZWxlcGhhbnQuIiwgImZpbGVuYW1l
-        IjogImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        ImYwZDZhNjY5LTZhN2UtNDhhOS05MmM3LTA3YjdiZjdkM2E5NyIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2
+        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
+        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
+        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
+        IjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGViZSJ9fSwgeyJtZXRhZGF0YSI6
+        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
+        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
+        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
+        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
+        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
+        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5
+        MTI5NzNmOGNkZTJhNGU0OCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
+        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
+        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU4
+        YyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
+        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
+        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
+        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
+        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90
+        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
+        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
+        NDkxMjk3M2Y4Y2RlMmE0ZTc2In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
+        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
+        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
+        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
+        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUz
         WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICJmMGQ2YTY2OS02YTdlLTQ4YTktOTJjNy0wN2I3YmY3ZDNhOTci
-        LCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzA5YSJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJm
-        MjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTVi
-        ODJkZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44
+        MTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
+        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU5NSJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
+        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
+        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
+        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
         Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
         ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZjk2NDdmZjgtZjVmMC00
-        ZTNhLTlkMGEtNWY2MTlhNDNjOGFhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0Nloi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImY5NjQ3ZmY4
-        LWY1ZjAtNGUzYS05ZDBhLTVmNjE5YTQzYzhhYSIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgyNDZmZGJjY2E5ZjM4OTVjMDI5In19LCB7Im1ldGFkYXRhIjog
-        eyJzb3VyY2VycG0iOiAia2FuZ2Fyb28tMC4yLTEuc3JjLnJwbSIsICJuYW1l
-        IjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgzM2FmNTk0YmMwYmEzMTI1
-        NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5YmY2MTBkZDYxMDNjZTRj
-        YzgiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28i
-        LCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlzX21vZHVsYXIiOiB0
-        cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
-        IiwgIl9pZCI6ICJmYmFjZWM2Zi0xNzRiLTQ0ODEtOTRiMC1iOTY1ZDVhNWY4
-        ZTAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
-        ZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5cGVfaWQiOiAi
-        cnBtIiwgInVuaXRfaWQiOiAiZmJhY2VjNmYtMTc0Yi00NDgxLTk0YjAtYjk2
-        NWQ1YTVmOGUwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlm
-        Mzg5NWMwNWUifX1d
+        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
+        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
+        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAi
+        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
+        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZWIwIn19LCB7Im1ldGFkYXRhIjog
+        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
+        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
+        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
+        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
+        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQi
+        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
+        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTcz
+        ZjhjZGUyYTRlNmMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
+        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
+        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
+        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
+        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
+        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
+        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlZDAifX0sIHsibWV0YWRh
+        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
+        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
+        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
+        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
+        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
+        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
+        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5
+        MTI5NzNmOGNkZTJhNGVhNyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
+        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
+        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
+        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
+        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGVj
+        NyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
+        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
+        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
+        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
+        b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
+        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
+        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        ZjQ5MTI5NzNmOGNkZTJhNGU1MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
+        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
+        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU2MyJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
+        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
+        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
+        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
+        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
+        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlM2IifX0sIHsibWV0YWRhdGEiOiB7
+        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
+        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
+        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
+        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
+        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVf
+        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
+        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEy
+        OTczZjhjZGUyYTRlMzEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
+        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
+        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
+        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
+        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
+        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
+        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZTI4In19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
+        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
+        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
+        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
+        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4
+        Y2RlMmE0ZTgzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
+        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
+        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
+        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
+        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
+        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
+        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
+        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlNWEifX1d
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1512,7 +1434,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1525,7 +1447,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -1538,10 +1460,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1551,7 +1473,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1564,7 +1486,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
@@ -1577,131 +1499,131 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzQxLzljMjZjYTAzMjJmMDQ1OGFi
-        NzRmNTg3NmUyOWEzNjZmODBjMmI0OTAyMGY2NjNhYmI5ZmY0YmJkY2JkNmNj
-        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIiwgImFydGlm
-        YWN0cyI6IFsid2FscnVzLTA6NS4yMS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
-        OiAiZmMwY2I5NTBlNTNjNWVhOTliMDNiY2FjNDI3MjVjNjAyOTVmMTQ4YWFh
-        ZGUxYTdjZTZjN2Q4MDI4YTA3M2I1OSIsICJfbGFzdF91cGRhdGVkIjogMTU4
-        ODE5NjE0NCwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
-        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdfSwgInN1bW1hcnkiOiAi
-        V2FscnVzIDUuMjEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVy
-        c2lvbiI6IDIwMTgwNzA0MTQ0MjAzLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1
-        bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIwMDBhODY4NS0w
-        ZGNkLTQ2OWItODE5My0xOTU5Y2NlMWZhOWQiLCAiYXJjaCI6ICJ4ODZfNjQi
-        LCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3YWxydXMgNS4y
-        MSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0w
-        NS0wMVQyMDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiMDAwYTg2ODUtMGRjZC00NjliLTgxOTMtMTk1OWNjZTFm
-        YTlkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlmMzg5NWMx
-        MTkifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
-        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
-        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
-        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
-        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
-        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgx
-        OTYxNDQsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
-        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
-        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjA5ZDMxOTZkLWRhNzUtNDNj
-        Yi04OTExLTU4MDZjNGJhMDdjOCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEw
-        OjQ2WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICIwOWQzMTk2ZC1kYTc1LTQzY2ItODkxMS01ODA2YzRiYTA3YzgiLCAiX2lk
-        IjogeyIkb2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzEwMiJ9fSwgeyJt
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
+        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
+        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
+        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
+        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
+        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
+        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY0NSJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
+        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
+        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
+        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
+        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
+        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
+        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
+        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
+        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
+        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
+        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
+        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
+        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY0ZSJ9fSwgeyJt
         ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
         bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
         ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
         bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
         OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
         OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
-        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MTk2
-        MTQ0LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
         cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
         bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
         aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
         fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjEzMjBhZGNlLWNj
-        NTQtNDc2NC1hYjc3LWNhNDZjODVkMDUwYSIsICJhcmNoIjogIm5vYXJjaCIs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
+        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
         ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0w
-        NS0wMVQyMDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiMTMyMGFkY2UtY2M1NC00NzY0LWFiNzctY2E0NmM4NWQw
-        NTBhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlmMzg5NWMw
-        ZWIifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
+        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRm
+        MjUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
+        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
+        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
+        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
+        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
+        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
+        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
+        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
+        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
+        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
+        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
+        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
+        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
+        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
+        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGYzYSJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
+        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
+        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
+        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
+        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
+        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
+        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
+        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
+        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
+        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
+        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
+        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
+        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
+        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
+        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
+        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRm
+        MmUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
         aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
         Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
         ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
         ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
         Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
         NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
-        IjogMTU4ODE5NjE0NCwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
+        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
         LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
         ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
         bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
         NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
         YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogIjI5NDkwOWE4LTk3OTEtNDU2Zi1hZmRkLWE5
-        ODdmMGEzM2Y4NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
+        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
+        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
         ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIyOTQ5
-        MDlhOC05NzkxLTQ1NmYtYWZkZC1hOTg3ZjBhMzNmODciLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzEyMiJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
-        dW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3OTdhMDdh
-        ODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImth
-        bmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJlODIwZTA4
-        YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgyNDI3OWUz
-        NmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MTk2MTQ0LCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
-        ZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkthbmdhcm9v
-        IDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjU5NzYzMDAyLWI0MTAtNDU2
-        Yy05YmE0LWVlNjRmODMxODgyYyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAuMiBwYWNr
-        YWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDo0NloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
-        aWQiOiAiNTk3NjMwMDItYjQxMC00NTZjLTliYTQtZWU2NGY4MzE4ODJjIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0NmZkYmNjYTlmMzg5NWMwZjkifX0s
-        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
-        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgxOTYxNDQs
-        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
-        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogImU1ZGI1MTk4LTljMjMtNDU2OC04ODJk
-        LWJkMmFiYzg1Njg4ZCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlNWRi
-        NTE5OC05YzIzLTQ1NjgtODgyZC1iZDJhYmM4NTY4OGQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjQ2ZmRiY2NhOWYzODk1YzExMCJ9fV0=
+        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
+        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY1YyJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1711,7 +1633,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1724,7 +1646,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -1737,10 +1659,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1750,7 +1672,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -1763,226 +1685,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:48 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1983'
+      - '1951'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
         W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYzODQ2
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
+        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
+        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
+        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
+        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
+        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
+        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
+        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
+        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
+        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
+        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
+        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
+        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
+        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
+        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTUwMmMifX0sIHsibWV0YWRh
+        dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
+        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
+        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
+        YXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9t
+        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
+        dGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2
+        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
+        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
+        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
+        ImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRp
+        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
+        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
+        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3MywgInJl
+        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
+        Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
+        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
+        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
+        NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
+        MC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
+        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
+        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJh
+        NGZmMyJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
+        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
+        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
+        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
+        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
+        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
+        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
+        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
+        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
+        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
+        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
+        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
+        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
+        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODcz
         LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
         LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIyZjVmOTI4NC1lNTUyLTRmZjgt
-        OTI4Yi1mYTcyNWE1ZjU2ZDgifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDo0NloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjJmNWY5Mjg0LWU1NTItNGZmOC05MjhiLWZh
-        NzI1YTVmNTZkOCIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDZmZGJjY2E5
-        ZjM4OTVjMTYzIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0w
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
+        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
+        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
+        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4
+        Y2RlMmE1MDEyIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
         MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
         cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
         Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2Fn
-        ZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6
-        ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2Vj
-        dXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0
-        dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwg
-        InN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6
-        Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIs
-        ICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3Rh
-        YmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0
-        ZSBPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgz
-        NjM4NDcsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50
-        IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5
-        IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjQyZTJhYTk2LWY3NDgt
-        NGE3MS1iZjAxLWNiNGYyNGYzMjNkZiJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1
-        LTAxVDIwOjEwOjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVh
-        dGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDdaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNDJlMmFhOTYtZjc0OC00YTcxLWJm
-        MDEtY2I0ZjI0ZjMyM2RmIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0N2Zk
-        YmNjYTlmMzg5NWMxZDcifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIy
-        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
-        c2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRF
-        TExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhh
-        dC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIs
-        ICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVi
-        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
-        a2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5m
-        ZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNl
-        IjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rp
-        b24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFz
-        dF91cGRhdGVkIjogMTU4ODM2Mzg0NiwgInJlc3RhcnRfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRp
-        b24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiOTZkZWIxZjEtN2JlYS00NDIxLWJlOTItZWY0NjQyMGNjYjQ4In0sICJ1
-        cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDdaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0N1oi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI5NmRl
-        YjFmMS03YmVhLTQ0MjEtYmU5Mi1lZjQ2NDIwY2NiNDgiLCAiX2lkIjogeyIk
-        b2lkIjogIjVlYWM4MjQ3ZmRiY2NhOWYzODk1YzFiOCJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dp
-        bl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBf
-        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
-        dHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6
-        ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRs
-        ZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0
-        dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2Vz
-        IjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAi
-        bmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAi
-        ZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJu
-        b2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIi
-        fV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogMTU4ODM2Mzg0NiwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
+        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
+        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
+        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
+        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
+        IjogMTYwMjA5Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
         dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
-        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYmRjMTU4
-        YjYtMThmZi00Nzk2LWIyMDUtYmUzMDU1NDBkZGNiIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJiZGMxNThiNi0xOGZm
-        LTQ3OTYtYjIwNS1iZTMwNTU0MGRkY2IiLCAiX2lkIjogeyIkb2lkIjogIjVl
-        YWM4MjQ2ZmRiY2NhOWYzODk1YzE5ZSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8v
-        cmhuLnJlZGhhdC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAi
-        dHlwZSI6ICJzZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAx
-        MDowODU4In0sIHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5j
-        b20vYnVnemlsbGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjog
-        ImJ1Z3ppbGxhIiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAx
-        MC0wNDA1IGJ6aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2Rl
-        Y29tcHJlc3MifSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20v
-        c2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUi
-        OiAiY3ZlIiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZF
-        LTIwMTAtMDQwNSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29t
-        L3NlY3VyaXR5L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIs
-        ICJ0eXBlIjogIm90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1d
-        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
-        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIs
-        ICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        SW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJp
-        dHkgdXBkYXRlIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24i
-        OiAiMyIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNl
-        Y3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJi
-        emlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1s
-        aWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1
-        NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQi
-        XSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZf
-        NjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJy
-        ZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMi
-        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
-        cDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2
-        YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgy
-        ZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZf
-        MC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
-        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNy
-        YyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJi
-        emlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTcz
-        ZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVm
-        NTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZf
-        MC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
-        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNy
-        YyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJi
-        emlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTVi
-        N2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3
-        NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVs
-        Nl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEu
-        MC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9
-        LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFt
-        ZSI6ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBk
-        ODliYTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2
-        YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4
-        Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41Iiwg
-        InJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5h
-        bWUiOiAiY29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6
-        ICJmaW5hbCIsICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAi
-        ZGVzY3JpcHRpb24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBo
-        aWdoLXF1YWxpdHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3Ro
-        XG5saWJiejIgbGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVw
-        ZGF0ZSB0byB0YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgz
-        NjM4NDYsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50
-        IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMi
-        LCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBt
-        YWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxl
-        dmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhp
-        cyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3Jr
-        LiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsg
-        dG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDov
-        L2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1h
-        cnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2Vj
-        dXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImMzMDNjMDg5
-        LTkxMmItNDAwMy05NjhlLWU4OGQ1YTc5ZWZmNyJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTA1LTAxVDIwOjEwOjQ2WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDZaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiYzMwM2MwODktOTEyYi00
-        MDAzLTk2OGUtZTg4ZDVhNzllZmY3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFj
-        ODI0NmZkYmNjYTlmMzg5NWMxN2YifX0sIHsibWV0YWRhdGEiOiB7Imlzc3Vl
-        ZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5IiwgInJlbG9naW5fc3VnZ2VzdGVk
-        IjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRh
-        dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6
-        ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5IiwgImZyb20iOiAiZXJyYXRhQHJl
-        ZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1Y2tfS2Fu
-        Z2Fyb29fRXJyYXR1bSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJz
-        aW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6
-        ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
-        ImR1Y2siLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImR1Y2stMC43LTEu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjogIjAuNyIs
-        ICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJtb2R1bGUiOiB7ImNvbnRleHQiOiAiZGVhZGJl
-        ZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIzMzEwMiIsICJhcmNoIjogIm5v
-        YXJjaCIsICJuYW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInNob3J0
-        IjogIiJ9LCB7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVk
-        b3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdW0iOiBu
-        dWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4zLTEubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24t
-        MSIsICJtb2R1bGUiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lv
-        biI6ICIyMDE4MDczMDIyMzQwNyIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1l
-        IjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIn0sICJzaG9ydCI6ICIifV0s
-        ICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiMjAxOC0wNy0yMCAw
-        NjowMDowMSBVVEMiLCAiZGVzY3JpcHRpb24iOiAiRHVja19LYW5nYXJvX0Vy
-        cmF0dW0gZGVzY3JpcHRpb24iLCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgzNjM4
-        NDcsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
-        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
-        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImNmNTk1MTQ3LTg2NTEtNGJl
-        OC1hMDQzLTkzZGI1ZDVmNThmYSJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAx
-        VDIwOjEwOjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMDUtMDFUMjA6MTA6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiY2Y1OTUxNDctODY1MS00YmU4LWEwNDMt
-        OTNkYjVkNWY1OGZhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0N2ZkYmNj
-        YTlmMzg5NWMxZjEifX1d
+        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
+        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
+        IjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90
+        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
+        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjQ5MTI5NzNmOGNkZTJhNGZhMCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
+        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
+        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
+        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
+        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
+        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
+        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
+        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
+        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
+        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
+        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
+        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
+        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
+        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
+        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
+        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5
+        NzNmOGNkZTJhNGZkOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
+        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
+        ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
+        dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
+        ZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0s
+        IHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemls
+        bGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxh
+        IiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6
+        aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3Mi
+        fSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkv
+        ZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwg
+        ImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
+        NSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
+        L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjog
+        Im90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91
+        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
+        dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIsICJmcm9tIjog
+        InNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50
+        IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBkYXRl
+        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMyIsICJy
+        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
+        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAu
+        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
+        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
+        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
+        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
+        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDIt
+        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
+        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
+        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
+        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
+        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
+        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
+        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
+        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
+        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
+        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
+        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZl
+        bCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2Vj
+        NGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0s
+        ICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82
+        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
+        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
+        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
+        MiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5
+        OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0s
+        ICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
+        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29s
+        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
+        dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
+        bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
+        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
+        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
+        aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
+        b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
+        YWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5
+        b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUg
+        aXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxz
+        IG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkg
+        dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
+        ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
+        YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
+        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
+        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
+        VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
+        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTcz
+        ZjhjZGUyYTRmYmEifX1d
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:48 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1992,7 +1914,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2005,7 +1927,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2018,10 +1940,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2031,7 +1953,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2044,57 +1966,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '443'
+      - '519'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE1ODgxOTYxNDQsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNWMwODAzNTgtODA4YS00
-        NTI3LWI4MzQtZDAyZmZjYWU0NjgyIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAyMC0wNS0wMVQyMDoxMDo0N1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ3WiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjVjMDgw
-        MzU4LTgwOGEtNDUyNy1iODM0LWQwMmZmY2FlNDY4MiIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWVhYzgyNDdmZGJjY2E5ZjM4OTVjMjA2In19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNTg4MTk2MTQ0LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOGEz
-        N2JiMGQtYjI5ZC00NzQzLWIxMTgtNGZlODg5ZmJlYzg3IiwgImRpc3BsYXlf
-        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0N1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEw
-        OjQ3WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogIjhhMzdiYjBkLWIyOWQtNDc0My1iMTE4LTRmZTg4OWZiZWM4NyIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDdmZGJjY2E5ZjM4OTVjMjEyIn19
-        XQ==
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJj
+        b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
+        YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
+        cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
+        OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
+        ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
+        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
+        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
+        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkx
+        Mjk3M2Y4Y2RlMmE1MDNjIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
+        ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
+        ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
+        cnNlIiwgImthbmdhcm9vIiwgImxpb24iLCAibW91c2UiLCAic3F1aXJyZWwi
+        LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
+        XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
+        InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
+        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
+        YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
+        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
+        MjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
+        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE1MDRjIn19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2104,7 +2029,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2117,7 +2042,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2130,10 +2055,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2143,7 +2068,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2156,60 +2081,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '550'
+      - '403'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvOWUvYjY2
-        NjBkZWYxMzNlNWI4NjdiYmVhMDgzNjEzYTY1YzQ5OGQ1OGFmMDFjMDBhZjU5
-        MjU5ZTg5OGVmMDkxYjEvNTY5YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIy
-        OGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJjNDA4ZjhkOTcxYi1zd2lkdGFncy54
-        bWwuZ3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjog
-        InN3aWR0YWdzIiwgImNoZWNrc3VtIjogIjU2OWMwYWMzMjQzMmEyMTMwODY3
-        OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3MWIi
-        LCAiX2xhc3RfdXBkYXRlZCI6IDE1ODgzNjM4NDUsICJfY29udGVudF90eXBl
-        X2lkIjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiZG93bmxvYWRlZCI6
-        IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9ucyI6ICJ1bml0
-        c195dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImNoZWNrc3VtX3R5cGUiOiAi
-        c2hhMjU2IiwgIl9pZCI6ICIzZGEwNThmZS1jZmNjLTRhYmUtYjhkYS0xMTkz
-        YTM5NWNlNjIifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NVoi
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTA1
-        LTAxVDIwOjEwOjQ1WiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0
-        YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogIjNkYTA1OGZlLWNmY2MtNGFiZS1i
-        OGRhLTExOTNhMzk1Y2U2MiIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDVm
-        ZGJjY2E5ZjM4OTViZmNjIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
-        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19t
-        ZXRhZGF0YV9maWxlL2I0LzVmM2E1OWVmNDE5ZTgzYjMwZGQwNWYyMmE1MWVh
-        MWVmZTMwNTdkYjZhNzQ3NDAwYWUzMThkNjU3NzcyYjFmLzBkMWViNzM4Njdj
-        NDU5Yjg2ZDE1OGNkYWQyNjYwMDJlNDU4ODE0MDUxZTM1NTI5OTcwNTNkMzU2
-        NzE0NGE3ZTItcHJvZHVjdGlkLmd6IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQx
-        ZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5
-        NzA1M2QzNTY3MTQ0YTdlMiIsICJfbGFzdF91cGRhdGVkIjogMTU4ODM2Mzg0
-        NSwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
-        IHt9LCAiX25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogIjViZjBhODQxLTY4
-        ODEtNGIwYy04Njk1LWRlMTRkZjMwOTc3NSJ9LCAidXBkYXRlZCI6ICIyMDIw
-        LTA1LTAxVDIwOjEwOjQ1WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDVaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiNWJm
-        MGE4NDEtNjg4MS00YjBjLTg2OTUtZGUxNGRmMzA5Nzc1IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZWFjODI0NWZkYmNjYTlmMzg5NWJmZDYifX1d
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYjQvNWYz
+        YTU5ZWY0MTllODNiMzBkZDA1ZjIyYTUxZWExZWZlMzA1N2RiNmE3NDc0MDBh
+        ZTMxOGQ2NTc3NzJiMWYvYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUyNzc1YWEw
+        ZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMi1wcm9kdWN0aWQu
+        Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
+        b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
+        ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODczLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
+        cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
+        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
+        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
+        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
+        N1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
+        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5
+        NzNmOGNkZTJhNGUwZSJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2219,7 +2126,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2232,7 +2139,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2245,10 +2152,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2260,7 +2167,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2273,7 +2180,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2286,10 +2193,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2299,7 +2206,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2312,13 +2219,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '532'
+      - '534'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2338,24 +2245,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU4ODM2
-        Mzg0NiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg3MywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjU2NDhhM2ZlLTJj
-        YmYtNDQyYS1hY2FiLTMwY2VkN2ZmYTllNSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6NDZaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0NloiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjU2NDhhM2ZlLTJj
-        YmYtNDQyYS1hY2FiLTMwY2VkN2ZmYTllNSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNDZmZGJjY2E5ZjM4OTVjMGRmIn19XQ==
+        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZjE2In19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2370,7 +2277,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2383,7 +2290,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2394,14 +2301,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M5ZWU4ODljLTQ1N2ItNDk2ZC1hNmZjLTRiYmE2NDA0YTRlZS8iLCAi
-        dGFza19pZCI6ICJjOWVlODg5Yy00NTdiLTQ5NmQtYTZmYy00YmJhNjQwNGE0
-        ZWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzY3ZDc4NWFjLTI0MDUtNDZiZS1iZmNhLTFjY2ZiN2Y3OTUwMC8iLCAi
+        dGFza19pZCI6ICI2N2Q3ODVhYy0yNDA1LTQ2YmUtYmZjYS0xY2NmYjdmNzk1
+        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2413,7 +2320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2426,7 +2333,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:54 GMT
       Server:
       - Apache
       Content-Length:
@@ -2437,14 +2344,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQwZmJlOGUxLWNkN2QtNDMyOS1iNWRkLTBjMTdkMTJhYTlmMy8iLCAi
-        dGFza19pZCI6ICI0MGZiZThlMS1jZDdkLTQzMjktYjVkZC0wYzE3ZDEyYWE5
-        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzhjOTUzYmQ3LTkwNmQtNGExYS1hY2VlLWM3YTc4MzdlMjAzNS8iLCAi
+        dGFza19pZCI6ICI4Yzk1M2JkNy05MDZkLTRhMWEtYWNlZS1jN2E3ODM3ZTIw
+        MzUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2454,7 +2361,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2467,7 +2374,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2478,14 +2385,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJjMjMzMmYwLWYyMTMtNGJiMC05OTg0LTgxY2FhYTQzZTMyZi8iLCAi
-        dGFza19pZCI6ICIyYzIzMzJmMC1mMjEzLTRiYjAtOTk4NC04MWNhYWE0M2Uz
-        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E4ODlhN2EzLTk3YTktNGQ4My05NWFjLWE0NmYzMWU2NzU3ZS8iLCAi
+        dGFza19pZCI6ICJhODg5YTdhMy05N2E5LTRkODMtOTVhYy1hNDZmMzFlNjc1
+        N2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2495,7 +2402,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2508,7 +2415,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2519,14 +2426,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkwYjVlZDAxLThmYzUtNGEyYy1iYjEyLTlkYzIwZTQ3Y2ZhNS8iLCAi
-        dGFza19pZCI6ICI5MGI1ZWQwMS04ZmM1LTRhMmMtYmIxMi05ZGMyMGU0N2Nm
-        YTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzExMDQwNDI1LTJmNmUtNDUyMC1hNjNkLTFhMjgzNWQ1ZTljMi8iLCAi
+        dGFza19pZCI6ICIxMTA0MDQyNS0yZjZlLTQ1MjAtYTYzZC0xYTI4MzVkNWU5
+        YzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2536,7 +2443,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2549,7 +2456,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2560,14 +2467,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzAyNTYzYjYyLTcxZTMtNGFlMi04MDJkLWEyYTQ0MzBjYTMyMC8iLCAi
-        dGFza19pZCI6ICIwMjU2M2I2Mi03MWUzLTRhZTItODAyZC1hMmE0NDMwY2Ez
-        MjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzdjNGQ1MmFiLTMzOWItNGE0OS05NTcxLTA1MDA0YWNjMDZmMy8iLCAi
+        dGFza19pZCI6ICI3YzRkNTJhYi0zMzliLTRhNDktOTU3MS0wNTAwNGFjYzA2
+        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2578,7 +2485,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2591,7 +2498,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2602,14 +2509,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2QyZTMzY2Q2LTM0MDAtNGQ4ZC04NjQzLWY1Njk3Mjc0NDg3Zi8iLCAi
-        dGFza19pZCI6ICJkMmUzM2NkNi0zNDAwLTRkOGQtODY0My1mNTY5NzI3NDQ4
-        N2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzZmMTVmMTZiLWZjMWMtNGMxNy1hNzNiLTdjNjJkYjk0NzJhMC8iLCAi
+        dGFza19pZCI6ICI2ZjE1ZjE2Yi1mYzFjLTRjMTctYTczYi03YzYyZGI5NDcy
+        YTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2620,7 +2527,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2633,7 +2540,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2644,14 +2551,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzMxNDI0YWVlLWY0NTQtNDU1OS1hNmRiLWM1NDRhODA2MGJmZi8iLCAi
-        dGFza19pZCI6ICIzMTQyNGFlZS1mNDU0LTQ1NTktYTZkYi1jNTQ0YTgwNjBi
-        ZmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2JmMTQ1YWYwLWM2NmItNGY5OS1hYzUyLTE1ODBjOTYyOGI1Ny8iLCAi
+        dGFza19pZCI6ICJiZjE0NWFmMC1jNjZiLTRmOTktYWM1Mi0xNTgwYzk2Mjhi
+        NTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2661,7 +2568,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2674,7 +2581,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:49 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2685,14 +2592,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkwNWU4N2YzLWNjOTgtNDIxNC05MWQ2LTVlZDRiMDU0ZmNjYy8iLCAi
-        dGFza19pZCI6ICI5MDVlODdmMy1jYzk4LTQyMTQtOTFkNi01ZWQ0YjA1NGZj
-        Y2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQ1MzY4OTYyLTZjNWEtNGQxNS05Njc5LTg3MDkxMDczYzA1OS8iLCAi
+        dGFza19pZCI6ICI0NTM2ODk2Mi02YzVhLTRkMTUtOTY3OS04NzA5MTA3M2Mw
+        NTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:49 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2702,7 +2609,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2715,7 +2622,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:50 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2726,14 +2633,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgwOWQ0OTg5LTIxYmUtNDEwYi04ZmIyLTA4MTBjYWM3MWE0ZS8iLCAi
-        dGFza19pZCI6ICI4MDlkNDk4OS0yMWJlLTQxMGItOGZiMi0wODEwY2FjNzFh
-        NGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI5ZTIyMzc5LWEyNzMtNDQwZi1hMWNlLTEyZmM4NDlhZTExZS8iLCAi
+        dGFza19pZCI6ICIyOWUyMjM3OS1hMjczLTQ0MGYtYTFjZS0xMmZjODQ5YWUx
+        MWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2743,7 +2650,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -2756,7 +2663,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:50 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Content-Length:
@@ -2767,14 +2674,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc4NjRhNzQyLWQ3Y2ItNGUwOC05MDIzLTVmZWQzOWY3YzFlOC8iLCAi
-        dGFza19pZCI6ICI3ODY0YTc0Mi1kN2NiLTRlMDgtOTAyMy01ZmVkMzlmN2Mx
-        ZTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzBmN2U1ZGQwLWExZDAtNDI4Ni05ODdiLTc4MmZjZWQyNDIwNS8iLCAi
+        dGFza19pZCI6ICIwZjdlNWRkMC1hMWQwLTQyODYtOTg3Yi03ODJmY2VkMjQy
+        MDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c9ee889c-457b-496d-a6fc-4bba6404a4ee/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/67d785ac-2405-46be-bfca-1ccfb7f79500/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2782,7 +2689,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2793,15 +2700,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:50 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Etag:
-      - '"864bea416088502a5fed872b505b1dfb-gzip"'
+      - '"a2505b7c42bbbeac32111f346564d14d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '559'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2809,448 +2716,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jOWVlODg5
-        Yy00NTdiLTQ5NmQtYTZmYy00YmJhNjQwNGE0ZWUvIiwgInRhc2tfaWQiOiAi
-        YzllZTg4OWMtNDU3Yi00OTZkLWE2ZmMtNGJiYTY0MDRhNGVlIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82N2Q3ODVh
+        Yy0yNDA1LTQ2YmUtYmZjYS0xY2NmYjdmNzk1MDAvIiwgInRhc2tfaWQiOiAi
+        NjdkNzg1YWMtMjQwNS00NmJlLWJmY2EtMWNjZmI3Zjc5NTAwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdf
-        a2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50Iiwg
-        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
-        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
-        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
-        X2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
-        IjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4
-        MjQ5ZmRiY2NhOWYzODk1YzQwOSJ9LCAiaWQiOiAiNWVhYzgyNDlmZGJjY2E5
-        ZjM4OTVjNDA5In0=
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/40fbe8e1-cd7d-4329-b5dd-0c17d12aa9f3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"1b40d3da9c94f1a95a45757ebe776677-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '419'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80MGZiZThl
-        MS1jZDdkLTQzMjktYjVkZC0wYzE3ZDEyYWE5ZjMvIiwgInRhc2tfaWQiOiAi
-        NDBmYmU4ZTEtY2Q3ZC00MzI5LWI1ZGQtMGMxN2QxMmFhOWYzIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDlmZGJjY2E5ZjM4OTVjNDIwIn0s
-        ICJpZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0MjAifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/2c2332f0-f213-4bb0-9984-81caaa43e32f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"2c4e434e1ba0e939e2b5ecaafdc418f4-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '419'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yYzIzMzJm
-        MC1mMjEzLTRiYjAtOTk4NC04MWNhYWE0M2UzMmYvIiwgInRhc2tfaWQiOiAi
-        MmMyMzMyZjAtZjIxMy00YmIwLTk5ODQtODFjYWFhNDNlMzJmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDlmZGJjY2E5ZjM4OTVjNDQyIn0s
-        ICJpZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0NDIifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/90b5ed01-8fc5-4a2c-bb12-9dc20e47cfa5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d4bd1475d0d710a2665e3e6d0e1a749b-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '504'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85MGI1ZWQw
-        MS04ZmM1LTRhMmMtYmIxMi05ZGMyMGU0N2NmYTUvIiwgInRhc2tfaWQiOiAi
-        OTBiNWVkMDEtOGZjNS00YTJjLWJiMTItOWRjMjBlNDdjZmE1IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjQ5
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5In0sICJ0eXBlX2lk
-        IjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1S
-        SFNBLTIwMTA6MDg1OCJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5p
-        dF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5
-        cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
-        TExPLVJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
-        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMi
-        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
-        ICJLQVRFTExPLVJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0
-        dW0ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0OWZkYmNj
-        YTlmMzg5NWM0NTgifSwgImlkIjogIjVlYWM4MjQ5ZmRiY2NhOWYzODk1YzQ1
-        OCJ9
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/02563b62-71e3-4ae2-802d-a2a4430ca320/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"c13ed3a01d1346c3bc88bb23d5a56116-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '475'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMjU2M2I2
-        Mi03MWUzLTRhZTItODAyZC1hMmE0NDMwY2EzMjAvIiwgInRhc2tfaWQiOiAi
-        MDI1NjNiNjItNzFlMy00YWUyLTgwMmQtYTJhNDQzMGNhMzIwIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlw
-        ZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9f
-        aWQiOiAiM192aWV3MSIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAi
-        cGFja2FnZV9ncm91cCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImlkIjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7
-        InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJt
-        YW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDlmZGJjY2E5ZjM4
-        OTVjNDczIn0sICJpZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0NzMifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/d2e33cd6-3400-4d8d-8643-f5697274487f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"f401a97d1ec52b87a9f3ecdc7f0ae3ec-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '422'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kMmUzM2Nk
-        Ni0zNDAwLTRkOGQtODY0My1mNTY5NzI3NDQ4N2YvIiwgInRhc2tfaWQiOiAi
-        ZDJlMzNjZDYtMzQwMC00ZDhkLTg2NDMtZjU2OTcyNzQ0ODdmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNDlmZGJjY2E5ZjM4OTVjNDg5In0s
-        ICJpZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0ODkifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/31424aee-f454-4559-a6db-c544a8060bff/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"6107f26980f25a4829105bca3fcead98-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '484'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMTQyNGFl
-        ZS1mNDU0LTQ1NTktYTZkYi1jNTQ0YTgwNjBiZmYvIiwgInRhc2tfaWQiOiAi
-        MzE0MjRhZWUtZjQ1NC00NTU5LWE2ZGItYzU0NGE4MDYwYmZmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1
-        Y3RpZCJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn0s
-        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJkYXRhX3R5
-        cGUiOiAic3dpZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRh
-        dGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjog
-        W3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRhdGFf
-        dHlwZSI6ICJzd2lkdGFncyJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRh
-        ZGF0YV9maWxlIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAi
-        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWVhYzgyNDlmZGJjY2E5ZjM4OTVjNGEyIn0sICJp
-        ZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0YTIifQ==
-    http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/905e87f3-cc98-4214-91d6-5ed4b054fccc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 01 May 2020 20:10:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"eb729bc7a3228fb012fb59d19e896b29-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '503'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85MDVlODdm
-        My1jYzk4LTQyMTQtOTFkNi01ZWQ0YjA1NGZjY2MvIiwgInRhc2tfaWQiOiAi
-        OTA1ZTg3ZjMtY2M5OC00MjE0LTkxZDYtNWVkNGIwNTRmY2NjIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJ2YXJpYW50IjogIlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYi
-        LCAiYXJjaCI6ICJ4ODZfNjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVz
-        dFZhcmlhbnQtMTYteDg2XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9
-        LCAidHlwZV9pZCI6ICJkaXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRf
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjog
+        InNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV0sICJ1bml0c19mYWlsZWRf
         c2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0YjYifSwgImlkIjog
-        IjVlYWM4MjQ5ZmRiY2NhOWYzODk1YzRiNiJ9
+        IHsiJG9pZCI6ICI1ZjdkZmY0YTEyOTczZjhjZGUyYTUyM2IifSwgImlkIjog
+        IjVmN2RmZjRhMTI5NzNmOGNkZTJhNTIzYiJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:50 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/809d4989-21be-410b-8fb2-0810cac71a4e/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/8c953bd7-906d-4a1a-acee-c7a7837e2035/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3258,7 +2750,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3269,15 +2761,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:51 GMT
+      - Wed, 07 Oct 2020 17:47:55 GMT
       Server:
       - Apache
       Etag:
-      - '"a77ee40e3ba1ace7bf251ab0013e3026-gzip"'
+      - '"cf2787cfd45b3798c3aaf7cc8976ac70-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '494'
+      - '425'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3285,39 +2777,458 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MDlkNDk4
-        OS0yMWJlLTQxMGItOGZiMi0wODEwY2FjNzFhNGUvIiwgInRhc2tfaWQiOiAi
-        ODA5ZDQ5ODktMjFiZS00MTBiLThmYjItMDgxMGNhYzcxYTRlIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84Yzk1M2Jk
+        Ny05MDZkLTRhMWEtYWNlZS1jN2E3ODM3ZTIwMzUvIiwgInRhc2tfaWQiOiAi
+        OGM5NTNiZDctOTA2ZC00YTFhLWFjZWUtYzdhNzgzN2UyMDM1IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
+        NzNmOGNkZTJhNTI2NCJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MjY0In0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/a889a7a3-97a9-4d83-95ac-a46f31e6757e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"be9e541acca3005690e06b668db6b6c9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '425'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hODg5YTdh
+        My05N2E5LTRkODMtOTVhYy1hNDZmMzFlNjc1N2UvIiwgInRhc2tfaWQiOiAi
+        YTg4OWE3YTMtOTdhOS00ZDgzLTk1YWMtYTQ2ZjMxZTY3NTdlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
+        NzNmOGNkZTJhNTI3YyJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MjdjIn0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/11040425-2f6e-4520-a63d-1a2835d5e9c2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"70f2a3fc3b7dac2bb4f61e7559587bdd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '509'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMTA0MDQy
+        NS0yZjZlLTQ1MjAtYTYzZC0xYTI4MzVkNWU5YzIvIiwgInRhc2tfaWQiOiAi
+        MTEwNDA0MjUtMmY2ZS00NTIwLWE2M2QtMWEyODM1ZDVlOWMyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
+        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
+        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
+        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1Mjk2In0sICJpZCI6ICI1ZjdkZmY0
+        YjEyOTczZjhjZGUyYTUyOTYifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7c4d52ab-339b-4a49-9571-05004acc06f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7843f602e9ca0866c1ba7c47387ebcb5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '483'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YzRkNTJh
+        Yi0zMzliLTRhNDktOTU3MS0wNTAwNGFjYzA2ZjMvIiwgInRhc2tfaWQiOiAi
+        N2M0ZDUyYWItMzM5Yi00YTQ5LTk1NzEtMDUwMDRhY2MwNmYzIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
+        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
+        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
+        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
+        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjRiMTI5NzNmOGNkZTJhNTJhNSJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3
+        M2Y4Y2RlMmE1MmE1In0=
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/6f15f16b-fc1c-4c17-a73b-7c62db9472a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a9ce735e7beb59707e76846a84175b01-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '473'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82ZjE1ZjE2
+        Yi1mYzFjLTRjMTctYTczYi03YzYyZGI5NDcyYTAvIiwgInRhc2tfaWQiOiAi
+        NmYxNWYxNmItZmMxYy00YzE3LWE3M2ItN2M2MmRiOTQ3MmEwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
+        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
+        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
+        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
+        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4
+        Y2RlMmE1MmMyIn0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyYzIi
+        fQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/bf145af0-c66b-4f99-ac52-1580c9628b57/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"04efd4a40d468f31d81bdcb4d0aca854-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '473'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZjE0NWFm
+        MC1jNjZiLTRmOTktYWM1Mi0xNTgwYzk2MjhiNTcvIiwgInRhc2tfaWQiOiAi
+        YmYxNDVhZjAtYzY2Yi00Zjk5LWFjNTItMTU4MGM5NjI4YjU3IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
+        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
+        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmQ1In0sICJpZCI6ICI1
+        ZjdkZmY0YjEyOTczZjhjZGUyYTUyZDUifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/45368962-6c5a-4d15-9679-87091073c059/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"530806b7932d032bad29e8fb6e2c76c4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '511'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80NTM2ODk2
+        Mi02YzVhLTRkMTUtOTY3OS04NzA5MTA3M2MwNTkvIiwgInRhc2tfaWQiOiAi
+        NDUzNjg5NjItNmM1YS00ZDE1LTk2NzktODcwOTEwNzNjMDU5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
+        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
+        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
+        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
+        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2Rl
+        MmE1MmYwIn0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyZjAifQ==
+    http_version: 
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/29e22379-a273-440f-a1ce-12fc849ae11e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Oct 2020 17:47:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"044256b17af86ae2ce119daa17e5effb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '500'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yOWUyMjM3
+        OS1hMjczLTQ0MGYtYTFjZS0xMmZjODQ5YWUxMWUvIiwgInRhc2tfaWQiOiAi
+        MjllMjIzNzktYTI3My00NDBmLWExY2UtMTJmYzg0OWFlMTFlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
+        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
+        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
+        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
         LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwg
-        InR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6
-        IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlw
-        ZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9z
-        aWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgIm5hbWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAi
-        bW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAibmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1v
-        ZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgIm5hbWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1v
-        ZHVsZW1kX2RlZmF1bHRzIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZWFjODI0YWZkYmNjYTlmMzg5NWM0ZTMifSwgImlkIjogIjVl
-        YWM4MjRhZmRiY2NhOWYzODk1YzRlMyJ9
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
+        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MzE4In0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUzMTgifQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:51 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/7864a742-d7cb-4e08-9023-5fed39f7c1e8/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/0f7e5dd0-a1d0-4286-987b-782fced24205/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3325,7 +3236,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3336,15 +3247,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:51 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Etag:
-      - '"7dcf71663a2c7812ab2bfb7c8ae92ee8-gzip"'
+      - '"58fc6ca55dde42509e7d901716ff98df-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '420'
+      - '426'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3352,27 +3263,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83ODY0YTc0
-        Mi1kN2NiLTRlMDgtOTAyMy01ZmVkMzlmN2MxZTgvIiwgInRhc2tfaWQiOiAi
-        Nzg2NGE3NDItZDdjYi00ZTA4LTkwMjMtNWZlZDM5ZjdjMWU4IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wZjdlNWRk
+        MC1hMWQwLTQyODYtOTg3Yi03ODJmY2VkMjQyMDUvIiwgInRhc2tfaWQiOiAi
+        MGY3ZTVkZDAtYTFkMC00Mjg2LTk4N2ItNzgyZmNlZDI0MjA1IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjUw
+        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNf
-        ZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNGFmZGJjY2E5ZjM4OTVjNGZhIn0s
-        ICJpZCI6ICI1ZWFjODI0YWZkYmNjYTlmMzg5NWM0ZmEifQ==
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
+        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
+        NzNmOGNkZTJhNTMzNyJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MzM3In0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:51 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3384,7 +3296,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3397,13 +3309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '346'
+      - '347'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3416,18 +3328,18 @@ http_interactions:
         YWdlIG9mIGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0w
         Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
         IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI0MDVmM2NhNS00ZjJj
-        LTRlY2EtYjZjZi1hZDE3OGUwMzY3NTIiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0OVoiLCAicmVwb19pZCI6
-        ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo0OVoi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjQwNWYzY2E1
-        LTRmMmMtNGVjYS1iNmNmLWFkMTc4ZTAzNjc1MiIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWVhYzgyNDlmZGJjY2E5ZjM4OTVjNDI1In19XQ==
+        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0
+        LTQzZjktOWM1NC0zNTI0OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwg
+        InVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoiLCAicmVwb19pZCI6
+        ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImM1OTBjNGI2
+        LWQ3MzQtNDNmOS05YzU0LTM1MjQ5ZDZiODc3MCIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWY3ZGZmNGExMjk3M2Y4Y2RlMmE1MjUyIn19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3439,7 +3351,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3452,7 +3364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -3465,10 +3377,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3478,7 +3390,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3491,7 +3403,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -3504,10 +3416,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3517,7 +3429,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3530,226 +3442,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1977'
+      - '1946'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
         W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYzODQ2
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIyZjVmOTI4NC1lNTUyLTRmZjgt
-        OTI4Yi1mYTcyNWE1ZjU2ZDgifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDo1MFoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAi
-        MjAyMC0wNS0wMVQyMDoxMDo1MFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0
-        dW0iLCAidW5pdF9pZCI6ICIyZjVmOTI4NC1lNTUyLTRmZjgtOTI4Yi1mYTcy
-        NWE1ZjU2ZDgiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjRhZmRiY2NhOWYz
-        ODk1YzRjZCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEt
-        MDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
-        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
-        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
-        QS0yMDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
-        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2Ug
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
+        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
+        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
+        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
+        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
+        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
+        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
+        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
+        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
+        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
+        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
+        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
+        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
+        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
+        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lkIjogIjI4MGJi
+        MjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmU5In19LCB7Im1ldGFkYXRh
+        IjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxvZ2lu
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91
+        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
+        dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMiLCAiZnJvbSI6
+        ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRs
+        ZSI6ICJBcm1hZGlsbG8iLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
+        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
+        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
+        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJh
+        cm1hZGlsbG8iLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImFybWFkaWxs
+        by0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIn1dLCAi
+        bmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVz
+        IjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJB
+        cm1hZGlsbG8iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0
+        YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdo
+        dHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogIjNmMmMxM2ZmLWEwYTYtNDhkYi04MTZkLTZl
+        YjRmMzAyM2MzOCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEw
+        LTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1
+        bml0X2lkIjogIjNmMmMxM2ZmLWEwYTYtNDhkYi04MTZkLTZlYjRmMzAyM2Mz
+        OCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmY4
+        In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTow
+        MTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
+        cyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
+        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6
+        MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
+        dHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEi
+        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
+        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
+        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
+        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51
+        bGwsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44
+        IiwgImFyY2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVk
+        b3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBu
+        dWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rp
+        b24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFj
+        a2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
+        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
+        aWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODli
+        LWIyODMxMzYwMjVhNiJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjU1WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIw
+        LTEwLTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIs
+        ICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIyODMxMzYw
+        MjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MmYyIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAw
+        MTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJl
+        bmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVu
+        dF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIw
+        MTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2
+        ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJfbnMiOiAi
+        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0Ijog
+        W10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
+        aXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        MjA5Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
+        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
+        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2MxYTQtYjM2
+        MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjogIjIwMjAt
+        MTAtMDdUMTc6NDc6NTVaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVh
+        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9pZCI6
+        ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNTRhY2MxYTQtYjM2MS00OWQ2LWE3
+        ZDAtZGJmZGVmMjU5NGQxIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YjEy
+        OTczZjhjZGUyYTUyZmIifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIy
+        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
+        c2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRF
+        TExPLVJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0
+        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2Ug
         ZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAi
         MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
         aXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRw
-        Oi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJz
-        dW0iOiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNl
-        IjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8v
-        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAi
-        c3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
-        bGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJj
-        b2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJs
-        ZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUg
-        T25lIHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYz
-        ODQ3LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6
-        ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6
-        ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0MmUyYWE5Ni1mNzQ4LTRh
-        NzEtYmYwMS1jYjRmMjRmMzIzZGYifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDo0OVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
-        OiAiMjAyMC0wNS0wMVQyMDoxMDo0OVoiLCAidW5pdF90eXBlX2lkIjogImVy
-        cmF0dW0iLCAidW5pdF9pZCI6ICI0MmUyYWE5Ni1mNzQ4LTRhNzEtYmYwMS1j
-        YjRmMjRmMzIzZGYiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjQ5ZmRiY2Nh
-        OWYzODk1YzRjMCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAt
-        MDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwg
-        InJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEwOjk5MTQzIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNv
-        bSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiQXJtYWRpbGxvIiwgIl9u
-        cyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rf
-        c3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xp
-        c3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9y
-        YXByb2plY3Qub3JnIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgInN1bSI6IG51
-        bGwsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMi4xLTEubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgInJlbGVhc2UiOiAi
-        MSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0w
-        IiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRl
-        ZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiQXJtYWRpbGxvIiwgIl9sYXN0X3Vw
-        ZGF0ZWQiOiAxNTg4MzYzODQ2LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6
-        ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI5
-        NmRlYjFmMS03YmVhLTQ0MjEtYmU5Mi1lZjQ2NDIwY2NiNDgifSwgInVwZGF0
-        ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo1MFoiLCAicmVwb19pZCI6ICIzX3Zp
-        ZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo1MFoiLCAidW5p
-        dF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI5NmRlYjFmMS03
-        YmVhLTQ0MjEtYmU5Mi1lZjQ2NDIwY2NiNDgiLCAiX2lkIjogeyIkb2lkIjog
-        IjVlYWM4MjRhZmRiY2NhOWYzODk1YzRjOSJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        aXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdn
-        ZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9t
-        ZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwg
-        ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFw
-        K3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJP
-        bmUgcGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAi
-        dmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5
-        cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3si
-        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
-        ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhh
-        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
-        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gi
-        fV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJz
-        dGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9u
-        IjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTU4
-        ODM2Mzg0NiwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
-        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
-        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYmRjMTU4YjYtMThm
-        Zi00Nzk2LWIyMDUtYmUzMDU1NDBkZGNiIn0sICJ1cGRhdGVkIjogIjIwMjAt
-        MDUtMDFUMjA6MTA6NTBaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVh
-        dGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NTBaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiYmRjMTU4YjYtMThmZi00Nzk2LWIy
-        MDUtYmUzMDU1NDBkZGNiIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0YWZk
-        YmNjYTlmMzg5NWM0YzQifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIy
-        MDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
-        c2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRo
-        YXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAi
-        c2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9
-        LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3pp
-        bGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxs
-        YSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBi
-        emlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNz
-        In0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
-        L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIs
-        ICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0
-        MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0
-        eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6
-        ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBf
-        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
-        dHVtIiwgImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6
-        ICJzZWN1cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9ydGFu
-        dCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0
-        ZSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAi
-        cmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIs
-        ICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4w
-        LjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJz
-        dW0iOiBbInNoYTI1NiIsICI4MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0
-        MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxl
-        bmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6
-        ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAy
-        LTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVs
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQz
-        MzAwOWI3M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVh
-        c2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnpp
-        cDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGli
-        cyIsICJzdW0iOiBbInNoYTI1NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZh
-        ZmY3YzM2MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVh
-        c2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnpp
-        cDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2
-        ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNl
-        YzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJd
-        LCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZf
-        NjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJy
-        ZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMi
-        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
-        cDIiLCAic3VtIjogWyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3Mzcw
-        OTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJd
-        LCAiZmlsZW5hbWUiOiAiYnppcDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNl
-        IjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNv
-        bGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwi
-        LCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0
-        aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFs
-        aXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoy
-        IGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8g
-        dGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYzODQ2LCAi
-        cmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAi
-        cmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0
-        aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJl
-        IGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8g
-        eW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRl
-        IGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWls
-        cyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5
-        IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5y
-        ZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVw
-        ZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlz
-        c3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJjMzAzYzA4OS05MTJiLTQw
-        MDMtOTY4ZS1lODhkNWE3OWVmZjcifSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDo0OVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
-        OiAiMjAyMC0wNS0wMVQyMDoxMDo0OVoiLCAidW5pdF90eXBlX2lkIjogImVy
-        cmF0dW0iLCAidW5pdF9pZCI6ICJjMzAzYzA4OS05MTJiLTQwMDMtOTY4ZS1l
-        ODhkNWE3OWVmZjciLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjQ5ZmRiY2Nh
-        OWYzODk1YzRiZCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgt
-        MDEtMjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwg
-        InJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0LmNvbSIs
-        ICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJvb19FcnJh
-        dHVtIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
-        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2Vt
-        ZW50IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRw
-        Oi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVjayIsICJz
-        dW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJlbGVhc2Ui
-        OiAiMSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlv
-        bi0wIiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
-        aW9uIjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNoIiwgIm5h
-        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn0sIHsi
-        cGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0
-        Lm9yZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGwsICJmaWxl
-        bmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        bnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNo
-        IjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwgIm1vZHVs
-        ZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIwMTgw
-        NzMwMjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fy
-        b28iLCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6
-        ICJzdGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVU
-        QyIsICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNj
-        cmlwdGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTU4ODM2Mzg0NywgInJlc3Rh
-        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
-        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
-        c2UiOiAiMSIsICJfaWQiOiAiY2Y1OTUxNDctODY1MS00YmU4LWEwNDMtOTNk
-        YjVkNWY1OGZhIn0sICJ1cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDla
-        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MTA6NDlaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
-        aXRfaWQiOiAiY2Y1OTUxNDctODY1MS00YmU4LWEwNDMtOTNkYjVkNWY1OGZh
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0OWZkYmNjYTlmMzg5NWM0Yjgi
+        Oi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQi
+        LCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6
+        ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0
+        YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFj
+        a2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
+        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
+        aWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjg1ZDhlYjE0LTk0ODctNGJiZS04Mjg1
+        LWViY2YyMzU4MWQ0YSJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjU1WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIw
+        LTEwLTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIs
+        ICJ1bml0X2lkIjogIjg1ZDhlYjE0LTk0ODctNGJiZS04Mjg1LWViY2YyMzU4
+        MWQ0YSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
+        MmY1In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0xMS0xMCAw
+        MDowMDowMCIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJl
+        bmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJh
+        dGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQi
+        OiBudWxsLCAidGl0bGUiOiAiUkhTQS0yMDEwOjA4NTgifSwgeyJocmVmIjog
+        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
+        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
+        NjI3ODgyIiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUgYnppcDI6IGludGVn
+        ZXIgb3ZlcmZsb3cgZmxhdyBpbiBCWjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYi
+        OiAiaHR0cHM6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9D
+        VkUtMjAxMC0wNDA1Lmh0bWwiLCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZF
+        LTIwMTAtMDQwNSIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJl
+        ZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9j
+        bGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAi
+        aWQiOiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRh
+        dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6
+        ICJLQVRFTExPLVJIU0EtMjAxMDowODU4IiwgImZyb20iOiAic2VjdXJpdHlA
+        cmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0bGUi
+        OiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1cGRhdGUiLCAiX25zIjog
+        InVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdn
+        ZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6
+        IFt7InBhY2thZ2VzIjogW3sic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAu
+        c3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQy
+        M2E0NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItbGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIs
+        ICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
+        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBb
+        InNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZh
+        YjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6
+        ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
+        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
+        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjog
+        WyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5
+        NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUi
+        OiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
+        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
+        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6
+        IFsic2hhMjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVk
+        Mzc0NjU2ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3
+        LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEu
+        MC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6
+        IFsic2hhMjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQy
+        YWY0YmVhMDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8w
+        IiwgImFyY2giOiAieDg2XzY0In1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
+        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
+        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
+        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
+        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
+        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
+        LiIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3MywgInJlc3RhcnRfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJD
+        b3B5cmlnaHQgMjAxMCBSZWQgSGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZv
+        cmUgYXBwbHlpbmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlv
+        dXNseS1yZWxlYXNlZCBlcnJhdGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVt
+        IGhhdmUgYmVlbiBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFi
+        bGUgdmlhIHRoZSBSZWQgSGF0IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRv
+        XG51c2UgdGhlIFJlZCBIYXQgTmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0
+        ZSBhcmUgYXZhaWxhYmxlIGF0XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9m
+        YXEvZG9jcy9ET0MtMTEyNTkiLCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAy
+        IHBhY2thZ2VzIHRoYXQgZml4IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxl
+        YXNlIjogIiIsICJfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAtNDdj
+        NGZlYWE3MTZkIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVa
+        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAtNDdjNGZlYWE3MTZk
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyZWQi
         fX1d
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3759,7 +3671,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3772,7 +3684,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -3785,10 +3697,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3798,7 +3710,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3811,56 +3723,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '439'
+      - '517'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJl
-        bGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3Vpbixz
-        cXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICIzX3Zp
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJi
+        ZWFyIiwgImNhbWVsIiwgImNhdCIsICJjaGVldGFoIiwgImNoaW1wYW56ZWUi
+        LCAiY293IiwgImRvZyIsICJkb2xwaGluIiwgImVsZXBoYW50IiwgImZveCIs
+        ICJnaXJhZmZlIiwgImdvcmlsbGEiLCAiaG9yc2UiLCAia2FuZ2Fyb28iLCAi
+        bGlvbiIsICJtb3VzZSIsICJzcXVpcnJlbCIsICJ0aWdlciIsICJ3YWxydXMi
+        LCAid2hhbGUiLCAid29sZiIsICJ6ZWJyYSJdLCAicmVwb19pZCI6ICIzX3Zp
         ZXcxIiwgIm5hbWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUs
         ICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3Vw
-        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTg4MzYzODUwLCAib3B0aW9uYWxfcGFj
+        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODc1LCAib3B0aW9uYWxfcGFj
         a2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFu
         c2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEi
         OiB7fSwgImRlZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRf
         dHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJf
-        aWQiOiAiNjllMzE1ODItNjRlZS00NzUwLTk0NDYtY2JjZTE1YzE1Mzk2Iiwg
+        aWQiOiAiY2VjZGE5YjEtMTk5Zi00M2ZhLThkYmYtMGQ2M2I1YWMyNGE3Iiwg
         ImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9u
-        YW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo1MFoi
-        LCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0w
-        MVQyMDoxMDo1MFoiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
-        LCAidW5pdF9pZCI6ICI2OWUzMTU4Mi02NGVlLTQ3NTAtOTQ0Ni1jYmNlMTVj
-        MTUzOTYiLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjRhZmRiY2NhOWYzODk1
-        YzUzOSJ9fSwgeyJtZXRhZGF0YSI6IHsibWFuZGF0b3J5X3BhY2thZ2VfbmFt
-        ZXMiOiBbInBlbmd1aW4iXSwgInJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
-        IjogImJpcmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0
-        cnVlLCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBk
-        YXRlZCI6IDE1ODgzNjM4NTAsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjog
-        W10sICJ0cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3Jp
-        cHRpb24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVs
-        dF9wYWNrYWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBh
-        Y2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiYzBkZmQzNzAt
-        MzA3Zi00NjU2LThmYWQtMTU4NTg2M2Y4ZTA1IiwgImRpc3BsYXlfb3JkZXIi
-        OiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo1MFoiLCAicmVwb19pZCI6ICIz
-        X3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0wNS0wMVQyMDoxMDo1MFoiLCAi
-        dW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJj
-        MGRmZDM3MC0zMDdmLTQ2NTYtOGZhZC0xNTg1ODYzZjhlMDUiLCAiX2lkIjog
-        eyIkb2lkIjogIjVlYWM4MjRhZmRiY2NhOWYzODk1YzUxYSJ9fV0=
+        YW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NVoi
+        LCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
+        N1QxNzo0Nzo1NVoiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
+        LCAidW5pdF9pZCI6ICJjZWNkYTliMS0xOTlmLTQzZmEtOGRiZi0wZDYzYjVh
+        YzI0YTciLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5NzNmOGNkZTJh
+        NTM2MSJ9fSwgeyJtZXRhZGF0YSI6IHsibWFuZGF0b3J5X3BhY2thZ2VfbmFt
+        ZXMiOiBbImNvY2thdGVlbCIsICJkdWNrIiwgInBlbmd1aW4iLCAic3Rvcmsi
+        XSwgInJlcG9faWQiOiAiM192aWV3MSIsICJuYW1lIjogImJpcmQiLCAidXNl
+        cl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVu
+        aXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4
+        NzUsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVk
+        X25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
+        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVz
+        IjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAi
+        aWQiOiAiYmlyZCIsICJfaWQiOiAiZWUwYjBmY2YtZmE3ZS00OGRiLTk3YWIt
+        OWU1MGY0MGU4NGNhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0
+        aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MC0wN1QxNzo0Nzo1NVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NVoiLCAidW5pdF90eXBlX2lkIjog
+        InBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJlZTBiMGZjZi1mYTdlLTQ4
+        ZGItOTdhYi05ZTUwZjQwZTg0Y2EiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
+        ZjRiMTI5NzNmOGNkZTJhNTM0NiJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3870,7 +3786,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3883,7 +3799,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -3896,10 +3812,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3909,7 +3825,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3922,13 +3838,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '401'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3937,45 +3853,27 @@ http_interactions:
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
         cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYzAvMTcw
         N2Q5YzhlOTkyNGIzOGQwNjYwMDlmODg1ODVkMjNhOGQxM2NiOTg3NjQxODFi
-        OTdjN2MyNDJiNDc3MDQvMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAw
-        MmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMi1wcm9kdWN0aWQu
+        OTdjN2MyNDJiNDc3MDQvYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUyNzc1YWEw
+        ZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMi1wcm9kdWN0aWQu
         Z3oiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJwcm9k
-        dWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2Rh
-        ZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMiIsICJf
-        bGFzdF91cGRhdGVkIjogMTU4ODM2Mzg1MCwgIl9jb250ZW50X3R5cGVfaWQi
+        dWN0aWQiLCAiY2hlY2tzdW0iOiAiYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUy
+        Nzc1YWEwZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMiIsICJf
+        bGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3NSwgIl9jb250ZW50X3R5cGVfaWQi
         OiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJkb3dubG9hZGVkIjogdHJ1
         ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX25zIjogInVuaXRzX3l1
         bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
-        NTYiLCAiX2lkIjogImQxNzIxZGRlLWQwNzUtNDQzNC1hMmQ4LWNhOTBkNzQ4
-        Zjg3NCJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTA1LTAxVDIw
-        OjEwOjUwWiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFf
-        ZmlsZSIsICJ1bml0X2lkIjogImQxNzIxZGRlLWQwNzUtNDQzNC1hMmQ4LWNh
-        OTBkNzQ4Zjg3NCIsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgyNGFmZGJjY2E5
-        ZjM4OTVjNThmIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjog
-        Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19tZXRhZGF0
-        YV9maWxlLzhhLzgxOTI0ODUzYThhNGU2NjgzZjU2MmEyM2ZhMzUyYjdlNzlm
-        YmYwZmE1MjQ3ZmU5MTBmYjgxODJhY2RhODgwLzU2OWMwYWMzMjQzMmEyMTMw
-        ODY3OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3
-        MWItc3dpZHRhZ3MueG1sLmd6IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJk
-        YXRhX3R5cGUiOiAic3dpZHRhZ3MiLCAiY2hlY2tzdW0iOiAiNTY5YzBhYzMy
-        NDMyYTIxMzA4Njc5M2E3MDUwMjIyOGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJj
-        NDA4ZjhkOTcxYiIsICJfbGFzdF91cGRhdGVkIjogMTU4ODM2Mzg1MCwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJk
-        b3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
-        X25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tz
-        dW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImVhOGU0ZWYxLTdhODQtNGZh
-        ZS1iMjQxLTQzZmIwYzk5ZDU3YyJ9LCAidXBkYXRlZCI6ICIyMDIwLTA1LTAx
-        VDIwOjEwOjUwWiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6
-        ICIyMDIwLTA1LTAxVDIwOjEwOjUwWiIsICJ1bml0X3R5cGVfaWQiOiAieXVt
-        X3JlcG9fbWV0YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogImVhOGU0ZWYxLTdh
-        ODQtNGZhZS1iMjQxLTQzZmIwYzk5ZDU3YyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWVhYzgyNGFmZGJjY2E5ZjM4OTVjNTgxIn19XQ==
+        NTYiLCAiX2lkIjogImRjZWI1MmZhLTg1ZTMtNDJmMi1hMGFhLTI0ZWNlODFh
+        OGYwZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJy
+        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3
+        OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFf
+        ZmlsZSIsICJ1bml0X2lkIjogImRjZWI1MmZhLTg1ZTMtNDJmMi1hMGFhLTI0
+        ZWNlODFhOGYwZSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4
+        Y2RlMmE1M2NlIn19XQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3985,7 +3883,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -3998,7 +3896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -4011,10 +3909,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4026,7 +3924,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -4039,7 +3937,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -4052,10 +3950,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -4065,7 +3963,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -4078,13 +3976,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:57 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '529'
+      - '531'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4104,24 +4002,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU4ODM2
-        Mzg0NiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
+        Mjg3MywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjU2NDhhM2ZlLTJj
-        YmYtNDQyYS1hY2FiLTMwY2VkN2ZmYTllNSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
+        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6NTBaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
-        cmVhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NTBaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICI1NjQ4YTNmZS0yY2Jm
-        LTQ0MmEtYWNhYi0zMGNlZDdmZmE5ZTUiLCAiX2lkIjogeyIkb2lkIjogIjVl
-        YWM4MjRhZmRiY2NhOWYzODk1YzViOCJ9fV0=
+        MjAtMTAtMDdUMTc6NDc6NTVaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
+        cmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICJlZDllNWQxNi03YmM4
+        LTQ0MzYtYTk3Yy1iYWE2NTM0ZTBhZTEiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        N2RmZjRiMTI5NzNmOGNkZTJhNTNmMCJ9fV0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:57 GMT
 - request:
     method: post
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4135,7 +4033,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Content-Length:
@@ -4148,7 +4046,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:52 GMT
+      - Wed, 07 Oct 2020 17:47:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -4159,14 +4057,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcwMDAyZWZjLWMzYTAtNDY5Ni1hZmY4LWNmYzI1MmMzZjVjMS8iLCAi
-        dGFza19pZCI6ICI3MDAwMmVmYy1jM2EwLTQ2OTYtYWZmOC1jZmMyNTJjM2Y1
-        YzEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzNlYjE5MTZkLWUwNTUtNDc2MS1hMTY4LWE4NWY1MzkzNDdmOC8iLCAi
+        dGFza19pZCI6ICIzZWIxOTE2ZC1lMDU1LTQ3NjEtYTE2OC1hODVmNTM5MzQ3
+        ZjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:52 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:57 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70002efc-c3a0-4696-aff8-cfc252c3f5c1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3eb1916d-e055-4761-a168-a85f539347f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4174,7 +4072,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4185,15 +4083,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:53 GMT
+      - Wed, 07 Oct 2020 17:47:58 GMT
       Server:
       - Apache
       Etag:
-      - '"60a00614d9d92ff53c2588cb494ff429-gzip"'
+      - '"417ee02372b625c55426296cc19aac6a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '468'
+      - '476'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4201,34 +4099,34 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi51bmFzc29jaWF0ZV9i
-        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzAw
-        MDJlZmMtYzNhMC00Njk2LWFmZjgtY2ZjMjUyYzNmNWMxLyIsICJ0YXNrX2lk
-        IjogIjcwMDAyZWZjLWMzYTAtNDY5Ni1hZmY4LWNmYzI1MmMzZjVjMSIsICJ0
+        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvM2Vi
+        MTkxNmQtZTA1NS00NzYxLWExNjgtYTg1ZjUzOTM0N2Y4LyIsICJ0YXNrX2lk
+        IjogIjNlYjE5MTZkLWUwNTUtNDc2MS1hMTY4LWE4NWY1MzkzNDdmOCIsICJ0
         YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6M192aWV3MSIsICJwdWxwOmFjdGlv
-        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0wNS0wMVQy
-        MDoxMDo1MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAyMC0wNS0wMVQyMDoxMDo1MloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0xMC0wN1Qx
+        Nzo0Nzo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAyMC0xMC0wN1QxNzo0Nzo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
-        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
-        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1
-        Y2Nlc3NmdWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVB
-        LTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9r
-        ZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVf
-        aWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExP
-        LVJIRUEtMjAxMDo5OTE0MyJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsi
-        dW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwg
-        InR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJL
-        QVRFTExPLVJIRUEtMjAxMjowMDU5In0sICJ0eXBlX2lkIjogImVycmF0dW0i
-        fV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjRj
-        ZmRiY2NhOWYzODk1YzZhMCJ9LCAiaWQiOiAiNWVhYzgyNGNmZGJjY2E5ZjM4
-        OTVjNmEwIn0=
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1r
+        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9rZXkiOiB7Imlk
+        IjogIktBVEVMTE8tUkhFQS0yMDEyOjAwNTkifSwgInR5cGVfaWQiOiAiZXJy
+        YXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAx
+        MDo5OTE0MyJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXki
+        OiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQi
+        OiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJI
+        RUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0
+        X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCJ9LCAidHlw
+        ZV9pZCI6ICJlcnJhdHVtIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0ZDEyOTczZjhjZGUyYTU0ZDgifSwgImlkIjogIjVm
+        N2RmZjRkMTI5NzNmOGNkZTJhNTRkOCJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:53 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4236,7 +4134,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4247,15 +4145,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:54 GMT
+      - Wed, 07 Oct 2020 17:47:58 GMT
       Server:
       - Apache
       Etag:
-      - '"7afeed8648de1b6c29f00e7965a5011c-gzip"'
+      - '"87987a8045785ca2a1fd9d319a855aac-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '622'
+      - '632'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4264,60 +4162,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZWFjODI0OGIwMmU1MzA3NTNhOTg1OTAifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5Zjc0MWU4ODNkMzkifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMDUtMDFUMjA6MTA6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWVhYzgyNDhiMDJlNTMwNzUzYTk4NThmIn0sICJjb25maWci
+        IiRvaWQiOiAiNWY3ZGZmNGEwMjIzOWY3NDFlODgzZDM4In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMDUtMDFUMjA6MTA6NDhaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0OGIwMmU1MzA3NTNhOTg1OGUifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5Zjc0MWU4ODNkMzcifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMDUt
-        MDFUMjA6MTA6NTBaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDIwLTA1LTAxVDIwOjEw
-        OjUyWiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
+        MDdUMTc6NDc6NTVaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
+        OjU3WiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
         IjogMiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiAxLCAi
         ZGlzdHJpYnV0aW9uIjogMSwgInJwbSI6IDEsICJ5dW1fcmVwb19tZXRhZGF0
-        YV9maWxlIjogMn0sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3si
-        cmVwb19pZCI6ICIzX3ZpZXcxIiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTA1
-        LTAxVDIwOjEwOjQ4WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
-        dG9yaWVzLzNfdmlldzEvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25z
-        IjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
-        X2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0
-        X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWVhYzgyNDhiMDJlNTMwNzUzYTk4NThkIn0sICJjb25maWciOiB7
-        fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3Vu
-        aXRzIjogOSwgIl9pZCI6IHsiJG9pZCI6ICI1ZWFjODI0OGIwMmU1MzA3NTNh
-        OTg1OGMifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAxMCwgImlkIjog
-        IjNfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
-        cy8zX3ZpZXcxLyJ9
+        YV9maWxlIjogMSwgInBhY2thZ2VfZW52aXJvbm1lbnQiOiAxfSwgIl9ucyI6
+        ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjNfdmlldzEi
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9pbXBv
+        cnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMi
+        LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9v
+        dmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3Jh
+        dGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5
+        Zjc0MWU4ODNkMzYifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9y
+        dGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiA5LCAiX2lkIjogeyIk
+        b2lkIjogIjVmN2RmZjRhMDIyMzlmNzQxZTg4M2QzNSJ9LCAidG90YWxfcmVw
+        b3NpdG9yeV91bml0cyI6IDEwLCAiaWQiOiAiM192aWV3MSIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4325,7 +4223,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4336,7 +4234,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:54 GMT
+      - Wed, 07 Oct 2020 17:47:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -4347,14 +4245,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZlMGMwZDU0LThjZmMtNDYyZC04ZWI0LTA4ZTZjZjIyMzE4My8iLCAi
-        dGFza19pZCI6ICI2ZTBjMGQ1NC04Y2ZjLTQ2MmQtOGViNC0wOGU2Y2YyMjMx
-        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MzZTU0M2ZjLTU4N2EtNDcxYi04ZTU2LTJlMzNhNDRkMzM1OC8iLCAi
+        dGFza19pZCI6ICJjM2U1NDNmYy01ODdhLTQ3MWItOGU1Ni0yZTMzYTQ0ZDMz
+        NTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/6e0c0d54-8cfc-462d-8eb4-08e6cf223183/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c3e543fc-587a-471b-8e56-2e33a44d3358/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4362,7 +4260,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4373,15 +4271,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:54 GMT
+      - Wed, 07 Oct 2020 17:47:58 GMT
       Server:
       - Apache
       Etag:
-      - '"18e6ba03a599db874497a8234ed397ba-gzip"'
+      - '"ec4e07c1a9527b5266cfc84b3751bd54-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '357'
+      - '363'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4389,25 +4287,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZTBjMGQ1NC04Y2ZjLTQ2MmQtOGViNC0wOGU2Y2YyMjMx
-        ODMvIiwgInRhc2tfaWQiOiAiNmUwYzBkNTQtOGNmYy00NjJkLThlYjQtMDhl
-        NmNmMjIzMTgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jM2U1NDNmYy01ODdhLTQ3MWItOGU1Ni0yZTMzYTQ0ZDMz
+        NTgvIiwgInRhc2tfaWQiOiAiYzNlNTQzZmMtNTg3YS00NzFiLThlNTYtMmUz
+        M2E0NGQzMzU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTA1LTAxVDIwOjEwOjU0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTA1LTAxVDIwOjEwOjU0WiIsICJ0cmFjZWJh
+        MDIwLTEwLTA3VDE3OjQ3OjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU4WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWVhYzgy
-        NGVmZGJjY2E5ZjM4OTVjNmU2In0sICJpZCI6ICI1ZWFjODI0ZWZkYmNjYTlm
-        Mzg5NWM2ZTYifQ==
+        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVmN2RmZjRlMTI5NzNmOGNkZTJhNTUyZiJ9LCAiaWQiOiAi
+        NWY3ZGZmNGUxMjk3M2Y4Y2RlMmE1NTJmIn0=
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
 - request:
     method: delete
-    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4415,7 +4313,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4426,7 +4324,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:54 GMT
+      - Wed, 07 Oct 2020 17:47:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -4437,14 +4335,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MwZDNlMTMyLTE0ODQtNGFlMS1hZjAwLWQ4ZWI0NDVkYmJhMi8iLCAi
-        dGFza19pZCI6ICJjMGQzZTEzMi0xNDg0LTRhZTEtYWYwMC1kOGViNDQ1ZGJi
-        YTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzEyZjhkNTMzLTBlODgtNGYyZS1iOWUwLTIyZDIxMGMxZGNmYi8iLCAi
+        dGFza19pZCI6ICIxMmY4ZDUzMy0wZTg4LTRmMmUtYjllMC0yMmQyMTBjMWRj
+        ZmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:54 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:59 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c0d3e132-1484-4ae1-af00-d8eb445dbba2/
+    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/12f8d533-0e88-4f2e-b9e0-22d210c1dcfb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4452,7 +4350,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4463,15 +4361,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2020 20:10:55 GMT
+      - Wed, 07 Oct 2020 17:47:59 GMT
       Server:
       - Apache
       Etag:
-      - '"b64a29afe8e4b270c0fa9656dbb5c697-gzip"'
+      - '"ef6e730c2a0e54a19dc9d27a566e3fe0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '354'
+      - '361'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4479,20 +4377,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMGQzZTEzMi0xNDg0LTRhZTEtYWYwMC1kOGViNDQ1ZGJi
-        YTIvIiwgInRhc2tfaWQiOiAiYzBkM2UxMzItMTQ4NC00YWUxLWFmMDAtZDhl
-        YjQ0NWRiYmEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy8xMmY4ZDUzMy0wZTg4LTRmMmUtYjllMC0yMmQyMTBjMWRj
+        ZmIvIiwgInRhc2tfaWQiOiAiMTJmOGQ1MzMtMGU4OC00ZjJlLWI5ZTAtMjJk
+        MjEwYzFkY2ZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0wNS0wMVQyMDoxMDo1NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0wNS0wMVQyMDoxMDo1NVoiLCAidHJhY2ViYWNr
+        MC0xMC0wN1QxNzo0Nzo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1OVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
-        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVlYWM4MjRl
-        ZmRiY2NhOWYzODk1YzczMCJ9LCAiaWQiOiAiNWVhYzgyNGVmZGJjY2E5ZjM4
-        OTVjNzMwIn0=
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZjdkZmY0ZjEyOTczZjhjZGUyYTU1ODIifSwgImlkIjogIjVm
+        N2RmZjRmMTI5NzNmOGNkZTJhNTU4MiJ9
     http_version: 
-  recorded_at: Fri, 01 May 2020 20:10:55 GMT
+  recorded_at: Wed, 07 Oct 2020 17:47:59 GMT
 recorded_with: VCR 3.0.3

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -20,7 +20,7 @@ module Support
 
     def with_pulp3_features(smart_proxy)
       spf = smart_proxy.smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => SmartProxy::PULP3_FEATURE))
-      spf.capabilities = ['pulp_file', 'pulp_container', 'pulp_ansible']
+      spf.capabilities = ['pulp_file', 'pulp_container', 'pulp_ansible', 'pulp_deb']
       spf.save!
     end
 


### PR DESCRIPTION
First goal is to implement
create, update, sync and delete debian repositories on pulp3

Probably not yet ready for final review, but definitely open for comments and critics :wink: 

### TODOs
- [x] verify if we want need repository verification in the first implementation
- [x] verify if we want need repository signing in the first implementation
For now we will assign hardcoded SigningService with name `katello_deb_sign`, if it exists.
- [x] fix https://pulp.plan.io/issues/6897 in pulp_deb to get the tests running
fix still needs to be cherry-picked into pulp_deb 2.4