### PR TITLE
Refs #29768 - explicitly depend on the pg gem

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fx", "< 1.0"
 
+  gem.add_dependency "pg"
+
   # Pulp
   gem.add_dependency "runcible", ">= 2.13.0", "< 3.0.0"
   gem.add_dependency "anemone"


### PR DESCRIPTION
5147705 introduced an explicit require of the PostgreSQL adaptor, but
that does not pull in the pg gem, so RPM builds fail with

    Gem::MissingSpecError: Could not find 'pg' (< 2.0, >= 0.18) among 165 total gem(s)