### PR TITLE
Fixes #28970 - Customize email notification for 'Subscriptions Expiring Soon'

### DIFF
--- a/app/mailers/katello/subscription_mailer.rb
+++ b/app/mailers/katello/subscription_mailer.rb
@@ -11,7 +11,7 @@ module Katello
       end
 
       set_locale_for(user) do
-        mail(:to => user.mail, :subject => _("You have subscriptions expiring within #{days_from_now} days"))
+        mail(:to => user.mail, :subject => _("You have subscriptions expiring within %s days") % days_from_now)
       end
     end
 

--- a/app/mailers/katello/subscription_mailer.rb
+++ b/app/mailers/katello/subscription_mailer.rb
@@ -4,12 +4,14 @@ module Katello
 
     def subscription_expiry(options)
       user = ::User.find(options[:user])
+      days_from_now = options[:query]
+
       ::User.as(user.login) do
-        @pools = Katello::Pool.readable.expiring_in_days(65)
+        @pools = Katello::Pool.readable.expiring_in_days(days_from_now)
       end
 
       set_locale_for(user) do
-        mail(:to => user.mail, :subject => _("Subscriptions expiring soon"))
+        mail(:to => user.mail, :subject => _("You have subscriptions expiring within #{days_from_now} days"))
       end
     end
 

--- a/app/mailers/katello/subscription_mailer.rb
+++ b/app/mailers/katello/subscription_mailer.rb
@@ -5,7 +5,7 @@ module Katello
     def subscription_expiry(options)
       user = ::User.find(options[:user])
       ::User.as(user.login) do
-        @pools = Katello::Pool.readable.expiring_in_days(30)
+        @pools = Katello::Pool.readable.expiring_in_days(65)
       end
 
       set_locale_for(user) do

--- a/app/views/users/_subscription_expiry_query_builder.html.erb
+++ b/app/views/users/_subscription_expiry_query_builder.html.erb
@@ -1,0 +1,16 @@
+<span style="padding: 7px;
+border: 1px solid #ccc;
+border-width: 0 0 1px 1px;
+border-radius: 0 0 0 10px;
+position: relative;
+left: 18%;
+top: -12px;">   </span>
+<div id="subscription_expiry_query_builder" class="input-group" style="
+  display: block;
+  top: -22px;
+  left: calc(20% + 16px);
+  width: 56%;
+">
+  <%= select_f(f, :mail_query, %w[7 30 60 90 180], :to_s, :to_translation, { :include_blank => _('Show all subscriptions') }, {:label => _('Days from Now'),
+             :label_help => _('The email notification will include subscriptions expiring in this number of days or fewer.')}) %>
+</div>

--- a/app/views/users/_subscriptions_expiring_soon_query_builder.html.erb
+++ b/app/views/users/_subscriptions_expiring_soon_query_builder.html.erb
@@ -11,6 +11,6 @@ top: -12px;">   </span>
   left: calc(20% + 16px);
   width: 56%;
 ">
-  <%= select_f(f, :mail_query, %w[7 30 60 90 180], :to_s, :to_translation, { :include_blank => _('Show all subscriptions') }, {:label => _('Days from Now'),
+  <%= select_f(f, :mail_query, %w[7 30 60 90 180], :to_s, :to_translation, { :include_blank => false }, {:label => _('Days from Now'),
              :label_help => _('The email notification will include subscriptions expiring in this number of days or fewer.')}) %>
 </div>

--- a/app/views/users/_subscriptions_expiring_soon_query_builder.html.erb
+++ b/app/views/users/_subscriptions_expiring_soon_query_builder.html.erb
@@ -11,6 +11,6 @@ top: -12px;">   </span>
   left: calc(20% + 16px);
   width: 56%;
 ">
-  <%= select_f(f, :mail_query, %w[7 30 60 90 180], :to_s, :to_translation, { :include_blank => false }, {:label => _('Days from Now'),
+  <%= select_f(f, :mail_query, %W[#{Setting[:expire_soon_days]}\ -\ System\ default 7 30 60 90 120 180], :to_i, :to_translation, { :include_blank => false }, {:label => _('Days from Now'),
              :label_help => _('The email notification will include subscriptions expiring in this number of days or fewer.')}) %>
 </div>

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -37,7 +37,8 @@ User.as(::User.anonymous_api_admin.login) do
      :description => N_('A list of subscriptions expiring within 30 days'),
      :mailer => 'Katello::SubscriptionMailer',
      :method => 'subscription_expiry',
-     :subscription_type => 'report'
+     :subscription_type => 'report',
+     :queryable => true
     }
   ]
 

--- a/test/factories/pool_factory.rb
+++ b/test/factories/pool_factory.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :katello_pool, :class => Katello::Pool do
     active { true }
     end_date { Date.today + 1.year }
+    cp_id { 1 }
+
+    trait :with_organization do
+      association :organization, :factory => :katello_organization
+    end
 
     trait :active do
       active { true }

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -3,7 +3,7 @@ require 'katello_test_helper'
 module Katello
   class TestBase < ActiveSupport::TestCase
     let(:pool_expiring_soon) do
-      FactoryBot.build(
+      FactoryBot.create(
         :katello_pool,
         :expiring_in_12_days,
         :with_organization,
@@ -16,7 +16,7 @@ module Katello
         contract_number: "123403949")
     end
     let(:expiring_in_120) do
-      FactoryBot.build(
+      FactoryBot.create(
         :katello_pool,
         :expiring_soon,
         :with_organization,
@@ -60,7 +60,7 @@ module Katello
     end
 
     def test_includes_expiring_subscription
-      pool_expiring_soon.save
+      pool_expiring_soon # ensures record is present before .deliver is called
       @user.user_mail_notifications.first.deliver
       email = ActionMailer::Base.deliveries.first
 
@@ -85,7 +85,7 @@ module Katello
     end
 
     def test_omits_non_expiring_subscription
-      pool_expiring_soon.save
+      pool_expiring_soon
       @user.user_mail_notifications.first.deliver
       email = ActionMailer::Base.deliveries.first
       rows = get_rows(email.body.encoded)
@@ -96,8 +96,8 @@ module Katello
     end
 
     def test_days_from_now_mail_query
-      pool_expiring_soon.save
-      expiring_in_120.save
+      pool_expiring_soon
+      expiring_in_120
 
       @user.user_mail_notifications.first.update(mail_query: "30")
       @user.user_mail_notifications.first.deliver

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -1,9 +1,32 @@
 require 'katello_test_helper'
 
 module Katello
-  class SubscriptionMailertest < ActiveSupport::TestCase
+  class TestBase < ActiveSupport::TestCase
+    let(:pool_expiring_soon) do
+      FactoryBot.build(
+        :katello_pool,
+        :expiring_in_12_days,
+        :with_organization,
+        cp_id: "123",
+        subscription_id: ActiveRecord::FixtureSet.identify(:basic_subscription),
+        pool_type: "normal",
+        quantity: 10,
+        start_date: "2011-10-11T04:00:00.000+0000",
+        account_number: "12400203",
+        contract_number: "123403949")
+    end
+    let(:expiring_in_120) do
+      FactoryBot.build(
+        :katello_pool,
+        :expiring_soon,
+        :with_organization,
+        subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription)) # Setting[:expire_soon_days] || 120
+    end
+  end
+  class SubscriptionMailerTest < TestBase
     def setup
-      @user = User.current = User.find(users('admin').id)
+      @user = User.find(users('admin').id)
+      User.current = @user
 
       FactoryBot.create(:mail_notification,
                         :name => 'subscriptions_expiring_soon',
@@ -15,25 +38,13 @@ module Katello
       @user.mail_notifications << MailNotification[:subscriptions_expiring_soon]
       @user.user_mail_notifications.first.update(mail_query: Setting[:expire_soon_days])
 
-      @pool_not_expiring_soon = FactoryBot.create(:katello_pool,
-                                                  :not_expiring_soon,
-                                                  :with_organization,
-                                                  cp_id: "1234",
-                                                  subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription))
-      ActionMailer::Base.deliveries = []
-    end
+      FactoryBot.create(:katello_pool,
+                        :not_expiring_soon,
+                        :with_organization,
+                        cp_id: "1234",
+                        subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription))
 
-    def set_up_expiring_pool
-      @pool_expiring_soon = FactoryBot.create(:katello_pool,
-                                              :expiring_in_12_days,
-                                              :with_organization,
-                                              cp_id: "123",
-                                              subscription_id: ActiveRecord::FixtureSet.identify(:basic_subscription),
-                                              pool_type: "normal",
-                                              quantity: 10,
-                                              start_date: "2011-10-11T04:00:00.000+0000",
-                                              account_number: "12400203",
-                                              contract_number: "123403949")
+      ActionMailer::Base.deliveries = []
     end
 
     def test_prevent_sending_blank_report
@@ -49,7 +60,7 @@ module Katello
     end
 
     def test_includes_expiring_subscription
-      set_up_expiring_pool
+      pool_expiring_soon.save
       @user.user_mail_notifications.first.deliver
       email = ActionMailer::Base.deliveries.first
 
@@ -57,16 +68,16 @@ module Katello
       subscription_row = rows[1]
       subscription_cells = subscription_row.css('td')
 
-      fields = [ @pool_expiring_soon.subscription.name,
-                 @pool_expiring_soon.account_number.to_s,
-                 @pool_expiring_soon.organization.name,
-                 @pool_expiring_soon.pool_type,
-                 @pool_expiring_soon.quantity.to_s,
-                 @pool_expiring_soon.subscription.cp_id,
-                 @pool_expiring_soon.contract_number.to_s,
-                 @pool_expiring_soon.start_date.to_s,
-                 @pool_expiring_soon.end_date.to_s,
-                 @pool_expiring_soon.days_until_expiration.to_s]
+      fields = [ pool_expiring_soon.subscription.name,
+                 pool_expiring_soon.account_number.to_s,
+                 pool_expiring_soon.organization.name,
+                 pool_expiring_soon.pool_type,
+                 pool_expiring_soon.quantity.to_s,
+                 pool_expiring_soon.subscription.cp_id,
+                 pool_expiring_soon.contract_number.to_s,
+                 pool_expiring_soon.start_date.to_s,
+                 pool_expiring_soon.end_date.to_s,
+                 pool_expiring_soon.days_until_expiration.to_s]
 
       fields.each_with_index do |field, i|
         assert_equal field, subscription_cells[i].children.text
@@ -74,7 +85,7 @@ module Katello
     end
 
     def test_omits_non_expiring_subscription
-      set_up_expiring_pool
+      pool_expiring_soon.save
       @user.user_mail_notifications.first.deliver
       email = ActionMailer::Base.deliveries.first
       rows = get_rows(email.body.encoded)
@@ -85,15 +96,15 @@ module Katello
     end
 
     def test_days_from_now_mail_query
-      set_up_expiring_pool
-      @expiring_in_120 = FactoryBot.create(:katello_pool, :expiring_soon, :with_organization, subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription)) # Setting[:expire_soon_days] || 120
+      pool_expiring_soon.save
+      expiring_in_120.save
 
       @user.user_mail_notifications.first.update(mail_query: "30")
       @user.user_mail_notifications.first.deliver
 
       email = ActionMailer::Base.deliveries.first
-      assert_includes email.body.encoded, @pool_expiring_soon.subscription.name
-      refute_includes email.body.encoded, @expiring_in_120.subscription.name
+      assert_includes email.body.encoded, pool_expiring_soon.subscription.name
+      refute_includes email.body.encoded, expiring_in_120.subscription.name
     end
   end
 end


### PR DESCRIPTION
~(WIP until #8638 is merged and I finish tests)~

#### Add 'Days from Now' dropdown to the email preferences page
![email_notification_1](https://user-images.githubusercontent.com/22042343/79130633-49249000-7d75-11ea-99ae-8d281922ddf7.png)
#### Changes the 'Subscriptions Expiring Soon' email notification to send a list of subscriptions expiring within XX days (no longer hard-coded to 30)
![info](https://user-images.githubusercontent.com/22042343/79130632-488bf980-7d75-11ea-9d0d-10257b71e502.png)
