### PR TITLE
Fixes #30368 - Make Candlepin CA file optional

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -18,8 +18,8 @@ module Katello
 
     include Katello::Concerns::FilterSensitiveData
 
-    class_attribute :consumer_secret, :consumer_key, :ca_cert_file, :prefix, :site, :default_headers,
-                    :ssl_client_cert, :ssl_client_key
+    class_attribute :consumer_secret, :consumer_key, :prefix, :site, :default_headers,
+                    :ssl_client_cert, :ssl_client_key, :ssl_ca_file
 
     attr_reader :json
 
@@ -128,7 +128,7 @@ module Katello
                    :authorize_path => "",
                    :access_token_path => ""}
 
-        params[:ca_file] = self.ca_cert_file unless self.ca_cert_file.nil?
+        params[:ca_file] = self.ssl_ca_file unless self.ssl_ca_file.nil?
         # New OAuth consumer to setup signing the request
         consumer = OAuth::Consumer.new(self.consumer_key,
                             self.consumer_secret,
@@ -147,7 +147,7 @@ module Katello
           :open_timeout => SETTINGS[:katello][:rest_client_timeout],
           :timeout => SETTINGS[:katello][:rest_client_timeout]
         }
-        options[:ssl_ca_file] = self.ca_cert_file unless self.ca_cert_file.nil?
+        options[:ssl_ca_file] = self.ssl_ca_file unless self.ssl_ca_file.nil?
         options[:ssl_client_cert] = self.ssl_client_cert unless self.ssl_client_cert.nil?
         options[:ssl_client_key] = self.ssl_client_key unless self.ssl_client_key.nil?
 

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -11,7 +11,7 @@ module Katello
         self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
         self.consumer_secret = cfg[:oauth_secret]
         self.consumer_key = cfg[:oauth_key]
-        self.ssl_ca_file = cfg[:ca_cert_file]
+        self.ssl_ca_file = ::Cert::Certs.backend_ca_cert_file(:candlepin)
 
         class << self
           def process_response(response)

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -11,7 +11,7 @@ module Katello
         self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
         self.consumer_secret = cfg[:oauth_secret]
         self.consumer_key = cfg[:oauth_key]
-        self.ca_cert_file = cfg[:ca_cert_file]
+        self.ssl_ca_file = cfg[:ca_cert_file]
 
         class << self
           def process_response(response)

--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -54,7 +54,6 @@ module Katello
             uri = URI.parse(content_app_url)
             self.prefix = "/pulpcore_registry/"
             self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
-            self.ssl_ca_file = Setting[:ssl_ca_file]
             pulp_primary.pulp3_ssl_configuration(self, :net_http)
 
             self

--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -54,7 +54,7 @@ module Katello
             uri = URI.parse(content_app_url)
             self.prefix = "/pulpcore_registry/"
             self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
-            self.ca_cert_file = Setting[:ssl_ca_file]
+            self.ssl_ca_file = Setting[:ssl_ca_file]
             pulp_primary.pulp3_ssl_configuration(self, :net_http)
 
             self

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -252,6 +252,7 @@ module Katello
       end
 
       def pulp3_ssl_configuration(config, connection_adapter = Faraday.default_adapter)
+        config.ssl_ca_file = ::Cert::Certs.backend_ca_cert_file(:pulp)
         case connection_adapter
         when :excon
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -260,7 +260,7 @@ module Katello
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert
           config.ssl_client_key = ::Cert::Certs.ssl_client_key
         else
-          fail "Unexpected connection_adapter #{Faraday.default_adapter}!  Cannot continue, this is likely a bug."
+          fail "Unexpected connection_adapter #{connection_adapter}!  Cannot continue, this is likely a bug."
         end
       end
 

--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -252,12 +252,11 @@ module Katello
       end
 
       def backend_status(url, backend)
-        ca_file = SETTINGS[:katello][backend][:ca_cert_file]
+        ca_file = ::Cert::Certs.backend_ca_cert_file(backend)
         request_id = ::Logging.mdc['request']
 
         options = {}
         options[:ssl_ca_file] = ca_file unless ca_file.nil?
-        options[:verify_ssl] = SETTINGS[:katello][backend][:verify_ssl] if SETTINGS[:katello][backend].key?(:verify_ssl)
         options[:headers] = { 'Correlation-ID' => request_id } if request_id
         client = RestClient::Resource.new("#{url}/status/", options)
 

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -9,7 +9,7 @@ module Cert
     end
 
     def self.candlepin_client_ca_cert
-      File.read(SETTINGS[:katello][:candlepin][:ca_cert_file])
+      File.read(backend_ca_cert_file(:candlepin))
     end
 
     def self.ssl_client_cert
@@ -28,10 +28,14 @@ module Cert
       Setting[:ssl_priv_key]
     end
 
+    def self.backend_ca_cert_file(backend)
+      SETTINGS.dig(:katello, backend, :ca_cert_file) || Setting[:ssl_ca_file]
+    end
+
     def self.verify_ueber_cert(organization)
       ueber_cert = OpenSSL::X509::Certificate.new(self.ueber_cert(organization)[:cert])
       cert_store = OpenSSL::X509::Store.new
-      cert_store.add_file SETTINGS[:katello][:candlepin][:ca_cert_file]
+      cert_store.add_file backend_ca_cert_file(:candlepin)
       organization.regenerate_ueber_cert unless cert_store.verify ueber_cert
     end
   end

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -17,22 +17,16 @@
     :oauth_key: katello
     :oauth_secret: katello
 
-    # refers to the candlepin-ca.crt location that is needed
-    # to connect to candlepin over https.This is not necessary
-    # if the candlepin server is running on the same machine as katello
-    # but required if the server is on a different machine.
-    # In the different machine case the katello host needs to have a
-    # copy of /etc/candlepin/certs/candlepin-ca.crt copied from
-    # the candlepin host and the location of the copied file needs to be
-    # specified here..
+    # Optional CA file to user to verify HTTPS connections to Candlepin. If not
+    # specified, Foreman's ssl_ca_file setting is used.
     :ca_cert_file:
     # :bulk_load_size: 1000
   # Setup your pulp environment here
   :pulp:
     :sync_threads: 4
     # refers to the apache certificate
-    # (typically /etc/pki/tls/certs/localhost.crt) location that is needed
-    # to connect to pulp over https.
+    # Optional CA file to user to verify HTTPS connections to Candlepin. If not
+    # specified, Foreman's ssl_ca_file setting is used.
     :ca_cert_file:
     :default_login: admin
     :sync_KBlimit:


### PR DESCRIPTION
This change makes the Candlepin CA file optional by falling back to the Foreman CA file. The result is a reduced configuration in most deployments.

For Pulp the certificate is now read in the same way as Candlepin. Previously it partly relied on the CA being in the global allowed CA. This may be an issue in some cases, but in the default deployment it isn't. Following the general SSL config makes the configuration more predictable for users. It can also be easier in a containerized setup or on a system where the admin is not allowed to modify the system CA certificates. The example config is now also consistent with reality.

The verify_ssl option is dropped from the ping model. This isn't respected elsewhere and it's misleading to have a valid ping only to have it fail at runtime.