### PR TITLE
Fixes #29611 - Manifest delete refreshes library

### DIFF
--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -13,7 +13,8 @@ module Actions
             plan_action(Candlepin::Owner::DestroyImports, label: organization.label)
 
             if SETTINGS[:katello][:use_pulp]
-              organization.products.redhat.flat_map(&:repositories).each do |repo|
+              repositories = ::Katello::Repository.in_default_view.in_product(::Katello::Product.redhat.in_org(organization))
+              repositories.each do |repo|
                 plan_action(Katello::Repository::RefreshRepository, repo)
               end
             end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -18,7 +18,8 @@ module Actions
             plan_action(Candlepin::Owner::ImportProducts, :organization_id => organization.id)
 
             if manifest_update && SETTINGS[:katello][:use_pulp]
-              organization.products.redhat.flat_map(&:repositories).each do |repo|
+              repositories = ::Katello::Repository.in_default_view.in_product(::Katello::Product.redhat.in_org(organization))
+              repositories.each do |repo|
                 plan_action(Katello::Repository::RefreshRepository, repo)
               end
             end


### PR DESCRIPTION
This commit makes the ManifestDelete and Manifest Import refresh only
the rh library repositories. Prior to this commit even non library
repositories belonging to content views were checked for refresh.