### PR TITLE
Fixes #29768 - Use debversion extension for sorting deb-versions

### DIFF
--- a/app/models/katello/deb.rb
+++ b/app/models/katello/deb.rb
@@ -29,5 +29,10 @@ module Katello
     def self.total_for_repositories(repos)
       self.in_repositories(repos).count
     end
+
+    def version=(version)
+      super(version)
+      self.version_sortable = version
+    end
   end
 end

--- a/config/initializers/postgresql_custom_types.rb
+++ b/config/initializers/postgresql_custom_types.rb
@@ -1,0 +1,39 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    if const_defined? :PostgreSQLAdapter
+      class PostgreSQLAdapter
+        NATIVE_DATABASE_TYPES.merge!(
+          debversion: { name: 'debversion' }
+        )
+      end
+
+      module AddCustomOIDs
+        def initialize_type_map(m = type_map)
+          m.register_type(
+            'debversion',
+            ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::SpecializedString.new(:debversion)
+          )
+          super(m)
+        end
+      end
+
+      PostgreSQLAdapter.prepend AddCustomOIDs
+    end
+
+    if const_defined? :PostgreSQL
+      module PostgreSQL
+        module AdditionalColumnMethods
+          extend ActiveSupport::Concern
+          included do
+            define_column_methods :debversion
+          end
+        end
+
+        TableDefinition.include AdditionalColumnMethods
+        Table.include AdditionalColumnMethods
+      end
+    end
+  end
+end

--- a/db/migrate/20200508180714_alter_katello_debs_alter_version_sortable.rb
+++ b/db/migrate/20200508180714_alter_katello_debs_alter_version_sortable.rb
@@ -1,0 +1,17 @@
+require 'fx'
+
+class AlterKatelloDebsAlterVersionSortable < ActiveRecord::Migration[6.0]
+  class Katello::Deb < Katello::Model
+  end
+
+  def up
+    enable_extension 'debversion'
+    change_column :katello_debs, :version_sortable, :debversion
+    Katello::Deb.update_all('version_sortable = version')
+  end
+
+  def down
+    change_column :katello_debs, :version_sortable, :string
+    disable_extension 'debversion'
+  end
+end


### PR DESCRIPTION
This requires that `rh-postgresql12-postgresql-debversion` package is installed.
Additionally the extension must be activated in the database:
```
CREATE EXTENSION debversion;
```
Not sure if this can/should be done in the migration-script.

Having this merged would make it possible to merge/review #7961 and #8277, because they rely on a possibility to compare Debian version numbers.