### PR TITLE
Fixes #29730 - Warn if resolving Traces will reboot the host

### DIFF
--- a/app/controllers/katello/api/v2/host_tracer_controller.rb
+++ b/app/controllers/katello/api/v2/host_tracer_controller.rb
@@ -1,7 +1,5 @@
 module Katello
   class Api::V2::HostTracerController < Api::V2::ApiController
-    #include Katello::Concerns::FilteredAutoCompleteSearch
-
     before_action :find_host, :only => :index
 
     resource_description do
@@ -22,7 +20,7 @@ module Katello
       traces = Katello::HostTracer.resolvable.where(id: params[:trace_ids])
 
       traces.each do |trace|
-        if trace.helper.include?('reboot')
+        if trace.reboot_required?
           trace.helper = 'reboot'
         end
       end

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -4,11 +4,17 @@ module Katello
 
     belongs_to :host, :inverse_of => :host_traces, :class_name => '::Host::Managed'
 
+    scope :reboot_required, -> { where(app_type: 'static') }
+
     validates :application, :length => {:maximum => 255}, :presence => true
     validates :app_type, :length => {:maximum => 255}, :presence => true
 
     scoped_search :on => :application, :complete_value => true
     scoped_search :on => :app_type
     scoped_search :on => :helper
+
+    def reboot_required?
+      self.app_type == 'static'
+    end
   end
 end

--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -35,7 +35,7 @@ module Katello
     end
 
     def to_status(_options = {})
-      if host.host_traces.where(:app_type => "static").any?
+      if host.host_traces.reboot_required.any?
         REQUIRE_REBOOT
       elsif host.host_traces.where.not(:app_type => "session").any?
         REQUIRE_PROCESS_RESTART

--- a/app/views/katello/api/v2/host_tracer/base.json.rabl
+++ b/app/views/katello/api/v2/host_tracer/base.json.rabl
@@ -1,7 +1,8 @@
 object @resource ||= @object
 
-attributes :id, :id
-attributes :application, :application
-attributes :helper, :helper
-attributes :app_type, :app_type
+attributes :id
+attributes :application
+attributes :helper
+attributes :app_type
 attributes :host_id, :host
+attributes :reboot_required? => :reboot_required

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
@@ -10,6 +10,7 @@
  * @requires BastionConfig
  * @requires hostIds
  * @requires HostTracesResolve
+ * @required ContentHostsHelper
  * @requires translate
  *
  * @description
@@ -17,8 +18,8 @@
  */
 /*jshint camelcase:false*/
 angular.module('Bastion.content-hosts').controller('ContentHostsBulkTracesController',
-    ['$scope', '$uibModalInstance', 'HostBulkAction', 'Notification', 'Nutupane', 'BastionConfig', 'hostIds', 'HostTracesResolve', 'translate',
-    function ($scope, $uibModalInstance, HostBulkAction, Notification, Nutupane, BastionConfig, hostIds, HostTracesResolve, translate) {
+    ['$scope', '$uibModalInstance', 'HostBulkAction', 'Notification', 'Nutupane', 'BastionConfig', 'hostIds', 'HostTracesResolve', 'ContentHostsHelper', 'translate',
+    function ($scope, $uibModalInstance, HostBulkAction, Notification, Nutupane, BastionConfig, hostIds, HostTracesResolve, ContentHostsHelper, translate) {
 
         var tracesNutupane = new Nutupane(HostBulkAction, hostIds, 'traces');
         tracesNutupane.enableSelectAllResults();
@@ -49,6 +50,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkTracesContro
             /* eslint-enable camelcase */
         };
 
+        $scope.rebootRequired = function() {
+            return ContentHostsHelper.rebootRequired($scope.table.getSelected());
+        };
+
         $scope.ok = function () {
             $uibModalInstance.close();
         };
@@ -56,6 +61,5 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkTracesContro
         $scope.cancel = function () {
             $uibModalInstance.dismiss('cancel');
         };
-
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
@@ -18,9 +18,14 @@
     <div data-extend-template="layouts/partials/table.html">
       <div data-block="search" ng-show="false"></div>
       <span data-block="list-actions">
-        <div bst-modal="performViaRemoteExecution()">
+        <div bst-modal="performViaRemoteExecution()" model="rebootRequired">
           <div data-block="modal-header" translate>Confirm services restart</div>
-          <div data-block="modal-body" translate>Are you sure you want to restart the services on the selected content hosts?</div>
+          <div data-block="modal-body">
+            <span translate>Are you sure you want to restart the services on the selected content hosts?</span>
+            <span ng-show="rebootRequired()">
+              <strong translate>Resolving the selected Traces will reboot this host.</strong>
+            </span>
+          </div>
           <span data-block="modal-confirm-button">
             <button class="btn btn-danger" ng-click="ok()">
               <span translate>Restart</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
@@ -47,5 +47,11 @@ angular.module('Bastion.content-hosts').service('ContentHostsHelper',
                 return 'pficon pficon-warning-triangle-o';
             }
         };
+
+        this.rebootRequired = function(traces) {
+            return traces.some(function(trace) {
+                return trace.reboot_required;
+            });
+        };
     }
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -40,7 +40,12 @@
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="performViaRemoteExecution(false)" model="host">
         <div data-block="modal-header" translate>Restart Services on Content Host "{{host.name}}"?</div>
-        <div data-block="modal-body" translate>Are you sure you want to restart services on content host "{{ host.name }}"?</div>
+        <div data-block="modal-body">
+          <span translate>Are you sure you want to restart services on content host "{{ host.name }}"?</span>
+          <span ng-show="host.rebootRequired()">
+            <strong translate>Resolving the selected Traces will reboot this host.</strong>
+          </span>
+        </div>
         <span data-block="modal-confirm-button">
           <button class="btn btn-primary" ng-click="ok()">
             <span translate>Restart</span>


### PR DESCRIPTION
- spin up katello-client
- install katello-host-tools-tracer
- upgrade the kernel
- resolving the trace from the host details or bulk hosts UI will warn of the restart involved

- downgrade the kernel
- the restart required messaging shouldn't be shown