### PR TITLE
Fixes #30329 - Errata filters lost when viewing from repo

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.errata').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('errata', {
-        url: '/errata',
+        url: '/errata?repositoryId',
         permission: ['view_products', 'view_content_views'],
         views: {
           '@': {


### PR DESCRIPTION
When the errata link for a specific repo under Products -> Repositories is selected to open in a new tab (using the right click context menu or middle-clicking), filtering information is lost due to the nature of Angular's `ui-sref`.  This PR adds the repo ID to the URL so that this filter information isn't lost.