### PR TITLE
Fixes #29942 - Prevent duplicate toasts on Subscriptions page

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -106,7 +106,7 @@ export const resetTasks = () => (dispatch) => {
 
 export const handleTask = task => async (dispatch, getState) => {
   if (selectIsPollingTask(getState(), SUBSCRIPTIONS)) {
-    if (!task.pending) {
+    if (!task.pending && task.result !== 'pending') {
       dispatch(stopPollingTask(SUBSCRIPTIONS));
       dispatch(toastTaskFinished(task));
       dispatch(resetTasks());

--- a/webpack/scenes/Tasks/TaskActions.js
+++ b/webpack/scenes/Tasks/TaskActions.js
@@ -5,8 +5,16 @@ import { stopInterval, withInterval } from 'foremanReact/redux/middlewares/Inter
 import { foremanTasksApi } from '../../services/api';
 import { bulkSearchKey, pollTaskKey, taskFinishedToast } from './helpers';
 
-export const toastTaskFinished = task => async dispatch =>
+const finishedTasks = {};
+
+export const toastTaskFinished = task => async (dispatch) => {
+  if (task.id) {
+    // Keep track of tasks we've already notified about to prevent duplicate toasts from appearing
+    if (finishedTasks[task.id]) return;
+    finishedTasks[task.id] = true;
+  }
   dispatch(addToast(taskFinishedToast(task)));
+};
 
 const taskBulkSearchParams = params => ({
   search: Object.entries(propsToSnakeCase(params))


### PR DESCRIPTION
Multiple toast notifications were appearing when importing a manifest:

![manifest_success](https://user-images.githubusercontent.com/22042343/83028390-5cc34780-9fff-11ea-9e10-64a6b0a8dc2a.png)

During API interval polling of the subscription task state, Katello is supposed to look for the first non-pending "stopped / success" response, stop polling, and send a Toast notification informing the user.  I'm not certain, but the issue was probably due to multiple "success" messages coming back because polling was not stopped soon enough.

Whatever the cause, this change will prevent multiple "task finished" toasts for the same task.