### PR TITLE
Fixes #30411 - Increase timeout for react-testing-lib

### DIFF
--- a/webpack/components/Search/__tests__/search.test.js
+++ b/webpack/components/Search/__tests__/search.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, waitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
 import nock, {
   nockInstance, assertNockRequest, mockAutocomplete, mockSetting,
 } from '../../../test-utils/nockWrapper';
@@ -45,7 +45,7 @@ test('Autocomplete shows on input', async (done) => {
 
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: 'foo' } });
 
-  await waitFor(() => expect(getByText(`${suggestion}`)).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByText(`${suggestion}`)).toBeInTheDocument());
 
   assertNockRequest(initialScope);
   assertNockRequest(autoSearchScope);
@@ -58,7 +58,7 @@ test('autosearch turned on does not show patternfly 4 search button', async (don
 
   const { queryByLabelText } = renderWithRedux(<Search {...props} />);
 
-  await waitFor(() => expect(queryByLabelText(searchButtonLabel)).not.toBeInTheDocument());
+  await patientlyWaitFor(() => expect(queryByLabelText(searchButtonLabel)).not.toBeInTheDocument());
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(autoSearchScope, done);
@@ -70,8 +70,9 @@ test('autosearch turned off does show patternfly 4 search button', async (done) 
 
   const { getByLabelText } = renderWithRedux(<Search {...props} />);
 
-  // Using waitFor as the autoSearch setting defaults to true, it won't be changed until http call
-  await waitFor(() => expect(getByLabelText(searchButtonLabel)).toBeInTheDocument());
+  // Using patientlyWaitFor as the autoSearch setting defaults to true,
+  // it won't be changed until http call
+  await patientlyWaitFor(() => expect(getByLabelText(searchButtonLabel)).toBeInTheDocument());
 
   assertNockRequest(autoSearchScope);
   assertNockRequest(autocompleteScope, done);
@@ -83,7 +84,7 @@ test('autosearch turned on does not affect patternfly 3 buttons', async (done) =
 
   const { getByLabelText } = renderWithRedux(<Search {...{ ...props, patternfly4: false }} />);
 
-  await waitFor(() => expect(getByLabelText('patternfly 3 search button')).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByLabelText('patternfly 3 search button')).toBeInTheDocument());
 
   assertNockRequest(autoSearchScope);
   assertNockRequest(autocompleteScope, done);
@@ -96,7 +97,7 @@ test('search function is called when search is typed into with autosearch', asyn
 
   const { getByLabelText } = renderWithRedux(<Search {...{ ...props, onSearch: mockSearch }} />);
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: 'foo' } });
-  await waitFor(() => expect(mockSearch.mock.calls).toHaveLength(1));
+  await patientlyWaitFor(() => expect(mockSearch.mock.calls).toHaveLength(1));
 
   assertNockRequest(autoSearchScope);
   assertNockRequest(autocompleteScope, done);
@@ -111,7 +112,7 @@ test('search function is called by clicking search button without autosearch', a
 
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: 'foo' } });
   let searchButton;
-  await waitFor(() => {
+  await patientlyWaitFor(() => {
     searchButton = getByLabelText(searchButtonLabel);
     expect(searchButton).toBeInTheDocument();
   });

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-escape */
 import React from 'react';
-import { renderWithRedux, waitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
 
 import CONTENT_VIEWS_KEY from '../ContentViewsConstants';
 import { createContentViewsParams } from '../ContentViewsActions';
@@ -51,7 +51,7 @@ test('Can call API for CVs and show on screen on page load', async (done) => {
   // Assert that the CV is not showing yet by searching by name and the query returning null
   expect(queryByText(firstCV.name)).toBeNull();
   // Assert that the CV name is now showing on the screen, but wait for it to appear.
-  await waitFor(() => expect(queryByText(firstCV.name)).toBeTruthy());
+  await patientlyWaitFor(() => expect(queryByText(firstCV.name)).toBeTruthy());
   // Assert request was made and completed, see helper function
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
@@ -74,7 +74,7 @@ test('Can handle no Content Views being present', async (done) => {
   const { queryByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
   expect(queryByText(firstCV.name)).toBeNull();
-  await waitFor(() => expect(queryByText(/don't have any Content Views/i)).toBeTruthy());
+  await patientlyWaitFor(() => expect(queryByText(/don't have any Content Views/i)).toBeTruthy());
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
 });
@@ -89,7 +89,7 @@ test('Can handle errored response', async (done) => {
   const { queryByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
   expect(queryByText(firstCV.name)).toBeNull();
-  await waitFor(() => expect(queryByText(/unable to connect/i)).toBeTruthy());
+  await patientlyWaitFor(() => expect(queryByText(/unable to connect/i)).toBeTruthy());
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
 });
@@ -121,7 +121,7 @@ test('Can handle unpublished Content Views', async (done) => {
 
   const { getAllByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
-  await waitFor(() => expect(getAllByText(/not yet published/i).length).toBeGreaterThan(0));
+  await patientlyWaitFor(() => expect(getAllByText(/not yet published/i).length).toBeGreaterThan(0));
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
 });
@@ -149,7 +149,7 @@ test('Can handle pagination', async (done) => {
   const { queryByText, getByLabelText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
   // Wait for first paginated page to load and assert only the first page of results are present
-  await waitFor(() => {
+  await patientlyWaitFor(() => {
     expect(queryByText(results[0].name)).toBeInTheDocument();
     expect(queryByText(results[19].name)).toBeInTheDocument();
     expect(queryByText(results[21].name)).not.toBeInTheDocument();
@@ -160,7 +160,7 @@ test('Can handle pagination', async (done) => {
   getByLabelText('Go to next page').click();
 
   // Wait for second paginated page to load and assert only the second page of results are present
-  await waitFor(() => {
+  await patientlyWaitFor(() => {
     expect(queryByText(results[20].name)).toBeInTheDocument();
     expect(queryByText(results[39].name)).toBeInTheDocument();
     expect(queryByText(results[41].name)).not.toBeInTheDocument();
@@ -197,13 +197,13 @@ test('Can search for specific Content View', async (done) => {
     queryByText,
   } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
-  await waitFor(() => expect(getByText(firstCV.name)).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByText(firstCV.name)).toBeInTheDocument());
 
   const searchInput = getByLabelText(/text input for search/i);
   expect(searchInput).toBeInTheDocument();
   fireEvent.change(searchInput, { target: { value: `name = \"${cvname}\"` } });
 
-  await waitFor(() => {
+  await patientlyWaitFor(() => {
     expect(getByText(cvname)).toBeInTheDocument();
     expect(queryByText(firstCV.name)).not.toBeInTheDocument();
   });
@@ -235,11 +235,11 @@ test('No results message is shown for empty search', async (done) => {
 
   const { getByLabelText, getByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
-  await waitFor(() => expect(getByText(firstCV.name)).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByText(firstCV.name)).toBeInTheDocument());
 
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: query } });
 
-  await waitFor(() => expect(getByText(/No matching Content Views found/i)).toBeInTheDocument(), { timeout: 5000 });
+  await patientlyWaitFor(() => expect(getByText(/No matching Content Views found/i)).toBeInTheDocument());
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(initialScope);

--- a/webpack/test-utils/react-testing-lib-wrapper.js
+++ b/webpack/test-utils/react-testing-lib-wrapper.js
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 import Immutable from 'seamless-immutable';
 import { APIMiddleware, reducers as apiReducer } from 'foremanReact/redux/API';
 import { STATUS } from 'foremanReact/constants';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
@@ -53,6 +53,10 @@ function renderWithRedux(
 
   return { ...render(connectedComponent), store };
 }
+
+// When the tests run slower, they can hit the default waitFor timeout, which is 1000ms
+// There doesn't seem to be a way to set it globally for r-t-lib, so using this wrapper function
+export const patientlyWaitFor = waitForFunc => waitFor(waitForFunc, { timeout: 5000 });
 
 // re-export everything, so the library can be used from this wrapper.
 export * from '@testing-library/react';


### PR DESCRIPTION
When the tests run on jenkins they can hit the default waitFor timeout, which is 1000ms. There doesn't seem to be a way to set it globally for r-t-lib, so created a wrapper function,