### PR TITLE
Fixes #29604 - Katello Applicability calculate module streams

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -120,6 +120,7 @@ module Katello
 
         ::Katello::Applicability::ApplicableContentHelper.new(self, ::Katello::Rpm, bound_repos).calculate_and_import
         ::Katello::Applicability::ApplicableContentHelper.new(self, ::Katello::Erratum, bound_repos).calculate_and_import
+        ::Katello::Applicability::ApplicableContentHelper.new(self, ::Katello::ModuleStream, bound_repos).calculate_and_import
       end
 
       def import_applicability(partial = false)


### PR DESCRIPTION
Adds Katello Applicability support for calculating which module streams have upgrades available.

Note: this PR requires the Pulp 3 RPM plugin

Start by enabling Katello Applicability in `katello.yaml`:
```
:katello_applicability: true
```

One way to test:
1) Sync this repo: https://partha.fedorapeople.org/test-repos/pteradactly-with-dino-errata/
2) Run these commands on a registered and properly subscribed el8 system: 
  - `dnf module enable duck`
  - `dnf install  duck-0.6-1.noarch`
3) Check that `duck-0.7-1.noarch` is an applicable package and that the duck module is marked "Upgrade Available"
