### PR TITLE
Fixes #29209 - Do not import_all for pulp3 content types

### DIFF
--- a/app/models/katello/ansible_collection.rb
+++ b/app/models/katello/ansible_collection.rb
@@ -1,5 +1,5 @@
 module Katello
-  class AnsibleCollection < ApplicationRecord
+  class AnsibleCollection < Katello::Model
     include Concerns::PulpDatabaseUnit
 
     self.table_name = 'katello_ansible_collections'


### PR DESCRIPTION
To test:
**On master:** 
1. On a box with file, docker, (yum) enabled on pulp3 run bundle exec rails katello:reimport 
2. Notice the failures. import_all is not supported with pulp3 content types since content api endpoints in pulp3 do not return associated repositories.

**On this branch:**
1. bundle exec rails katello:reimport
2. Notice output ignoring all pulp3 content types.