### PR TITLE
Fixes #29650 - detect and fix pulpcore missing capabilities

### DIFF
--- a/app/lib/actions/katello/pulp_selector.rb
+++ b/app/lib/actions/katello/pulp_selector.rb
@@ -3,6 +3,7 @@ module Actions
     module PulpSelector
       def plan_pulp_action(backend_actions, repository, smart_proxy, *args)
         fail "nil smart_proxy passed to PulpSelector" if smart_proxy.nil?
+        smart_proxy.fix_pulp3_capabilities(repository.content_type)
         planned = plan_optional_pulp_action(backend_actions, repository, smart_proxy, *args)
         fail "Could not locate an action for type #{smart_proxy.backend_service_type(repository)}" unless planned
         planned

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -45,6 +45,12 @@ module Katello
       end
     end
 
+    class PulpcoreMissingCapabilities < StandardError
+      def message
+        _("A smart proxy seems to have been refreshed without pulpcore being running.  You may want to ")
+      end
+    end
+
     class ConnectionRefusedException < StandardError; end
 
     class MaxHostsReachedException < StandardError; end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -154,6 +154,19 @@ module Katello
         end
       end
 
+      def missing_pulp3_capabilities?
+        pulp3_enabled? && self.capabilities(PULP3_FEATURE).empty?
+      end
+
+      def fix_pulp3_capabilities(type)
+        if missing_pulp3_capabilities? && !pulp2_preferred_for_type?(type)
+          self.refresh
+          if self.capabilities(::SmartProxy::PULP3_FEATURE).empty?
+            fail Katello::Errors::PulpcoreMissingCapabilities
+          end
+        end
+      end
+
       def pulp3_repository_type_support?(repository_type, check_pulp2_preferred = true)
         repository_type_obj = repository_type.is_a?(String) ? Katello::RepositoryTypeManager.repository_types[repository_type] : repository_type
         fail "Cannot find repository type #{repository_type}, is it enabled?" unless repository_type_obj

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -14,6 +14,7 @@ module Support
             proxy.features << pulp_feature
           end
         end
+        proxy.smart_proxy_features.where(:feature_id => @pulp3_feature.id).update(:capabilities => [:pulpcore])
       end
     end
 


### PR DESCRIPTION
There is a condition where a smart proxy is running and
tries to either register or refresh from the foreman server
but the pulpcore server is not up yet.  This results in a
pulpcore feature, but no capabilities.  Since apache has been
configured by the installer to point to pulpcore for serving content
and katello thinks pulpcore cant support that plugin, it falls back to
pulp2 and clients get a 404. This tries to solve this in 2 ways:

1) on a refresh, when capabilities are updated, detect the problem
   and launch a task in the background to try to correct it
2) for more serious longer lasting issues, detect this problem
   any time the pulp selector is invoked and throw an error