### PR TITLE
Fixes #27546 - adds srpm json templates for compare action

### DIFF
--- a/app/views/katello/api/v2/srpms/backend.json.rabl
+++ b/app/views/katello/api/v2/srpms/backend.json.rabl
@@ -1,0 +1,11 @@
+attributes :description
+attributes :license, :buildhost, :vendor, :relativepath
+attributes :children, :checksumtype, :size, :url, :build_time, :summary, :group, :requires, :provides, :files
+
+node :human_readable_size do |package|
+  number_to_human_size(package.size) if package.size
+end
+
+node :build_time_utc do |package|
+  Time.at(package.build_time).to_datetime if package.build_time
+end

--- a/app/views/katello/api/v2/srpms/base.json.rabl
+++ b/app/views/katello/api/v2/srpms/base.json.rabl
@@ -1,0 +1,5 @@
+object @resource
+
+attributes :id, :pulp_id, :name, :filename
+attributes :created_at, :updated, :version, :arch, :release
+attributes :epoch, :checksum, :summary, :nvra

--- a/app/views/katello/api/v2/srpms/compare.json.rabl
+++ b/app/views/katello/api/v2/srpms/compare.json.rabl
@@ -4,4 +4,7 @@ extends "katello/api/v2/common/metadata"
 
 child @collection[:results] => :results do
   extends 'katello/api/v2/srpms/base'
+  node :comparison do |result|
+    result.comparison
+  end
 end

--- a/app/views/katello/api/v2/srpms/show.json.rabl
+++ b/app/views/katello/api/v2/srpms/show.json.rabl
@@ -1,5 +1,5 @@
 object @resource
 
-attributes :id, :pulp_id, :name, :filename
-attributes :created_at, :updated, :version, :arch, :release
-attributes :epoch, :checksum, :summary, :nvra
+extends "katello/api/v2/srpms/base"
+extends "katello/api/v2/srpms/backend",
+  :object => SmartProxy.pulp_master!.content_service("srpm").new(@resource.pulp_id)

--- a/test/controllers/api/v2/srpms_controller_test.rb
+++ b/test/controllers/api/v2/srpms_controller_test.rb
@@ -61,5 +61,11 @@ module Katello
         get :index, params: { :repository_id => @repo.id }
       end
     end
+
+    def test_compare
+      get :compare, params: { :content_view_version_ids => [@repo.content_view_version_id, @repo.content_view_version_id] }
+      assert_response :success
+      assert_template "katello/api/v2/srpms/compare"
+    end
   end
 end


### PR DESCRIPTION
This PR adds SRPM view templates for compare actions, etc.

After applying these changes, comparing content view versions with srpm content should show you srpm details, and not thrown an error messages. For example
```
[vagrant@centos7-katello-devel-stable foreman]$ curl --header "Accept:application/json" --header "Content-Type:application/json" --request GET --insecure --user admin:changeme https://`hostname`/katello/api/srpms/compare --data "{\"content_view_version_ids\":[2,3]}"  | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1356    0  1322  100    34   3107     79 --:--:-- --:--:-- --:--:--  3103
{
  "total": 3,
  "subtotal": 3,
  "page": 1,
  "per_page": 20,
  "error": null,
  "search": null,
  "sort": {
    "by": null,
    "order": null
  },
  "results": [
    {
      "id": 2,
      "pulp_id": "/pulp/api/v3/content/rpm/packages/4d712d87-875f-4b5a-b792-5d45efe5a175/",
      "name": "test-srpm01",
      "filename": "test-srpm01-1.0-1.src.rpm",
      "created_at": "2020-06-11 15:31:46 UTC",
      "version": "1.0",
      "arch": "src",
      "release": "1",
      "epoch": "0",
      "checksum": "54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d",
      "summary": "Dummy Package to provide tomcat5",
      "nvra": "--",
      "comparison": [
        2,
        3
      ]
    },
    {
      "id": 3,
      "pulp_id": "/pulp/api/v3/content/rpm/packages/adb02506-6960-485d-b1d3-570d5f24b0ec/",
      "name": "test-srpm02",
      "filename": "test-srpm02-1.0-1.src.rpm",
      "created_at": "2020-06-11 15:31:46 UTC",
      "version": "1.0",
      "arch": "src",
      "release": "1",
      "epoch": "0",
      "checksum": "f8d675b4edd9933b8c43884c81f3d9f135cdbe741a90133435de0f0632075e4c",
      "summary": "Dummy Package to provide tomcat5",
      "nvra": "--",
      "comparison": [
        2,
        3
      ]
    },
    {
      "id": 1,
      "pulp_id": "/pulp/api/v3/content/rpm/packages/da3dd1d0-37f2-426f-913f-ada14aa4214c/",
      "name": "test-srpm03",
      "filename": "test-srpm03-1.0-1.src.rpm",
      "created_at": "2020-06-11 15:31:46 UTC",
      "version": "1.0",
      "arch": "src",
      "release": "1",
      "epoch": "0",
      "checksum": "76db66099c0435f245b6dcba545cc8db62765f6e80276e0d66db65c16d8c7bac",
      "summary": "Dummy Package to provide tomcat5",
      "nvra": "--",
      "comparison": [
        2,
        3
      ]
    }
  ]
}
```