### PR TITLE
Fixes #29657 - intermittent ContentViewCompontent test

### DIFF
--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -122,7 +122,7 @@ module Katello
       view1 = create(:katello_content_view)
       version_max = create(:katello_content_view_version, :content_view => view1, :major => "12")
       create(:katello_content_view_version, :content_view => view1, :major => "2")
-      create(:katello_content_view_version, :content_view => view1, :major => "2", :minor => "9")
+      create(:katello_content_view_version, :content_view => view1, :major => "2")
 
       ContentViewComponent.create!(:composite_content_view => @composite,
                                    :content_view => view1, :latest => true)


### PR DESCRIPTION
This test sometimes fails:

```
Error
ActiveRecord::RecordInvalid: Validation failed: Minor , must be unique to major and version id version....
Stacktrace
ActiveRecord::RecordInvalid: Validation failed: Minor , must be unique to major and version id version.
    test/factories/disable_auditing.rb:13:in `block (3 levels) in <top (required)>'
    test/factories/disable_auditing.rb:13:in `block (2 levels) in <top (required)>'
    /home/jenkins/workspace/katello-pr-test/test/models/content_view_component_test.rb:125:in `test_latest_versions' (ActiveRecord::RecordInvalid)
/usr/local/rvm/gems/ruby-2.5.1@jenkins-katello-pr-test-3618/gems/activerecord-6.0.2.1/lib/active_record/validations.rb:53
```

It's because of the FactoryBot factory uses a 'sequence' on the major and minor fields. If the sequence was at 9 for the minor version at line 124, then line 125 raises an error because it specified 9 as its minor version. Doesn't look like the minor versions are really part of what this test is asserting so I removed the specified minor version.