### PR TITLE
Fixes #29948 - Unable to re-import subscriptions in large environment

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -164,7 +164,7 @@ module Katello
       def import_hosts
         uuids = Resources::Candlepin::Pool.consumer_uuids(self.cp_id)
 
-        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where(:uuid => uuids).pluck([:id, :host_id]).transpose
+        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where('uuid in (?)', uuids).pluck([:id, :host_id]).transpose
         sub_facet_ids_from_cp ||= []
         host_ids_from_cp ||= []
 

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -117,6 +117,15 @@ module Katello
       Pool.import_all(org, false)
     end
 
+    def test_import_hosts
+      host = FactoryBot.create(:host, :with_subscription)
+      Resources::Candlepin::Pool.expects(:consumer_uuids).returns([host.subscription_facet.uuid])
+
+      @pool_one.import_hosts
+
+      assert @pool_one.subscription_facets.where(id: host.subscription_facet.id).any?
+    end
+
     def test_quantity_available_unlimited
       pool = FactoryBot.build(:katello_pool, quantity: -1, consumed: 3)
       assert_equal(-1, pool.quantity_available)


### PR DESCRIPTION
Prevent active record from generating a query that postgres doesn't like (we use this approach in other places too).

I couldn't reproduce on my dev box, so recommend doing it downstream.

Testing the approach is simple from the console:

```
uuids = []
100000.times { |x| uuids << SecureRandom.uuid }
Katello::Host:::SubscriptionFacet.where(uuid: uuids)
```

This raises an error: `ActiveRecord::StatementInvalid (PG::ProtocolViolation: ERROR: invalid message format)`

But running the query as it is in the PR works:

```
Katello::Host:::SubscriptionFacet.where('uuid in (?)', uuids)
```

You can test the actual functionality by running `Katello::Pool.import_all` from the rails console. I also added a unit test since we have 0 coverage here it seems! 