### PR TITLE
Fixes #30314 - Fix exception in deb sync progress

### DIFF
--- a/app/lib/actions/pulp/repository/presenters/deb_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/deb_presenter.rb
@@ -54,11 +54,11 @@ module Actions
           end
 
           def items_done
-            task_details&.inject(0) { |sum, details| sum + details[:num_success].to_i }
+            task_details&.inject(0) { |sum, details| sum + details[:num_success].to_i } || 0
           end
 
           def items_total
-            task_details&.inject(0) { |sum, details| sum + details[:items_total].to_i }
+            task_details&.inject(0) { |sum, details| sum + details[:items_total].to_i } || 0
           end
 
           def size_done


### PR DESCRIPTION
Makes sure `items_total` and `items_done` always return an integer.

Not sure if returning `-1` might be better to make it more clear that the value is not 'valid'.
Then again this might create more crazy errors :smile: 