### PR TITLE
Fixes #26954 - Fix auto-closing rows on Subscriptions table

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
@@ -29,7 +29,10 @@ class SubscriptionsTable extends Component {
       nextProps.subscriptions !== undefined &&
       !isEqual(nextProps.subscriptions, prevState.subscriptions)
     ) {
-      const groupedSubscriptions = groupSubscriptionsByProductId(nextProps.subscriptions);
+      const groupedSubscriptions = groupSubscriptionsByProductId(
+        nextProps.subscriptions,
+        prevState.groupedSubscriptions,
+      );
       const rows = buildTableRows(
         groupedSubscriptions,
         nextProps.subscriptions.availableQuantities,
@@ -188,19 +191,20 @@ class SubscriptionsTable extends Component {
 
 
   toggleSubscriptionGroup = (groupId) => {
-    const { subscriptions } = this.props;
-    const { groupedSubscriptions, updatedQuantity } = this.state;
-    const { open } = groupedSubscriptions[groupId];
+    this.setState((prevState) => {
+      const { subscriptions } = this.props;
+      const { groupedSubscriptions, updatedQuantity } = prevState;
+      const { open } = groupedSubscriptions[groupId];
 
-    groupedSubscriptions[groupId].open = !open;
+      groupedSubscriptions[groupId].open = !open;
 
-    const rows = buildTableRows(
-      groupedSubscriptions,
-      subscriptions.availableQuantities,
-      updatedQuantity,
-    );
-
-    this.setState({ rows, groupedSubscriptions });
+      const rows = buildTableRows(
+        groupedSubscriptions,
+        subscriptions.availableQuantities,
+        updatedQuantity,
+      );
+      return { rows, groupedSubscriptions };
+    });
   };
 
   enableEditing = (editingState) => {
@@ -211,15 +215,17 @@ class SubscriptionsTable extends Component {
   };
 
   updateRows = (updatedQuantity) => {
-    const { groupedSubscriptions } = this.state;
-    const { subscriptions } = this.props;
+    this.setState((prevState) => {
+      const { groupedSubscriptions } = prevState;
+      const { subscriptions } = this.props;
 
-    const rows = buildTableRows(
-      groupedSubscriptions,
-      subscriptions.availableQuantities,
-      updatedQuantity,
-    );
-    this.setState({ rows, updatedQuantity });
+      const rows = buildTableRows(
+        groupedSubscriptions,
+        subscriptions.availableQuantities,
+        updatedQuantity,
+      );
+      return { rows, updatedQuantity };
+    });
   };
 
   showUpdateConfirm = (show) => {

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
@@ -76,13 +76,17 @@ export const buildTableRows = (groupedSubscriptions, availableQuantities, update
   return rows;
 };
 
-export const groupSubscriptionsByProductId = ({ results: subscriptions }) => {
+export const groupSubscriptionsByProductId = (
+  { results: subscriptions },
+  prevGroupedSubscriptions,
+) => {
   const grouped = {};
 
   subscriptions.forEach((subscription) => {
     if (grouped[subscription.product_id] === undefined) {
+      const prevOpenState = prevGroupedSubscriptions?.[subscription.product_id]?.open || false;
       grouped[subscription.product_id] = {
-        open: false,
+        open: prevOpenState,
         subscriptions: [],
       };
     }


### PR DESCRIPTION
(Broken out into a separate PR from #8730)

This change updates `SubscriptionsTable.js` to fix the bug where expanded rows would collapse as soon as you click to select a row.  (The cause was that a variable called `groupedSubscriptions` was being cleared out every time new props were received.)  In the process I discovered that two functions were using React `setState` [incorrectly](https://reactjs.org/docs/faq-state.html#why-is-setstate-giving-me-the-wrong-value).  Refactored using the function form of `setState` so that we can rely on the previous state values.

