### PR TITLE
Fixes #29595 - Orphaned dangling content in katello fails migration

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -13,6 +13,19 @@ module Actions
                 Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans,
                 proxy)
             end
+            plan_self
+          end
+        end
+
+        def run
+          models = []
+          ::Katello::RepositoryTypeManager.repository_types.each_value do |repo_type|
+            indexable_types = repo_type.content_types_to_index
+            models += indexable_types&.map(&:model_class)
+            models.select! { |model| model.many_repository_associations }
+          end
+          models.each do |model|
+            model.joins("left join katello_#{model.repository_association} on #{model.table_name}.id = katello_#{model.repository_association}.#{model.unit_id_field}").where("katello_#{model.repository_association}.#{model.unit_id_field} IS NULL").destroy_all
           end
         end
       end


### PR DESCRIPTION
**To reproduce:**

1. On pulp2 create and sync 2 docker repos and 2 file repos
2. Delete 1 repo of each type.
3. Run bundle exec rails katello:pulp3_migration
4. Run bundle exec rails katello:delete_orphaned_content
5. Run bundle exec rails katello:pulp3_content_switchover

You'll notice an error with Docker content type. If you delete the Katello:DockerTag records where migrated_href is nil, next you'll see issues with Manifests and so on. Once you fight through Docker content, you'll see the same issue for FileUnit. 


