### PR TITLE
Fixes #25921 - Sync Smart Proxies before installing Errata during Incremental Update

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -2,7 +2,7 @@ module Actions
   module Katello
     module ContentView
       class Promote < Actions::EntryAction
-        def plan(version, environments, is_force = false, description = nil)
+        def plan(version, environments, is_force = false, description = nil, incremental_update = false)
           action_subject(version.content_view)
           version.check_ready_to_promote!(environments)
 
@@ -13,7 +13,7 @@ module Actions
           environments.each do |environment|
             sequence do
               plan_action(Katello::ContentViewVersion::BeforePromoteHook, :id => version.id)
-              plan_action(ContentView::PromoteToEnvironment, version, environment, description)
+              plan_action(ContentView::PromoteToEnvironment, version, environment, description, incremental_update)
               plan_action(Katello::ContentViewVersion::AfterPromoteHook, :id => version.id)
             end
           end

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -334,7 +334,7 @@ module Actions
         end
 
         def promote(new_version, environments)
-          plan_action(Katello::ContentView::Promote, new_version, environments, true)
+          plan_action(Katello::ContentView::Promote, new_version, environments, true, nil, true)
         end
 
         def copy_deb_content(new_repo, dep_solve, deb_ids)

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -74,7 +74,7 @@ module ::Actions::Katello::ContentView
     end
   end
 
-  class PromoteToEnviromentTest < TestBase
+  class PromoteToEnvironmentTest < TestBase
     let(:action_class) { ::Actions::Katello::ContentView::PromoteToEnvironment }
 
     let(:environment) do
@@ -88,8 +88,21 @@ module ::Actions::Katello::ContentView
     it 'plans' do
       assert_empty content_view_version.history
       action.stubs(:task).returns(success_task)
+
       plan_action(action, content_view_version, environment, 'description')
+
       refute_empty content_view_version.history
+      refute_action_planned(action, Actions::Katello::ContentView::CapsuleSync)
+    end
+
+    it 'plans for incremental update' do
+      action.stubs(:task).returns(success_task)
+      action.expects(:sync_proxies?).returns(true)
+
+      plan_action(action, content_view_version, environment, 'description', true)
+
+      refute_empty content_view_version.history
+      assert_action_planned(action, Actions::Katello::ContentView::CapsuleSync)
     end
 
     context 'finalize phase' do


### PR DESCRIPTION
Builds on the changes in #7946 and addresses the additional feedback here: https://github.com/Katello/katello/pull/7946#issuecomment-506422122

The goal of this change is to sync affected smart proxies before installing applicable errata during an incremental update. It achieves this by providing a new execution path through the `PromoteToEnvironment` action which will plan the smart proxy sync in the plan phase rather than using .async_task in the run phase. The behavior of CV promotion is not changed outside of incremental update.

I had a very bad time trying to test this on master with pulp3. I tried switching back to pulp2 but experienced different issues but those may have been related for my environment. For those reasons I would recommend testing this against 3.15 where I found it to work flawlessly.

**To test**

- Create a new Lifecycle Environment, Library -> **Stage**
- register a proxy to Katello
- associate Library and Stage environments to the proxy
- register a client (katello-client) to the proxy and make sure katello-agent is running.
- create a product with a repo that provides some errata: https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
- create a content view with the repo you created
- Promote the CV to Stage
- Add the client to the Stage env and the CV you created
- Install walrus-0.71 on the client
- add an errata excludes filter to the CV to omit the 'sea' errata in the repo. publish and promote it to Stage
- walrus-5.2 should **not** be available to the client (verify)

**Finally:**

- initiate an incremental update of the CVV you published and promoted: `hammer content-view version incremental-update  --content-view-version-id=$LATEST_CVV_ID --errata-ids=RHEA-2012:0055 --update-all-hosts=1 --lifecycle-environment-ids=$STAGE_LCE_ID
`
- verify walrus-5.2 is now install on the client