### PR TITLE
Fixes #26977 - Host sub status resets on build

### DIFF
--- a/app/models/katello/purpose_addons_status.rb
+++ b/app/models/katello/purpose_addons_status.rb
@@ -1,5 +1,6 @@
 module Katello
   class PurposeAddonsStatus < HostStatus::Status
+    UNKNOWN = Katello::PurposeStatus::UNKNOWN
     def self.status_name
       N_('Addons')
     end

--- a/app/models/katello/purpose_role_status.rb
+++ b/app/models/katello/purpose_role_status.rb
@@ -1,5 +1,6 @@
 module Katello
   class PurposeRoleStatus < HostStatus::Status
+    UNKNOWN = Katello::PurposeStatus::UNKNOWN
     def self.status_name
       N_('Role')
     end

--- a/app/models/katello/purpose_sla_status.rb
+++ b/app/models/katello/purpose_sla_status.rb
@@ -1,5 +1,6 @@
 module Katello
   class PurposeSlaStatus < HostStatus::Status
+    UNKNOWN = Katello::PurposeStatus::UNKNOWN
     def self.status_name
       N_('Service Level')
     end

--- a/app/models/katello/purpose_usage_status.rb
+++ b/app/models/katello/purpose_usage_status.rb
@@ -1,5 +1,6 @@
 module Katello
   class PurposeUsageStatus < HostStatus::Status
+    UNKNOWN = Katello::PurposeStatus::UNKNOWN
     def self.status_name
       N_('Usage')
     end

--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -3,7 +3,7 @@ module Katello
     REQUIRE_REBOOT = 2
     REQUIRE_PROCESS_RESTART = 1
     UP_TO_DATE = 0
-
+    UNKNOWN = -1
     def self.status_name
       N_("Traces")
     end

--- a/app/services/katello/host_status_manager.rb
+++ b/app/services/katello/host_status_manager.rb
@@ -1,0 +1,13 @@
+module Katello
+  class HostStatusManager
+    STATUSES = [
+      Katello::ErrataStatus,
+      Katello::SubscriptionStatus,
+      Katello::PurposeSlaStatus,
+      Katello::PurposeRoleStatus,
+      Katello::PurposeUsageStatus,
+      Katello::PurposeAddonsStatus,
+      Katello::PurposeStatus,
+      Katello::TraceStatus].freeze
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,6 +1,6 @@
 require 'katello/permission_creator'
 require 'katello/repository_types.rb'
-
+require 'katello/host_status_manager.rb'
 # rubocop:disable Metrics/BlockLength
 Foreman::Plugin.register :katello do
   requires_foreman '>= 1.24'
@@ -266,14 +266,9 @@ Foreman::Plugin.register :katello do
       :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) }
   end
 
-  register_custom_status(Katello::ErrataStatus)
-  register_custom_status(Katello::SubscriptionStatus)
-  register_custom_status(Katello::PurposeSlaStatus)
-  register_custom_status(Katello::PurposeRoleStatus)
-  register_custom_status(Katello::PurposeUsageStatus)
-  register_custom_status(Katello::PurposeAddonsStatus)
-  register_custom_status(Katello::PurposeStatus)
-  register_custom_status(Katello::TraceStatus)
+  ::Katello::HostStatusManager::STATUSES.each do |status_class|
+    register_custom_status(status_class)
+  end
 
   register_ping_extension { Katello::Ping.ping }
   register_status_extension { Katello::Ping.status }

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -50,6 +50,22 @@ module Katello
       refute_includes found, other_host
     end
 
+    def test_host_status_reset
+      host = FactoryBot.create(:host)
+      host.host_statuses.delete_all
+      Katello::SubscriptionStatus.create!(host: host, :status => Katello::SubscriptionStatus::VALID)
+      host.reload
+      assert_equal Katello::SubscriptionStatus::VALID, host.host_statuses.first.status
+      host.reset_katello_status
+      assert_equal Katello::SubscriptionStatus::UNKNOWN, host.host_statuses.first.status
+    end
+
+    def test_unknown_statuses_exists_in_katello_status_classes
+      ::Katello::HostStatusManager::STATUSES.each do |status_class|
+        assert status_class.const_defined?(:UNKNOWN), "Checking #{status_class.name}"
+      end
+    end
+
     def test_pools_expiring_in_days
       host_with_pool = FactoryBot.create(:host, :with_subscription)
       host_with_pool.subscription_facet.pools << FactoryBot.build(:katello_pool, :expiring_in_12_days, cp_id: 1)


### PR DESCRIPTION
This commit enables one to ensure that the Host Status is reset to unknown when
the "build" button is set.