### PR TITLE
Fixes #29555 - Add description to repository create API

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -209,7 +209,8 @@ module Katello
     end
 
     api :POST, "/repositories", N_("Create a custom repository")
-    param :name, String, :required => true
+    param :name, String, :desc => N_("Name of the repository"), :required => true
+    param :description, String, :desc => N_("Description of the repository"), :required => false
     param_group :repo_create
     param_group :repo
     def create


### PR DESCRIPTION
This PR adds a description parameter so it can be called via `hammer` and I updated the description for the name parameter since `hammer` was showing the help text as blank.

Tests are already using description so didn't update them and they pass locally. 

```shell
[vagrant@hammer hammer-cli-katello]$ hammer repository create --help
Usage:
    hammer repository create [OPTIONS]

Options:
 --description DESCRIPTION                                         Description of the repository
 --name NAME                                                       Name of the repository
 -h, --help                                                        Print help
```