### PR TITLE
Fixes #30010 - removed proxy.hostname from safemode

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -332,7 +332,3 @@ module Katello
     end
   end
 end
-
-class ::SmartProxy::Jail < Safemode::Jail
-  allow :hostname
-end


### PR DESCRIPTION
As this was added into Foreman core:

https://github.com/theforeman/foreman/pull/7713

Tests will fail until the core PR is merged.