### PR TITLE
Fixes #30425 - fix page redirect during smart proxy sync

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
@@ -10,21 +10,9 @@
 */
 angular.module('Bastion.capsule-content').config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $urlRouterProvider) {
     //Catch the url to prevent the router to perform redirect.
-    $urlRouterProvider.when('/smart_proxies/:proxyId', ['$match', '$stateParams', function ($match, $stateParams) {
-        $stateParams.pageName = 'smart_proxies/detail';
+    $urlRouterProvider.when('/smart_proxies/:proxyId', [function () {
         return true;
     }]);
-
-    // Add rule to redirect links on the smart proxy detail page.
-    // Changing state doesn't work there since there's no <ui-view> element there
-    $urlRouterProvider.rule(function ($injector, $location) {
-        var $stateParams = $injector.get('$stateParams'),
-            $window = $injector.get('$window');
-
-        if ($stateParams.pageName === 'smart_proxies/detail') {
-            $window.location.href = $location.path();
-        }
-    });
 }]);
 
 /**


### PR DESCRIPTION
This was likely caused by the recent upgrade to angular,
although the exact root cause is not fully clear.  I believe
this code was meant to handle a link to a smart proxy page from
another bastion page, however this did not even work on older
builds (where this bug was not present).  No such links exist
today, but if you try to add one, it will not work.

Thus this change does not cause any regressions, but if we
ever add a link to the smart proxy details page from a bastion page
it will (still) not redirect to that page.