### PR TITLE
Fixes #29951 - Auto Enable/Disable repository

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -57,6 +57,7 @@ module Katello
       param :ansible_collection_requirements, String, :desc => N_("Contents of requirement yaml file to sync from URL")
       param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policies for HTTP proxy for content sync")
       param :http_proxy_id, :number, :desc => N_("ID of a HTTP Proxy")
+      param :auto_enabled, :bool, :desc => N_("if true, the repositories will be automatically enabled on a registered host subscribed to this product. Default: true")
     end
 
     def_param_group :repo_create do
@@ -463,7 +464,7 @@ module Katello
 
     def repository_params
       keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username,
-              :ostree_upstream_sync_depth, :ostree_upstream_sync_policy,
+              :ostree_upstream_sync_depth, :ostree_upstream_sync_policy, :auto_enabled,
               :deb_releases, :deb_components, :deb_architectures, :description, :http_proxy_policy, :http_proxy_id,
               {:ignorable_content => []}
              ]
@@ -514,6 +515,7 @@ module Katello
       root.ansible_collection_requirements = repo_params[:ansible_collection_requirements] if root.ansible_collection?
       root.http_proxy_policy = repo_params[:http_proxy_policy] if repo_params.key?(:http_proxy_policy)
       root.http_proxy_id = repo_params[:http_proxy_id] if repo_params.key?(:http_proxy_id)
+      root.auto_enabled = repo_params[:auto_enabled] if repo_params.key?(:auto_enabled)
 
       if root.ostree?
         root.ostree_upstream_sync_policy = repo_params[:ostree_upstream_sync_policy]

--- a/app/lib/actions/candlepin/product/content_update_enablement.rb
+++ b/app/lib/actions/candlepin/product/content_update_enablement.rb
@@ -1,17 +1,16 @@
 module Actions
   module Candlepin
     module Product
-      class ContentAdd < Candlepin::Abstract
+      class ContentUpdateEnablement < Candlepin::Abstract
         input_format do
-          param :product_id
-          param :content_id
+          param :content_enablements
           param :owner
-          param :enabled
+          param :product_id
         end
 
         def run
           output[:response] = ::Katello::Resources::Candlepin::Product.
-              add_content(input[:owner], input[:product_id], input[:content_id], input[:enabled])
+              update_enabled(input[:owner], input[:product_id], input[:content_enablements])
         end
       end
     end

--- a/app/lib/actions/katello/product/content_create.rb
+++ b/app/lib/actions/katello/product/content_create.rb
@@ -17,7 +17,8 @@ module Actions
               content_id = content_create.output[:response][:id]
               plan_action(Candlepin::Product::ContentAdd, owner: root.product.organization.label,
                                     product_id: root.product.cp_id,
-                                    content_id: content_id)
+                                    content_id: content_id,
+                                    enabled: root.auto_enabled?)
 
             else
               content_id = root.content_id
@@ -51,8 +52,7 @@ module Actions
                                                content_url: root.custom_content_path,
                                                vendor: ::Katello::Provider::CUSTOM)
 
-          #custom product content is always enabled by default
-          ::Katello::ProductContent.create!(product: root.product, content: content, enabled: true)
+          ::Katello::ProductContent.create!(product: root.product, content: content, enabled: root.auto_enabled?)
         end
       end
     end

--- a/app/lib/actions/katello/repository/content_update.rb
+++ b/app/lib/actions/katello/repository/content_update.rb
@@ -1,0 +1,41 @@
+module Actions
+  module Katello
+    module Repository
+      class ContentUpdate < Actions::Base
+        def plan(repository, update_auto_enabled: false)
+          root = repository.root
+          content = root.content
+          plan_action(::Actions::Candlepin::Product::ContentUpdate,
+                      :owner => repository.organization.label,
+                      :content_id => root.content_id,
+                      :name => root.name,
+                      :content_url => root.custom_content_path,
+                      :gpg_key_url => repository.yum_gpg_key_url,
+                      :label => content.label,
+                      :type => root.content_type,
+                      :arches => root.format_arches)
+
+          if update_auto_enabled
+            plan_action(::Actions::Candlepin::Product::ContentUpdateEnablement,
+                        :owner => repository.organization.label,
+                        :product_id => root.product.cp_id,
+                        :content_enablements => root.content_enablements)
+            plan_self(:repository_id => repository.id)
+          end
+
+          content.update!(name: root.name,
+                                     content_url: root.custom_content_path,
+                                     content_type: repository.content_type,
+                                     label: content.label,
+                                     gpg_url: repository.yum_gpg_key_url)
+        end
+
+        def run
+          repository = ::Katello::Repository.find(input[:repository_id])
+          ::Katello::ProductContent.where(:product => repository.product, :content => repository.content)
+                                 .update(:enabled => repository.root.auto_enabled?)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -66,6 +66,17 @@ module Katello
             self.post(join_path(path(owner_label, product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).code.to_i
           end
 
+          def update_enabled(owner_label, product_id, contents)
+            options = { id: product_id }
+            options[:productContent] = contents.map do |content|
+              ret = { content: { id: content[:id] } }
+              ret[:enabled] = content[:enabled] if content.key?(:enabled)
+              ret
+            end
+
+            update(owner_label, options)
+          end
+
           def remove_content(owner_label, product_id, content_id)
             self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), self.default_headers).code.to_i
           end

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -6,7 +6,7 @@ attributes :pulp_id => :backend_identifier
 attributes :relative_path, :container_repository_name, :full_path, :library_instance_id
 
 glue(@object.root) do
-  attributes :content_type, :url, :arch, :content_id
+  attributes :content_type, :url, :arch, :content_id, :auto_enabled
   attributes :major, :minor
 
   child :product do |_product|

--- a/db/migrate/20200701150946_add_auto_enabled_to_root_repository.rb
+++ b/db/migrate/20200701150946_add_auto_enabled_to_root_repository.rb
@@ -1,0 +1,5 @@
+class AddAutoEnabledToRootRepository < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_root_repositories, :auto_enabled, :boolean, default: true
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -150,6 +150,15 @@
         </dd>
       </span>
 
+      <span ng-show="repository.content_type === 'yum' && !product.redhat">
+        <dt translate>Enable on Registration</dt>
+        <dd bst-edit-checkbox="repository.auto_enabled"
+            formatter="booleanToYesNo"
+            on-save="save(repository)"
+            readonly="denied('edit_products', product)">
+        </dd>
+      </span>
+
       <span>
         <dt translate>HTTP Proxy</dt>
         <dd bst-edit-custom="repository.http_proxy_policy"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -62,7 +62,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         };
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true,
-            'checksum_type': null, 'mirror_on_sync': true, 'verify_ssl_on_sync': true,
+            'checksum_type': null, 'mirror_on_sync': true, 'verify_ssl_on_sync': true, 'auto_enabled': true,
             'download_policy': BastionConfig.defaultDownloadPolicy, 'arch': null,
             'ostree_upstream_sync_policy': 'latest'});
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -220,6 +220,17 @@
         </p>
       </div>
 
+      <div class="checkbox" ng-if="repository.content_type === 'yum'">
+        <label>
+          <input id="auto_enabled" name="auto_enabled" ng-model="repository.auto_enabled" type="checkbox"/>
+          <span translate>Enable on Registration</span>
+        </label>
+
+        <p class="help-block" translate>
+          Selecting this option will automatically enable this Repository when a Host registers and consumes this subscription.
+        </p>
+      </div>
+
       <div bst-form-group label="{{ 'HTTP Proxy Policy' | translate }}">
         <select required
                 id="http_proxy_policy"

--- a/test/actions/candlepin/product_test.rb
+++ b/test/actions/candlepin/product_test.rb
@@ -32,6 +32,18 @@ class Actions::Candlepin::Product::ContentUpdateTest < ActiveSupport::TestCase
       run_action planned_action
     end
   end
+
+  describe 'ContentUpdateEnablement' do
+    let(:action_class) { ::Actions::Candlepin::Product::ContentUpdateEnablement }
+    let(:planned_action) do
+      create_and_plan_action action_class, id: 123
+    end
+
+    it 'runs' do
+      ::Katello::Resources::Candlepin::Product.expects(:update_enabled)
+      run_action planned_action
+    end
+  end
 end
 
 class Actions::Candlepin::Product::UpdateTest < ActiveSupport::TestCase

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -86,7 +86,7 @@ module ::Actions::Katello::Repository
   class UpdateTest < TestBase
     let(:action_class) { ::Actions::Katello::Repository::Update }
     let(:pulp_action_class) { ::Actions::Pulp::Orchestration::Repository::Refresh }
-    let(:candlepin_action_class) { ::Actions::Candlepin::Product::ContentUpdate }
+    let(:katello_candlepin_action_class) { ::Actions::Katello::Repository::ContentUpdate }
     let(:repository) { katello_repositories(:fedora_17_unpublished) }
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::Update }
     def setup
@@ -102,7 +102,7 @@ module ::Actions::Katello::Repository
       plan_action action, repository.root, :unprotected => true
       assert_action_planed_with action, pulp_action_class,
         repository, proxy
-      assert_action_planed action, candlepin_action_class
+      assert_action_planed_with action, katello_candlepin_action_class, repository, update_auto_enabled: false
     end
   end
 
@@ -178,6 +178,45 @@ module ::Actions::Katello::Repository
           returns(mock('discovery', run: nil))
 
       run_action action_planned
+    end
+  end
+
+  class ContentUpdateTest < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::ContentUpdate }
+    let(:repository) { katello_repositories(:fedora_17_unpublished) }
+    let(:candlepin_action_class) { ::Actions::Candlepin::Product::ContentUpdate }
+    let(:candlepin_enablement_class) { ::Actions::Candlepin::Product::ContentUpdateEnablement }
+    let(:action_planned_yes) { create_and_plan_action action_class, repository, update_auto_enabled: true }
+    let(:action_planned_no) { create_and_plan_action action_class, repository }
+
+    def setup
+      content = FactoryBot.create(:katello_content, cp_content_id: repository.content_id, organization_id: repository.product.organization_id)
+      Katello::ProductContent.create!(:content_id => content.id, :product_id => repository.product_id)
+      super
+    end
+
+    it 'plans' do
+      action = create_action action_class
+      plan_action action, repository, update_auto_enabled: true
+      assert_action_planned action, candlepin_action_class
+      assert_action_planed action, candlepin_enablement_class
+    end
+
+    it 'runs-content-update' do
+      assert_run_phase action_planned_yes
+    end
+
+    it 'doesnot-run-content-update' do
+      refute_run_phase action_planned_no
+    end
+
+    it 'plans-no-enable' do
+      action = create_action action_class
+      action.stubs(:action_subject).with(repository)
+
+      plan_action action, repository, update_auto_enabled: false
+      assert_action_planed action, candlepin_action_class
+      refute_action_planed action, candlepin_enablement_class
     end
   end
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -400,6 +400,14 @@ module Katello
       end
     end
 
+    def test_create_with_auto_enabled_true
+      auto_enabled = true
+      ENV['test'] = 'true'
+      run_test_individual_attribute(:auto_enabled => auto_enabled) do |_, repo|
+        repo.root.expects(:auto_enabled=).with(auto_enabled)
+      end
+    end
+
     def test_create_with_ignorable_content
       ignorable_content = ["srpm", "erratum"]
       run_test_individual_attribute(:ignorable_content => ignorable_content) do |_, repo|

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -61,6 +61,22 @@ module Katello
           ::Katello::Resources::Candlepin::Pool.expects(:create).with(owner.label, expected_pool).returns('{}')
           ::Katello::Resources::Candlepin::Product.create_unlimited_subscription(owner.label, product_id, start_date)
         end
+
+        def test_update_enablement
+          product_id = 3
+          owner_label = "cool_org"
+          content_enablements = [ { id: 100, enabled: false }, { id: 200 }]
+          expected_enablements = {
+            id: product_id,
+            productContent: [
+              { content: {id: 100}, enabled: false },
+              { content: {id: 200} }
+            ]
+          }
+
+          ::Katello::Resources::Candlepin::Product.expects(:update).with(owner_label, expected_enablements)
+          ::Katello::Resources::Candlepin::Product.update_enabled(owner_label, product_id, content_enablements)
+        end
       end
     end
   end


### PR DESCRIPTION
This commit adds a "auto_enabled" flag to the repository. This flag will
set the default "enablement" state for the content in candlepin. On host
registration the redhat repo will be automatically set to the
auto_enabled value by subscription manager.
This feature is only available for custom repos.

This commit also adds UI in addition to the API bindings.