### PR TITLE
Fixes #29516 - Add Tracer bulk action support

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -225,6 +225,13 @@ module Katello
       respond_for_async :resource => task
     end
 
+    api :POST, "/hosts/bulk/traces", N_("Fetch traces for one or more hosts")
+    param_group :bulk_params
+    def traces
+      collection = scoped_search(Katello::HostTracer.where(host_id: @hosts.pluck(:id)), 'application', 'desc', resource_class: Katello::HostTracer)
+      respond_for_index(:collection => collection, :template => '../../../api/v2/host_tracer/index')
+    end
+
     api :POST, "/hosts/bulk/available_incremental_updates", N_("Given a set of hosts and errata, lists the content view versions" \
                                                                  " and environments that need updating.")
     param_group :bulk_params

--- a/app/models/katello/authorization/host_tracer.rb
+++ b/app/models/katello/authorization/host_tracer.rb
@@ -1,0 +1,14 @@
+module Katello
+  module Authorization::HostTracer
+    extend ActiveSupport::Concern
+
+    include Authorizable
+
+    module ClassMethods
+      def resolvable
+        relation = joins_authorized(::Host::Managed, :edit_hosts)
+        relation
+      end
+    end
+  end
+end

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -1,5 +1,7 @@
 module Katello
   class HostTracer < Katello::Model
+    include Katello::Authorization::HostTracer
+
     belongs_to :host, :inverse_of => :host_traces, :class_name => '::Host::Managed'
 
     validates :application, :length => {:maximum => 255}, :presence => true

--- a/app/views/katello/api/v2/host_tracer/base.json.rabl
+++ b/app/views/katello/api/v2/host_tracer/base.json.rabl
@@ -4,3 +4,4 @@ attributes :id, :id
 attributes :application, :application
 attributes :helper, :helper
 attributes :app_type, :app_type
+attributes :host_id, :host

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -304,6 +304,12 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :traces, :only => [], :controller => 'host_tracer' do
+          collection do
+            put :resolve
+          end
+        end
+
         api_resources :srpms, :only => [:index, :show], :controller => 'srpms' do
           collection do
             get :auto_complete_search

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -76,6 +76,7 @@ Foreman::Application.routes.draw do
             match '/bulk/destroy' => 'hosts_bulk_actions#destroy_hosts', :via => :put
             match '/bulk/environment_content_view' => 'hosts_bulk_actions#environment_content_view', :via => :put
             match '/bulk/release_version' => 'hosts_bulk_actions#release_version', :via => :put
+            match '/bulk/traces' => 'hosts_bulk_actions#traces', :via => :post
             match '/bulk/available_incremental_updates' => 'hosts_bulk_actions#available_incremental_updates', :via => :post
             match '/bulk/module_streams' => 'hosts_bulk_actions#module_streams', :via => :post
             match '/subscriptions/' => 'host_subscriptions#create', :via => :post

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
@@ -1,0 +1,61 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-hosts.controller:ContentHostsBulkTracesController
+ *
+ * @requires $scope
+ * @requires $uibModalInstance
+ * @requires HostBulkAction
+ * @requires Notification
+ * @requires Nutupane
+ * @requires BastionConfig
+ * @requires hostIds
+ * @requires HostTracesResolve
+ * @requires translate
+ *
+ * @description
+ *   Provides the functionality to support resolving traces on multiple hosts.
+ */
+/*jshint camelcase:false*/
+angular.module('Bastion.content-hosts').controller('ContentHostsBulkTracesController',
+    ['$scope', '$uibModalInstance', 'HostBulkAction', 'Notification', 'Nutupane', 'BastionConfig', 'hostIds', 'HostTracesResolve', 'translate',
+    function ($scope, $uibModalInstance, HostBulkAction, Notification, Nutupane, BastionConfig, hostIds, HostTracesResolve, translate) {
+
+        var tracesNutupane = new Nutupane(HostBulkAction, hostIds, 'traces');
+        tracesNutupane.enableSelectAllResults();
+        tracesNutupane.masterOnly = true;
+        $scope.table = tracesNutupane.table;
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+
+        $scope.performViaRemoteExecution = function() {
+            var traceids = _.map($scope.table.getSelected(), 'id');
+
+            var onSuccess = function () {
+                var message = translate('Successfully initiated restart of services.');
+                Notification.setSuccessMessage(message, {
+                    link: {
+                        children: translate("View job invocations."),
+                        href: translate("/job_invocations")
+                    }});
+                $scope.ok();
+            };
+
+            var onFailure = function (response) {
+                angular.forEach(response.data.errors, function (responseError) {
+                    Notification.setErrorMessage(responseError);
+                });
+            };
+            /* eslint-disable camelcase */
+            HostTracesResolve.resolve({trace_ids: traceids}, onSuccess, onFailure);
+            /* eslint-enable camelcase */
+        };
+
+        $scope.ok = function () {
+            $uibModalInstance.close();
+        };
+
+        $scope.cancel = function () {
+            $uibModalInstance.dismiss('cancel');
+        };
+
+    }
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
@@ -1,0 +1,74 @@
+<div data-extend-template="components/views/bst-modal.html">
+  <h4 data-block="modal-header">Content Host Traces Management</h4>
+
+  <div data-block="modal-body">
+
+    <div class="row">
+      <div class="col-sm-12">
+        <div bst-global-notification></div>
+      </div>
+    </div>
+
+    <div bst-alert="info" ng-hide="remoteExecutionPresent">
+      <span translate>
+        The Remote Execution plugin needs to be installed in order to resolve Traces.
+      </span>
+    </div>
+    
+    <div data-extend-template="layouts/partials/table.html">
+      <div data-block="search" ng-show="false"></div>
+      <span data-block="list-actions">
+        <div bst-modal="performViaRemoteExecution()">
+          <div data-block="modal-header" translate>Confirm services restart</div>
+          <div data-block="modal-body" translate>Are you sure you want to restart the services on the selected content hosts?</div>
+          <span data-block="modal-confirm-button">
+            <button class="btn btn-danger" ng-click="ok()">
+              <span translate>Restart</span>
+            </button>
+          </span>
+        </div>
+  
+          <span class="btn-group">
+            <button class="btn btn-danger" type="button"
+                    translate
+                    ng-hide="denied('edit_hosts', host)"
+                    ng-disabled="table.getSelected().length == 0 || !remoteExecutionPresent"
+                    ng-click="openModal()">
+              Restart Selected
+            </button>
+          </span>
+      </span>
+  
+      <span data-block="no-rows-message" translate>
+        There are no Traces to display.
+      </span>
+  
+      <div data-block="table">
+        <div data-extend-template="layouts/select-all-results.html"></div>
+        <table bst-table="table" class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
+          <thead>
+            <tr bst-table-head row-select>
+              <th bst-table-column="application" translate>Application</th>
+              <th bst-table-column="app_type" translate>Type</th>
+              <th bst-table-column="helper" translate>Helper</th>
+              <th bst-table-column="affected_hosts" translate>Hostname</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr bst-table-row ng-repeat="trace in table.rows" row-select="trace">
+              <td bst-table-cell >{{ trace.application }}</td>
+              <td bst-table-cell >{{ trace.app_type }}</td>
+              <td bst-table-cell >{{ trace.helper }}</td>
+              <td bst-table-cell >{{ trace.host }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div data-block="modal-footer">
+    <button type="button" class="btn btn-primary" ng-click="cancel()" translate>
+      Cancel
+    </button>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
@@ -69,6 +69,17 @@ angular.module('Bastion.content-hosts').service('ContentHostsModalHelper', ['$ui
             });
         };
 
+        this.openTracesModal = function() {
+            $uibModal.open({
+                templateUrl: 'content-hosts/bulk/views/content-hosts-bulk-traces-modal.html',
+                controller: 'ContentHostsBulkTracesController',
+                size: 'lg',
+                resolve: {
+                    hostIds: this.resolveFunc()
+                }
+            });
+        };
+
         this.openSubscriptionsModal = function() {
             $uibModal.open({
                 templateUrl: 'content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -157,5 +157,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
             nutupane.invalidate();
             ContentHostsModalHelper.openModuleStreamsModal();
         };
+
+        $scope.openTracesModal = function () {
+            nutupane.invalidate();
+            ContentHostsModalHelper.openTracesModal();
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -51,6 +51,10 @@
           <a ng-click="openModuleStreamsModal()" disable-link="table.numSelected === 0" translate>Manage Module Streams</a>
         </li>
 
+        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openTracesModal()" disable-link="table.numSelected === 0" translate>Manage Host Traces</a>
+        </li>
+
         <li class="divider"></li>
 
         <li role="menuitem" ng-show="permitted('destroy_hosts')" ng-class="{disabled: table.numSelected === 0}">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
@@ -25,7 +25,8 @@ angular.module('Bastion.hosts').factory('HostBulkAction',
             environmentContentView: {method: 'PUT', params: {action: 'environment_content_view'}},
             releaseVersion: {method: 'PUT', params: {action: 'release_version'}},
             availableIncrementalUpdates: {method: 'POST', isArray: true, params: {action: 'available_incremental_updates'}},
-            moduleStreams: {method: 'POST', params: {action: 'module_streams'}}
+            moduleStreams: {method: 'POST', params: {action: 'module_streams'}},
+            traces: {method: 'POST', params: {action: 'traces'}}
         });
 
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-traces-resolve.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-traces-resolve.factory.js
@@ -1,0 +1,18 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.hosts.factory:HostTracesResolve
+ *
+ * @requires BastionResource
+ *
+ * @description
+ *   Provides a BastionResource for resolving traces on a set of systems.
+ */
+angular.module('Bastion.hosts').factory('HostTracesResolve',
+    ['BastionResource', function (BastionResource) {
+
+        return BastionResource('katello/api/v2/traces/:action', {}, {
+            resolve: {method: 'PUT', isArray: true, params: {action: 'resolve'}}
+        });
+
+    }]
+);

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -26,6 +26,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
   'katello/api/v2/hosts_bulk_actions/content_overrides',
   'katello/api/v2/hosts_bulk_actions/environment_content_view',
   'katello/api/v2/hosts_bulk_actions/release_version',
+  'katello/api/v2/hosts_bulk_actions/traces',
   'katello/api/rhsm/candlepin_dynflow_proxy/upload_package_profile',
   'katello/api/rhsm/candlepin_dynflow_proxy/upload_profiles',
   'katello/api/rhsm/candlepin_dynflow_proxy/deb_package_profile',
@@ -55,6 +56,7 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/host_debs/index',
   'katello/api/v2/host_packages/index',
   'katello/api/v2/host_tracer/index',
+  'katello/api/v2/host_tracer/resolve',
   'katello/remote_execution/new',
   'katello/remote_execution/create'
 ]

--- a/test/controllers/api/v2/host_tracer_controller_test.rb
+++ b/test/controllers/api/v2/host_tracer_controller_test.rb
@@ -2,11 +2,16 @@
 
 require "katello_test_helper"
 
+unless Katello.with_remote_execution?
+  class JobInvocationComposer
+  end
+end
+
 module Katello
   class Api::V2::HostTracerControllerTest < ActionController::TestCase
     def models
-      @host = hosts(:one)
-      @host.host_traces.create!(:app_type => 'foo', :application => 'scrumm')
+      @host1 = hosts(:one)
+      @host2 = hosts(:two)
     end
 
     def setup
@@ -15,10 +20,61 @@ module Katello
     end
 
     def test_index
-      results = JSON.parse(get(:index, params: { :host_id => @host.id }).body)
+      @host1.host_traces.create!(:id => 1, :host_id => 1, :helper => 'agile', :app_type => 'foo', :application => 'scrumm')
+
+      results = JSON.parse(get(:index, params: { :host_id => @host1.id }).body)
 
       assert_response :success
-      assert_includes results['results'].collect { |item| item['id'] }, @host.host_traces.first.id
+      assert_includes results['results'].collect { |item| item['id'] }, @host1.host_traces.first.id
+    end
+
+    def test_resolve_group_by_helper
+      trace_one = Katello::HostTracer.create(host_id: @host1.id, application: 'rsyslog', app_type: 'daemon', helper: 'systemctl restart rsyslog')
+      trace_two = Katello::HostTracer.create(host_id: @host2.id, application: 'rsyslog', app_type: 'daemon', helper: 'systemctl restart rsyslog')
+      helper = {:helper => trace_two.helper}
+
+      job_invocation = {"description" => "Restart Services", "id" => 1, "job_category" => "Katello"}
+      JobInvocationComposer.expects(:for_feature).with(:katello_service_restart, [@host1.id, @host2.id], helper).returns(mock(trigger: true, job_invocation: job_invocation))
+
+      put :resolve, params: { use_route: 'traces/resolve', :trace_ids => [trace_one.id, trace_two.id]}
+
+      assert_response :success
+
+      response_body = JSON.parse(response.body)
+      assert_equal response_body, [job_invocation]
+    end
+
+    def test_resolve_reboot_service
+      trace = Katello::HostTracer.create(host_id: @host1.id, application: 'kernel', app_type: 'static', helper: 'reboot the system')
+      helper = {:helper => 'reboot'}
+
+      job_invocation = {"description" => "Restart Services", "id" => 1, "job_category" => "Katello"}
+      JobInvocationComposer.expects(:for_feature).with(:katello_service_restart, [@host1.id], helper).returns(mock(trigger: true, job_invocation: job_invocation))
+
+      put :resolve, params: { use_route: 'traces/resolve', :trace_ids => [trace.id]}
+
+      assert_response :success
+
+      response_body = JSON.parse(response.body)
+      assert_equal response_body, [job_invocation]
+    end
+
+    def test_group_by_host_ids
+      trace_one = Katello::HostTracer.create(host_id: @host1.id, application: 'rsyslog', app_type: 'daemon', helper: 'systemctl restart rsyslog')
+      trace_two = Katello::HostTracer.create(host_id: @host2.id, application: 'tuned', app_type: 'daemon', helper: 'systemctl restart tuned')
+      trace_three = Katello::HostTracer.create(host_id: @host2.id, application: 'firewalld', app_type: 'daemon', helper: 'systemctl restart firewalld')
+      job_invocation = {"description" => "Restart Services", "id" => 1, "job_category" => "Katello"}
+      helpers = [trace_two.helper, trace_three.helper].join(',')
+
+      JobInvocationComposer.expects(:for_feature).with(:katello_service_restart, [@host1.id], {:helper => trace_one.helper}).returns(mock(trigger: true, job_invocation: job_invocation))
+      JobInvocationComposer.expects(:for_feature).with(:katello_service_restart, [@host2.id], {:helper => helpers}).returns(mock(trigger: true, job_invocation: job_invocation))
+
+      put :resolve, params: { use_route: 'traces/resolve', :trace_ids => [trace_one.id, trace_two.id, trace_three.id]}
+
+      assert_response :success
+
+      response_body = JSON.parse(response.body)
+      assert_equal [job_invocation, job_invocation], response_body
     end
   end
 end


### PR DESCRIPTION
This PR adds the ability to manage traces on multiple host with the bulk action controller.

Video of the functionality:

https://nimbusweb.me/s/share/4143240/6bngqh187rdak5u2ap42

To test you will need 2 CentOS 7 clients either from forklift or manually installing them and remote_execution on the Katello Devel box.

Katello Devel steps to enable remote execution:

In the foreman directory of the katello-devel box create the following file:

`bundler.d/my.local.rb`

Add in the following:

`gem 'foreman_remote_execution'`

Stop the rails server, then run the following commands:
```bash
bundle install
bundle exec rails db:migrate RAILS_ENV=development
bundle exec rails db:seed RAILS_ENV=development
```
Start the rails server back up.

Client steps:

Install subscription-manager

`# yum install subscription-manager`

Register them to your Katello Devel box

Install katello-host-tools and katello-host-tools-tracer from here:

https://theforeman.org/plugins/katello/3.15/installation/clients.html

Run yum update on both of them to get a list of traces for both clients:

`# yum update -y`

Navigate to Hosts - Content Hosts, select both hosts and do Bulk Actions - Manage Traces

Select a few traces and click on Restart Selected

Unfortunately REX is not working with the devel box so the jobs will goto an error state right away.

You can goto Monitor - Jobs and look at the jobs and confirm the selections of services and reboot got handled correctly.

I will file the redmine issues that I have found for the UI for the next triage session. 