### PR TITLE
Fixes #29653 - fix 0 epoch package profile upload

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -119,7 +119,7 @@ module Katello
 
       def import_package_profile(simple_packages)
         found = import_package_profile_in_bulk(simple_packages)
-        sync_package_associations(found.map(&:id))
+        sync_package_associations(found.map(&:id).uniq)
       end
 
       def import_package_profile_in_bulk(simple_packages)
@@ -140,9 +140,14 @@ module Katello
                                           :arch => simple_package.arch)
         end
         InstalledPackage.import(installed_packages, validate: false, on_duplicate_key_ignore: true)
+        #re-lookup all imported to pickup any duplicates/conflicts
+        imported = InstalledPackage.where(:nvrea => installed_packages.map(&:nvrea)).select(:id).to_a
 
-        found << installed_packages
-        found.flatten
+        if imported.count != installed_packages.count
+          Rails.logger.warn("Mismatch found in installed package insertion, expected #{installed_packages.count} but only could find #{imported.count}.  This is most likley a bug.")
+        end
+
+        (found + imported).flatten
       end
 
       def import_enabled_repositories(repos)

--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -4,8 +4,8 @@ module Katello
       allow :nvra, :nvrea, :name
     end
 
-    has_many :hosts, :through => :host_installed_packages, :class_name => "::Host"
     has_many :host_installed_packages, :class_name => "Katello::HostInstalledPackage", :dependent => :destroy, :inverse_of => :installed_package
+    has_many :hosts, :through => :host_installed_packages, :class_name => "::Host"
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :nvrea

--- a/app/services/katello/pulp/simple_package.rb
+++ b/app/services/katello/pulp/simple_package.rb
@@ -13,8 +13,8 @@ module Katello
       end
 
       def nvrea
-        if epoch == "0"
-          @nvra
+        if epoch.nil? || epoch.to_s == "0"
+          nvra
         else
           "#{@name}-#{@epoch}:#{@version}-#{@release}.#{@arch}"
         end

--- a/db/migrate/20200429153103_installed_package_bad_nvrea.rb
+++ b/db/migrate/20200429153103_installed_package_bad_nvrea.rb
@@ -1,0 +1,14 @@
+class InstalledPackageBadNvrea < ActiveRecord::Migration[5.2]
+  def up
+    Katello::InstalledPackage.where(:epoch => "0").find_each do |pkg|
+      simple = Katello::Pulp::SimplePackage.new(pkg.attributes)
+      if pkg.nvrea != simple.nvrea
+        pkg.update_column(:nvrea, simple.nvrea)
+      end
+    end
+  end
+
+  def down
+    #noop
+  end
+end

--- a/db/migrate/20200501155054_installed_package_unique_nvrea.rb
+++ b/db/migrate/20200501155054_installed_package_unique_nvrea.rb
@@ -1,0 +1,64 @@
+class InstalledPackageUniqueNvrea < ActiveRecord::Migration[5.2]
+  def fix_missing_attributes
+    #bug in dynflow may have resulted in old code running and not properly populating fields
+    # This block is basically copied from 20200129172534_add_epoch_version_release_arch_to_katello_installed_packages.rb
+    epoch_non_0 = ::Katello::Rpm.where.not(epoch: [0, nil]).pluck(:nvra, :epoch).to_h
+    installed_packages = []
+    ::Katello::InstalledPackage.where(:nvrea => nil).each do |pkg|
+      epoch = epoch_non_0[pkg.nvra] || "0"
+
+      attributes_hash = ::Katello::Util::Package.parse_nvrea(pkg.nvra)
+      attributes_hash[:epoch] = epoch
+      attributes_hash[:nvra] = pkg.nvra
+      if epoch == "0"
+        attributes_hash[:nvrea] = pkg.nvra
+      else
+        attributes_hash[:nvrea] = "#{pkg.name}-#{epoch}:#{attributes_hash[:version]}-"\
+                                  "#{attributes_hash[:release]}.#{attributes_hash[:arch]}"
+      end
+
+      installed_packages << ::Katello::InstalledPackage.new(attributes_hash)
+    end
+    ::Katello::InstalledPackage.import(installed_packages, validate: false, batch_size: 50_000,
+                                       on_duplicate_key_update: {conflict_target: [:nvra],
+                                                                 columns: [:nvrea, :epoch, :version, :release, :arch]})
+  end
+
+  def consolidate_duplicate_nvreas
+    host_installed_packages = []
+    deletable_installed_package_ids = []
+    Katello::InstalledPackage.having('count(nvrea) > 1').group(:nvrea).pluck(:nvrea).each do |nvrea|
+      found = Katello::InstalledPackage.includes(:host_installed_packages).where(:nvrea => nvrea).to_a
+      to_keep = found.pop
+      found.each do |duplicate|
+        duplicate.host_ids.each do |host_id|
+          host_installed_packages << {:installed_package_id => to_keep.id, :host_id => host_id}
+        end
+        deletable_installed_package_ids << duplicate.id
+      end
+    end
+    if host_installed_packages.any?
+      Katello::HostInstalledPackage.import(host_installed_packages, validate: false, on_duplicate_key_ignore: true)
+    end
+    if deletable_installed_package_ids.any?
+      Katello::HostInstalledPackage.where(installed_package_id: deletable_installed_package_ids).delete_all
+      Katello::InstalledPackage.where(id: deletable_installed_package_ids).delete_all
+    end
+  end
+
+  def up
+    fix_missing_attributes
+    #now there should be no NULL nvreas
+    change_column :katello_installed_packages, :nvrea, :string, :null => false
+
+    consolidate_duplicate_nvreas
+    add_index "katello_installed_packages", [:nvrea], :unique => true
+    remove_index "katello_installed_packages", [:nvra]
+  end
+
+  def down
+    remove_index "katello_installed_packages", [:nvrea]
+    add_index "katello_installed_packages", [:nvra], :unique => true
+    change_column :katello_installed_packages, :nvrea, :string, :null => true
+  end
+end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -27,7 +27,7 @@ module Katello
     def test_katello_agent_installed?
       refute host.content_facet.katello_agent_installed?
 
-      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-agent', 'nvra' => 'katello-agent-1.0.x86_64')
+      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-agent', 'nvrea' => 'katello-agent-1.0.x86_64', 'nvra' => 'katello-agent-1.0.x86_64')
 
       assert host.reload.content_facet.katello_agent_installed?
     end
@@ -35,7 +35,7 @@ module Katello
     def test_tracer_installed?
       refute host.content_facet.tracer_installed?
 
-      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-host-tools-tracer', 'nvra' => 'katello-host-tools-tracer-1.0.x86_64')
+      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-host-tools-tracer', 'nvrea' => 'katello-host-tools-tracer-1.0.x86_64', 'nvra' => 'katello-agent-1.0.x86_64')
 
       assert host.reload.content_facet.tracer_installed?
     end

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -157,7 +157,7 @@ module Katello
 
     def test_epoch_updates_evr_string
       rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
-      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch, :nvrea => rpm.nvrea)
       rpm.update(epoch: '99')
       installed_package.update(epoch: '99')
       rpm.reload
@@ -169,7 +169,7 @@ module Katello
 
     def test_version_updates_evr_string
       rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
-      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch, :nvrea => rpm.nvrea)
       rpm.update(version: '2.0')
       installed_package.update(version: '2.0')
       rpm.reload
@@ -181,7 +181,7 @@ module Katello
 
     def test_release_updates_evr_string
       rpm = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
-      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch)
+      installed_package = InstalledPackage.create(name: rpm.name, nvra: rpm.nvra, epoch: rpm.epoch, version: rpm.version, release: rpm.release, arch: rpm.arch, :nvrea => rpm.nvrea)
       rpm.update(release: '3.el8')
       installed_package.update(release: '3.el8')
       rpm.reload

--- a/test/services/katello/applicability/applicable_content_helper_test.rb
+++ b/test/services/katello/applicability/applicable_content_helper_test.rb
@@ -32,10 +32,10 @@ module Katello
 
           @installed_package1 = InstalledPackage.create(name: @rpm1.name, nvra: @rpm1.nvra, epoch: @rpm1.epoch,
                                                                    version: @rpm1.version, release: @rpm1.release,
-                                                                   arch: @rpm1.arch)
+                                                                   arch: @rpm1.arch, nvrea: @rpm1.nvrea)
           @installed_package2 = InstalledPackage.create(name: @rpm2.name, nvra: @rpm2.nvra, epoch: @rpm2.epoch,
                                                                    version: @rpm2.version, release: @rpm2.release,
-                                                                   arch: @rpm2.arch)
+                                                                   arch: @rpm2.arch, nvrea: @rpm2.nvrea)
 
           trigger_evrs([@rpm_one, @rpm_two, @rpm_three, @rpm1, @rpm2, @installed_package1, @installed_package2])
 

--- a/test/services/katello/pulp/simple_package_test.rb
+++ b/test/services/katello/pulp/simple_package_test.rb
@@ -1,0 +1,21 @@
+require 'katello_test_helper'
+
+module Katello
+  module Pulp
+    class SimplePackageTest < ActiveSupport::TestCase
+      def test_nvrea
+        sp = Katello::Pulp::SimplePackage.new(name: 'foo', version: '1.0', release: '1', epoch: 0, arch: 'x86_64')
+        assert_equal 'foo-1.0-1.x86_64', sp.nvrea
+
+        sp = Katello::Pulp::SimplePackage.new(name: 'foo', version: '1.0', release: '1', epoch: '0', arch: 'x86_64')
+        assert_equal 'foo-1.0-1.x86_64', sp.nvrea
+
+        sp = Katello::Pulp::SimplePackage.new(name: 'foo', version: '1.0', release: '1', epoch: nil, arch: 'x86_64')
+        assert_equal 'foo-1.0-1.x86_64', sp.nvrea
+
+        sp = Katello::Pulp::SimplePackage.new(name: 'foo', version: '1.0', release: '1', epoch: 1, arch: 'x86_64')
+        assert_equal 'foo-1:1.0-1.x86_64', sp.nvrea
+      end
+    end
+  end
+end


### PR DESCRIPTION
This resolves a couple of issues:
1. Epochs come in with an epoch of 0 as an integeter,
   but the code to calculate nvrea only was checking for a string
2. If we tried to insert an installed package, but got a conflict
   likely due to a race condition (but also problem #1), the code
   would try to insert an inst. package id of zero, which was not
   correct.  this adds code to lookup any installed packages in case
   a conflict occurs, and log an error if at least one could not be found.
3. Adds a migration to correct 1)