### PR TITLE
Fixes #30112 - Add host registration check before changing organization

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -18,6 +18,17 @@ module Katello
       included do
         prepend Overrides
 
+        def update_multiple_taxonomies(type)
+          registered_host = @hosts.detect { |host| host.subscription_facet }
+          unless registered_host.nil?
+            error _("Unregister host %s before assigning an organization") % registered_host.name
+            redirect_back_or_to hosts_path
+            return
+          end
+
+          super
+        end
+
         def destroy
           if Katello::RegistrationManager.unregister_host(@host, :unregistering => false)
             process_success redirection_url_on_host_deletion

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -39,6 +39,12 @@ module Katello
       end
     end
 
+    class HostRegisteredException < StandardError
+      def message
+        _("Content host must be unregistered before performing this action.")
+      end
+    end
+
     class EmptyBulkActionException < StandardError
       def message
         _("No hosts registered with subscription-manager found in selection.")

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -50,6 +50,7 @@ module Katello
 
         before_save :correct_puppet_environment
         before_validation :correct_kickstart_repository
+        before_update :check_host_registration, :if => proc { organization_id_changed? }
 
         scope :with_pools_expiring_in_days, ->(days) { joins(:pools).merge(Katello::Pool.expiring_in_days(days)).distinct }
 
@@ -73,6 +74,12 @@ module Katello
           else
             { :conditions => "1=0" }
           end
+        end
+      end
+
+      def check_host_registration
+        if subscription_facet
+          fail ::Katello::Errors::HostRegisteredException
         end
       end
 

--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -117,6 +117,8 @@ module Katello::Host
       end
 
       it 'existing hypervisor, no org' do
+        ::Host.any_instance.stubs(:check_host_registration).returns(true)
+
         @host.organization = nil
         @host.save!
 

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -155,6 +155,8 @@ module Katello
     end
 
     def test_apply_protected
+      ::Host.any_instance.stubs(:check_host_registration).returns(true)
+
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @create_permission, @destroy_permission]
 

--- a/test/controllers/api/v2/host_module_streams_controller_test.rb
+++ b/test/controllers/api/v2/host_module_streams_controller_test.rb
@@ -34,6 +34,8 @@ module Katello
     end
 
     def test_view_permissions
+      ::Host.any_instance.stubs(:check_host_registration).returns(true)
+
       good_perms = [@view_permission]
       bad_perms = [@update_permission, @create_permission, @destroy_permission]
 

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -118,6 +118,8 @@ module Katello
     end
 
     def test_view_permissions
+      ::Host.any_instance.stubs(:check_host_registration).returns(true)
+
       good_perms = [@view_permission]
       bad_perms = [@update_permission, @create_permission, @destroy_permission]
 
@@ -135,6 +137,8 @@ module Katello
     end
 
     def test_permissions
+      ::Host.any_instance.stubs(:check_host_registration).returns(true)
+
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @create_permission, @destroy_permission]
 

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -18,6 +18,17 @@ class HostsControllerTest < ActionController::TestCase
     permissions
   end
 
+  test 'cannot update registered host organization' do
+    @request.env['HTTP_REFERER'] = hosts_path
+    host = Host.find_by(name: "host1.example.com")
+    dest_org_id = ::Organization.find_by(name: "Organization 1").id
+    post :update_multiple_organization, params: { host_ids: [host.id],
+                                                  organization: { id: dest_org_id, optimistic_import: "yes" } }
+    assert_redirected_to :controller => :hosts, :action => :index
+    assert_not_equal dest_org_id, host.organization_id
+    assert_equal "Unregister host host1.example.com before assigning an organization", flash[:error]
+  end
+
   test 'puppet environment for content_view' do
     get :puppet_environment_for_content_view, params: { :content_view_id => @library_dev_staging_view.id, :lifecycle_environment_id => @library.id }
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -23,6 +23,13 @@ module Katello
   end
 
   class HostManagedExtensionsTest < HostManagedExtensionsTestBase
+    def test_update_organization
+      host = FactoryBot.create(:host, :with_subscription)
+      assert_raises ::Katello::Errors::HostRegisteredException do
+        host.update(organization_id: ::Organization.find_by(name: "Empty Organization").id)
+      end
+    end
+
     def test_rhsm_fact_values
       assert_empty @foreman_host.rhsm_fact_values
 


### PR DESCRIPTION
Hosts need to be unaffiliated from Candlepin before the organization is changed.  Currently, it is allowed to do so, which causes numerous bugs for the host's content facet.

My PR blocks org changes in a couple of places and tells the user to unregister first:
1) When changing the `organization_id` through the API.  For example:
```
echo '{"id": "centos8.cannolo.example.com", "host": {"organization_id": 3} }' | http PUT https://admin:changeme@centos7-katello-devel-2.cannolo.example.com/api/hosts/centos8.cannolo.example.com
```
returns, in response:
```
{
    "error": {
        "message": "Content host must be unregistered first before performing this action."
    }
}
```

2) When using "Assign Organization" from the `/hosts` page.  A message such as "Unregister host centos8.cannolo.example.com before assigning an organization" will appear and block the org update.

To test, try both scenarios above on a registered content host.