### PR TITLE
Fixes #29847 - Cannot enable dep solving or auto publish

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -228,7 +228,8 @@ module Katello
     end
 
     def view_params
-      attrs = [:name, :description, :force_puppet_environment, {:component_ids => []}]
+      attrs = [:name, :description, :force_puppet_environment, :auto_publish, :solve_dependencies,
+               :default, :created_at, :updated_at, :next_version, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
       if (!@view || !@view.composite?)
         attrs.push({:repository_ids => []}, :repository_ids)

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -150,12 +150,20 @@ module Katello
 
     test_attributes :pid => '3f1457f2-586b-472c-8053-99017c4a4909'
     def test_update
-      params = { :name => "My View", :description => "New description", :solve_dependencies => true }
+      params = { :name => "My View", :description => "New description", :solve_dependencies => true,
+                 :force_puppet_environment => false, :auto_publish => false, :label => "test_label", :default => "test_default",
+                 :created_at => "test_created_at", :updated_at => "test_updated_at", :composite => false,
+                 :next_version => "test_next_version" }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:name).must_equal true
-        content_view_params[:name].must_equal params[:name]
-        content_view_params.key?(:description).must_equal true
-        content_view_params[:description].must_equal params[:description]
+        params.each do |key, value|
+          if key == :label || key == :composite
+            content_view_params.key?(key).must_equal false
+            assert_nil content_view_params[key]
+          else
+            content_view_params.key?(key).must_equal true
+            content_view_params[key].must_equal value
+          end
+        end
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 


### PR DESCRIPTION
Dep solving and auto publish were broken by Rails 6 it appears.  Adding these attributes to `view_params` fixes the issue.