### PR TITLE
Fixes #30336 - Fix React test intermittent failure

### DIFF
--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -239,7 +239,7 @@ test('No results message is shown for empty search', async (done) => {
 
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: query } });
 
-  await waitFor(() => expect(getByText(/No matching Content Views found/i)).toBeInTheDocument());
+  await waitFor(() => expect(getByText(/No matching Content Views found/i)).toBeInTheDocument(), { timeout: 5000 });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(initialScope);


### PR DESCRIPTION
We are seeing this issue happen with jenkins, it seems to run quite a bit slower than GH actions.

I believe the `waitFor` command is timing out as it waits for the text to appear on the screen. react-testing-library doesn't have a way to increase the default (1000ms) waitFor afaict, so we can set it in the waitFor commands where needed. If it continues to be a problem, we can think about making a wrapper function that calls waitFor with a longer timeout.