### PR TITLE
Fixes #29791 - Disable subscription attach for Simple Content Access

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -134,6 +134,10 @@ module Katello
       param :quantity, :number, :desc => N_("Quantity of this subscriptions to add"), :required => true
     end
     def add_subscriptions
+      if @host.organization.simple_content_access?
+        fail ::Katello::HttpErrors::BadRequest, _("This host's organization has Simple Content Access enabled.  Attaching subscriptions is neither necessary nor allowed.")
+      end
+
       pools_with_quantities = params.require(:subscriptions).map do |sub_params|
         PoolWithQuantities.new(Pool.with_identifier(sub_params['id']), sub_params['quantity'].to_i)
       end

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -135,7 +135,7 @@ module Katello
     end
     def add_subscriptions
       if @host.organization.simple_content_access?
-        fail ::Katello::HttpErrors::BadRequest, _("This host's organization has Simple Content Access enabled.  Attaching subscriptions is neither necessary nor allowed.")
+        fail ::Katello::HttpErrors::BadRequest, _("This host's organization is in Simple Content Access mode. Attaching subscriptions is disabled.")
       end
 
       pools_with_quantities = params.require(:subscriptions).map do |sub_params|

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -10,6 +10,7 @@ module Katello
     before_action :find_deletable_hosts, :only => [:destroy_hosts]
     before_action :find_readable_hosts, :only => [:applicable_errata, :installable_errata, :available_incremental_updates]
     before_action :find_errata, :only => [:available_incremental_updates]
+    before_action :find_organization, :only => [:add_subscriptions]
     before_action :deprecate_katello_agent, :only => [:install_content, :update_content, :remove_content]
 
     before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
@@ -301,9 +302,7 @@ module Katello
     end
 
     def validate_organization
-      org_id = params[:organization_id] || params[:included]&.[](:params)&.[](:organization_id)
-      fail HttpErrors::BadRequest, _("Organization ID is required") if org_id.blank?
-      @organization = Organization.find org_id
+      fail HttpErrors::BadRequest, _("Organization ID is required") if @organization.blank?
     end
 
     def validate_host_collection_membership_limit

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -13,6 +13,7 @@ module Katello
     before_action :deprecate_katello_agent, :only => [:install_content, :update_content, :remove_content]
 
     before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
+    before_action :validate_organization, :only => [:add_subscriptions]
 
     # disable *_count fields on erratum rabl, since they perform N+1 queries
     before_action :disable_erratum_hosts_count
@@ -173,6 +174,10 @@ module Katello
       param :quantity, :number, :desc => N_("Quantity of this subscriptions to add"), :required => true
     end
     def add_subscriptions
+      if @organization.simple_content_access?
+        fail HttpErrors::BadRequest, _("The specified organization is in Simple Content Access mode. Attaching subscriptions is disabled")
+      end
+
       pools_with_quantities = params.require(:subscriptions).map do |sub_params|
         PoolWithQuantities.new(Pool.find(sub_params['id']), sub_params['quantity'])
       end
@@ -293,6 +298,12 @@ module Katello
 
     def find_deletable_hosts
       find_bulk_hosts(:destroy_hosts, params)
+    end
+
+    def validate_organization
+      org_id = params[:organization_id] || params[:included]&.[](:params)&.[](:organization_id)
+      fail HttpErrors::BadRequest, _("Organization ID is required") if org_id.blank?
+      @organization = Organization.find org_id
     end
 
     def validate_host_collection_membership_limit

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -5,19 +5,19 @@ module Katello
 
       def find_bulk_hosts(permission, bulk_params, restrict_to = nil)
         #works on a structure of param_group bulk_params and transforms it into a list of systems
-        organization = find_organization
+        find_organization
         bulk_params[:included] ||= {}
         bulk_params[:excluded] ||= {}
         @hosts = []
 
         unless bulk_params[:included][:ids].blank?
           @hosts = ::Host::Managed.authorized(permission).where(:id => bulk_params[:included][:ids])
-          @hosts = @hosts.where(:organization_id => organization.id) if organization
+          @hosts = @hosts.where(:organization_id => @organization.id) if @organization
         end
 
         if bulk_params[:included][:search]
           search_hosts = ::Host::Managed.authorized(permission)
-          search_hosts = search_hosts.where(:organization_id => organization.id) if params[:organization_id]
+          search_hosts = search_hosts.where(:organization_id => @organization.id) if @organization
           search_hosts = search_hosts.search_for(bulk_params[:included][:search])
           if @hosts.any?
             @hosts = ::Host.where(id: @hosts).or(::Host.where(id: search_hosts))
@@ -38,7 +38,7 @@ module Katello
       end
 
       def find_organization
-        @organization ||= Organization.find(params[:organization_id])
+        @organization ||= Organization.find_by_id(params[:organization_id])
       end
     end
   end

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -38,7 +38,7 @@ module Katello
       end
 
       def find_organization
-        Organization.find_by_id(params[:organization_id])
+        @organization ||= Organization.find(params[:organization_id])
       end
     end
   end

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -17,7 +17,7 @@ module Katello
 
         if bulk_params[:included][:search]
           search_hosts = ::Host::Managed.authorized(permission)
-          search_hosts = search_hosts.where(:organization_id => organization_id) if params[:organization_id]
+          search_hosts = search_hosts.where(:organization_id => organization.id) if params[:organization_id]
           search_hosts = search_hosts.search_for(bulk_params[:included][:search])
           if @hosts.any?
             @hosts = ::Host.where(id: @hosts).or(::Host.where(id: search_hosts))

--- a/app/models/katello/subscription_status.rb
+++ b/app/models/katello/subscription_status.rb
@@ -22,7 +22,7 @@ module Katello
       when UNSUBSCRIBED_HYPERVISOR
         N_("Unsubscribed hypervisor")
       when DISABLED
-        N_("Disabled")
+        N_("Simple Content Access")
       else
         N_("Unknown subscription status")
       end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
             function getBulkSubscriptionParams() {
                 var bulkParams = hostIds;
                 bulkParams.subscriptions = SubscriptionsHelper.getSelectedSubscriptionAmounts($scope.table);
-                bulkParams.organization_id = CurrentOrganization; //eslint-disable-line camelcase
+                bulkParams['organization_id'] = CurrentOrganization; // eslint-disable-line camelcase
                 return bulkParams;
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
             function getBulkSubscriptionParams() {
                 var bulkParams = hostIds;
                 bulkParams.subscriptions = SubscriptionsHelper.getSelectedSubscriptionAmounts($scope.table);
-                bulkParams.organization_id = CurrentOrganization;
+                bulkParams.organization_id = CurrentOrganization; //eslint-disable-line camelcase
                 return bulkParams;
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
@@ -30,6 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
             function getBulkSubscriptionParams() {
                 var bulkParams = hostIds;
                 bulkParams.subscriptions = SubscriptionsHelper.getSelectedSubscriptionAmounts($scope.table);
+                bulkParams.organization_id = CurrentOrganization;
                 return bulkParams;
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -13,6 +13,7 @@
  * @requires Notification
  * @requires CurrentOrganization
  * @requires ContentHostsHelper
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality specific to Content Hosts for use with the Nutupane UI pattern.
@@ -20,8 +21,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsController',
-    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer',
-    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer) {
+    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled',
+    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled) {
         var nutupane, params, query;
 
         if ($location.search().search) {
@@ -47,6 +48,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
 
         $scope.table = nutupane.table;
         $scope.nutupane = nutupane;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         // @TODO begin hack necessary because of foreman API bug http://projects.theforeman.org/issues/13877
         $scope.table.sortBy = function (column) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
@@ -134,7 +134,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         controller: 'ContentHostAddSubscriptionsController',
         templateUrl: 'content-hosts/details/views/content-host-add-subscriptions.html',
         ncyBreadcrumb: {
-            label: "{{ 'Add Subscriptipons' | translate }}",
+            label: "{{ 'Add Subscriptions' | translate }}",
             parent: 'content-host.info'
         }
     });

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -52,7 +52,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
         };
 
         $scope.disableAddButton = function () {
-            return $scope.simpleContentAccessEnabled || $scope.table.numSelected === 0 || $scope.isAdding;
+            return $scope.table.numSelected === 0 || $scope.isAdding;
         };
 
         $scope.addSelected = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -52,7 +52,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
         };
 
         $scope.disableAddButton = function () {
-            return $scope.table.numSelected === 0 || $scope.isAdding;
+            return $scope.simpleContentAccessEnabled || $scope.table.numSelected === 0 || $scope.isAdding;
         };
 
         $scope.addSelected = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -13,13 +13,14 @@
  * @requires ApiErrorHandler
  * @requires deleteHostOnUnregister
  * @requires ContentHostsHelper
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper',
-    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper) {
+    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled) {
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
@@ -34,6 +35,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         $scope.defaultServiceLevels = ['Self-Support', 'Standard', 'Premium'];
 
         $scope.purposeAddonsCount = 0;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         $scope.panel = {
             error: false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -29,7 +29,7 @@
   </div>
 
   <span data-block="no-rows-message" translate>
-      You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
+      You currently don't have any Products to subscribe to. You can add Products after selecting 'Products' under 'Content' in the main menu.
   </span>
 
   <span data-block="no-search-results-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -69,6 +69,7 @@
         </a>
       </li>
       <li uib-dropdown
+          ng-if="!simpleContentAccessEnabled"
           ng-class="{active: stateIncludes('content-host.subscriptions.list') || stateIncludes('content-host.subscriptions.add')}">
         <a translate
            ui-sref="content-host.subscriptions.list">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -95,7 +95,7 @@
         </dd>
 
         <dt translate ng-if="!simpleContentAccessEnabled">Details</dt>
-        <dd>
+        <dd ng-if="!simpleContentAccessEnabled">
           <ul class="compliance-reasons">
             <li ng-repeat="reason in host.subscription_facet_attributes.compliance_reasons">{{ reason }}</li>
           </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -89,18 +89,9 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Subscription Status</dt>
-        <dd ng-if="!simpleContentAccessEnabled">
+        <dd>
           <i ng-class="getHostStatusIcon(host.subscription_global_status)"></i>
           {{ host.subscription_status_label }}
-        </dd>
-        <dd ng-if="simpleContentAccessEnabled">
-          <!-- always display green icon for SCA -->
-          <i
-            ng-class="getHostStatusIcon(0)"
-            title = "{{ 'This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.' | translate }}"
-            >
-          </i>
-          {{ 'Simple Content Access' | translate }}
         </dd>
 
         <dt translate>Details</dt>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -94,15 +94,14 @@
           {{ host.subscription_status_label }}
         </dd>
 
-        <dt translate>Details</dt>
+        <dt translate ng-if="!simpleContentAccessEnabled">Details</dt>
         <dd>
           <ul class="compliance-reasons">
             <li ng-repeat="reason in host.subscription_facet_attributes.compliance_reasons">{{ reason }}</li>
           </ul>
         </dd>
 
-        <dt translate>Auto-Attach Details</dt>
-        <dd ng-if="simpleContentAccessEnabled" translate>Not Applicable</dd>
+        <dt translate ng-if="!simpleContentAccessEnabled">Auto-Attach Details</dt>
         <dd ng-if="!simpleContentAccessEnabled"
             bst-edit-select="host.subscription_facet_attributes.autoheal"
             selector="host.subscription_facet_attributes.autoheal"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -89,9 +89,18 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Subscription Status</dt>
-        <dd>
+        <dd ng-if="!simpleContentAccessEnabled">
           <i ng-class="getHostStatusIcon(host.subscription_global_status)"></i>
           {{ host.subscription_status_label }}
+        </dd>
+        <dd ng-if="simpleContentAccessEnabled">
+          <!-- always display green icon for SCA -->
+          <i
+            ng-class="getHostStatusIcon(0)"
+            title = "{{ 'This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.' | translate }}"
+            >
+          </i>
+          {{ 'Simple Content Access' | translate }}
         </dd>
 
         <dt translate>Details</dt>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -13,8 +13,12 @@
     </div>
   </div>
 
-  <span data-block="no-rows-message" translate>
-     You currently don't have any Subscriptions associated with this Content Host, you can add Subscriptions after selecting the 'Add' tab.
+  <span data-block="no-rows-message" ng-if="!simpleContentAccessEnabled" translate>
+     You currently don't have any Subscriptions associated with this Content Host. You can add Subscriptions after selecting the 'Add' tab.
+  </span>
+
+  <span data-block="no-rows-message" ng-if="simpleContentAccessEnabled" translate>
+     You currently don't have any Subscriptions associated with this Content Host. Because Simple Content Access is enabled, adding subscriptions is not necessary.
   </span>
 
   <span data-block="no-search-results-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -13,12 +13,8 @@
     </div>
   </div>
 
-  <span data-block="no-rows-message" ng-if="!simpleContentAccessEnabled" translate>
+  <span data-block="no-rows-message" translate>
      You currently don't have any Subscriptions associated with this Content Host. You can add Subscriptions after selecting the 'Add' tab.
-  </span>
-
-  <span data-block="no-rows-message" ng-if="simpleContentAccessEnabled" translate>
-     You currently don't have any Subscriptions associated with this Content Host. Because Simple Content Access is enabled, adding subscriptions is not necessary.
   </span>
 
   <span data-block="no-search-results-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -78,7 +78,7 @@
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" sortable><span translate>Name</span></th>
-          <th bst-table-column="subscription_status" ng-if="!simpleContentAccessEnabled" sortable>
+          <th bst-table-column="subscription_status" ng-hide="simpleContentAccessEnabled" sortable>
             {{ 'Subscription Status' | translate }}
           </th>
           <th bst-table-column="status">
@@ -102,7 +102,7 @@
               {{ host.name }}
             </a>
           </td>
-          <td bst-table-cell ng-if="!simpleContentAccessEnabled">
+          <td bst-table-cell ng-hide="simpleContentAccessEnabled">
             <span ng-class="table.getHostStatusIcon(host.subscription_global_status)">
             </span>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -78,8 +78,8 @@
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" sortable><span translate>Name</span></th>
-          <th bst-table-column="subscription_status" sortable>
-            {{ "Subscription Status" | translate }}
+          <th bst-table-column="subscription_status" ng-if="!simpleContentAccessEnabled" sortable>
+            {{ 'Subscription Status' | translate }}
           </th>
           <th bst-table-column="status">
             <span translate>Installable Updates</span>
@@ -102,9 +102,9 @@
               {{ host.name }}
             </a>
           </td>
-          <td bst-table-cell>
-          <span ng-class="table.getHostStatusIcon(host.subscription_global_status)">
-          </span>
+          <td bst-table-cell ng-if="!simpleContentAccessEnabled">
+            <span ng-class="table.getHostStatusIcon(host.subscription_global_status)">
+            </span>
           </td>
           <td>
             <a ui-sref="content-host.errata.index({hostId: host.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -39,7 +39,7 @@
           <a ng-click="openSetReleaseVersionModal()" disable-link="table.numSelected === 0" translate>Set Release Version</a>
         </li>
 
-        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+        <li role="menuitem" ng-show="permitted('edit_hosts') && !simpleContentAccessEnabled" ng-class="{disabled: table.numSelected === 0}">
           <a ng-click="openSubscriptionsModal()" disable-link="table.numSelected === 0" translate>Manage Subscriptions</a>
         </li>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
@@ -11,13 +11,14 @@
  * @requires HostCollection
  * @requires Notification
  * @requires ApiErrorHandler
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the host collection details action pane.
  */
 angular.module('Bastion.host-collections').controller('HostCollectionDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'Host', 'ContentHostsModalHelper', 'HostCollection', 'Notification', 'ApiErrorHandler',
-    function ($scope, $state, $q, translate, Host, ContentHostsModalHelper, HostCollection, Notification, ApiErrorHandler) {
+    ['$scope', '$state', '$q', 'translate', 'Host', 'ContentHostsModalHelper', 'HostCollection', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, translate, Host, ContentHostsModalHelper, HostCollection, Notification, ApiErrorHandler, simpleContentAccessEnabled) {
         $scope.panel = {
             error: false,
             loading: true
@@ -26,6 +27,8 @@ angular.module('Bastion.host-collections').controller('HostCollectionDetailsCont
         if ($scope.hostCollection) {
             $scope.panel.loading = false;
         }
+
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         $scope.hostCollection = HostCollection.get({id: $scope.$stateParams.hostCollectionId}, function (hostCollection) {
             $scope.$broadcast('hostCollection.loaded', hostCollection);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-info.html
@@ -106,7 +106,7 @@
           </a>
         </li>
 
-        <li bst-feature-flag="subscription_management">
+        <li bst-feature-flag="subscription_management" ng-hide="simpleContentAccessEnabled">
           <a translate ng-click="openSubscriptionsModal()">
             Subscription Management
           </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -1,4 +1,4 @@
-<div bst-alert="info" ng-show="simpleContentAccessEnabled">
+<div id="content-access-mode-banner" bst-alert="info" ng-show="simpleContentAccessEnabled">
   <span translate>
 This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.
   </span>

--- a/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
@@ -52,7 +52,8 @@ describe('Controller: ContentHostsController', function() {
             Nutupane: Nutupane,
             $uibModal: $uibModal,
             ContentHostsModalHelper:ContentHostsModalHelper,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
         });
     }));
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -114,7 +114,8 @@ describe('Controller: ContentHostDetailsController', function() {
             CurrentOrganization: CurrentOrganization,
             Organization: Organization,
             HostSubscription: HostSubscription,
-            MenuExpander: MenuExpander
+            MenuExpander: MenuExpander,
+            simpleContentAccessEnabled: false
         });
     }));
 

--- a/engines/bastion_katello/test/host-collections/details/host-collection-details.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-details.controller.test.js
@@ -83,7 +83,8 @@ describe('Controller: HostCollectionDetailsController', function() {
             Host: Host,
             HostCollection: HostCollection,
             ContentHostsModalHelper: ContentHostsModalHelper,
-            ApiErrorHandler: ApiErrorHandler
+            ApiErrorHandler: ApiErrorHandler,
+            simpleContentAccessEnabled: false
         });
     }));
 

--- a/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
+++ b/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
@@ -15,10 +15,10 @@ module Katello
 
   class Api::V2::BulkHostsExtensionsTest < ActiveSupport::TestCase
     def models
-      @host1 = FactoryBot.create(:host)
-      @host2 = FactoryBot.create(:host)
-      @host3 = FactoryBot.create(:host)
       @organization = get_organization
+      @host1 = FactoryBot.create(:host, organization: @organization)
+      @host2 = FactoryBot.create(:host, organization: @organization)
+      @host3 = FactoryBot.create(:host, organization: @organization)
     end
 
     def permissions
@@ -29,7 +29,7 @@ module Katello
       set_user
       models
       permissions
-      @controller = TestController.new
+      @controller = TestController.new(organization_id: @organization.id)
     end
 
     def test_search

--- a/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
+++ b/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
@@ -16,9 +16,9 @@ module Katello
   class Api::V2::BulkHostsExtensionsTest < ActiveSupport::TestCase
     def models
       @organization = get_organization
-      @host1 = FactoryBot.create(:host, organization: @organization)
-      @host2 = FactoryBot.create(:host, organization: @organization)
-      @host3 = FactoryBot.create(:host, organization: @organization)
+      @host1 = hosts(:one)
+      @host2 = hosts(:two)
+      @host3 = hosts(:without_content_facet)
     end
 
     def permissions

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -93,6 +93,7 @@ module Katello
     end
 
     def test_add_subscriptions
+      Organization.any_instance.stubs(:simple_content_access?).returns(false)
       assert_sync_task(::Actions::Katello::Host::AttachSubscriptions) do |host, pools_with_quantities|
         assert_equal @host, host
         assert_equal 1, pools_with_quantities.count

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -286,23 +286,24 @@ module Katello
       pool = katello_pools(:pool_one)
 
       assert_protected_action(:content_overrides, good_perms, bad_perms) do
-        put :content_overrides, params: { :included => {:ids => @host_ids}, :content_overrides => [{:content_label => 'some-content', :value => 1}] }
+        put :content_overrides, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :content_overrides => [{:content_label => 'some-content', :value => 1}] }
       end
 
       assert_protected_action(:add_subscriptions, good_perms, bad_perms) do
-        put :add_subscriptions, params: { :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}] }
+        put :add_subscriptions, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :subscriptions => [{:id => pool.id, :quantity => 1}] }
       end
 
       assert_protected_action(:remove_subscriptions, good_perms, bad_perms) do
-        put :remove_subscriptions, params: { :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}] }
+        put :remove_subscriptions, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :subscriptions => [{:id => pool.id, :quantity => 1}] }
       end
 
       assert_protected_action(:auto_attach, good_perms, bad_perms) do
-        put :auto_attach, params: { :included => {:ids => @host_ids} }
+        put :auto_attach, params: { :organization_id => @org.id, :included => {:ids => @host_ids} }
       end
     end
 
     def test_add_subscriptions
+      Organization.any_instance.stubs(:simple_content_access?).returns(false)
       pool = katello_pools(:pool_one)
 
       assert_async_task(::Actions::BulkAction) do |action_class, hosts, pools_with_quantities|
@@ -312,8 +313,15 @@ module Katello
         assert_equal pool, pools_with_quantities[0].pool
         assert_equal [1], pools_with_quantities[0].quantities.map(&:to_i)
       end
-      put :add_subscriptions, params: { :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}] }
+      put :add_subscriptions, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :subscriptions => [{:id => pool.id, :quantity => 1}] }
       assert_response :success
+    end
+
+    def test_add_subscriptions_with_simple_content_access
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
+      pool = katello_pools(:pool_one)
+      put :add_subscriptions, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :subscriptions => [{:id => pool.id, :quantity => 1}] }
+      assert_response :bad_request
     end
 
     def test_remove_subscriptions
@@ -326,7 +334,7 @@ module Katello
         assert_equal pool, pools_with_quantities[0].pool
         assert_equal [1], pools_with_quantities[0].quantities.map(&:to_i)
       end
-      put :remove_subscriptions, params: { :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}] }
+      put :remove_subscriptions, params: { :organization_id => @org.id, :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}] }
       assert_response :success
     end
 
@@ -336,7 +344,7 @@ module Katello
         assert_includes hosts, @host1
         assert_includes hosts, @host2
       end
-      put :auto_attach, params: { :included => {:ids => @host_ids} }
+      put :auto_attach, params: { :organization_id => @org.id, :included => {:ids => @host_ids} }
       assert_response :success
     end
 
@@ -354,7 +362,7 @@ module Katello
         assert_equal expected_content_labels, content_overrides.map(&:content_label)
         assert_equal expected_values, content_overrides.map(&:value)
       end
-      put :content_overrides, params: { :included => {:ids => @host_ids}, :content_overrides => expected_content_overrides }
+      put :content_overrides, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :content_overrides => expected_content_overrides }
       assert_response :success
     end
 
@@ -373,6 +381,7 @@ module Katello
       Katello::HostTracer.create(host_id: @host2.id, application: 'dbus', app_type: 'static', helper: 'reboot the system')
 
       post :traces, params: {
+        organization_id: @org.id,
         included: {:ids => @host_ids}
       }
 


### PR DESCRIPTION
[sat-e-492] As a user, I should not be able to attach a subscription to a host with SCA enabled

* `PUT hosts/:host_id/subscriptions/add_subscriptions` will now return a Bad Request
* Content Hosts page:
  * Subscription Status section does not show
* Content Hosts -> details -> Subscriptions:
  * Tab does not show
  * Simple Content Access Banner is visible, explaining that you don't need subscriptions

- [x] Disallow API call to attach subscriptions
- [x] Don’t show Subscriptions tab in Content Host details page
- [x] Don't show ‘Subscription Status’ table column
- [x] Change messaging in Subscription section of Content Host Details
