### PR TITLE
Refs #30354 - use public setting interface in tests

### DIFF
--- a/test/actions/katello/applicability/generate_applicability_test.rb
+++ b/test/actions/katello/applicability/generate_applicability_test.rb
@@ -16,7 +16,7 @@ module ::Actions::Katello::Applicability::Host
 
     after :all do
       SETTINGS[:katello][:katello_applicability] = false
-      ::Setting::Content.find_by(name: "applicability_batch_size").update(value: 50)
+      ::Setting['applicability_batch_size'] = 50
     end
 
     describe 'Host Generate Applicability using Katello Applicability' do

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -8,11 +8,8 @@ module Katello
       Rake.application.rake_require 'katello/tasks/update_content_default_http_proxy'
       Rake::Task['katello:update_default_http_proxy'].reenable
       Rake::Task.define_task(:environment)
-      unless Setting.find_by_name('content_default_http_proxy')
-        Setting[:content_default_http_proxy] = FactoryBot.create(
-          :setting, category: 'Setting::Content', name: 'content_default_http_proxy')
-      end
-      @setting = Setting.find_by_name('content_default_http_proxy')
+      @setting = Setting.find_by(name: 'content_default_http_proxy')
+      @setting ||= Setting::Content.create(FactoryBot.attributes_for(:setting, name: 'content_default_http_proxy').except(:category))
       assert @setting
 
       HttpProxy.delete_all

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -19,9 +19,9 @@ module Katello
       test 'without SEED_LOCATION' do
         seed_location
         # check that default_location_subscribed_hosts gets set
-        assert_equal Setting.find_by_name('default_location_subscribed_hosts').value, Location.first.title
+        assert_equal Setting['default_location_subscribed_hosts'], Location.first.title
         # check that default_location_puppet_content gets set
-        assert_equal Setting.find_by_name('default_location_puppet_content').value, Location.first.title
+        assert_equal Setting['default_location_puppet_content'], Location.first.title
       end
     end
 

--- a/test/models/concerns/operatingsystem_extensions_test.rb
+++ b/test/models/concerns/operatingsystem_extensions_test.rb
@@ -4,23 +4,17 @@ require 'katello_test_helper'
 
 module Katello
   class OperatingsystemExtensionsTest < ActiveSupport::TestCase
+    let(:template) { templates(:mystring2) }
+    let(:ptable) { FactoryBot.create(:ptable) }
+
     def setup
       User.current = User.find(users(:admin).id)
       @my_distro = OpenStruct.new(:name => 'RedHat', :family => 'Red Hat Enterprise Linux', :version => '9.0')
+      Setting['katello_default_ptable'] = ptable.name
     end
 
     def test_assign_template
-      template = templates(:mystring2)
-      ptable = FactoryBot.create(:ptable)
-
-      Setting.create(:name => 'katello_default_provision', :description => 'default template',
-                     :category => 'Setting::Content', :settings_type => 'string',
-                     :default => template.name)
-
-      Setting.create(:name => 'katello_default_ptable', :description => 'default template',
-                     :category => 'Setting::Content', :settings_type => 'string',
-                     :default => ptable.name)
-
+      Setting['katello_default_provision'] = template.name
       os = ::Redhat.create_operating_system(@my_distro.name, '9', '0')
       assert ::OsDefaultTemplate.where(:template_kind_id => ::TemplateKind.find_by_name('provision').id,
                                        :provisioning_template_id => template.id,
@@ -30,16 +24,7 @@ module Katello
     end
 
     def test_assign_template_for_atomic
-      template = templates(:mystring2)
-      ptable = FactoryBot.create(:ptable)
-      Setting.create(:name => 'katello_default_atomic_provision', :description => 'atomic default template',
-                     :category => 'Setting::Content', :settings_type => 'string',
-                     :default => template.name)
-
-      Setting.create(:name => 'katello_default_ptable', :description => 'default template',
-                     :category => 'Setting::Content', :settings_type => 'string',
-                     :default => ptable.name)
-
+      Setting['katello_default_atomic_provision'] = template.name
       os_attributes = {:major => "7", :minor => "3", :name => ::Operatingsystem::REDHAT_ATOMIC_HOST_OS}
       os = Operatingsystem.create!(os_attributes)
 

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -479,8 +479,7 @@ module Katello
 
     def test_check_composite_action_allowed_when_setting_enabled
       # Testing composite content view restrictions (Setting: restrict_composite_view=true)
-      Setting.create(:name => 'restrict_composite_view', :category => 'Setting::Content',
-                     :settings_type => 'boolean', :default => true)
+      Setting['restrict_composite_view'] = true
 
       library = KTEnvironment.find(katello_environments(:library).id)
       composite = ContentView.find(katello_content_views(:composite_view).id)
@@ -502,8 +501,7 @@ module Katello
 
     def test_check_composite_action_allowed_when_setting_enabled_with_active_record_relation
       # Testing composite content view restrictions (Setting: restrict_composite_view=true)
-      Setting.create(:name => 'restrict_composite_view', :category => 'Setting::Content',
-                     :settings_type => 'boolean', :default => true)
+      Setting['restrict_composite_view'] = true
 
       library = KTEnvironment.where(:id => katello_environments(:library).id)
       composite = ContentView.find(katello_content_views(:composite_view).id)
@@ -525,8 +523,7 @@ module Katello
 
     def test_check_composite_action_allowed_when_setting_disabled
       # Testing the default behavior (Setting: restrict_composite_view=false)
-      Setting.create(:name => 'restrict_composite_view', :category => 'Setting::Content',
-                     :settings_type => 'boolean', :default => false)
+      Setting['restrict_composite_view'] = false
 
       library = KTEnvironment.find(katello_environments(:library).id)
       composite = ContentView.find(katello_content_views(:composite_view).id)

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -30,9 +30,7 @@ module Katello
 
     def test_recalculate_errata_status
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Host::RecalculateErrataStatus)
-      setting = Setting.where(:name => 'errata_status_installable').first
-      setting.value = !setting.value
-      setting.save!
+      Setting['errata_status_installable'] = !Setting['errata_status_installable']
     end
   end
 end

--- a/test/services/katello/applicable_host_queue_test.rb
+++ b/test/services/katello/applicable_host_queue_test.rb
@@ -3,7 +3,7 @@ require 'katello_test_helper'
 module Katello
   class ApplicableHostQueueTest < ActiveSupport::TestCase
     def setup
-      ::Setting::Content.find_by(name: "applicability_batch_size").update(value: 50)
+      Setting['applicability_batch_size'] = 50
     end
 
     def test_pop_nothing
@@ -25,7 +25,7 @@ module Katello
     end
 
     def test_pop_batch_size_only
-      ::Setting::Content.find_by(name: "applicability_batch_size").update(value: 3)
+      Setting['applicability_batch_size'] = 3
       5.times { |i| ApplicableHostQueue.push_host(i) }
       popped_hosts = ApplicableHostQueue.pop_hosts
 

--- a/test/services/katello/pulp/repository/yum_test.rb
+++ b/test/services/katello/pulp/repository/yum_test.rb
@@ -189,14 +189,15 @@ module Katello
       class RpmTestWithProxy < ActiveSupport::TestCase
         include RepositorySupport
 
+        let(:default_proxy) do
+          FactoryBot.create(:http_proxy, name: 'best proxy', url: 'http://url_1')
+        end
+
         def setup
           @master = FactoryBot.create(:smart_proxy, :default_smart_proxy)
           User.current = users(:admin)
 
-          @default_proxy = FactoryBot.create(:http_proxy, name: 'best proxy',
-                                             url: "http://url_1")
-          Setting.find_by(name: 'content_default_http_proxy').update(
-            value: @default_proxy.name)
+          Setting['content_default_http_proxy'] = default_proxy.name
           @repo = katello_repositories(:fedora_17_x86_64)
         end
 
@@ -206,7 +207,7 @@ module Katello
           backend_data = @repo.backend_service(@master).backend_data
           importers = backend_data['importers']
           config = importers.first['config']
-          uri = URI(@default_proxy.url)
+          uri = URI(default_proxy.url)
           assert_equal "http://" + uri.host, config['proxy_host']
         end
 
@@ -217,7 +218,7 @@ module Katello
           backend_data = @repo.backend_service(@master).backend_data
           importers = backend_data['importers']
           config = importers.first['config']
-          uri = URI(@default_proxy.url)
+          uri = URI(default_proxy.url)
           assert_equal "http://" + uri.host, config['proxy_host']
         end
 

--- a/test/services/katello/pulp/repository_test.rb
+++ b/test/services/katello/pulp/repository_test.rb
@@ -6,13 +6,13 @@ module Katello
     class RepositoryMergeProxyOptionsTest < ActiveSupport::TestCase
       include RepositorySupport
 
+      let(:default_proxy) { FactoryBot.create(:http_proxy, name: 'best proxy') }
+
       def setup
         @master = FactoryBot.create(:smart_proxy, :default_smart_proxy)
         User.current = users(:admin)
 
-        @default_proxy = FactoryBot.create(:http_proxy, name: 'best proxy')
-        Setting.find_by(name: 'content_default_http_proxy').update(
-          value: @default_proxy.name)
+        Setting['content_default_http_proxy'] = default_proxy.name
         @repo = katello_repositories(:fedora_17_x86_64)
         @pulp_repo = Katello::Pulp::Repository.new(@repo, @master)
       end
@@ -36,12 +36,12 @@ module Katello
         @repo.root.update(http_proxy_policy: RootRepository::GLOBAL_DEFAULT_HTTP_PROXY,
                           http_proxy: another_proxy)
         assert @repo.root.http_proxy_id
-        uri = URI(@default_proxy.url)
+        uri = URI(default_proxy.url)
         expected_options = {
           proxy_host: uri.scheme + '://' + uri.host,
           proxy_port: uri.port,
-          proxy_username: @default_proxy.username,
-          proxy_password: @default_proxy.password
+          proxy_username: default_proxy.username,
+          proxy_password: default_proxy.password
         }
         assert_equal expected_options, @pulp_repo.proxy_options
       end
@@ -49,12 +49,12 @@ module Katello
       def test_no_options_merged_if_global_default_proxy_an_no_proxy_set
         @repo.root.update(http_proxy_policy: RootRepository::GLOBAL_DEFAULT_HTTP_PROXY)
         assert_nil @repo.root.http_proxy_id
-        uri = URI(@default_proxy.url)
+        uri = URI(default_proxy.url)
         expected_options = {
           proxy_host: uri.scheme + '://' + uri.host,
           proxy_port: uri.port,
-          proxy_username: @default_proxy.username,
-          proxy_password: @default_proxy.password
+          proxy_username: default_proxy.username,
+          proxy_password: default_proxy.password
         }
         assert_equal expected_options, @pulp_repo.proxy_options
       end


### PR DESCRIPTION
https://github.com/theforeman/foreman/pull/7702 is trying to move the unchanged settings to memory only.
That requires accessing the setting only through the public interface.

This is changing it wherever possible in tests, improving some while at it.