### PR TITLE
Fixes #29709 - Remove deleted repositories post migration

### DIFF
--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphaned_migrated_repositories.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphaned_migrated_repositories.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Pulp3
+    module OrphanCleanup
+      class DeleteOrphanedMigratedRepositories < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def run
+          output[:pulp_tasks] = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy).delete_orphan_repositories
+        end
+      end
+    end
+  end
+end

--- a/lib/katello/tasks/pulp3_post_migration_check.rake
+++ b/lib/katello/tasks/pulp3_post_migration_check.rake
@@ -3,7 +3,11 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 namespace :katello do
   desc "Runs a post Pulp3 migration check for supported content types."
   task :pulp3_post_migration_check => :environment do
+    User.current = User.anonymous_admin
     repository_types = Katello::Pulp3::Migration::REPOSITORY_TYPES
+
+    # Take care of repository deletions
+    ForemanTasks.sync_task(Actions::Pulp3::OrphanCleanup::DeleteOrphanedMigratedRepositories, SmartProxy.pulp_master)
 
     repository_types.each do |type|
       # check version

--- a/test/lib/tasks/pulp3_post_migration_check_test.rb
+++ b/test/lib/tasks/pulp3_post_migration_check_test.rb
@@ -20,6 +20,7 @@ module Katello
       @task_name = 'katello:pulp3_post_migration_check'
       Rake::Task[@task_name].reenable
       Rake::Task.define_task(:environment)
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
     end
 
     def test_fails_if_file_repository_has_nil_version_href


### PR DESCRIPTION
To test:
On pulp2 create a file repo
Run bundle exec rails katello:pulp3_migration
Delete file repo on pulp2
Run bundle exec rails katello:pulp3_migration
See that the migrated file repo is not deleted in pulp3
Run bundle exec rails katello:pulp3_post_migration_check
Verify that the deleted file repo is deleted in pulp3

This also needs to fix https://projects.theforeman.org/issues/29595 to not have unmigrated docker tags from orphaned repos.