### PR TITLE
Fixes #29488 - Make modular errata applicable

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -431,8 +431,12 @@ module Katello
       path
     end
 
+    def library_instance_or_self
+      self.library_instance || self
+    end
+
     def generate_repo_path(content_path = nil)
-      _org, _content, content_path = (self.library_instance || self).relative_path.split("/", 3) if content_path.blank?
+      _org, _content, content_path = library_instance_or_self.relative_path.split("/", 3) if content_path.blank?
       content_path = content_path.sub(%r|^/|, '')
       if self.environment
         cve = ContentViewEnvironment.where(:environment_id => self.environment,
@@ -505,7 +509,7 @@ module Katello
         end
       end
       clone = Repository.new(:environment => to_env,
-                     :library_instance => self.library_instance || self,
+                     :library_instance => library_instance_or_self,
                      :root => self.root,
                      :content_view_version => to_version,
                      :saved_checksum_type => checksum_type)

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -12,6 +12,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'},
     {:name => 'katello:upgrades:3.13:republish_deb_metadata'},
     {:name => 'katello:upgrades:3.15:set_sub_facet_dmi_uuid'},
-    {:name => 'katello:upgrades:3.15:reindex_rpm_modular'}
+    {:name => 'katello:upgrades:3.15:reindex_rpm_modular'},
+    {:name => 'katello:upgrades:3.16:update_applicable_el8_hosts'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.16/update_applicable_el8_hosts.rake
+++ b/lib/katello/tasks/upgrades/3.16/update_applicable_el8_hosts.rake
@@ -1,0 +1,29 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.16' do
+      desc <<-DESCRIPTION
+      Update the applicability calculations for Rhel8 hosts.
+      This migration is to be run to address -> https://bugzilla.redhat.com/show_bug.cgi?id=1814095
+      DESCRIPTION
+      task :update_applicable_el8_hosts, [:input_file] => ["environment"] do
+        User.current = User.anonymous_api_admin
+
+        # Find me only those hosts that follow ALL the conditions below
+        # 1) Have a module stream enabled.
+        # 2) Bound to Non Library repositories. (i.e must belong to a CV thats not the default)
+        # 3) Bound repositories must have module streams in them
+        hosts = Host.joins(:content_facet => :content_facet_repositories).
+                 where("#{Host.table_name}.id" => ::Katello::HostAvailableModuleStream.enabled.select(:host_id)).
+                 where("#{Katello::ContentFacetRepository.table_name}.repository_id" =>
+                        ::Katello::Repository.joins(:repository_module_streams).
+                                          in_non_default_view.
+                                          non_archived)
+        hosts.each do |host|
+          available_streams = ::Katello::HostAvailableModuleStream.joins(:available_module_stream).
+                                                enabled.where(:host_id => host).select(:name, :stream)
+          ::Actions::Katello::Host::UploadProfiles.upload_modules_to_pulp(available_streams, host)
+        end
+      end
+    end
+  end
+end

--- a/test/lib/tasks/update_applicable_el8_hosts_test.rb
+++ b/test/lib/tasks/update_applicable_el8_hosts_test.rb
@@ -1,0 +1,53 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class UpdateApplicableEl8HostsTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/3.16/update_applicable_el8_hosts'
+      Rake::Task['katello:upgrades:3.16:update_applicable_el8_hosts'].reenable
+      Rake::Task.define_task(:environment)
+      @host = katello_content_facets(:content_facet_two).host
+    end
+
+    def bind_repos(repo_name = :fedora_17_x86_64_dev)
+      repo = katello_repositories(repo_name)
+      @host.content_facet.bound_repositories << repo
+      @host.content_facet.save!
+    end
+
+    def add_available_module_streams(status = 'enabled')
+      available_module_stream = katello_available_module_streams(:available_module_stream_one)
+      HostAvailableModuleStream.create!(available_module_stream: available_module_stream, host: @host, status: status)
+    end
+
+    def test_applicable_hosts_not_found_non_library
+      bind_repos(:fedora_17_x86_64) # note this is a library repo, so should not get picked
+      add_available_module_streams
+      ::Actions::Katello::Host::UploadProfiles.expects(:upload_modules_to_pulp).never
+      Rake.application.invoke_task('katello:upgrades:3.16:update_applicable_el8_hosts')
+    end
+
+    def test_applicable_hosts_not_found_no_stream
+      # Host with no available module streams
+      bind_repos
+      ::Actions::Katello::Host::UploadProfiles.expects(:upload_modules_to_pulp).never
+      Rake.application.invoke_task('katello:upgrades:3.16:update_applicable_el8_hosts')
+    end
+
+    def test_applicable_hosts_not_found_no_enabled_stream
+      # Host with no available module streams
+      bind_repos
+      add_available_module_streams('unknown')
+      ::Actions::Katello::Host::UploadProfiles.expects(:upload_modules_to_pulp).never
+      Rake.application.invoke_task('katello:upgrades:3.16:update_applicable_el8_hosts')
+    end
+
+    def test_applicable_hosts_found
+      bind_repos
+      add_available_module_streams
+      ::Actions::Katello::Host::UploadProfiles.expects(:upload_modules_to_pulp).once
+      Rake.application.invoke_task('katello:upgrades:3.16:update_applicable_el8_hosts')
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit the applicable errata was not properly
calculated.

Content hosts upload a list of packages, enabled repos and modulemd
information (aka profiles) on every dnf transaction.
* When katello receives this information it passes on pulp to calculate
  Packages, Errata and Module Streams that are applicable.
* Applicable errata is calculated against the "library_instance" of the
  repositories bound to the content host.

However module streams introduce some quirkiness. The prior upload
module stream method would just pass the actual module stream that is
available to the system.

This commit passes the module stream available in the library instance
of the bound repos instead to pulp.

So when new errata get added overtime the new errata would automatically
be marked "applicable".