### PR TITLE
Refs #29928 remove subscription widgets

### DIFF
--- a/app/helpers/katello/concerns/dashboard_helper_extensions.rb
+++ b/app/helpers/katello/concerns/dashboard_helper_extensions.rb
@@ -28,6 +28,16 @@ module Katello
       def unsubscribed_hypervisor_count
         host_query.search_for("subscription_status = unsubscribed_hypervisor").size
       end
+
+      def removed_widgets
+        widgets = super
+
+        if Organization.current&.simple_content_access?
+          widgets.reject! { |widget| ::Widget.singleton_class::SUBSCRIPTION_TEMPLATES.include? widget[:template] }
+        end
+
+        widgets
+      end
     end
   end
 end

--- a/app/models/katello/concerns/widget_extensions.rb
+++ b/app/models/katello/concerns/widget_extensions.rb
@@ -1,0 +1,23 @@
+module Katello
+  module Concerns
+    module WidgetExtensions
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        SUBSCRIPTION_TEMPLATES = %w[subscription_status_widget subscription_widget].freeze
+
+        def without_subscription_widgets
+          where.not(template: ::Widget.singleton_class::SUBSCRIPTION_TEMPLATES)
+        end
+
+        def available
+          if Organization.current&.simple_content_access?
+            super.without_subscription_widgets
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -223,6 +223,7 @@ module Katello
       end
 
       ::AuditSearch::ClassMethods.prepend Katello::Concerns::AuditSearch
+      ::Widget.singleton_class.prepend Katello::Concerns::WidgetExtensions::ClassMethods
 
       load 'katello/repository_types.rb'
       load 'katello/scheduled_jobs.rb'

--- a/test/models/concerns/widget_extensions_test.rb
+++ b/test/models/concerns/widget_extensions_test.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class WidgetExtensionsTest < ActiveSupport::TestCase
+    def setup
+      Organization.current = get_organization(:empty_organization)
+    end
+
+    def test_available_scope
+      Widget.stubs(:available).returns(Widget.all)
+      assert_equal 0, Widget.available.count
+    end
+  end
+end


### PR DESCRIPTION
What was done
=> Remove subscriptions widgets from Dashboard when SCA is enabled.
=> Remove "Add subscriptions widgets" from manage button drop down when SCA is enbled.
 