### PR TITLE
Fixes #29790 - New macro to show only Red Hat subscriptions

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -8,7 +8,8 @@ module Katello
           super + [:errata, :host_subscriptions, :host_applicable_errata_ids, :host_applicable_errata_filtered,
                    :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications, :host_content_facet,
                    :host_sla, :host_products, :sub_name, :sub_sku, :registered_through, :last_checkin, :host_collections,
-                   :host_subscriptions_names, :host_subscriptions, :host_products_names, :host_collections_names]
+                   :host_subscriptions_names, :host_subscriptions, :host_products_names, :host_collections_names,
+                   :host_redhat_subscription_names]
         end
       end
 
@@ -26,6 +27,10 @@ module Katello
 
       def host_subscriptions_names(host)
         host.subscriptions.map(&:name)
+      end
+
+      def host_redhat_subscription_names(host)
+        host.subscriptions.redhat.pluck(:name)
       end
 
       def host_content_facet(host)

--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -11,6 +11,8 @@ module Katello
 
     scope :in_organization, ->(org) { where(:organization => org) }
 
+    scope :redhat, -> { joins(:products).merge(Katello::Product.redhat).distinct }
+
     def self.subscribable
       product_ids = Product.subscribable.pluck(:id) + [nil]
       joins(:pools).joins("LEFT OUTER JOIN #{Katello::PoolProduct.table_name} pool_prod ON #{Pool.table_name}.id = pool_prod.pool_id")


### PR DESCRIPTION
Adding this new macro `host_redhat_subscriptions` to report only Red Hat subscription consumption. 

Here the assumption is that the `support_level` field for Custom Subscriptions are always null. 