### PR TITLE
Fixes #17798 - Add message for client action needed on cv change

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-environment-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-environment-modal.html
@@ -3,7 +3,11 @@
 
   <div data-block="modal-body">
     <h4 translate>Assign Lifecycle Environment and Content View</h4>
-
+    <p>Please run the following commands on the client, so the new Content View can take effect.</p>
+    <pre>
+    # yum clean all
+    # subscription-manager refresh
+    </pre>
     <div class="row">
       <div class="col-sm-12">
         <div bst-global-notification></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -42,6 +42,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         });
 
         $scope.showVersionAlert = false;
+        $scope.showCVAlert = false;
         $scope.editContentView = false;
         $scope.disableEnvironmentSelection = false;
         $scope.environments = [];
@@ -62,6 +63,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         };
 
         $scope.cancelContentViewUpdate = function () {
+            $scope.showCVAlert = false;
             if ($scope.editContentView) {
                 $scope.editContentView = false;
                 $scope.host.content_facet_attributes['lifecycle_environment'] = $scope.originalEnvironment;
@@ -76,6 +78,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
                 $scope.originalEnvironment = response.content_facet_attributes.lifecycle_environment;
             });
             $scope.disableEnvironmentSelection = false;
+            $scope.showCVAlert = false;
         };
 
         $scope.releaseVersions = function () {
@@ -122,7 +125,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
             ContentView.queryUnpaged({ 'environment_id': $scope.host.content_facet_attributes.lifecycle_environment.id}, function (response) {
                 deferred.resolve(response.results);
                 $scope.contentViews = response.results;
+                $scope.showCVAlert = true;
             });
+
+            $scope.showCVAlert = true;
 
             return deferred.promise;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -273,13 +273,21 @@
         </dd>
 
         <dt translate>Content View</dt>
-        <dd bst-edit-select="host.content_facet_attributes.content_view.name"
+        <dd>
+          <div bst-edit-select="host.content_facet_attributes.content_view.name"
             readonly="denied('edit_hosts', host)"
             selector="host.content_facet_attributes.content_view.id"
             options="contentViews()"
             on-cancel="cancelContentViewUpdate()"
             on-save="saveContentView(host)"
             edit-trigger="editContentView">
+            </div>
+            <div bst-alert="info" ng-show="showCVAlert">
+              <p>Please run the following commands on the client,</p>
+              <p>so the new Content View can take effect.</p>
+              <p><code># yum clean all</code></p>
+              <p><code># subscription-manager refresh</code></p>
+            </div>
         </dd>
 
         <dt bst-feature-flag="lifecycle_environments">


### PR DESCRIPTION
This PR adds a message to run the following commands upon changing a content view for a Content Host:

`yum clean all`
`subscription-manager refresh`

These were suggested from this BZ comment:

https://bugzilla.redhat.com/show_bug.cgi?id=1305773#c12

Here is a video showing the changes with the code patch applied. 

https://nimb.ws/1nR7xc

I did create a redmine for an issue I found with Jturel that exists on master and in downstream 6.6+

When changing a Content View on a single Content Host, after changing it once, then going back and changing it again we get a n angular js error and my message does not show up.

https://projects.theforeman.org/issues/30361