### PR TITLE
Fixes #29694 - Handles race condition on pool deletion

### DIFF
--- a/app/services/katello/candlepin/message_handler.rb
+++ b/app/services/katello/candlepin/message_handler.rb
@@ -81,9 +81,8 @@ module Katello
       end
 
       def delete_pool
-        if pool
-          Rails.logger.info "deleting pool #{pool.id} from Katello"
-          pool.destroy!
+        if Katello::Pool.where(:cp_id => pool_id).destroy_all.any?
+          Rails.logger.info "deleted pool #{pool_id} from Katello"
         end
       end
     end

--- a/test/services/candlepin/message_handler_test.rb
+++ b/test/services/candlepin/message_handler_test.rb
@@ -136,5 +136,13 @@ module Katello
       @handler.delete_pool
       assert_empty Katello::Pool.find_by(:cp_id => @pool_id)
     end
+
+    def test_delete_pool_on_null
+      pool = @handler.pool
+      @handler.stubs(:pool).returns(pool).then.returns(nil)
+      # assert no errors are raised
+      @handler.delete_pool
+      assert_empty Katello::Pool.find_by(:cp_id => @pool_id)
+    end
   end
 end


### PR DESCRIPTION
This commit handles the race condition where multiple
pool destroy messages  are run on the same pool.