### PR TITLE
Fixes #29428 - removing react-helmet dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "jed": "^1.1.1",
     "ngreact": "^0.5.0",
     "query-string": "^6.1.0",
-    "react-bootstrap": "^0.32.1",
-    "react-helmet": "^5.2.0"
+    "react-bootstrap": "^0.32.1"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
react-helmet is included from `vendor` v.4.1
https://github.com/theforeman/foreman-js/pull/124 