### PR TITLE
Fixes #28971 - Generating and adding entitlements expiring soon report link in email

### DIFF
--- a/app/helpers/katello/subscription_mailer_helper.rb
+++ b/app/helpers/katello/subscription_mailer_helper.rb
@@ -1,0 +1,23 @@
+module Katello
+  module SubscriptionMailerHelper
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::UrlHelper
+
+    def report_url
+      base_url = report_data_report_template_path(@report_template.id, job_id: @provider_job_id)
+      "#{Setting[:foreman_url]}#{base_url}"
+    end
+
+    def report_link
+      link_to _("View a report of the affected hosts"), report_url
+    end
+
+    def start_report_task(days_from_now)
+      @report_template = ReportTemplate.find_by(name: "Subscription - Entitlement Report")
+      template_input_id = @report_template.template_inputs.find_by_name("Days from Now").id.to_s
+      params = { format: 'csv', template_id: @report_template.id, input_values: { template_input_id => { value: days_from_now} } }
+      composer = ReportComposer.new(params)
+      @provider_job_id = composer.schedule_rendering.provider_job_id
+    end
+  end
+end

--- a/app/views/katello/subscription_mailer/subscription_expiry.html.erb
+++ b/app/views/katello/subscription_mailer/subscription_expiry.html.erb
@@ -41,5 +41,7 @@
       <% end %>
     </table>
 </div>
+<br/>
+  <%= @report_link %>
 </body>
 </html>

--- a/app/views/katello/subscription_mailer/subscription_expiry.text.erb
+++ b/app/views/katello/subscription_mailer/subscription_expiry.text.erb
@@ -13,3 +13,7 @@
   <%= _("Days Remaining") %>:       <%= pool.days_until_expiration %>
 
 <% end %>
+
+<%if @report_url %>
+  <%= _("View a report of the affected hosts") %>:               <%= @report_url %>
+<% end %>

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -34,7 +34,7 @@ User.as(::User.anonymous_api_admin.login) do
     },
 
     {:name => :subscriptions_expiring_soon,
-     :description => N_('A list of subscriptions expiring within 30 days'),
+     :description => N_('A list of subscriptions expiring soon'),
      :mailer => 'Katello::SubscriptionMailer',
      :method => 'subscription_expiry',
      :subscription_type => 'report',

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -44,6 +44,9 @@ module Katello
                         cp_id: "1234",
                         subscription_id: ActiveRecord::FixtureSet.identify(:other_subscription))
 
+      template = FactoryBot.create(:report_template, name: 'Subscription - Entitlement Report')
+      FactoryBot.create(:template_input, name: 'Days from Now', template_id: template.id)
+
       ActionMailer::Base.deliveries = []
     end
 


### PR DESCRIPTION
This PR generates the entitlements expiring soon report link and attaches it in the email notification.