### PR TITLE
Fixes #29689 - check that the HttpProxy table exists 

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -2,7 +2,7 @@ class Setting::Content < Setting
   #rubocop:disable Metrics/MethodLength
   #rubocop:disable Metrics/AbcSize
 
-  validate :content_default_http_proxy, if: proc { |s| s.name == 'content_default_http_proxy' }
+  validate :content_default_http_proxy, if: proc { |s| s.name == 'content_default_http_proxy' && HttpProxy.table_exists? }
 
   after_save :add_organizations_and_locations_if_global_http_proxy
 


### PR DESCRIPTION
This PR adds a check for the HttpProxy table before setting validations. Otherwise, it's possible that the validation will throw an error because the model itself isn't present in the schema. This possibility increases as seen in scenarios with an external database for the foreman schema.

This also may help eliminate some occasional test failures seen in CI.