### PR TITLE
Fixes #30239 - Fix breaking changes for patternfly upgrade

### DIFF
--- a/webpack/components/Table/Loading.js
+++ b/webpack/components/Table/Loading.js
@@ -12,7 +12,7 @@ const Loading = ({ size }) => (
   <Bullseye>
     <EmptyState>
       <EmptyStateIcon variant="container" component={Spinner} />
-      <Title size={size}>
+      <Title size={size} headingLevel="h4">
         Loading
       </Title>
     </EmptyState>

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Pagination, Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
+import { Pagination, Flex, FlexItem } from '@patternfly/react-core';
 
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
@@ -53,7 +53,7 @@ const TableWrapper = ({
         <FlexItem>
           <Search patternfly4 {...{ onSearch, getAutoCompleteParams }} />
         </FlexItem>
-        <FlexItem breakpointMods={[{ modifier: FlexModifiers['align-right'] }]}>
+        <FlexItem align={{ default: 'alignRight' }}>
           <Pagination
             itemCount={total}
             page={page}


### PR DESCRIPTION
@patternfly/react-core is being upgrade from v3 to v4 and there are major version changes. Note that both versions are considered "patternfly 4", the version of the design library, its just the react package that is updating with some more new breaking changes.

When https://github.com/theforeman/foreman-js/pull/142 is merged and released, `npm update` in Foreman and test the content view page at `labs/content_views` works. The subscription and rh-repos pages should not be affected by this change, but its worth clicking through those to make sure.

Update: this was merged, run `npm update` in Foreman to test