### PR TITLE
Fixes #30101 - Use delete_all for SubscriptionFacetPools association

### DIFF
--- a/app/lib/katello/logging.rb
+++ b/app/lib/katello/logging.rb
@@ -1,0 +1,14 @@
+module Katello
+  module Logging
+    def self.time(message, data: {}, logger: Rails.logger, level: :info)
+      start = Time.now
+
+      yield
+
+      data[:duration] = ((Time.now - start) * 1000).truncate(2)
+      data_string = data.map { |k, v| "#{k}=#{v}" }.join(' ')
+
+      logger.send(level, "#{message} #{data_string}")
+    end
+  end
+end

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -36,11 +36,15 @@ module Katello
 
           objects = self.in_organization(org)
           objects.each do |item|
-            if candlepin_ids.include?(item.cp_id)
-              item.import_data
-              item.import_managed_associations if import_managed_associations && item.respond_to?(:import_managed_associations)
-            else
-              item.destroy
+            exists_in_candlepin = candlepin_ids.include?(item.cp_id)
+
+            Katello::Logging.time("Imported #{self}", data: { cp_id: item.cp_id, destroyed: !exists_in_candlepin }) do
+              if exists_in_candlepin
+                item.import_data
+                item.import_managed_associations if import_managed_associations && item.respond_to?(:import_managed_associations)
+              else
+                item.destroy
+              end
             end
           end
         end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -187,8 +187,13 @@ module Katello
       end
 
       def import_managed_associations
-        import_hosts
-        create_activation_key_associations
+        Katello::Logging.time("Imported host associations") do
+          import_hosts
+        end
+
+        Katello::Logging.time("Imported activation key associations") do
+          create_activation_key_associations
+        end
       end
 
       def hosts

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -132,11 +132,18 @@ module Katello
         cp_products = cp_products.select { |prod| Glue::Candlepin::Product.engineering_product_id?(prod['id']) }
 
         prod_content_importer = Katello::ProductContentImporter.new
-        cp_products.each do |product_json|
-          product = import_product(product_json)
-          prod_content_importer.add_product_content(product, product_json['productContent']) if product.redhat?
+
+        Katello::Logging.time("Imported #{cp_products.size} products") do
+          cp_products.each do |product_json|
+            product = import_product(product_json)
+            prod_content_importer.add_product_content(product, product_json['productContent']) if product.redhat?
+          end
         end
-        prod_content_importer.import
+
+        Katello::Logging.time("Imported product content") do
+          prod_content_importer.import
+        end
+
         self.index_subscriptions(self.organization)
         prod_content_importer
       end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -9,7 +9,7 @@ module Katello
     has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :pool
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"
 
-    has_many :subscription_facet_pools, :class_name => "Katello::SubscriptionFacetPool", :dependent => :destroy
+    has_many :subscription_facet_pools, :class_name => "Katello::SubscriptionFacetPool", :dependent => :delete_all
     has_many :subscription_facets, :through => :subscription_facet_pools
 
     belongs_to :organization, :class_name => 'Organization', :inverse_of => :pools

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -117,6 +117,14 @@ module Katello
       Pool.import_all(org, false)
     end
 
+    def test_import_all_destroy
+      org = get_organization
+      Pool.expects(:import_candlepin_ids).with(org).returns([])
+      Pool.expects(:in_organization).with(org).returns([@pool_one])
+      Pool.import_all(org)
+      refute Pool.find_by_id(@pool_one.id)
+    end
+
     def test_import_hosts
       host = FactoryBot.create(:host, :with_subscription)
       Resources::Candlepin::Pool.expects(:consumer_uuids).returns([host.subscription_facet.uuid])


### PR DESCRIPTION
Deleting a pool would issue individual SQL queries when cleaning up SubscriptionFacetPool objects:

```
2020-06-10T15:36:46 [D|sql|]   Katello::SubscriptionFacetPool Destroy (0.2ms)  DELETE FROM "katello_subscription_facet_pools" WHERE "katello_subscription_facet_pools"."id" = $1  [["id", 476743]] 
```

Using delete_all issues a single query:
```
2020-06-11T13:07:23 [D|sql|]   Katello::SubscriptionFacetPool Destroy (29.1ms)  DELETE FROM "katello_subscription_facet_pools" WHERE "katello_subscription_facet_pools"."pool_id" = $1  [["pool_id", 394]] 
```

In a real-world scenario this affects manifest import speed, and the speedup is significant:

before:
```
5: Actions::Candlepin::Owner::ImportProducts (success) [ 2351.84s / 2351.84s ]
```

after:
```
5: Actions::Candlepin::Owner::ImportProducts   (success)        [ 3.78s / 3.78s ]
```

In a simulated scenario I saw speedup like this for a single pool with 50000 SubscriptionFacetPools when calling `Katello::Pool.import_all`

before:
```
=> [#<Benchmark::Tms:0x00000000179f48b0 @cstime=0.0, @cutime=0.0, @label="", @real=14.058943261043169, @stime=0.767635, @total=10.296436, @utime=9.528801>]
```

after (29ms was spent deleting)
```
=> [#<Benchmark::Tms:0x000000001561f318 @cstime=0.0, @cutime=0.0, @label="", @real=0.12148274498758838, @stime=0.003206999999999738, @total=0.030070000000048225, @utime=0.026863000000048487>]
```

This is how I set up the scenario: https://gist.github.com/jturel/317e9f892fb19e84480880f1f674e74e