### PR TITLE
Fixes #30157 - Correct APIMiddleware path for react tests

### DIFF
--- a/webpack/test-utils/react-testing-lib-wrapper.js
+++ b/webpack/test-utils/react-testing-lib-wrapper.js
@@ -4,13 +4,12 @@
 import React from 'react';
 import thunk from 'redux-thunk';
 import Immutable from 'seamless-immutable';
-import { reducers as apiReducer } from 'foremanReact/redux/API';
+import { APIMiddleware, reducers as apiReducer } from 'foremanReact/redux/API';
 import { STATUS } from 'foremanReact/constants';
 import { render } from '@testing-library/react';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-import { APIMiddleware } from 'foremanReact/redux/middlewares';
 
 // Renders testable component with redux and react-router according to Katello's usage
 // This should be used when you want a fully connected component with Redux state and actions.


### PR DESCRIPTION
Fixes current failures on master: 

```
[2020-06-18T18:43:56.020Z]   ● Can handle unpublished Content Views

[2020-06-18T18:43:56.020Z] 

[2020-06-18T18:43:56.020Z]     TypeError: middleware is not a function

[2020-06-18T18:43:56.020Z] 

[2020-06-18T18:43:56.020Z]       27 |   const initialFullState = Immutable({ API: { [namespace]: initialState } });

[2020-06-18T18:43:56.020Z]       28 |   const middlewares = applyMiddleware(thunk, APIMiddleware);

[2020-06-18T18:43:56.020Z]     > 29 |   const store = createStore(combinedReducers, initialFullState, middlewares);

[2020-06-18T18:43:56.020Z]          |                 ^

[2020-06-18T18:43:56.021Z]       30 |   const connectedComponent = (

[2020-06-18T18:43:56.021Z]       31 |     <Provider store={store}>

[2020-06-18T18:43:56.021Z]       32 |       <MemoryRouter>{component}</MemoryRouter>

[2020-06-18T18:43:56.021Z] 

[2020-06-18T18:43:56.021Z]       at foreman/node_modules/redux/lib/redux.js:648:16

[2020-06-18T18:43:56.021Z]           at Array.map (<anonymous>)

[2020-06-18T18:43:56.021Z]       at foreman/node_modules/redux/lib/redux.js:647:31

[2020-06-18T18:43:56.021Z]       at createStore (foreman/node_modules/redux/lib/redux.js:85:33)

[2020-06-18T18:43:56.021Z]       at renderWithApiRedux (webpack/test-utils/react-testing-lib-wrapper.js:29:17)

[2020-06-18T18:43:56.021Z]       at _callee4$ (webpack/scenes/ContentViews/__tests__/contentViewPage.test.js:96:28)

[2020-06-18T18:43:56.021Z]       at tryCatch (foreman/node_modules/regenerator-runtime/runtime.js:45:40)

[2020-06-18T18:43:56.021Z]       at Generator.invoke [as _invoke] (foreman/node_modules/regenerator-runtime/runtime.js:274:22)

[2020-06-18T18:43:56.021Z]       at Generator.prototype.<computed> [as next] (foreman/node_modules/regenerator-runtime/runtime.js:97:21)

[2020-06-18T18:43:56.021Z]       at asyncGeneratorStep (webpack/scenes/ContentViews/__tests__/contentViewPage.test.js:27:103)

[2020-06-18T18:43:56.021Z]       at _next (webpack/scenes/ContentViews/__tests__/contentViewPage.test.js:29:194)

[2020-06-18T18:43:56.021Z]       at webpack/scenes/ContentViews/__tests__/contentViewPage.test.js:29:364

[2020-06-18T18:43:56.021Z]       at Object.<anonymous> (webpack/scenes/ContentViews/__tests__/contentViewPage.test.js:29:97)

```

Looks related to https://github.com/theforeman/foreman/pull/7186