### PR TITLE
Fixes #29987 - Increase nock testing timeout

### DIFF
--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -4,3 +4,6 @@
 global.console.error = (error) => {
   throw new Error(error);
 };
+
+// Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
+jest.setTimeout(10000);

--- a/webpack/test-utils/nockWrapper.js
+++ b/webpack/test-utils/nockWrapper.js
@@ -10,7 +10,7 @@ export const nockInstance = nock('http://localhost');
 
 // Calling .done() with nock asserts that the request was fufilled. We use a timeout to ensure
 // that the component has set up and made the request before the assertion is made.
-export const assertNockRequest = (scope, timeout = 5000) => {
+export const assertNockRequest = (scope, timeout = 10000) => {
   setTimeout(() => {
     scope.done();
   }, timeout);


### PR DESCRIPTION
We see this fail on jenkins intermittenly, it appears the timeout is not enough, but it could be due to other factors. I would like to see if this fixes it first.