### PR TITLE
Fixes #29576 - Run linting from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - '10'
-script: ./travis_run_js_tests.sh
+script:
+  - npm run lint

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test:current": "jest webpack --watch",
     "format": "prettier --single-quote --trailing-comma es5 --write 'webpack/**/*.js'",
     "build": "npm run format && npm run lint",
-    "lint": "eslint webpack/",
-    "lint:fix": "eslint --fix webpack/",
+    "lint": "npx eslint webpack/",
+    "lint:fix": "npx eslint --fix webpack/",
     "lint:test": "npm run lint && npm test",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },

--- a/travis_run_js_tests.sh
+++ b/travis_run_js_tests.sh
@@ -1,2 +1,0 @@
-set -ev
-  npm run lint;


### PR DESCRIPTION
Travis has been failing with `eslint: command not found`

My best guess is running the linting command from a bash script was causing some sort of environmental difference and eslint couldn't be found on the $PATH