### PR TITLE
Fixes #30092 - provide current organization as parameter to content view versions controller api

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
@@ -9,10 +9,10 @@
  *   Provides a BastionResource for interacting with Content View Versions.
  */
 angular.module('Bastion.content-views.versions').factory('ContentViewVersion',
-    ['BastionResource', function (BastionResource) {
+    ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
         return BastionResource('katello/api/v2/content_view_versions/:id/:action',
-            {id: '@id'},
+            {id: '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 update: {method: 'PUT'},

--- a/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: ContentViewVersion', function () {
     });
 
     it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('katello/api/v2/content_view_versions').respond(contentViewVersion);
+        $httpBackend.expectGET('katello/api/v2/content_view_versions?organization_id=ACME').respond(contentViewVersion);
 
         ContentViewVersion.queryPaged(function (contentViewVersion) {
             expect(contentViewVersion.records.length).toBe(1);
@@ -34,7 +34,7 @@ describe('Factory: ContentViewVersion', function () {
     });
 
     it('provides a way to get an incremental update', function () {
-        $httpBackend.expectPOST('katello/api/v2/content_view_versions/incremental_update').respond({});
+        $httpBackend.expectPOST('katello/api/v2/content_view_versions/incremental_update?organization_id=ACME').respond({});
         ContentViewVersion.incrementalUpdate();
     });
 });


### PR DESCRIPTION
This PR introduces the current organization as a parameter to content view version requests.

Without this parameter it was possible to view (when an one organization is currently selected) content view version details of a content view that belongs to another organization.