### PR TITLE
Fixes #30343 - Sync plan fails

### DIFF
--- a/app/lib/actions/katello/sync_plan/run.rb
+++ b/app/lib/actions/katello/sync_plan/run.rb
@@ -19,7 +19,7 @@ module Actions
             syncable_products = sync_plan.products.syncable
             syncable_roots = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
 
-            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_roots.map(&:library_instance)) unless syncable_roots.empty?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_roots.map(&:library_instance).compact) unless syncable_roots.empty?
             plan_self(:sync_plan_name => sync_plan.name)
           end
         end


### PR DESCRIPTION
Sync plan fails when root_repo has no library_instance