### PR TITLE
Fixes #30448 - Initialize event daemon in to_prepare

### DIFF
--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -17,7 +17,7 @@ module Katello
     end
 
     def setup
-      Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
+      Katello::EventDaemon.register_service(:mock_service, MockService)
       Katello::EventDaemon.stubs(:runnable?).returns(true)
       Katello::EventDaemon.stubs(:pid_file).returns(Rails.root.join('tmp', 'test_katello_daemon.pid'))
 


### PR DESCRIPTION
Sometimes reloading the code in dev will put the event daemon in a weird state because the related classes haven't been initialized. It appears to be related to when we load the classes.

This change:

- Moves the CandlepinEventListener configuration out of its own initializer and into `config.to_prepare` so that it happens upon each code reload and not just when the app starts. It avoids this error:

```
undefined method `call' for nil:NilClass
/home/vagrant/katello/app/services/katello/candlepin_event_listener.rb:36:in `run' 
```

- Moves the `EventDaemon.initialize` and related code to the top of the `config.to_prepare` block. In the event of bad code being loaded (ie syntax error), it prevents the following error from being raised:

```
NoMethodError (undefined method `fetch' for nil:NilClass):
| /home/vagrant/katello/app/services/katello/event_daemon.rb:123:in `runnable?'     
```

- Decouples the desired services from `EventDaemon` by providing a `register_service` method similar to the `EventQueue` class. This is a totally unrelated change, but since I was in the area I thought it was a good improvement to make.

Overall, none of this affects the runtime behavior of the event daemon and you can test that events are still processed from the rails console (or however you like):

```
Katello::Resources::Candlepin::Consumer.update(::Host.first.subscription_facet.uuid, {'role' => SecureRandom.uuid})
Katello::EventQueue.push_event('generate_host_applicability', 100)
```