### PR TITLE
Fixes #29519 - Transient test failure: missing org labels

### DIFF
--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -16,6 +16,7 @@ module Katello
 
     def models
       @organization = get_organization
+      fix_organization_mismatches(@organization)
     end
 
     def setup

--- a/test/glue/candlepin/owner_test.rb
+++ b/test/glue/candlepin/owner_test.rb
@@ -6,7 +6,7 @@ module Katello
     include VCR::TestCase
 
     def setup
-      User.current = User.find(FIXTURES['users']['admin']['id'])
+      set_user
     end
   end
 

--- a/test/glue/candlepin/provider_test.rb
+++ b/test/glue/candlepin/provider_test.rb
@@ -10,7 +10,7 @@ module Katello
     # and pared down using the below script to keep this test fast and not load unnecessary data
     # https://github.com/candlepin/candlepin/blob/master/server/bin/manifest_manipulator.rb
     def setup
-      User.current = User.find(FIXTURES['users']['admin']['id'])
+      set_user
       @org = CandlepinOwnerSupport.create_organization('GlueCandlepinProviderTest', 'GlueCandlepinProviderTest')
       manifest_path = File.join(::Katello::Engine.root, 'test', 'fixtures', 'files', 'manifest_small.zip')
       CandlepinOwnerSupport.import_manifest(@org.label, manifest_path)

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -331,7 +331,7 @@ module Katello
     end
 
     def test_package_groups
-      @fedora_17_x86_64 = Repository.find(FIXTURES['katello_repositories']['fedora_17_x86_64']['id'])
+      @fedora_17_x86_64 = katello_repositories(:fedora_17_x86_64)
       package_groups = @fedora_17_x86_64.package_groups
 
       refute_empty package_groups.select { |group| group.name == 'mammals' }
@@ -342,7 +342,7 @@ module Katello
     def setup
       super
 
-      @fedora_17_x86_64_dev = Repository.find(FIXTURES['katello_repositories']['fedora_17_x86_64_dev']['id'])
+      @fedora_17_x86_64_dev = katello_repositories(:fedora_17_x86_64_dev)
 
       RepositorySupport.create_repo(@fedora_17_x86_64)
       RepositorySupport.sync_repo(@fedora_17_x86_64)

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -10,7 +10,6 @@ module Katello
       @katello_id = "KT_Org_Env_View_1"
 
       @org = get_organization
-      @org.label = @org.label.tr(' ', '_')
       @env = katello_environments(:dev)
       @content_view = katello_content_views(:library_dev_view)
       @content_view_puppet_env = katello_content_view_puppet_environments(:library_view_puppet_environment)

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -8,7 +8,6 @@ module Katello
       User.current = User.find(users(:admin).id)
       set_default_location
       @org = get_organization(:empty_organization)
-      @org.label = @org.label.tr(' ', ' ')
     end
 
     def test_active_pools_count

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -4,7 +4,7 @@ module Katello
   class ProductCreateTest < ActiveSupport::TestCase
     def setup
       super
-      User.current = @@admin
+      set_user
       @product = build(:katello_product,
                        :organization => get_organization,
                        :provider => katello_providers(:anonymous)

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -7,7 +7,7 @@ module Katello
       include VCR::TestCase
 
       def setup
-        User.current = User.find(FIXTURES['users']['admin']['id'])
+        set_user
       end
     end
 

--- a/test/services/katello/pulp/smart_proxy_repository_test.rb
+++ b/test/services/katello/pulp/smart_proxy_repository_test.rb
@@ -132,15 +132,15 @@ module Katello
 
       describe "current_repositories_data" do
         let(:repo_lib_cv1) do
-          { "id" => FIXTURES['katello_repositories']['p_forge']['pulp_id'].to_s }
+          { "id" => katello_repositories(:p_forge).pulp_id }
         end
 
         let(:repo_lib_cv2) do
-          { "id" => FIXTURES['katello_repositories']['lib_p_forge']['pulp_id'].to_s }
+          { "id" => katello_repositories(:lib_p_forge).pulp_id }
         end
 
         let(:repo_dev_cv2) do
-          { "id" => FIXTURES['katello_repositories']['dev_p_forge']['pulp_id'].to_s }
+          { "id" => katello_repositories(:dev_p_forge).pulp_id }
         end
 
         let(:lib) do

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -4,10 +4,6 @@ module Katello
   module Service
     class RegistrationManagerTestBase < ActiveSupport::TestCase
       include VCR::TestCase
-
-      def setup
-        User.current = User.find(FIXTURES['users']['admin']['id'])
-      end
     end
 
     class RegistrationManager < RegistrationManagerTestBase
@@ -15,7 +11,7 @@ module Katello
       allow_transactions_for_any_importer
 
       before :all do
-        User.current = users(:admin)
+        set_user
         @content_view = katello_content_views(:library_dev_view)
         @library = katello_environments(:library)
         @content_view_environment = katello_content_view_environments(:library_dev_view_library)


### PR DESCRIPTION
Need to run the tests here a bunch of times to see if it fixes the problem

Aim is to fix this problem: https://ci.theforeman.org/blue/organizations/jenkins/katello-pr-test/detail/katello-pr-test/3389/tests