### PR TITLE
Fixes #29692 - Enable installation of Tracer from the UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
@@ -3,12 +3,19 @@
  * @name  Bastion.content-hosts.controller:ContentHostPackagesActionsController
  *
  * @requires $scope
+ * @requires $location
  *
  * @description
  *   Provides the functionality for the content host package actions.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesActionsController',
-    ['$scope', function ($scope) {
+    ['$scope', '$location', function ($scope, $location) {
+        var packageName = $location.search().package_name;
+
         $scope.packageAction = {actionType: 'packageInstall'}; //default to packageInstall
+
+        if (packageName) {
+            $scope.packageAction.term = packageName;
+        }
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -16,12 +16,6 @@
     </p>
   </div>
 
-  <div bst-alert="info" ng-hide="host.content_facet_attributes.katello_tracer_installed">
-    <span translate>
-      To use Tracer, install the katello-host-tools-tracer package.
-    </span>
-  </div>
-
   <form id="traceActionForm" method="post" action="/katello/remote_execution">
     <input type="hidden" name="remote_action" value="service_restart"/>
     <input type="hidden" name="name" ng-value="traceActionFormValues.helper"/>
@@ -33,6 +27,13 @@
   <div bst-feature-flag="remote_actions">
     <h3 translate>Traces</h3>
     <h4 translate>Tracer helps administrators identify applications that need to be restarted after a system is patched.</h4>
+    <button
+      class="btn btn-default"
+      type="button"
+      ng-hide="denied('edit_hosts', host) || host.content_facet_attributes.katello_tracer_installed"
+      ng-click="installTracerPackage(host)">
+      <span translate>Enable Traces on this host</span>
+    </button>
   </div>
 
   <div data-extend-template="layouts/partials/table.html">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -31,15 +31,24 @@
         <dt translate>Type</dt>
         <dd>{{ host.subscription_facet_attributes.host_type }}</dd>
 
-        <dt translate>Katello Tracer</dt>
-          <dd>
+        <dt>
+          <span translate>Katello Tracer</span>
+          <span>
+            <i class="pficon-info" title="{{ 'Tracer helps administrators identify applications that need to be restarted after a system is patched.' | translate }}"></i>
+          </span>
+        </dt>
+        <dd>
           <span ng-show="host.content_facet_attributes.katello_tracer_installed">
             <span class="{{ getHostStatusIcon(0) }}"></span>
             <span translate>Installed</span>
           </span>
-          <span ng-hide="host.content_facet_attributes.katello_tracer_installed">
-            <span translate>Not installed</span>
-          </span>
+          <button
+            class="btn btn-default"
+            type="button"
+            ng-hide="denied('edit_hosts', host) || host.content_facet_attributes.katello_tracer_installed"
+            ng-click="installTracerPackage(host)">
+            <span translate>Enable Traces on this host</span>
+          </button>
         </dd>
 
         <dt bst-feature-flag="remote_actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task-details.controller.js
@@ -10,8 +10,8 @@
  *   Provides the functionality for the details of a task.
  */
 angular.module('Bastion.tasks').controller('TaskDetailsController',
-    ['$scope', 'Task',
-    function ($scope, Task) {
+    ['$scope', '$rootScope', 'Task',
+    function ($scope, $rootScope, Task) {
         var taskId;
 
         taskId = $scope.$stateParams.taskId;
@@ -24,6 +24,7 @@ angular.module('Bastion.tasks').controller('TaskDetailsController',
         $scope.updateTask = function (task) {
             $scope.task = task;
             if (!$scope.task.pending) {
+                $rootScope.$broadcast('TaskFinished', $scope.task);
                 $scope.unregisterSearch();
             }
         };


### PR DESCRIPTION
This PR adds a button to install the katello-host-tools-tracer package from the host details page and Traces tab if it's not installed. Also adds a tooltip on the details page to explain what Tracer does. Clicking the button will redirect to the package actions page with the form input pre-filled with 'katello-host-tools-tracer' so it can be installed via agent or REX

May wanna test this in conjunction with https://github.com/Katello/katello-host-tools/pull/111 for an easy 2 for 1.  found the bug while implementing this