### PR TITLE
Fixes #30350 - adds the scoped_search form parameter 

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/components/nutupane.factory.js
+++ b/engines/bastion/app/assets/javascripts/bastion/components/nutupane.factory.js
@@ -295,12 +295,14 @@ angular.module('Bastion.components').factory('Nutupane',
                     },
                     excluded: {
                         ids: []
-                    }
+                    },
+                    allResultsSelected: false
                 };
 
                 if (self.table.allResultsSelected) {
                     selected.included.search = self.table.searchTerm || '';
                     selected.excluded.ids = _.map(self.getDeselected(), identifier);
+                    selected.allResultsSelected = true;
                 } else {
                     selectedRows = self.table.getSelected();
                     selected.included.ids = _.map(selectedRows, identifier);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -57,12 +57,15 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.initialLoad = true;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.allHostsSelected = hostIds.allResultsSelected;
 
         $scope.errataActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
         };
 
-        if (hostIds.included.ids) {
+        if ($scope.allHostsSelected) {
+            $scope.errataActionFormValues.scopedSearch = hostIds.included.search;
+        } else if (hostIds.included.ids.length > 0) {
             $scope.errataActionFormValues.hostIds = hostIds.included.ids.join(',');
         }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
@@ -119,6 +119,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
 
             $scope.content.confirm = false;
             $scope.packageActionFormValues.customize = customize;
+            $scope.allHostsSelected = selectedHosts.allResultsSelected;
 
             if (!action) {
                 action = $scope.content.action;
@@ -134,7 +135,9 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
                 $scope.packageActionFormValues.remoteAction = 'package_' + action;
             }
 
-            if (selectedHosts.included.ids) {
+            if ($scope.allHostsSelected) {
+                $scope.packageActionFormValues.scopedSearch = selectedHosts.included.search;
+            } else if (selectedHosts.included.ids.length > 0) {
                 $scope.packageActionFormValues.hostIds = selectedHosts.included.ids.join(',');
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -8,6 +8,7 @@
       <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+      <input type="hidden" ng-if="allHostsSelected" name="scoped_search" ng-value="errataActionFormValues.scopedSearch"/>
     </form>
 
     <div bst-alert="info" ng-show="showConfirm">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -38,6 +38,7 @@
       <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
+      <input type="hidden" ng-if="allHostsSelected" name="scoped_search" ng-value="packageActionFormValues.scopedSearch"/>
     </form>
 
     <div ng-form name="systemContentForm" class="form" ng-hide="content.workingMode || denied('edit_hosts')" novalidate>

--- a/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
+++ b/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
@@ -117,5 +117,20 @@ module Katello
       refute_includes result, @host2
       refute_includes result, @host3
     end
+
+    def test_ids_with_scoped_search
+      bulk_params = {
+        :included => {
+          :ids => [@host1.id, @host2.id],
+          :search => nil
+        }
+      }
+
+      result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+      assert_includes result.pluck(:id), @host1.id
+      assert_includes result.pluck(:id), @host2.id
+      refute_includes result.pluck(:id), @host3.id
+    end
   end
 end


### PR DESCRIPTION
This PR repairs bulk host actions for errata (and packages) modals from the content hosts summary page.

The "scoped_search" form parameter was missing and here we attempt to populate that value before the form is submitted.

To test this change, register at least as many content hosts as the page volume allows, plus 1 more. (You want more hosts to be selectable than can be shown in 1 page of results.)

![Screenshot from 2020-07-10 13-51-13](https://user-images.githubusercontent.com/266755/87183664-889b4380-c2b4-11ea-9820-11e4faa0a9b9.png)

Next, select top checkbox for all hosts, then click the "Select All ..." link near the top to the results table. Then choose an action from the Select Action option, picking "Manage Errata".

Assuming there is applicable errata indicated for at least one of the hosts, select that errata. Then click "Install" with the "remote execution" option. The subsequent task to install the errata should be applied against all hosts (not just the ones shown on the first page).

Note that the same errors appear for "Manage Packages", and this PR repairs that functionality as well.