### PR TITLE
Fixes #29521 - Add hypervisors heartbeat endpoint to CandlepinProxies…

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -13,7 +13,7 @@ module Katello
                                         :available_releases, :serials, :upload_tracer_profile]
     before_action :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
     before_action :authorize_client_or_user, :only => [:consumer_show, :regenerate_identity_certificates, :upload_tracer_profile, :facts, :proxy_jobs_get_path]
-    before_action :authorize_client_or_admin, :only => [:hypervisors_update, :async_hypervisors_update]
+    before_action :authorize_client_or_admin, :only => [:hypervisors_update, :async_hypervisors_update, :hypervisors_heartbeat]
     before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
     before_action :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
                                                :enabled_repos, :available_releases]
@@ -135,6 +135,10 @@ module Katello
         sync_task(::Actions::Katello::Host::Hypervisors, params.except(:controller, :action, :format).to_h)
       end
       render :json => task.output[:results]
+    end
+
+    def hypervisors_heartbeat
+      render json: Katello::Resources::Candlepin::Consumer.hypervisors_heartbeat(owner: params[:owner], reporter_id: params[:reporter_id])
     end
 
     #api :PUT, "/consumers/:id/checkin/", N_("Update consumer check-in time")

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -61,6 +61,12 @@ module Katello
             JSON.parse(response).with_indifferent_access
           end
 
+          def hypervisors_heartbeat(owner:, reporter_id:)
+            url = "/candlepin/hypervisors/#{owner}/heartbeat?reporter_id=#{reporter_id}"
+            response = self.put(url, {}.to_json, self.default_headers).body
+            JSON.parse(response).with_indifferent_access
+          end
+
           def register_hypervisors(params)
             url = "/candlepin/hypervisors"
             url << "?owner=#{params[:owner]}&env=#{params[:env]}"

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -17,6 +17,7 @@ Katello::Engine.routes.draw do
       match '/consumers' => 'candlepin_proxies#consumer_create', :via => :post
       match '/hypervisors' => 'candlepin_proxies#hypervisors_update', :via => :post
       match '/hypervisors/:owner/' => 'candlepin_proxies#async_hypervisors_update', :via => :post
+      match '/hypervisors/:owner/heartbeat' => 'candlepin_proxies#hypervisors_heartbeat', :via => :put
       match '/owners/:organization_id/environments' => 'candlepin_proxies#rhsm_index', :via => :get
       match '/owners/:organization_id/pools' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_pools_path
       match '/owners/:organization_id/servicelevels' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_servicelevels_path

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -32,6 +32,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
   'katello/api/rhsm/candlepin_proxies/regenerate_identity_certificates',
   'katello/api/rhsm/candlepin_proxies/hypervisors_update',
   'katello/api/rhsm/candlepin_proxies/async_hypervisors_update',
+  'katello/api/rhsm/candlepin_proxies/hypervisors_heartbeat',
   'katello/api/rhsm/candlepin_proxies/upload_tracer_profile'
 ]
 

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -301,6 +301,16 @@ module Katello
       end
     end
 
+    describe "hypervisors_heartbeat" do
+      it "sends the request to candlepin" do
+        Katello::Resources::Candlepin::Consumer.expects(:hypervisors_heartbeat).with(owner: @organization.label, reporter_id: 123)
+
+        put :hypervisors_heartbeat, params: { owner: @organization.label, reporter_id: 123 }
+
+        assert_response 200
+      end
+    end
+
     describe "available releases" do
       it "can be listed by matching consumer" do
         # Stub out the current user to simulate consumer auth.


### PR DESCRIPTION
…Controller

To test:

- `yum install subscription-manager virt-who` on your dev box (we need the latest virt-who)
- Install the consumer RPM from /var/www/html on your dev box
- register your dev box to itself with subscription-manager
- set up /etc/virt-who.d/test.conf with your own hostname:
```
[libvirt]
type=libvirt
server=qemu:///system
owner=Default_Organization
env=Library
hypervisor_id=hostname
rhsm_hostname=centos7-katello-devel.example.com

rhsm_proxy_hostname=""
rhsm_username=admin
rhsm_password=changeme
rhsm_prefix=/rhsm
```

- run `sudo virt-who -od` and observe this error:

```
ManagerError: Communication with subscription manager failed with code 404: Server error attempting a PUT to /rhsm/hypervisors/Default_Organization/heartbeat?reporter_id=centos7-katello-deve
l.jturel.example.com-e4c7e8c1cc0d4096b1d61ff1746b6db8 returned status 404
```

Run the same with this PR checked out, and see that there is no error. You can curl the endpoint manually as well:

```
curl http://localhost:3000/rhsm/hypervisors/Default_Organization/heartbeat?reporter_id=foo -X PUT -d '' -H 'Content-Type: application/json' -H 'Accept: application/json' -u 'admin:changeme'
```