### PR TITLE
Fixes #29553 - Katello Applicability of rpms with modules

### DIFF
--- a/db/migrate/20200506163345_add_applicability_indicesto_katello_host_available_module_streams.rb
+++ b/db/migrate/20200506163345_add_applicability_indicesto_katello_host_available_module_streams.rb
@@ -1,0 +1,12 @@
+class AddApplicabilityIndicestoKatelloHostAvailableModuleStreams < ActiveRecord::Migration[6.0]
+  def up
+    add_index :katello_host_available_module_streams,
+      [:host_id, :available_module_stream_id, :status],
+      :name => 'rpm_and_module_applicability_related_indices'
+  end
+
+  def down
+    remove_index :katello_host_available_module_streams,
+      :name => 'rpm_and_module_applicability_related_indices'
+  end
+end

--- a/test/services/katello/applicability/applicable_content_helper_test.rb
+++ b/test/services/katello/applicability/applicable_content_helper_test.rb
@@ -13,6 +13,12 @@ module Katello
           end
         end
 
+        def bound_repos(host)
+          host.content_facet.bound_repositories.collect do |repo|
+            repo.library_instance_id.nil? ? repo.id : repo.library_instance_id
+          end
+        end
+
         def setup
           @repo = katello_repositories(:fedora_17_x86_64)
           @host = FactoryBot.build(:host, :with_content, :with_subscription,
@@ -29,6 +35,12 @@ module Katello
           @rpm2 = Rpm.where(nvra: "one-1.0-2.el7.x86_64").first
 
           @erratum = Erratum.find_by(errata_id: "RHBA-2014-013")
+
+          @module_stream = ModuleStream.find_by(name: "Ohio")
+
+          HostAvailableModuleStream.create(host_id: @host.id,
+                                           available_module_stream_id: AvailableModuleStream.find_by(name: "Ohio").id,
+                                           status: "enabled")
 
           @installed_package1 = InstalledPackage.create(name: @rpm1.name, nvra: @rpm1.nvra, epoch: @rpm1.epoch,
                                                                    version: @rpm1.version, release: @rpm1.release,
@@ -47,76 +59,87 @@ module Katello
 
           Katello::ContentFacetRepository.create(content_facet_id: @host.content_facet.id, repository_id: @repo.id)
           Katello::RepositoryErratum.create(erratum_id: @erratum.id, repository_id: @repo.id)
-
-          @bound_repos = @host.content_facet.bound_repositories.collect do |repo|
-            repo.library_instance_id.nil? ? repo.id : repo.library_instance_id
-          end
         end
 
         def teardown
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).remove(@rpm2.id)
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).remove(@erratum.id)
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).remove(@rpm2.id)
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).remove(@erratum.id)
+
+          @rpm_one.update(modular: false)
+          @rpm_one_two.update(modular: false)
+          ModuleStreamRpm.delete_all
         end
 
         def test_rpm_content_ids_returns_something
-          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).fetch_content_ids
+          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).fetch_content_ids
           assert_equal [@rpm2.id], package_content_ids
         end
 
         def test_rpm_content_ids_returns_nothing
           @installed_package1.destroy
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).fetch_content_ids
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          package_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).fetch_content_ids
           assert_empty package_content_ids
         end
 
         def test_erratum_content_ids_returns_something
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).fetch_content_ids
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).fetch_content_ids
           assert_equal [@erratum.id], erratum_content_ids
         end
 
         def test_erratum_content_ids_returns_nothing
-          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).fetch_content_ids
+          erratum_content_ids = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).fetch_content_ids
           assert_empty erratum_content_ids
         end
 
         def test_applicable_differences_adds_rpm_id
-          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).applicable_differences
           assert_equal [[@rpm2.id], []], rpm_differences
         end
 
         def test_applicable_differences_adds_and_removes_no_rpm_ids
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).applicable_differences
           assert_equal [[], []], rpm_differences
         end
 
         def test_applicable_differences_removes_rpm_id
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
           @installed_package1.destroy
-          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).applicable_differences
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).applicable_differences
           assert_equal [[], [@rpm2.id]], rpm_differences
         end
 
         def test_applicable_differences_adds_erratum_id
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).applicable_differences
           assert_equal [[@erratum.id], []], erratum_differences
         end
 
         def test_applicable_differences_adds_and_removes_no_errata_ids
-          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).applicable_differences
           assert_equal [[], []], erratum_differences
         end
 
         def test_applicable_differences_remove_erratum_id
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).calculate_and_import
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).calculate_and_import
           @installed_package1.destroy
-          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, @bound_repos).calculate_and_import
-          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, @bound_repos).applicable_differences
+          ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).calculate_and_import
+          erratum_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Erratum, bound_repos(@host)).applicable_differences
           assert_equal [[], [@erratum.id]], erratum_differences
+        end
+
+        def test_applicable_differences_adds_rpm_in_module
+          @rpm_one.update(modular: true)
+          @rpm_one_two.update(modular: true)
+
+          ModuleStreamRpm.create(module_stream_id: @module_stream.id, rpm_id: @rpm_one.id)
+          ModuleStreamRpm.create(module_stream_id: @module_stream.id, rpm_id: @rpm_one_two.id)
+
+          rpm_differences = ::Katello::Applicability::ApplicableContentHelper.new(@host.content_facet, ::Katello::Rpm, bound_repos(@host)).applicable_differences
+          assert_equal [[@rpm_one_two.id], []], rpm_differences
         end
       end
     end


### PR DESCRIPTION
Note: this functionality only works with Pulp 3 due to the use of its module stream <-> rpm relationship.

Extends the logic of `fetch_content_ids` in Katello Applicability's `ApplicableContentHelper` to take enabled module streams into account when calculating RPM applicability.

RPMs that are applicable must:
1) Exist within a host's bound library instance repositories
2) Belong to the host
3) Either:
  a) Not be modular, or,
  b) Exist in the host's enabled modules

My PR here is a work in progress because I think the queries could be combined in a more efficient way.