### PR TITLE
Fixes #30100 - reset http proxy in repos if deleted

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -100,7 +100,7 @@ module Katello
     scope :with_no_proxy, -> { where(:http_proxy_policy => RootRepository::NO_DEFAULT_HTTP_PROXY) }
     scope :with_selected_proxy, ->(http_proxy_id) {
       where(:http_proxy_policy => RootRepository::USE_SELECTED_HTTP_PROXY).
-      where("http_proxy_id = ?", http_proxy_id)
+      where(:http_proxy_id => http_proxy_id)
     }
     delegate :redhat?, :provider, :organization, to: :product
 


### PR DESCRIPTION
This PR handles cases where repositories are set to use a particular HTTP Proxy and then that HTTP Proxy is deleted.

After the deletion, the repositories are set to use the global default instead of still displaying the now deleted proxy. Likewise, any repository set to use a deleted global default proxy will now display the "Global Default (None)" instead of incorrectly displaying the old, deleted global proxy name.

Finally, the Content setting for the global default is reset to the "blank" option ("no global default"), which is the value shown when katello is first initialized (and there is no HTTP Proxy).