### PR TITLE
Fixes #28953 - incremental update copy module defaults

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -173,6 +173,12 @@ module Actions
           history = ::Katello::ContentViewHistory.find(input[:history_id])
           history.status = ::Katello::ContentViewHistory::SUCCESSFUL
           history.save!
+
+          version.repositories.each do |repo|
+            SmartProxy.pulp_master.pulp_api.extensions.send(:module_default).
+              copy(repo.library_instance.pulp_id,
+              repo.pulp_id)
+          end
         end
 
         # given a composite version, and a list of new components, calculate the list of all components for the new version


### PR DESCRIPTION
Copies over modulemd-defaults after an incremental update.

To test:

1) Download https://partha.fedorapeople.org/test-repos/pteradactly-with-dino-errata/ locally to disk
2) Comment out the modulemd-defaults from modules.yaml and run `./create.sh`
3) Host the repository using `python2 -m SimpleHTTPServer 2020`
4) Sync the repository
5) Add back the modulemd-defaults
6) Create some new errata in the repo metadata and run `./create.sh`
7) Perform a complete sync on the repository
8) Perform and incremental update with the errata you just created:
```
hammer content-view version incremental-update --content-view-version-id [id] --errata-ids [errata id] --lifecycle-environments Library --organization-id [org id]
```
9) Inspect the v1.1 repository's metadata or modulemd-default count in pulp-admin to see that the modulemd-defaults were not copied over
10) Apply my patch
11) Perform another incremental update and see that the modulemd-defaults are copied over to the new v1.2 repository

Questions:
1) Is it okay to stick this in `finalize`?
2) modulemd-defaults are a behind-the-scenes Pulp unit.  Environment groups are also behind-the-scenes, and since incremental update copies by unit, environment groups won't get copied either.  Should I add them in as well?