### PR TITLE
Fixes #30161 - Attach subscriptions task failed in finalize

### DIFF
--- a/app/lib/actions/katello/host/attach_subscriptions.rb
+++ b/app/lib/actions/katello/host/attach_subscriptions.rb
@@ -28,10 +28,12 @@ module Actions
           end
         end
 
-        def finalize
-          ::Katello::Pool.where(:id => input[:pool_ids]).map { |pool| pool.import_data(false) }
-          host = ::Host.find_by(:id => input[:host_id])
-          host.subscription_facet.import_database_attributes
+        def run
+          ActiveRecord::Base.transaction do
+            ::Katello::Pool.where(:id => input[:pool_ids]).map { |pool| pool.import_data(false) }
+            host = ::Host.find_by(:id => input[:host_id])
+            host.subscription_facet.import_database_attributes
+          end
         end
 
         def rescue_strategy

--- a/app/lib/actions/katello/host/remove_subscriptions.rb
+++ b/app/lib/actions/katello/host/remove_subscriptions.rb
@@ -23,10 +23,12 @@ module Actions
           plan_self(:host_id => host.id, :host_name => host.name, :pool_ids => pool_ids)
         end
 
-        def finalize
-          ::Katello::Pool.where(:cp_id => input[:pool_ids]).map { |pool| pool.import_data(false) }
-          host = ::Host.find_by(:id => input[:host_id])
-          host.subscription_facet.import_database_attributes
+        def run
+          ActiveRecord::Base.transaction do
+            ::Katello::Pool.where(:cp_id => input[:pool_ids]).map { |pool| pool.import_data(false) }
+            host = ::Host.find_by(:id => input[:host_id])
+            host.subscription_facet.import_database_attributes
+          end
         end
 
         def rescue_strategy


### PR DESCRIPTION
For some reasons User.current is not set when the after_commit
foreman hook is triggered in the finalize method. The nil
User.current is causing foreman hook to raise an error
because it is not able to set the ENV['FOREMAN_HOOKS_USER'].
This issue seems to be related to the fiber-local and
thread-local storage in the Thread. If I set the User.current
using thread-local then it will work without issue. It will
also work if I remove the transaction block around the finalize
method. After some testing, I found that the easiest way to
prevent this issue is to move the code from the finalize method
to the run method.