### PR TITLE
Fixes #30335 - Stop collecting coverage from React tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,14 +5,6 @@ const foremanReactFull = foremanRelativePath(foremanReactRelative);
 
 // Jest configuration
 module.exports = {
-  collectCoverage: true,
-  collectCoverageFrom: [
-    'webpack/**/*.js',
-    '!webpack/**/bundle*',
-  ],
-  coverageReporters: [
-    'lcov',
-  ],
   testURL: 'http://localhost/',
   setupFiles: [
     './webpack/test_setup.js',


### PR DESCRIPTION
We don't do anything with this information and it takes time to collect after each run.

If we would like to add coverage reports, we can in the future, but I don't see a reason to collect the information when we do nothing with it.