### PR TITLE
Fixes #27970 - handle objects in toast actions

### DIFF
--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -69,9 +69,10 @@ export const apiResponse = (actionType, result, additionalData = {}) => (dispatc
 
 export const sendErrorNotifications = messages => (dispatch) => {
   messages.forEach((msg) => {
+    const message = typeof msg === 'string' ? msg : `${msg.message}: ${msg.details}`;
     dispatch(addToast({
       type: 'error',
-      message: msg,
+      message,
       sticky: true,
     }));
   });


### PR DESCRIPTION
The helper function was assuming that the message object was always a string.  This change handles both strings and objects, and prevents the toast from being suppressed.  It also prevents the resultant PropType errors.

To test:
1. Log in as / impersonate a user with only Viewer permissions
2. Navigate to /subscriptions
