### PR TITLE
Fixes #29527 - Load distributor version from a constant

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -1,5 +1,7 @@
 module Katello
   module Glue::Provider
+    DISTRIBUTOR_VERSION = 'sat-6.7'.freeze
+
     def self.included(base)
       base.send :include, InstanceMethods
     end
@@ -73,7 +75,7 @@ module Katello
         params[:capabilities] = Resources::Candlepin::CandlepinPing.ping['managerCapabilities'].inject([]) do |result, element|
           result << {'name' => element}
         end
-        params[:facts] = {:distributor_version => 'sat-6.5'}
+        params[:facts] = {:distributor_version => DISTRIBUTOR_VERSION }
         Resources::Candlepin::UpstreamConsumer.update("#{url}#{upstream['uuid']}", upstream['idCert']['cert'],
                                                       upstream['idCert']['key'], ca_file, params)
       end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -9,7 +9,7 @@ module Katello
 
       def setup
         @upstream_params = { 'apiUrl' => api_url, 'idCert' => { 'key' => '', 'cert' => ''}}
-        expected_params = [expected_url, "", "", nil, { :capabilities => [], :facts => { :distributor_version => "sat-6.5" } }]
+        expected_params = [expected_url, "", "", nil, { :capabilities => [], :facts => { :distributor_version => Katello::Glue::Provider::DISTRIBUTOR_VERSION } }]
         Resources::Candlepin::UpstreamConsumer.expects(:update).with(*expected_params)
         Resources::Candlepin::CandlepinPing.stubs(:ping).returns('managerCapabilities' => [])
       end


### PR DESCRIPTION
This updates the distributor version to 'sat-6.7' and loads it from a constant. This will enable us to override the version with our downstream theme gem, so that we won't have to worry about forgetting to update it in the upstream where it's less crucial. That'll work because we can define the override based on the downstream version.

To test:

- create a manifest and select a version prior to '6.7'.
- import that manifest and refresh it.
- portal should reflect 6.7 as the version instead of whatever was set intially