### PR TITLE
Fixes #30266, #30262, #30261, #30263 - Add DSL docs for CV KTEnv Product

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -709,6 +709,12 @@ module Katello
       self.organization
     end
 
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Content View'
+      refs 'ContentView'
+      sections only: %w[all additional]
+      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Content View' }
+    end
     class Jail < ::Safemode::Jail
       allow :name, :label
     end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -383,6 +383,13 @@ module Katello
       [self.content_view]
     end
 
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Content View Version'
+      refs 'ContentViewVersion'
+      sections only: %w[all additional]
+      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Content View Version' }
+      property :version, String, desc: 'Returns version of this content view'
+    end
     class Jail < ::Safemode::Jail
       allow :name, :label, :version
     end

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -261,6 +261,12 @@ module Katello
       'lifecycle_environments'
     end
 
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Katello Environment'
+      refs 'KTEnvironment'
+      sections only: %w[all additional]
+      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Katello Environment' }
+    end
     class Jail < ::Safemode::Jail
       allow :name, :label
     end

--- a/app/models/katello/model.rb
+++ b/app/models/katello/model.rb
@@ -3,6 +3,13 @@ module Katello
     include ActiveModel::ForbiddenAttributesProtection
     self.abstract_class = true
 
+    apipie :prop_group, name: :katello_basic_props do
+      meta_example = ", e.g. #{@meta[:example]}" if @meta[:example]
+      name_desc = @meta[:name_desc] || "Name of the #{@meta[:friendly_name] || @meta[:class_scope]}#{meta_example}"
+      property :name, String, desc: name_desc
+      property :label, String, desc: "Label of the #{@meta[:friendly_name] || @meta[:class_scope]}"
+    end
+
     def destroy!
       unless destroy
         fail self.errors.full_messages.join('; ')

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -245,6 +245,12 @@ module Katello
       end
     end
 
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Product'
+      refs 'Product'
+      sections only: %w[all additional]
+      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Product' }
+    end
     class Jail < ::Safemode::Jail
       allow :name, :label
     end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -227,6 +227,9 @@ Foreman::Plugin.register :katello do
   end
   apipie_documented_controllers ["#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"]
   apipie_ignored_controllers %w(::Api::V2::OrganizationsController)
+  ApipieDSL.configuration.dsl_classes_matchers.concat [
+    "#{Katello::Engine.root}/app/models/katello/**/*.rb"
+  ]
 
   parameter_filter ::Host::Managed, :host_collection_ids => [],
     :content_facet_attributes => [:content_view_id, :lifecycle_environment_id, :content_source_id,


### PR DESCRIPTION
To see the result, you can run `FOREMAN_APIPIE_LANGS='en' bundle exec rake apipie_dsl:cache` and then go to Administer > About > Templates DSL link or directly to `https://fqdn/templates_doc`

UPD: Also I was thinking about adding a new section called `Content` for models and macros related to the content management. What do you think?