### PR TITLE
Fixes #29448 - do not import puppet if not enabled

### DIFF
--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -21,7 +21,8 @@ module Katello
             foreman_environment.save!
           end
 
-          if (foreman_smart_proxy = SmartProxy.pulp_master)
+          foreman_smart_proxy = SmartProxy.pulp_master
+          if foreman_smart_proxy.has_feature?('Puppet')
             PuppetClassImporter.new(:url => foreman_smart_proxy.url, :env => foreman_environment.name).update_environment
           end
         end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -314,6 +314,7 @@ module Katello
           content_counts[content_type::CONTENT_TYPE] = content_type.in_repositories(self.repositories.archived).count
         end
       end
+      self.content_counts[PuppetModule::CONTENT_TYPE] = self.puppet_modules.count
       save!
     end
 

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -119,6 +119,7 @@ module Katello
       counts = cvv.content_counts_map
       assert_equal manifest_count, counts["docker_manifest_count"]
       assert_equal tag_count, counts["docker_tag_count"]
+      assert_equal 0, counts["puppet_module_count"]
     end
 
     def test_active_history_nil_task


### PR DESCRIPTION
this adds a check when we trigger an  import of puppet classes
as part of a CV publish.  If a smart proxy does not have the feature,
then we know that import cannot take place