### PR TITLE
fixing #30296 - Fixing not listed macros

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -3,20 +3,6 @@ module Katello
     module BaseTemplateScopeExtensions
       extend ActiveSupport::Concern
 
-      module Overrides
-        def allowed_helpers
-          super + [:errata, :host_subscriptions, :host_applicable_errata_ids, :host_applicable_errata_filtered,
-                   :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications, :host_content_facet,
-                   :host_sla, :host_products, :sub_name, :sub_sku, :registered_through, :last_checkin, :host_collections,
-                   :host_subscriptions_names, :host_subscriptions, :host_products_names, :host_collections_names,
-                   :host_redhat_subscription_names, :registered_at]
-        end
-      end
-
-      included do
-        prepend Overrides
-      end
-
       def errata(id)
         Katello::Erratum.in_repositories(Katello::Repository.readable).with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
       end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -154,7 +154,6 @@ module Katello
 
       # Lib Extensions
       ::Foreman::Renderer::Scope::Variables::Base.include Katello::Concerns::RendererExtensions
-      ::Foreman::Renderer::Scope::Base.include Katello::Concerns::BaseTemplateScopeExtensions
 
       # Model extensions
       ::Environment.include Katello::Concerns::EnvironmentExtensions

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -220,6 +220,8 @@ Foreman::Plugin.register :katello do
 
   allowed_template_helpers :subscription_manager_configuration_url, :repository_url
   extend_template_helpers Katello::KatelloUrlsHelper
+  extend_template_helpers Katello::Concerns::BaseTemplateScopeExtensions
+
   register_global_js_file 'fills'
 
   search_path_override("Katello") do |resource|


### PR DESCRIPTION
This fix solves problem where Katello template macros was not listed in template page at help section but they're working. The reason why is not working is fairly simple. In current implementation in `BaseTemplateScopeExtensions` where we're overriding  `allowed_helpers` in `Foreman::Renderer::Configuration`. However, this extension is pointed to `::Foreman::Renderer::Scope::Base` so these macros are not in `allowed_helpers`. 

So this problem why I make this PR, solution is fairy simple - I've split macros and `allowed_helpers` to two different modules that they're injected to correct classes. It's only draft for now because I don't know if it's best solution for this problem ;) 