### PR TITLE
Fixes #30220 - Align Arrow position to center

### DIFF
--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -68,3 +68,7 @@
 .popover-large {
   max-width: 100%;
 }
+
+.uib-increment, .uib-decrement {
+  text-align: center;
+}


### PR DESCRIPTION
Go to Sync Plan > New Plan
The Start time increment/decrement arrows should be aligned in the center. 
**Before change:**
![sync_date_pre](https://user-images.githubusercontent.com/21146741/85757957-e852f580-b6dd-11ea-9b26-a4528352a358.png)
**After Change:**
![sync_date_post](https://user-images.githubusercontent.com/21146741/85757979-eee16d00-b6dd-11ea-9090-4267559f6b7a.png)
