### PR TITLE
Refs #29929 - disable subscription through activation key in SCA

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class Api::V2::ActivationKeysController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
     include Katello::Concerns::Api::V2::ContentOverridesController
@@ -11,6 +12,7 @@ module Katello
                                                   :content_override, :add_subscriptions, :remove_subscriptions,
                                                   :subscriptions]
     before_action :authorize
+    before_action :verify_simple_content_access_disabled, :only => [:add_subscriptions]
 
     wrap_parameters :include => (ActivationKey.attribute_names + %w(host_collection_ids service_level auto_attach purpose_role purpose_usage purpose_addons content_view_environment))
 
@@ -347,6 +349,12 @@ module Katello
       end
 
       key_params
+    end
+
+    def verify_simple_content_access_disabled
+      if @activation_key.organization.simple_content_access?
+        fail HttpErrors::BadRequest, _("The specified organization is in Simple Content Access mode. Attaching subscriptions is disabled")
+      end
     end
   end
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -9,13 +9,14 @@
  * @requires ActivationKey
  * @requires ContentHostsHelper
  * @requires CurrentOrganization
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for activation key associations.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host',
-    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host', 'simpleContentAccessEnabled',
+    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host, simpleContentAccessEnabled) {
         var contentHostsNutupane, nutupaneParams, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -59,5 +60,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.memory = ContentHostsHelper.memory;
+
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -11,17 +11,19 @@
  * @requires Organization
  * @requires Notification
  * @requires ApiErrorHandler
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the activation key details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler',
-    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler) {
+    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler, simpleContentAccessEnabled) {
         $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
         $scope.defaultUsages = ['Production', 'Development/Test', 'Disaster Recovery'];
 
         $scope.purposeAddonsCount = 0;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         $scope.organization = Organization.get({id: CurrentOrganization}, function(org) {
             $scope.purposeAddonsCount += org.system_purposes.addons.length;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -13,7 +13,7 @@
   </div>
 
   <span data-block="no-rows-message" translate>
-     You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
+     You currently don't have any Products to subscribe to. You can add Products after selecting 'Products' under 'Content' in the main menu.
   </span>
 
   <span data-block="no-search-results-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -14,7 +14,7 @@
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name" sortable><span translate>Name</span></th>
-          <th bst-table-column="status" translate>
+          <th bst-table-column="status" ng-if="!simpleContentAccessEnabled" translate>
             Subscription Status
           </th>
           <th bst-table-column="environment" sortable><span translate>Environment</span></th>
@@ -32,7 +32,7 @@
               {{ host.name }}
             </a>
           </td>
-          <td bst-table-cell>
+          <td bst-table-cell ng-if="!simpleContentAccessEnabled">
             <span ng-class="getHostStatusIcon(host.subscription_global_status)">
             </span>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
@@ -40,7 +40,7 @@
           </span>
         </a>
       </li>
-      <li ng-class="{active: stateIncludes('activation-key.subscriptions')}">
+      <li ng-class="{active: stateIncludes('activation-key.subscriptions')}"  ng-hide="simpleContentAccessEnabled">
         <a ui-sref="activation-key.subscriptions.list">
           <span translate>
             Subscriptions

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
@@ -40,7 +40,8 @@ describe('Controller: ActivationKeyAssociationsController', function() {
             ActivationKey: ActivationKey,
             Host: Host,
             ContentHostsHelper: {},
-            CurrentOrganization: "ACME"
+            CurrentOrganization: 'ACME',
+            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
         });
     }));
 

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
@@ -70,7 +70,8 @@ describe('Controller: ActivationKeyDetailsController', function() {
             $state: $state,
             ActivationKey: ActivationKey,
             CurrentOrganization: CurrentOrganization,
-            Organization: Organization
+            Organization: Organization,
+            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
         });
     }));
 

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -461,9 +461,19 @@ module Katello
       allowed_perms = [@update_permission]
       denied_perms = [@view_permission, @create_permission, @destroy_permission]
 
+      Organization.any_instance.stubs(:simple_content_access?).returns(false)
+
       assert_protected_action(:add_subscriptions, allowed_perms, denied_perms, [@organization]) do
         post(:add_subscriptions, params: { :organization_id => @organization.id, :id => @activation_key.id, :subscription_id => 123 })
       end
+    end
+
+    def test_add_subscriptions_fails
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
+
+      post(:add_subscriptions, params: { :organization_id => @organization.id, :id => @activation_key.id, :subscription_id => 123 })
+
+      assert_response :bad_request
     end
 
     def test_remove_subscriptions_protected


### PR DESCRIPTION
What was done:
Remove subscription tab from activation_key page for SCA enabled org.
Check for SCA enabled org while adding subscription through activation-key in controller
Remove subscription status column from content host association table at activation key page.
Add test for activation key controller changes.

Not included:
If we come on subscription page through url, we will display the subscription page then but because we have changed the add_subscription method in controller, user can only see the page, can not do anything.