### PR TITLE
Fixes #30184 - Add set_dependent_action :destroy for Hostgroup::ContentFacet

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -5,6 +5,7 @@ module Katello
 
       included do
         before_save :add_organization_for_environment
+
         has_one :kickstart_repository, :through => :content_facet
         has_one :content_source, :through => :content_facet
         has_one :content_view, :through => :content_facet

--- a/app/models/katello/hostgroup/content_facet.rb
+++ b/app/models/katello/hostgroup/content_facet.rb
@@ -6,7 +6,6 @@ module Katello
       include Facets::HostgroupFacet
 
       belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_hostgroup_content_facets
-
       belongs_to :content_view, :inverse_of => :hostgroup_content_facets, :class_name => "Katello::ContentView"
       belongs_to :lifecycle_environment, :inverse_of => :hostgroup_content_facets, :class_name => "Katello::KTEnvironment"
       belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hostgroup_content_facets

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -296,7 +296,9 @@ Foreman::Plugin.register :katello do
       extend_model ::Katello::Concerns::ContentFacetHostExtensions
     end
 
-    configure_hostgroup(::Katello::Hostgroup::ContentFacet)
+    configure_hostgroup(::Katello::Hostgroup::ContentFacet) do
+      set_dependent_action :destroy
+    end
   end
 
   register_facet Katello::Host::SubscriptionFacet, :subscription_facet do


### PR DESCRIPTION
Errors like this were getting raised if the hostgroup had a content facet (lce, cv, kickstart, or content source are set):

```
PG::ForeignKeyViolation: ERROR: update or delete on table "hostgroups" violates foreign key constraint "fk_rails_434951f902" on table "katello_hostgroup_content_facets" DETAIL: Key (id)=(4) is still referenced from table "katello_hostgroup_content_facets".
```