### PR TITLE
Fixes #29717 - Fix React tests

### DIFF
--- a/webpack/mockRequest.js
+++ b/webpack/mockRequest.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import nock from 'nock';
 
 // TODO: figure out way to reuse this from foreman
 export const mock = new MockAdapter(axios);
@@ -32,18 +31,3 @@ export const mockErrorRequest = ({
 
 export const mockReset = () => mock.reset();
 
-// Using the library 'nock' as it matches actual network requests rather than mock another
-// library. This is helpful when the request is not coming from Katello. For example, axios
-// called within Katello can be mocked with axios-mock-adapter or similar, but a http request
-// made by axios that is coming from Foreman cannot be mocked by axios-mock-adapter or a
-// jest mock within Katello. So to do this, we can mock the request a level deeper within
-// nodejs by using nock.
-export const nockInstance = nock('http://localhost');
-
-// Calling .done() with nock asserts that the request was fufilled. We use a timeout to ensure
-// that the component has set up and made the request before the assertion is made.
-export const assertNockRequest = (scope, timeout = 2000) => {
-  setTimeout(() => {
-    scope.done();
-  }, timeout);
-};

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -4,7 +4,7 @@ import { renderWithApiRedux, waitFor } from 'react-testing-lib-wrapper';
 import CONTENT_VIEWS_KEY from '../ContentViewsConstants';
 import ContentViewsPage from '../../ContentViews';
 import api from '../../../services/api';
-import { nockInstance, assertNockRequest } from '../../../mockRequest';
+import { nockInstance, assertNockRequest } from '../../../test-utils/nockWrapper';
 
 
 const cvIndexData = require('./contentViewList.fixtures.json');

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
@@ -48,7 +48,7 @@ const store = mockStore(Immutable({
   },
 }));
 
-afterEach(() => {
+beforeEach(() => {
   store.clearActions();
   mockReset();
 });

--- a/webpack/test-utils/nockWrapper.js
+++ b/webpack/test-utils/nockWrapper.js
@@ -1,0 +1,17 @@
+import nock from 'nock';
+
+// Using the library 'nock' as it matches actual network requests rather than mock another
+// library. This is helpful when the request is not coming from Katello. For example, axios
+// called within Katello can be mocked with axios-mock-adapter or similar, but a http request
+// made by axios that is coming from Foreman cannot be mocked by axios-mock-adapter or a
+// jest mock within Katello. So to do this, we can mock the request a level deeper within
+// nodejs by using nock.
+export const nockInstance = nock('http://localhost');
+
+// Calling .done() with nock asserts that the request was fufilled. We use a timeout to ensure
+// that the component has set up and made the request before the assertion is made.
+export const assertNockRequest = (scope, timeout = 2000) => {
+  setTimeout(() => {
+    scope.done();
+  }, timeout);
+};


### PR DESCRIPTION
Recently nock was introduced to testing. Importing `nock` from a place we also use `axios-mock-adapter` was causing issues as these mock network requests differently. Nock mocks from the nodejs level and axios-mock-adapter mocks the axios library. So initializing axios-mock-adapter and nock caused axios-mock-adapter to try to interecept the request before nock could.

We didn't see this locally because our dev env is on nodejs 10 and jenkins is on 12. I'm not sure why some runs passed and others have not.

Its likely a snapshot has to be re-recorded on nodejs 12 as well for the SubscriptionActions failure.