### PR TITLE
Fixes #28969 - Adding 'Subscriptions expiring soon' email to email preferences

### DIFF
--- a/app/mailers/katello/subscription_mailer.rb
+++ b/app/mailers/katello/subscription_mailer.rb
@@ -1,0 +1,24 @@
+module Katello
+  class SubscriptionMailer < ApplicationMailer
+    after_action :prevent_sending_blank_report
+
+    def subscription_expiry(options)
+      user = ::User.find(options[:user])
+      ::User.as(user.login) do
+        @pools = Katello::Pool.readable.expiring_in_days(30)
+      end
+
+      set_locale_for(user) do
+        mail(:to => user.mail, :subject => _("Subscriptions expiring soon"))
+      end
+    end
+
+    private
+
+    def prevent_sending_blank_report
+      if @pools.blank?
+        mail.perform_deliveries = false
+      end
+    end
+  end
+end

--- a/app/views/katello/subscription_mailer/subscription_expiry.html.erb
+++ b/app/views/katello/subscription_mailer/subscription_expiry.html.erb
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1;">
+<body>
+<style type="text/css">
+  a, a:visited {
+    color: #6bb5df !important;
+  }
+
+  a:hover {
+    color: #CCCCCC !important;
+  }
+</style>
+<div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1;">
+  <h2 style="font-weight: normal;"><%= _("SUBSCRIPTIONS EXPIRING SOON").html_safe %></h2>
+    <table border="0" width="100%" id="emailBody" style="background-color: #fff; margin-top: 10px; padding: 0px 0px 15px;" bgcolor="#fff">
+      <tr>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Subscription Name") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Account Number") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Organization") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Type") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Quantity") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("SKU") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Contract") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Start Date") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("End Date") %></th>
+        <th style="text-align: center; border-collapse: collapse; padding: 4px; border: 1px solid #cccccc;" align="center"><%= _("Days Remaining") %></th>
+      </tr>
+      <% @pools.each do |pool| %>
+        <tr>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.subscription.name %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.account_number %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.organization.name %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.pool_type %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.quantity %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.subscription.cp_id  %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.contract_number %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.start_date %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.end_date %></td>
+          <td align="left" valign="top" style="padding: 0px 20px 5px;"><%= pool.days_until_expiration %></td>
+        </tr>
+      <% end %>
+    </table>
+</div>
+</body>
+</html>

--- a/app/views/katello/subscription_mailer/subscription_expiry.text.erb
+++ b/app/views/katello/subscription_mailer/subscription_expiry.text.erb
@@ -1,0 +1,15 @@
+<%= _("Subscriptions expiring soon") %>
+
+<% @pools.each do |pool| %>
+  <%= _("Subscription Name") %>:    <%= pool.subscription.name %>
+  <%= _("Account Number") %>:       <%= pool.account_number %>
+  <%= _("Organization") %>:         <%= pool.organization.name %>
+  <%= _("Type") %>:                 <%= pool.pool_type %>
+  <%= _("Quantity") %>:             <%= pool.quantity %>
+  <%= _("SKU") %>:                  <%= pool.subscription.cp_id %>
+  <%= _("Contract") %>:             <%= pool.contract_number %>
+  <%= _("Start Date") %>:           <%= pool.start_date %>
+  <%= _("End Date") %>:             <%= pool.end_date %>
+  <%= _("Days Remaining") %>:       <%= pool.days_until_expiration %>
+
+<% end %>

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -31,6 +31,13 @@ User.as(::User.anonymous_api_admin.login) do
      :mailer => 'Katello::ErrataMailer',
      :method => 'promote_errata',
      :subscription_type => 'alert'
+    },
+
+    {:name => :subscriptions_expiring_soon,
+     :description => N_('A list of subscriptions expiring within 30 days'),
+     :mailer => 'Katello::SubscriptionMailer',
+     :method => 'subscription_expiry',
+     :subscription_type => 'report'
     }
   ]
 

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -1,0 +1,85 @@
+require 'katello_test_helper'
+
+module Katello
+  class SubscriptionMailertest < ActiveSupport::TestCase
+    def setup
+      @user = User.current = User.find(users('admin').id)
+
+      FactoryBot.create(:mail_notification,
+                        :name => 'subscriptions_expiring_soon',
+                        :description => 'A list of subscriptions expiring within 30 days',
+                        :mailer => 'Katello::SubscriptionMailer',
+                        :method => 'subscription_expiry',
+                        :subscription_type => 'report')
+
+      @user.mail_notifications << MailNotification[:subscriptions_expiring_soon]
+
+      @pool_not_expiring_soon = FactoryBot.create(:katello_pool,
+                                                  :not_expiring_soon,
+                                                  cp_id: "1234",
+                                                  subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription))
+      ActionMailer::Base.deliveries = []
+    end
+
+    def setup_expiring_pool
+      @pool_expiring_soon = FactoryBot.create(:katello_pool,
+                                              :expiring_in_12_days,
+                                              cp_id: "123",
+                                              subscription_id: ActiveRecord::FixtureSet.identify(:basic_subscription),
+                                              organization_id: ActiveRecord::FixtureSet.identify(:empty_organization),
+                                              pool_type: "normal",
+                                              quantity: 10,
+                                              start_date: "2011-10-11T04:00:00.000+0000",
+                                              account_number: "12400203",
+                                              contract_number: "123403949")
+    end
+
+    def test_prevent_sending_blank_report
+      @user.user_mail_notifications.first.deliver
+
+      assert_empty ActionMailer::Base.deliveries
+    end
+
+    def get_rows(email)
+      doc = Nokogiri::HTML(email, nil, 'UTF-8')
+      table = doc.css('table').first
+      table.css('tr')
+    end
+
+    def test_includes_expiring_subscription
+      setup_expiring_pool
+      @user.user_mail_notifications.first.deliver
+      email = ActionMailer::Base.deliveries.first
+
+      rows = get_rows(email.body.encoded)
+      subscription_row = rows[1]
+      subscription_cells = subscription_row.css('td')
+
+      fields = [ @pool_expiring_soon.subscription.name,
+                 @pool_expiring_soon.account_number.to_s,
+                 @pool_expiring_soon.organization.name,
+                 @pool_expiring_soon.pool_type,
+                 @pool_expiring_soon.quantity.to_s,
+                 @pool_expiring_soon.subscription.cp_id,
+                 @pool_expiring_soon.contract_number.to_s,
+                 @pool_expiring_soon.start_date.to_s,
+                 @pool_expiring_soon.end_date.to_s,
+                 @pool_expiring_soon.days_until_expiration.to_s]
+
+      fields.each_with_index do |field, i|
+        assert_equal field, subscription_cells[i].children.text
+      end
+    end
+
+    def test_omits_non_expiring_subscription
+      setup_expiring_pool
+      @user.user_mail_notifications.first.deliver
+      email = ActionMailer::Base.deliveries.first
+      rows = get_rows(email.body.encoded)
+
+      # row headings is counted as one row
+      assert_equal rows.length, 2
+      assert Katello::Pool.readable.size > 1
+    end
+  end
+end


### PR DESCRIPTION
Adding a new email notification to the Email Preferences tab of the User edit screen. Users can subscribe to get notifications about subscriptions expiring in 30 days.