### PR TITLE
Refs #29330 - fix install_all errata

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -43,7 +43,7 @@ module Katello
       end
 
       def errata_inputs
-        if params[:install_all]
+        if ::Foreman::Cast.to_bool(params[:install_all])
           Erratum.installable_for_hosts(hosts).pluck(:errata_id).join(',')
         else
           params[:name]


### PR DESCRIPTION
@sbernhard @jlsherrill REX always tried to install all applicable errata, even if only a subset had been selected.