### PR TITLE
Fixes #18035 - filter repos for CV with perms

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -5,6 +5,7 @@ module Katello
     include Api::V2::Rendering
     include Api::V2::ErrorHandling
     include ::Foreman::Controller::CsvResponder
+    include Concerns::Api::V2::AssociationsPermissionCheck
 
     # support for session (thread-local) variables must be the last filter in this class
     include Foreman::ThreadSession::Cleaner

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -22,6 +22,13 @@ module Katello
       param :solve_dependencies, :bool, :desc => N_("Solve RPM dependencies by default on Content View publish, defaults to false")
     end
 
+    def filtered_associations
+      {
+        :component_ids => Katello::ContentViewVersion,
+        :repository_ids => Katello::Repository
+      }
+    end
+
     api :GET, "/organizations/:organization_id/content_views", N_("List content views")
     api :GET, "/content_views", N_("List content views")
     param :organization_id, :number, :desc => N_("organization identifier")

--- a/app/controllers/katello/concerns/api/v2/associations_permission_check.rb
+++ b/app/controllers/katello/concerns/api/v2/associations_permission_check.rb
@@ -1,0 +1,67 @@
+module Katello
+  module Concerns
+    module Api::V2::AssociationsPermissionCheck
+      extend ActiveSupport::Concern
+
+      # The purpose of this module is to protect a controller from a user creating or updating some association
+      # when they do not have permissions to view the associated items.  An example would be adding random repository ids to
+      # content view.
+      # To support this, within the controller define a method such as:
+      #     def filtered_associations
+      #       {
+      #         :component_ids => Katello::ContentViewVersion,
+      #         :repository_ids => Katello::Repository
+      #       }
+      #     end
+      # This assumes that the parameters are 'wrapped'.  So the above in the content_views_controller, actually looks at
+      #  a subhash of 'content_view'
+
+      included do
+        before_action :check_association_ids, :only => [:create, :update]
+      end
+
+      def check_association_ids
+        if filtered_associations
+          wrapped_params = params[self._wrapper_options.name]
+          find_param_arrays(wrapped_params).each do |key_path|
+            if (model_class = filtered_associations.with_indifferent_access.dig(*key_path))
+              param_ids = wrapped_params.dig(*key_path)
+              filtered_ids = model_class.readable.where(:id => param_ids).pluck(:id)
+              if (unfound_ids = param_ids_missing(param_ids, filtered_ids)).any?
+                fail HttpErrors::NotFound, _("One or more ids (%{ids}) were not found for %{assoc}.  You may not have permissions to see them.") %
+                    {ids: unfound_ids, assoc: key_path.last}
+              end
+            else
+              fail _("Unfiltered params array: %s.") % key_path
+            end
+          end
+        else
+          Rails.logger.warn("#{self.class.name} may has unprotected associations, see associations_permission_check.rb for details.") if ENV['RAILS_ENV'] == 'development'
+        end
+      end
+
+      def filtered_associations
+        #should return {} when supported by all controllers
+        nil
+      end
+
+      def param_ids_missing(param_ids, filtered_ids)
+        param_ids.map(&:to_i).uniq - filtered_ids.map(&:to_i).uniq
+      end
+
+      #returns an array of list of keys pointing to an array in a params hash i.e.:
+      # {"a"=> {"b" => [3]}}  =>  [["a", "b"]]
+      def find_param_arrays(hash = params)
+        list_of_paths = []
+        hash.each do |key, value|
+          if value.is_a?(ActionController::Parameters) || value.is_a?(Hash)
+            list_of_paths += find_param_arrays(value).compact.map { |inner_keys| [key] + inner_keys }
+          elsif value.is_a?(Array)
+            list_of_paths << [key]
+          end
+        end
+        list_of_paths.compact
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/concerns/associations_permission_check_test.rb
+++ b/test/controllers/api/v2/concerns/associations_permission_check_test.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class TestAssociationIdController
+    def initialize(params, filtered_associations)
+      @params = params
+      @filtered_associations = filtered_associations
+    end
+
+    def self.before_action(*_args)
+    end
+
+    include Concerns::Api::V2::AssociationsPermissionCheck
+
+    attr_accessor :filtered_associations
+    attr_reader :params
+
+    def _wrapper_options
+      OpenStruct.new(:name => :content_view)
+    end
+  end
+
+  class Api::V2::AssociationsPermissionCheckTest < ActiveSupport::TestCase
+    def setup
+      @cv = katello_content_views(:acme_default)
+      @repo = katello_repositories(:fedora_17_x86_64)
+
+      @params = {
+        content_view: {
+          foo: [@cv.id],
+          foo2: 3,
+          foo3: {
+            baz: [@repo.id],
+            baz2: 9
+          }
+        }
+      }
+
+      @filtered_associations = {
+        foo: ::Katello::ContentView,
+        foo3: {
+          baz: ::Katello::Repository
+        }
+      }
+    end
+
+    def test_find_param_arrays
+      controller = TestAssociationIdController.new(@params, @filtered_associations)
+      assert_equal [[:content_view, :foo], [:content_view, :foo3, :baz]].sort, controller.find_param_arrays.sort
+    end
+
+    def test_check_association_ids_positive
+      controller = TestAssociationIdController.new(@params, @filtered_associations)
+
+      controller.check_association_ids
+    end
+
+    def test_check_association_ids_not_found_id
+      @params[:content_view][:foo] << -1
+      controller = TestAssociationIdController.new(@params, @filtered_associations)
+
+      assert_raises(Katello::HttpErrors::NotFound) do
+        controller.check_association_ids
+      end
+    end
+
+    def test_check_association_ids_not_defined
+      @params[:content_view][:not_defined] = [1]
+      controller = TestAssociationIdController.new(@params, @filtered_associations)
+
+      assert_raises(StandardError) do
+        controller.check_association_ids
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds permission filtering to associations
within content view create and update.  the idea is that
we can easily spread this to other controllers as well.

Not only are associations filtered, but any array within the 
parameters is checked for permissions on update/create. 
An error is thrown if the correct class to check has not been defined. 