### PR TITLE
Fixes #27501 - Filter private keys in Katello logs

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -488,7 +488,7 @@ module Katello
 
     def process_action(method_name, *args)
       ::Api::V2::BaseController.instance_method(:process_action).bind(self).call(method_name, *args)
-      Rails.logger.debug "With body: #{response.body}\n" unless route_name == 'pull_blob'
+      Rails.logger.debug "With body: #{filter_sensitive_data(response.body)}\n" unless route_name == 'pull_blob'
     end
 
     def item_not_found(item)

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -160,7 +160,7 @@ module Katello
       end
 
       r = Resources::Registry::Proxy.get(@_request.fullpath, headers)
-      logger.debug r
+      logger.debug filter_sensitive_data(r)
       results = JSON.parse(r)
 
       response.header['Docker-Content-Digest'] = "sha256:#{Digest::SHA256.hexdigest(r)}"

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -12,7 +12,9 @@ module Katello
     before_action :authorize_repository_write, only: [:push_manifest]
     skip_before_action :check_content_type, only: [:start_upload_blob, :upload_blob, :finish_upload_blob,
                                                    :chunk_upload_blob, :push_manifest]
-    skip_after_action :log_response_body, :only => [:pull_blob]
+    if defined?(log_response_body)
+      skip_after_action :log_response_body, :only => [:pull_blob]
+    end
 
     wrap_parameters false
 

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -12,9 +12,6 @@ module Katello
     before_action :authorize_repository_write, only: [:push_manifest]
     skip_before_action :check_content_type, only: [:start_upload_blob, :upload_blob, :finish_upload_blob,
                                                    :chunk_upload_blob, :push_manifest]
-    if defined?(log_response_body)
-      skip_after_action :log_response_body, :only => [:pull_blob]
-    end
 
     wrap_parameters false
 

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -73,25 +73,25 @@ module Katello
 
     def get
       r = Resources::Candlepin::Proxy.get(@request_path)
-      logger.debug r
+      logger.debug filter_sensitive_data(r)
       render :json => r
     end
 
     def delete
       r = Resources::Candlepin::Proxy.delete(@request_path, @request_body.read)
-      logger.debug r
+      logger.debug filter_sensitive_data(r)
       render :json => r
     end
 
     def post
       r = Resources::Candlepin::Proxy.post(@request_path, @request_body.read)
-      logger.debug r
+      logger.debug filter_sensitive_data(r)
       render :json => r
     end
 
     def put
       r = Resources::Candlepin::Proxy.put(@request_path, @request_body.read)
-      logger.debug r
+      logger.debug filter_sensitive_data(r)
       render :json => r
     end
 

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -30,6 +30,8 @@ module Katello
 
     prepend_before_action :convert_owner_to_organization_id, :except => [:hypervisors_update, :async_hypervisors_update], :if => lambda { params.key?(:owner) }
     prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create], :if => lambda { params.key?(:organization_id) }
+    # avoid a duplicate log message from Foreman's API::BaseController with private keys not filtered out
+    skip_after_action :log_response_body
 
     def repackage_message
       yield

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -30,8 +30,6 @@ module Katello
 
     prepend_before_action :convert_owner_to_organization_id, :except => [:hypervisors_update, :async_hypervisors_update], :if => lambda { params.key?(:owner) }
     prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create], :if => lambda { params.key?(:organization_id) }
-    # avoid a duplicate log message from Foreman's API::BaseController with private keys not filtered out
-    skip_after_action :log_response_body
 
     def repackage_message
       yield

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -10,6 +10,8 @@ module Katello
     include Foreman::ThreadSession::Cleaner
 
     skip_before_action :setup_has_many_params # TODO: get this working #8862
+    # avoid a duplicate log message from Foreman's API::BaseController with private keys not filtered out
+    skip_after_action :log_response_body
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -2,6 +2,7 @@ module Katello
   module Concerns
     module Api::ApiController
       extend ActiveSupport::Concern
+      include Katello::Concerns::FilterSensitiveData
 
       included do
         include ForemanTasks::Triggers
@@ -38,10 +39,6 @@ module Katello
       def process_action(method_name, *args)
         super(method_name, *args)
         Rails.logger.debug "With body: #{filter_sensitive_data(response.body)}\n"
-      end
-
-      def filter_sensitive_data(payload)
-        payload.gsub(/-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
       end
 
       def split_order(order)

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -37,7 +37,11 @@ module Katello
 
       def process_action(method_name, *args)
         super(method_name, *args)
-        Rails.logger.debug "With body: #{response.body}\n"
+        Rails.logger.debug "With body: #{filter_sensitive_data(response.body)}\n"
+      end
+
+      def filter_sensitive_data(payload)
+        payload.gsub(/-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
       end
 
       def split_order(order)

--- a/app/lib/katello/concerns/filter_sensitive_data.rb
+++ b/app/lib/katello/concerns/filter_sensitive_data.rb
@@ -10,7 +10,7 @@ module Katello
 
       class_methods do
         def filter_sensitive_data(payload)
-          payload.gsub(/-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
+          payload.gsub(/-----BEGIN RSA PRIVATE KEY-----[\s\S]*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
         end
       end
     end

--- a/app/lib/katello/concerns/filter_sensitive_data.rb
+++ b/app/lib/katello/concerns/filter_sensitive_data.rb
@@ -1,0 +1,18 @@
+module Katello
+  module Concerns
+    module FilterSensitiveData
+      extend ActiveSupport::Concern
+
+      # This is called at both the instance and class levels, so must be available as both.
+      def filter_sensitive_data(payload)
+        self.class.filter_sensitive_data(payload)
+      end
+
+      class_methods do
+        def filter_sensitive_data(payload)
+          payload.gsub(/-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -15,6 +15,8 @@ module Katello
       end
     end
 
+    include Katello::Concerns::FilterSensitiveData
+
     class_attribute :consumer_secret, :consumer_key, :ca_cert_file, :prefix, :site, :default_headers,
                     :ssl_client_cert, :ssl_client_key
 
@@ -60,10 +62,6 @@ module Katello
           end
         end
         fail RestClientException, {:message => message, :service_code => service_code, :code => status_code}, caller
-      end
-
-      def filter_sensitive_data(payload)
-        payload.gsub(/-----BEGIN RSA PRIVATE KEY-----.*-----END RSA PRIVATE KEY-----/, '[filtered]')
       end
 
       def print_debug_info(_a_path, headers = {}, payload = {})

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -76,7 +76,7 @@ module Katello
                  else v
                  end
         end
-        logger.debug "Body: #{payload_to_print.to_json}"
+        logger.debug "Body: #{filter_sensitive_data(payload_to_print.to_json)}"
       rescue
         logger.debug "Unable to print debug information"
       end


### PR DESCRIPTION
This change filters out RSA private keys before they're logged.  In the log file, the private key is replaced with `[private key filtered]`.

To test:

```
tail -f log/development.log | grep "BEGIN RSA PRIVATE KEY"
```
* Navigate to Katello pages (subscriptions, Red Hat Repositories, etc.)
* Verify that no private keys are logged
* Compare results with `master`