### PR TITLE
Fixes #30391 fix link of 'Guest of virt-who' on subscription page

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionTypeFormatter.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionTypeFormatter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 
@@ -9,11 +8,12 @@ export const subscriptionTypeFormatter = (value, { rowData }) => {
   if (rowData.virt_only === false) {
     cellContent = __('Physical');
   } else if (rowData.hypervisor) {
+    const hypervisorLink = urlBuilder('content_hosts', '', rowData.hypervisor.id);
     cellContent = (
       <span>
         {__('Guests of')}
         {' '}
-        <Link to={urlBuilder('content_hosts', '', rowData.hypervisor.id)}>{rowData.hypervisor.name}</Link>
+        <a href={hypervisorLink}>{rowData.hypervisor.name}</a>
       </span>
     );
   } else if (rowData.unmapped_guest) {

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionTypeFormatter.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionTypeFormatter.test.js.snap
@@ -5,11 +5,11 @@ exports[`subscriptionTypeFormatter renders link to a host 1`] = `
   <span>
     Guests of
      
-    <Link
-      to="/content_hosts/83/"
+    <a
+      href="/content_hosts/83/"
     >
       host.example.com
-    </Link>
+    </a>
   </span>
 </td>
 `;


### PR DESCRIPTION
Issue =>  Opening blank page if click on "Guest of virt-who" link under Content -> Subscription

changes => Fix the link, so click on "Guest of virt-who" link will redirect to hypervisor page.