### PR TITLE
Fixes #30114 - Stop Pulp 2 consumer binding if Katello Applicability is in use

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -82,10 +82,10 @@ module Katello
       def update_bound_repositories(repos)
         self.bound_repositories = repos
         self.save!
-        self.propagate_yum_repos
         if SETTINGS[:katello][:katello_applicability]
           ::Katello::EventQueue.push_event(::Katello::Events::GenerateHostApplicability::EVENT_TYPE, self.host.id)
         else
+          self.propagate_yum_repos
           ForemanTasks.async_task(Actions::Katello::Host::GenerateApplicability, [self.host])
         end
       end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -67,6 +67,20 @@ module Katello
       content_facet_rec = host1.associated_audits.where(auditable_id: content_facet1.id)
       assert content_facet_rec, "No associated audit record for content_facet"
     end
+
+    def test_pulp2_binding_with_katello_applicability
+      SETTINGS[:katello][:katello_applicability] = true
+      org = taxonomies(:empty_organization)
+      host = ::Host::Managed.create!(:name => 'foohost', :managed => false, :organization_id => org.id)
+      content_facet = Katello::Host::ContentFacet.create!(
+        :content_view_id => view.id, :lifecycle_environment_id => library.id, :host => host
+      )
+
+      ::Katello::Host::ContentFacet.expects(:propagate_yum_repos).never
+      content_facet.update_bound_repositories([::Katello::Repository.find_by(pulp_id: "Fedora_17")])
+    ensure
+      SETTINGS[:katello][:katello_applicability] = nil
+    end
   end
 
   class ContentFacetErrataTest < ContentFacetBase


### PR DESCRIPTION
Pulp 2 consumer binding should never happen if Katello Applicability (Pulp 3 applicability) is in use.