### PR TITLE
Fixes #29721 - Show Traces status in Hosts API

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -290,6 +290,14 @@ module Katello
         @purpose_addons_status_label ||= get_status(::Katello::PurposeAddonsStatus).to_label(options)
       end
 
+      def traces_status
+        @traces_status ||= get_status(::Katello::TraceStatus).status
+      end
+
+      def traces_status_label(options = {})
+        @traces_status_label ||= get_status(::Katello::TraceStatus).to_label(options)
+      end
+
       def valid_content_override_label?(content_label)
         available_content = subscription_facet.candlepin_consumer.available_product_content
         available_content.map(&:content).any? { |content| content.label == content_label }

--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -46,8 +46,8 @@ module Katello
 
     def relevant?(_options = {})
       # traces cannot be reported from hosts lower than el7
-      return false if host.operatingsystem.try(:major).to_i.between?(1, 6)
-      host.content_facet.try(:uuid)
+      return false if host.operatingsystem.try(:major).to_i.between?(1, 6) || !host.content_facet&.tracer_installed?
+      host.content_facet.try(:uuid).present?
     end
   end
 end


### PR DESCRIPTION
Now it's there:

/api/v2/hosts/2
```
"traces_status": 0,
"traces_status_label": "No processes require restarting",
```

This also makes the TraceStatus 'relevant' if it the tracer package is installed on the client. If it's missing the status won't be shown in the UI or API