### PR TITLE
Fixes #29823 - Ignore Traces that have no helper

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -226,11 +226,13 @@ module Katello
       end
 
       def import_tracer_profile(tracer_profile)
-        host_traces.delete_all
         traces = []
         tracer_profile.each do |trace, attributes|
+          next if attributes[:helper].blank?
+
           traces << { host_id: self.id, application: trace, helper: attributes[:helper], app_type: attributes[:type] }
         end
+        host_traces.delete_all
         Katello::HostTracer.import(traces, validate: false)
         update_trace_status
       end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -361,9 +361,22 @@ module Katello
   class HostTracerTest < HostManagedExtensionsTestBase
     def setup
       super
-      tracer_json = {"sshd": {"type": "daemon", "helper": "sudo systemctl restart sshd"}}
+      tracer_json = {
+        "sshd": {
+          "type": "daemon",
+          "helper": "sudo systemctl restart sshd"
+        },
+        "tuned": {
+          "type": "daemon",
+          "helper": ""
+        }
+      }
       @foreman_host.import_tracer_profile(tracer_json)
       @foreman_host.reload
+    end
+
+    def test_trace_blank_helper
+      assert_empty @foreman_host.host_traces.where(application: 'tuned')
     end
 
     def test_known_traces


### PR DESCRIPTION
We can't act on these, like 'su' or 'sudo', so don't show them