### PR TITLE
Fixes #30238 - Fix undefined method `klass' when searching on hosts

### DIFF
--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -28,7 +28,8 @@ module Katello
         has_one :content_view, :through => :content_facet
         has_one :lifecycle_environment, :through => :content_facet
         has_one :content_source, :through => :content_facet
-        has_many :applicable_errata, :through => :content_facet
+        has_many :content_facet_errata, :through => :content_facet, :class_name => 'Katello::ContentFacetErratum'
+        has_many :applicable_errata, :through => :content_facet_errata, :source => :erratum
         has_many :applicable_rpms, :through => :content_facet
         has_many :applicable_module_streams, :through => :content_facet
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "dynflow", ">= 1.2.0"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "stomp"
+  gem.add_dependency "scoped_search", ">= 4.1.9"
 
   gem.add_dependency "gettext_i18n_rails"
   gem.add_dependency "apipie-rails", ">= 0.5.14"


### PR DESCRIPTION
This error could be reproduced by searching like this
Host.search_for('applicable_errata_issued = "10 days ago"')

Requirements:
- [x] https://github.com/wvanbergen/scoped_search/pull/196