### PR TITLE
Fixes #29228 - Ignore 404 on delete

### DIFF
--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -78,15 +78,19 @@ module Katello
           PulpcoreClient::Upload
         end
 
+        def ignore_404_exception(*)
+          yield
+        rescue self.class.api_exception_class => e
+          raise e unless e.code == 404
+          nil
+        end
+
         def delete_orphans
           [orphans_api.delete]
         end
 
         def delete_remote(remote_href)
-          remotes_api.delete(remote_href)
-        rescue self.class.api_exception_class => e
-          raise e if e.code != 404
-          nil
+          ignore_404_exception { remotes_api.delete(remote_href) }
         end
 
         def repository_versions(options = {})
@@ -111,17 +115,11 @@ module Katello
         end
 
         def get_distribution(href)
-          distributions_api.read(href)
-        rescue self.class.api_exception_class => e
-          raise e if e.code != 404
-          nil
+          ignore_404_exception { distributions_api.read(href) }
         end
 
         def delete_distribution(href)
-          distributions_api.delete(href)
-        rescue self.class.api_exception_class => e
-          raise e if e.code != 404
-          nil
+          ignore_404_exception { distributions_api.delete(href) }
         end
 
         def list_all(options = {})

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -84,6 +84,9 @@ module Katello
 
         def delete_remote(remote_href)
           remotes_api.delete(remote_href)
+        rescue self.class.api_exception_class => e
+          raise e if e.code != 404
+          nil
         end
 
         def repository_versions(options = {})

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -74,6 +74,9 @@ module Katello
 
       def delete_remote(href = repo.remote_href)
         api.remotes_api.delete(href) if href
+      rescue api.class.api_exception_class => e
+        raise e if e.code != 404
+        nil
       end
 
       def self.instance_for_type(repo, smart_proxy)
@@ -177,6 +180,9 @@ module Katello
       def delete(href = repository_reference.try(:repository_href))
         repository_reference.try(:destroy)
         api.repositories_api.delete(href) if href
+      rescue api.class.api_exception_class => e
+        raise e if e.code != 404
+        nil
       end
 
       def sync
@@ -232,6 +238,9 @@ module Katello
 
       def delete_version
         api.repository_versions_api.delete(repo.version_href)
+      rescue api.class.api_exception_class => e
+        raise e if e.code != 404
+        nil
       end
 
       def create_version(options = {})
@@ -252,6 +261,9 @@ module Katello
           api.delete_distribution(dist_ref.href)
           dist_ref.destroy!
         end
+      rescue api.class.api_exception_class => e
+        raise e if e.code != 404
+        nil
       end
 
       def delete_distributions_by_path
@@ -298,14 +310,14 @@ module Katello
 
       def lookup_version(href)
         api.repository_versions_api.read(href) if href
-      rescue api.api_exception_class => e
+      rescue api.class.api_exception_class => e
         Rails.logger.error "Exception when calling repository_versions_api->read: #{e}"
         nil
       end
 
       def lookup_publication(href)
         api.publications_api.read(href) if href
-      rescue api.api_exception_class => e
+      rescue api.class.api_exception_class => e
         Rails.logger.error "Exception when calling publications_api->read: #{e}"
         nil
       end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -52,6 +52,9 @@ module Katello
 
       def delete(href = repository_href)
         api.repositories_api.delete(href) if href
+      rescue api.class.api_exception_class => e
+        raise e if e.code != 404
+        nil
       end
 
       def repository_href

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/delete_deleted_distribution_references.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/delete_deleted_distribution_references.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -89,7 +89,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -113,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -134,7 +134,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -158,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -179,7 +179,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:31 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
@@ -205,13 +205,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/861e8a6c-ca3e-433c-9215-e09050d01a89/"
+      - "/pulp/api/v3/repositories/file/file/e9ed39b2-c6dc-4f04-9fb8-74fba0e22761/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -226,17 +226,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIxNS1lMDkwNTBkMDFhODkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wNC0yNFQxMzoxMjozNC43MDM4MjVaIiwi
+        ZmlsZS9lOWVkMzliMi1jNmRjLTRmMDQtOWZiOC03NGZiYTBlMjI3NjEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wNC0yNFQxMzoxMjozMS4yMDc4ODFaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzg2MWU4YTZjLWNhM2UtNDMzYy05MjE1LWUwOTA1MGQwMWE4OS92
+        ZS9maWxlL2U5ZWQzOWIyLWM2ZGMtNGYwNC05ZmI4LTc0ZmJhMGUyMjc2MS92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvODYxZThhNmMtY2EzZS00MzNjLTky
-        MTUtZTA5MDUwZDAxYTg5L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvZTllZDM5YjItYzZkYy00ZjA0LTlm
+        YjgtNzRmYmEwZTIyNzYxL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
         bnVsbH0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:31 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
@@ -265,13 +265,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/86cef936-46de-438c-95b2-78221f4cb87d/"
+      - "/pulp/api/v3/remotes/file/file/d056eae1-8cb0-4694-8d60-726745a7932f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -286,16 +286,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ODZjZWY5MzYtNDZkZS00MzhjLTk1YjItNzgyMjFmNGNiODdkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzQuNzc5MzE1WiIsIm5hbWUi
+        ZDA1NmVhZTEtOGNiMC00Njk0LThkNjAtNzI2NzQ1YTc5MzJmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzEuMjg3MTEyWiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzQuNzc5MzI5WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzEuMjg3MTM2WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:31 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/file/file/
@@ -303,8 +303,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIxNS1lMDkwNTBk
-        MDFhODkvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS9lOWVkMzliMi1jNmRjLTRmMDQtOWZiOC03NGZiYTBl
+        MjI3NjEvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -341,13 +341,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZjgxZWFlLTUxOGYtNDA2
-        NC1hODdkLTljMmJhMzUzYmI5Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNjU2NWQwLWFhY2EtNDRh
+        MS1iOTViLTg4MDFkYTdkODc0Yy8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:31 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/bef81eae-518f-4064-a87d-9c2ba353bb97/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/2b6565d0-aaca-44a1-b95b-8801da7d874c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -368,7 +368,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -386,23 +386,23 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmVmODFlYWUtNTE4
-        Zi00MDY0LWE4N2QtOWMyYmEzNTNiYjk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzUuMDcyMzMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI2NTY1ZDAtYWFj
+        YS00NGExLWI5NWItODgwMWRhN2Q4NzRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MzEuNzkxMDYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuMTY4MDcz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNS4yNjI3NTRa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzEuODc2NDM5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozMS45NDQyMjRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzNiZmM4MWIxLThhZjgtNGZiMy1iN2IzLWUwYjE0MDg4MzZjYy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNjQ3ZDY4
-        NjEtNjdmMC00NDgxLThlZjItYTQxZDBkMmExMDA4LyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNDFiYjdj
+        OTktZGRjYS00NDdiLWJjYTEtZTJmNzk3NGEwZWVjLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzg2MWU4YTZjLWNhM2UtNDMzYy05MjE1LWUwOTA1MGQwMWE4
-        OS8iXX0=
+        ZmlsZS9maWxlL2U5ZWQzOWIyLWM2ZGMtNGYwNC05ZmI4LTc0ZmJhMGUyMjc2
+        MS8iXX0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:32 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/
@@ -412,8 +412,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015
         X0ZpbGVzIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
         TXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNh
-        dGlvbnMvZmlsZS9maWxlLzY0N2Q2ODYxLTY3ZjAtNDQ4MS04ZWYyLWE0MWQw
-        ZDJhMTAwOC8ifQ==
+        dGlvbnMvZmlsZS9maWxlLzQxYmI3Yzk5LWRkY2EtNDQ3Yi1iY2ExLWUyZjc5
+        NzRhMGVlYy8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -431,7 +431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -449,13 +449,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmOTllMWNlLWQ1MzItNGJk
-        Zi1iZDA5LTg1MzkxNGI5NDc5Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwNGMzNDExLThjMjctNGQw
+        MC1hYzI2LTA5NDdhYzM2MDNjMC8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:32 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/3f99e1ce-d532-4bdf-bd09-853914b94792/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/104c3411-8c27-4d00-ac26-0947ac3603c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -476,7 +476,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -490,28 +490,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '346'
+      - '347'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y5OWUxY2UtZDUz
-        Mi00YmRmLWJkMDktODUzOTE0Yjk0NzkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzUuNDA5OTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTA0YzM0MTEtOGMy
+        Ny00ZDAwLWFjMjYtMDk0N2FjMzYwM2MwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MzIuMDk1MjA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuNTMzMzk4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNS43ODM5ODFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzIuMjQyNzY2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozMi40NTUyNjVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzkyZTQ5
-        YzFkLWRlOTQtNDM5NC05ZGNkLTA3MWFmNDA0YWYwYi8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2NhMjBm
+        MzEwLTllMDMtNDI0Yy1iMDJlLTM0Y2RmODNlZjNmMy8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:32 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/92e49c1d-de94-4394-9dcd-071af404af0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/ca20f310-9e03-424c-b02e-34cdf83ef3f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -532,7 +532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -546,26 +546,26 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '287'
+      - '286'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvOTJlNDljMWQtZGU5NC00Mzk0LTlkY2QtMDcxYWY0MDRhZjBiLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuNzcwOTAxWiIs
+        L2ZpbGUvY2EyMGYzMTAtOWUwMy00MjRjLWIwMmUtMzRjZGY4M2VmM2YzLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzIuNDQyNDU3WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
         RmlsZXMiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWthdGVsbG8tZGV2
         ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L015X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6
         bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
         RmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlv
-        bnMvZmlsZS9maWxlLzY0N2Q2ODYxLTY3ZjAtNDQ4MS04ZWYyLWE0MWQwZDJh
-        MTAwOC8ifQ==
+        bnMvZmlsZS9maWxlLzQxYmI3Yzk5LWRkY2EtNDQ3Yi1iY2ExLWUyZjc5NzRh
+        MGVlYy8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:32 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/86cef936-46de-438c-95b2-78221f4cb87d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/ca20f310-9e03-424c-b02e-34cdf83ef3f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -586,7 +586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -604,13 +604,58 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzODUyODhmLTQyZjQtNDc5
-        NS04N2RlLTVkNzViMTg5MTdjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2MGVjN2FhLTE2NDItNGM3
+        NC05NzFlLWYyNjdlMGE4NDRhYS8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:32 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/d056eae1-8cb0-4694-8d60-726745a7932f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 24 Apr 2020 13:12:33 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4MTIwY2VhLTFmZDgtNDhi
+        ZC05YjA2LTI5ODU4N2ViNDc1NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 24 Apr 2020 13:12:33 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8385288f-42f4-4795-87de-5d75b18917c8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/88120cea-1fd8-48bd-9b06-298587eb4755/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -631,7 +676,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -645,28 +690,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM4NTI4OGYtNDJm
-        NC00Nzk1LTg3ZGUtNWQ3NWIxODkxN2M4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzYuMDc5MjA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODgxMjBjZWEtMWZk
+        OC00OGJkLTliMDYtMjk4NTg3ZWI0NzU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MzMuMTM1NjM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzYuMTY3OTQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNi4yMjU5Njha
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzMuMjMxNDg5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozMy4yNzcyNTda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
+        LzNiZmM4MWIxLThhZjgtNGZiMy1iN2IzLWUwYjE0MDg4MzZjYy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS84NmNlZjkzNi00NmRlLTQzOGMtOTViMi03
-        ODIyMWY0Y2I4N2QvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS9kMDU2ZWFlMS04Y2IwLTQ2OTQtOGQ2MC03
+        MjY3NDVhNzkzMmYvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:33 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/92e49c1d-de94-4394-9dcd-071af404af0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/e9ed39b2-c6dc-4f04-9fb8-74fba0e22761/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -687,7 +732,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -705,58 +750,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4ZGM3MTZhLTA3ZTMtNDQ1
-        MC1iNGVmLWM0ZTRkMDUxNTdkNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiMDQ5YjBiLWM5ZWQtNDZh
+        OS05YzI2LWQ0ZDliNzUwOTNhMS8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
-- request:
-    method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/861e8a6c-ca3e-433c-9215-e09050d01a89/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.2.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 centos7-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlYzExNjIwLWFiMWItNDQ3
-        Yi1hYTMyLWQzOWVkYTcwYWJkZi8ifQ==
-    http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:33 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/fec11620-ab1b-447b-aa32-d39eda70abdf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/ab049b0b-c9ed-46a9-9c26-d4d9b75093a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:45 GMT
+      - Fri, 24 Apr 2020 13:12:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -791,23 +791,23 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVjMTE2MjAtYWIx
-        Yi00NDdiLWFhMzItZDM5ZWRhNzBhYmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzYuMzc1NDk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWIwNDliMGItYzll
+        ZC00NmE5LTljMjYtZDRkOWI3NTA5M2ExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MzMuMzcwODQ1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA0LTI0VDEzOjEyOjM2LjUzNDYyNVoi
-        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDUuNjU0OTg4WiIs
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA0LTI0VDEzOjEyOjMzLjQ2OTk0NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzMuNTUxMzI4WiIs
         ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
         NTlkNWZlOC02ZDkxLTRkYTMtYTY3Ny0wNTRmYjc5NWY0ZTcvIiwicGFyZW50
         X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
         bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
         XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIx
-        NS1lMDkwNTBkMDFhODkvIl19
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9lOWVkMzliMi1jNmRjLTRmMDQtOWZi
+        OC03NGZiYTBlMjI3NjEvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:45 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:33 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/delete_deleted_remote_references.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/delete_deleted_remote_references.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:27 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -89,7 +89,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:27 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -113,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -134,7 +134,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:27 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -158,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -179,7 +179,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:27 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
@@ -205,13 +205,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/861e8a6c-ca3e-433c-9215-e09050d01a89/"
+      - "/pulp/api/v3/repositories/file/file/4f0c97c8-31cd-4f78-abe5-e1979ba87720/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -226,17 +226,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIxNS1lMDkwNTBkMDFhODkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wNC0yNFQxMzoxMjozNC43MDM4MjVaIiwi
+        ZmlsZS80ZjBjOTdjOC0zMWNkLTRmNzgtYWJlNS1lMTk3OWJhODc3MjAvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wNC0yNFQxMzoxMjoyNy44ODg4MDRaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzg2MWU4YTZjLWNhM2UtNDMzYy05MjE1LWUwOTA1MGQwMWE4OS92
+        ZS9maWxlLzRmMGM5N2M4LTMxY2QtNGY3OC1hYmU1LWUxOTc5YmE4NzcyMC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvODYxZThhNmMtY2EzZS00MzNjLTky
-        MTUtZTA5MDUwZDAxYTg5L3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNGYwYzk3YzgtMzFjZC00Zjc4LWFi
+        ZTUtZTE5NzliYTg3NzIwL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
         bnVsbH0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:27 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
@@ -265,13 +265,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:34 GMT
+      - Fri, 24 Apr 2020 13:12:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/86cef936-46de-438c-95b2-78221f4cb87d/"
+      - "/pulp/api/v3/remotes/file/file/4fe80f87-cebe-4bd9-8870-8cb26d72afe2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -286,16 +286,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ODZjZWY5MzYtNDZkZS00MzhjLTk1YjItNzgyMjFmNGNiODdkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzQuNzc5MzE1WiIsIm5hbWUi
+        NGZlODBmODctY2ViZS00YmQ5LTg4NzAtOGNiMjZkNzJhZmUyLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MjcuOTk0NzE5WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzQuNzc5MzI5WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MjcuOTk0NzM4WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:34 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:28 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/file/file/
@@ -303,8 +303,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIxNS1lMDkwNTBk
-        MDFhODkvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS80ZjBjOTdjOC0zMWNkLTRmNzgtYWJlNS1lMTk3OWJh
+        ODc3MjAvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -341,13 +341,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZjgxZWFlLTUxOGYtNDA2
-        NC1hODdkLTljMmJhMzUzYmI5Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4Y2E4MjNhLTY3ODctNDlh
+        MS04OWJhLTZmYWMwYmJlYjdiZi8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:28 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/bef81eae-518f-4064-a87d-9c2ba353bb97/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/d8ca823a-6787-49a1-89ba-6fac0bbeb7bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -368,7 +368,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -382,27 +382,27 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '372'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmVmODFlYWUtNTE4
-        Zi00MDY0LWE4N2QtOWMyYmEzNTNiYjk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzUuMDcyMzMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDhjYTgyM2EtNjc4
+        Ny00OWExLTg5YmEtNmZhYzBiYmViN2JmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MjguMzM2MDU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuMTY4MDcz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNS4yNjI3NTRa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MjguNDQ3Njgz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjoyOC41MTY4NjJa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzNiZmM4MWIxLThhZjgtNGZiMy1iN2IzLWUwYjE0MDg4MzZjYy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNjQ3ZDY4
-        NjEtNjdmMC00NDgxLThlZjItYTQxZDBkMmExMDA4LyJdLCJyZXNlcnZlZF9y
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYjQxYjcz
+        NzMtNmJmOC00MWQwLWE4ZDItZGVlNTc1ZjhlYTM1LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzg2MWU4YTZjLWNhM2UtNDMzYy05MjE1LWUwOTA1MGQwMWE4
-        OS8iXX0=
+        ZmlsZS9maWxlLzRmMGM5N2M4LTMxY2QtNGY3OC1hYmU1LWUxOTc5YmE4Nzcy
+        MC8iXX0=
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:28 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/
@@ -412,8 +412,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015
         X0ZpbGVzIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
         TXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNh
-        dGlvbnMvZmlsZS9maWxlLzY0N2Q2ODYxLTY3ZjAtNDQ4MS04ZWYyLWE0MWQw
-        ZDJhMTAwOC8ifQ==
+        dGlvbnMvZmlsZS9maWxlL2I0MWI3MzczLTZiZjgtNDFkMC1hOGQyLWRlZTU3
+        NWY4ZWEzNS8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -431,7 +431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -449,13 +449,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmOTllMWNlLWQ1MzItNGJk
-        Zi1iZDA5LTg1MzkxNGI5NDc5Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1ZjgyZmQ1LTc5ODAtNGQy
+        Zi05N2E5LTFlZTVkMmM1NDQxYy8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:28 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/3f99e1ce-d532-4bdf-bd09-853914b94792/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/35f82fd5-7980-4d2f-97a9-1ee5d2c5441c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -476,7 +476,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -490,28 +490,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '346'
+      - '348'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y5OWUxY2UtZDUz
-        Mi00YmRmLWJkMDktODUzOTE0Yjk0NzkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzUuNDA5OTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzVmODJmZDUtNzk4
+        MC00ZDJmLTk3YTktMWVlNWQyYzU0NDFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MjguNjY1NjAwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuNTMzMzk4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNS43ODM5ODFa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MjguNzUwMzUx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjoyOS4wMDE4NjNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
+        LzNiZmM4MWIxLThhZjgtNGZiMy1iN2IzLWUwYjE0MDg4MzZjYy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzkyZTQ5
-        YzFkLWRlOTQtNDM5NC05ZGNkLTA3MWFmNDA0YWYwYi8iXSwicmVzZXJ2ZWRf
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlLzkxMTdk
+        N2M5LWExMTItNDUyYi1iNTBmLTVlMTI1OTUzMmI0ZC8iXSwicmVzZXJ2ZWRf
         cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/92e49c1d-de94-4394-9dcd-071af404af0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/9117d7c9-a112-452b-b50f-5e1259532b4d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -532,7 +532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:35 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -546,26 +546,26 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '287'
+      - '290'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvOTJlNDljMWQtZGU5NC00Mzk0LTlkY2QtMDcxYWY0MDRhZjBiLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MzUuNzcwOTAxWiIs
+        L2ZpbGUvOTExN2Q3YzktYTExMi00NTJiLWI1MGYtNWUxMjU5NTMyYjRkLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6MjguOTg1ODU4WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
         RmlsZXMiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWthdGVsbG8tZGV2
         ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L015X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6
         bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
         RmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlv
-        bnMvZmlsZS9maWxlLzY0N2Q2ODYxLTY3ZjAtNDQ4MS04ZWYyLWE0MWQwZDJh
-        MTAwOC8ifQ==
+        bnMvZmlsZS9maWxlL2I0MWI3MzczLTZiZjgtNDFkMC1hOGQyLWRlZTU3NWY4
+        ZWEzNS8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:35 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/86cef936-46de-438c-95b2-78221f4cb87d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/4fe80f87-cebe-4bd9-8870-8cb26d72afe2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -586,7 +586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -604,13 +604,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzODUyODhmLTQyZjQtNDc5
-        NS04N2RlLTVkNzViMTg5MTdjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1OGZlN2FiLWY5YjAtNDYx
+        Zi04ZjU2LTkxMjkwZDQyZTllZS8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8385288f-42f4-4795-87de-5d75b18917c8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/e58fe7ab-f9b0-461f-8f56-91290d42e9ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -631,7 +631,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -645,28 +645,73 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM4NTI4OGYtNDJm
-        NC00Nzk1LTg3ZGUtNWQ3NWIxODkxN2M4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzYuMDc5MjA0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTU4ZmU3YWItZjli
+        MC00NjFmLThmNTYtOTEyOTBkNDJlOWVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MjkuMjQ5MTIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzYuMTY3OTQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjozNi4yMjU5Njha
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MjkuMzcxMDI2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjoyOS40MTMyNzBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL2ZpbGUvZmlsZS84NmNlZjkzNi00NmRlLTQzOGMtOTViMi03
-        ODIyMWY0Y2I4N2QvIl19
+        My9yZW1vdGVzL2ZpbGUvZmlsZS80ZmU4MGY4Ny1jZWJlLTRiZDktODg3MC04
+        Y2IyNmQ3MmFmZTIvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/92e49c1d-de94-4394-9dcd-071af404af0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/4fe80f87-cebe-4bd9-8870-8cb26d72afe2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 24 Apr 2020 13:12:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/9117d7c9-a112-452b-b50f-5e1259532b4d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -687,7 +732,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -705,13 +750,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4ZGM3MTZhLTA3ZTMtNDQ1
-        MC1iNGVmLWM0ZTRkMDUxNTdkNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyMDIxMjllLTg2OGYtNDBk
+        Zi05ZDY4LWI0NmU5YzhlYmU2My8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/861e8a6c-ca3e-433c-9215-e09050d01a89/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/4f0c97c8-31cd-4f78-abe5-e1979ba87720/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -732,7 +777,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:36 GMT
+      - Fri, 24 Apr 2020 13:12:29 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -750,13 +795,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlYzExNjIwLWFiMWItNDQ3
-        Yi1hYTMyLWQzOWVkYTcwYWJkZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxMWU2M2QzLTNiNTgtNDM3
+        Ny1iZjNjLWIxMGJkYjBjOWM5My8ifQ==
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:36 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:29 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/fec11620-ab1b-447b-aa32-d39eda70abdf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/d11e63d3-3b58-4377-bf3c-b10bdb0c9c93/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +822,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 24 Apr 2020 13:12:45 GMT
+      - Fri, 24 Apr 2020 13:12:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -791,23 +836,23 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '340'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVjMTE2MjAtYWIx
-        Yi00NDdiLWFhMzItZDM5ZWRhNzBhYmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDQtMjRUMTM6MTI6MzYuMzc1NDk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDExZTYzZDMtM2I1
+        OC00Mzc3LWJmM2MtYjEwYmRiMGM5YzkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6MjkuNzk4NDA2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA0LTI0VDEzOjEyOjM2LjUzNDYyNVoi
-        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDUuNjU0OTg4WiIs
-        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
-        NTlkNWZlOC02ZDkxLTRkYTMtYTY3Ny0wNTRmYjc5NWY0ZTcvIiwicGFyZW50
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA0LTI0VDEzOjEyOjI5Ljk4MTkyMloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6MzAuMDgzMTIzWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8z
+        YmZjODFiMS04YWY4LTRmYjMtYjdiMy1lMGIxNDA4ODM2Y2MvIiwicGFyZW50
         X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
         bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
         XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84NjFlOGE2Yy1jYTNlLTQzM2MtOTIx
-        NS1lMDkwNTBkMDFhODkvIl19
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80ZjBjOTdjOC0zMWNkLTRmNzgtYWJl
+        NS1lMTk3OWJhODc3MjAvIl19
     http_version: 
-  recorded_at: Fri, 24 Apr 2020 13:12:45 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:30 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/repository_reference_is_deleted.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_delete/repository_reference_is_deleted.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -89,7 +89,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -113,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -134,7 +134,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -158,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -179,7 +179,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
@@ -205,13 +205,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/2a37be98-40d5-484b-b6f5-9469ac094ea2/"
+      - "/pulp/api/v3/repositories/file/file/1ad5f2e5-817e-4ca6-a20a-d62d1f93613d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -226,17 +226,17 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8yYTM3YmU5OC00MGQ1LTQ4NGItYjZmNS05NDY5YWMwOTRlYTIvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMC0wMy0yM1QyMzo0ODoxOS41MTcyMjNaIiwi
+        ZmlsZS8xYWQ1ZjJlNS04MTdlLTRjYTYtYTIwYS1kNjJkMWY5MzYxM2QvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMC0wNC0yNFQxMzoxMjo0Ni44NDQxNzZaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzJhMzdiZTk4LTQwZDUtNDg0Yi1iNmY1LTk0NjlhYzA5NGVhMi92
+        ZS9maWxlLzFhZDVmMmU1LTgxN2UtNGNhNi1hMjBhLWQ2MmQxZjkzNjEzZC92
         ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMmEzN2JlOTgtNDBkNS00ODRiLWI2
-        ZjUtOTQ2OWFjMDk0ZWEyL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMWFkNWYyZTUtODE3ZS00Y2E2LWEy
+        MGEtZDYyZDFmOTM2MTNkL3ZlcnNpb25zLzAvIiwibmFtZSI6IkRlZmF1bHRf
         T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
         bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
@@ -265,13 +265,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:46 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/c661fed9-f88c-4793-a6b9-dad12e42fee6/"
+      - "/pulp/api/v3/remotes/file/file/4d9adc9b-e918-4cf7-ad74-6da545a0afe6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -286,16 +286,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        YzY2MWZlZDktZjg4Yy00NzkzLWE2YjktZGFkMTJlNDJmZWU2LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjAtMDMtMjNUMjM6NDg6MTkuNTk5NDQ1WiIsIm5hbWUi
+        NGQ5YWRjOWItZTkxOC00Y2Y3LWFkNzQtNmRhNTQ1YTBhZmU2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6NDYuOTI3OTA2WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjAtMDMtMjNUMjM6NDg6MTkuNTk5NDY4WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6NDYuOTI3OTE5WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:46 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/file/file/
@@ -303,8 +303,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS8yYTM3YmU5OC00MGQ1LTQ4NGItYjZmNS05NDY5YWMw
-        OTRlYTIvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        aWVzL2ZpbGUvZmlsZS8xYWQ1ZjJlNS04MTdlLTRjYTYtYTIwYS1kNjJkMWY5
+        MzYxM2QvdmVyc2lvbnMvMC8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
         fQ==
     headers:
       Content-Type:
@@ -323,7 +323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:19 GMT
+      - Fri, 24 Apr 2020 13:12:47 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -341,13 +341,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0MjkyNGM0LTY4MGQtNDMy
-        Yy05NjNmLTAwYzE4MTVkMDNhNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3OTZlMDEzLTNhOTQtNDBm
+        Zi1iN2UyLWJlNWUxNjk5ZTY3NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:19 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:47 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/042924c4-680d-432c-963f-00c1815d03a4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/e796e013-3a94-40ff-b7e2-be5e1699e675/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -368,7 +368,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:47 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -382,25 +382,27 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '345'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDQyOTI0YzQtNjgw
-        ZC00MzJjLTk2M2YtMDBjMTgxNWQwM2E0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDMtMjNUMjM6NDg6MTkuODM0NzU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTc5NmUwMTMtM2E5
+        NC00MGZmLWI3ZTItYmU1ZTE2OTllNjc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6NDcuMjYyMTM2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3MucHVibGlzaGluZy5wdWJs
-        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDMtMjNUMjM6NDg6MTkuOTE2MTI3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wMy0yM1QyMzo0ODoxOS45NjMyOTZa
+        aXNoIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDcuMzQ3MTg2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjo0Ny40MTIxODNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzFiYWUwMThkLTkyYTQtNGIzMS05YmFlLTFjODJhYTQ4NGI4ZC8iLCJwcm9n
-        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
-        YXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZWViZGE1MzYtOTRhOC00
-        MGQ3LWE1M2QtZTUyNGJhNjVkNThmLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
-        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzJhMzdiZTk4LTQwZDUtNDg0Yi1iNmY1LTk0NjlhYzA5NGVhMi8iXX0=
+        LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNTQwMjVj
+        YTEtOTRlZi00MmRjLWJjOGItOGJjMGIwNzllNzYwLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzFhZDVmMmU1LTgxN2UtNGNhNi1hMjBhLWQ2MmQxZjkzNjEz
+        ZC8iXX0=
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:47 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/
@@ -410,8 +412,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015
         X0ZpbGVzIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
         TXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNh
-        dGlvbnMvZmlsZS9maWxlL2VlYmRhNTM2LTk0YTgtNDBkNy1hNTNkLWU1MjRi
-        YTY1ZDU4Zi8ifQ==
+        dGlvbnMvZmlsZS9maWxlLzU0MDI1Y2ExLTk0ZWYtNDJkYy1iYzhiLThiYzBi
+        MDc5ZTc2MC8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -429,7 +431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:47 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -447,13 +449,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0NmM2Y2FlLTg0NmEtNDAz
-        YS1iMjVjLWE1NWNkODRhZTFiOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2NmY0ZTE4LWI3ZjgtNGNk
+        MS04NGFlLWQ0YjJiZmUyYjc4NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:47 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/a46c6cae-846a-403a-b25c-a55cd84ae1b9/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/666f4e18-b7f8-4cd1-84ae-d4b2bfe2b785/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -474,7 +476,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:47 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -488,27 +490,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '322'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQ2YzZjYWUtODQ2
-        YS00MDNhLWIyNWMtYTU1Y2Q4NGFlMWI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDMtMjNUMjM6NDg6MjAuMDY3NTA5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjY2ZjRlMTgtYjdm
+        OC00Y2QxLTg0YWUtZDRiMmJmZTJiNzg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6NDcuNTE2Njc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDMtMjNUMjM6NDg6MjAuMTM2OTgy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wMy0yM1QyMzo0ODoyMC4yOTY3MDBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDcuNTk4MDQ5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjo0Ny44MDgwMjNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzFiYWUwMThkLTkyYTQtNGIzMS05YmFlLTFjODJhYTQ4NGI4ZC8iLCJwcm9n
-        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAv
-        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2ViZTUwZjc2LWY2MjEt
-        NDE1Zi1hMzQwLTU3MzYzYjNiNjc3Mi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
-        X3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
+        LzA1OWQ1ZmU4LTZkOTEtNGRhMy1hNjc3LTA1NGZiNzk1ZjRlNy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmlsZS9maWxlL2YzMjE0
+        MjFlLTBlZTMtNDkyNS04ODFiLTk3ZGE1NWNhMmVmNS8iXSwicmVzZXJ2ZWRf
+        cmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:47 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/ebe50f76-f621-415f-a340-57363b3b6772/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/f321421e-0ee3-4925-881b-97da55ca2ef5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -529,7 +532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:47 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -543,26 +546,26 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '288'
+      - '289'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvZWJlNTBmNzYtZjYyMS00MTVmLWEzNDAtNTczNjNiM2I2NzcyLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDMtMjNUMjM6NDg6MjAuMjg4NDI3WiIs
+        L2ZpbGUvZjMyMTQyMWUtMGVlMy00OTI1LTg4MWItOTdkYTU1Y2EyZWY1LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjAtMDQtMjRUMTM6MTI6NDcuNzc4MDA2WiIs
         ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
         RmlsZXMiLCJiYXNlX3VybCI6Imh0dHA6Ly9jZW50b3M3LWthdGVsbG8tZGV2
         ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L015X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6
         bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
         RmlsZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlv
-        bnMvZmlsZS9maWxlL2VlYmRhNTM2LTk0YTgtNDBkNy1hNTNkLWU1MjRiYTY1
-        ZDU4Zi8ifQ==
+        bnMvZmlsZS9maWxlLzU0MDI1Y2ExLTk0ZWYtNDJkYy1iYzhiLThiYzBiMDc5
+        ZTc2MC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:47 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/c661fed9-f88c-4793-a6b9-dad12e42fee6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/4d9adc9b-e918-4cf7-ad74-6da545a0afe6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -583,7 +586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:48 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -601,13 +604,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwNzY5NDE5LWI2ZDktNDVk
-        MC05YTBjLWM1YjVlZTI5OWMxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxMzhlMTU0LWFkMjEtNGFl
+        YS05M2VhLTc5ZTgyMDJlNzc2Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:48 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/60769419-b6d9-45d0-9a0c-c5b5ee299c1d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/6138e154-ad21-4aea-93ea-79e8202e776f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -628,7 +631,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:48 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -642,27 +645,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '314'
+      - '337'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjA3Njk0MTktYjZk
-        OS00NWQwLTlhMGMtYzViNWVlMjk5YzFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDMtMjNUMjM6NDg6MjAuNjA2MTk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjEzOGUxNTQtYWQy
+        MS00YWVhLTkzZWEtNzllODIwMmU3NzZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6NDguMTQzNzEzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDMtMjNUMjM6NDg6MjAuNjg5NjQz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wMy0yM1QyMzo0ODoyMC43MTc2Mzla
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDguMjM3MDcx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wNC0yNFQxMzoxMjo0OC4yNzg4ODJa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2Y4Y2VmNzI0LWVlN2ItNGJhYy04NzAxLWIxOTlhMzZhMzgyYy8iLCJwcm9n
-        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNl
-        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVz
-        L2ZpbGUvZmlsZS9jNjYxZmVkOS1mODhjLTQ3OTMtYTZiOS1kYWQxMmU0MmZl
-        ZTYvIl19
+        LzNiZmM4MWIxLThhZjgtNGZiMy1iN2IzLWUwYjE0MDg4MzZjYy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL2ZpbGUvZmlsZS80ZDlhZGM5Yi1lOTE4LTRjZjctYWQ3NC02
+        ZGE1NDVhMGFmZTYvIl19
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:48 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/ebe50f76-f621-415f-a340-57363b3b6772/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/f321421e-0ee3-4925-881b-97da55ca2ef5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +687,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:48 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -701,13 +705,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0OTkwYmIwLTc5ZjYtNDQy
-        NS1iMGU2LTUwN2E1ZjJmNzdhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmYThlN2Y5LTNiMjctNGYy
+        OC05NDUzLWMzOWEzNTNlZTZlNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:48 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/2a37be98-40d5-484b-b6f5-9469ac094ea2/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/1ad5f2e5-817e-4ca6-a20a-d62d1f93613d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -728,7 +732,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:20 GMT
+      - Fri, 24 Apr 2020 13:12:48 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -746,13 +750,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjM2IxOTcwLWIzZTUtNGUw
-        OS04ODZiLTk2NmVhN2VkNzRiOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1NDIwZDUwLTI2NzAtNGQ1
+        Mi04NWZjLTdmYTNkZTBjNjJmNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:20 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:48 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/fc3b1970-b3e5-4e09-886b-966ea7ed74b8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/d5420d50-2670-4d52-85fc-7fa3de0c62f5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -773,7 +777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 Mar 2020 23:48:21 GMT
+      - Fri, 24 Apr 2020 13:12:48 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -787,22 +791,23 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '314'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmMzYjE5NzAtYjNl
-        NS00ZTA5LTg4NmItOTY2ZWE3ZWQ3NGI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDMtMjNUMjM6NDg6MjAuODI1ODg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDU0MjBkNTAtMjY3
+        MC00ZDUyLTg1ZmMtN2ZhM2RlMGM2MmY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDQtMjRUMTM6MTI6NDguNDQxMjU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
-        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTAzLTIzVDIzOjQ4OjIwLjk0NjQ5MVoi
-        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDMtMjNUMjM6NDg6MjEuMDE5NDA1WiIs
-        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8x
-        YmFlMDE4ZC05MmE0LTRiMzEtOWJhZS0xYzgyYWE0ODRiOGQvIiwicHJvZ3Jl
-        c3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2
-        ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS8yYTM3YmU5OC00MGQ1LTQ4NGItYjZmNS05NDY5YWMw
-        OTRlYTIvIl19
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIwLTA0LTI0VDEzOjEyOjQ4LjYyMTE0M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjAtMDQtMjRUMTM6MTI6NDguNzA1NTQwWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        NTlkNWZlOC02ZDkxLTRkYTMtYTY3Ny0wNTRmYjc5NWY0ZTcvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xYWQ1ZjJlNS04MTdlLTRjYTYtYTIw
+        YS1kNjJkMWY5MzYxM2QvIl19
     http_version: 
-  recorded_at: Mon, 23 Mar 2020 23:48:21 GMT
+  recorded_at: Fri, 24 Apr 2020 13:12:48 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
To test:
1. Create a repo and sync
2. curl --cert /etc/pki/katello/certs/pulp-client.crt --key /etc/pki/katello/private/pulp-client.key https://`hostname`/pulp/api/v3/repositories/file/file/  to get the **repo_href.**
3. curl -X DELETE --cert /etc/pki/katello/certs/pulp-client.crt --key /etc/pki/katello/private/pulp-client.key https://`hostname`/pulp/api/v3/repositories/file/file/**repo_href**/
4. Delete the repo in katello UI. It should succeed.