### PR TITLE
Fixes #30451 - attach subscription to unregstered host gives useful e…

### DIFF
--- a/app/lib/actions/katello/host/attach_subscriptions.rb
+++ b/app/lib/actions/katello/host/attach_subscriptions.rb
@@ -8,12 +8,16 @@ module Actions
 
         def plan(host, pools_with_quantities_params)
           action_subject(host)
+
+          subscription_facet = host.subscription_facet
+          fail _("Register host '%s' before attaching subscriptions") % host.name unless subscription_facet
+
           sequence do
             pool_ids = []
             pools_with_quantities = pools_with_quantities_params.map do |pool_with_quantity|
               ::Katello::PoolWithQuantities.fetch(pool_with_quantity)
             end
-            existing_pool_ids = host.subscription_facet.candlepin_consumer.pool_ids
+            existing_pool_ids = subscription_facet.candlepin_consumer.pool_ids
             pools_with_quantities.each do |pool_with_quantities|
               unless existing_pool_ids.include?(pool_with_quantities.pool.cp_id.to_s)
                 pool_ids << pool_with_quantities.pool.id

--- a/test/actions/katello/host/attach_subscriptions_test.rb
+++ b/test/actions/katello/host/attach_subscriptions_test.rb
@@ -15,7 +15,7 @@ module Katello::Host
     describe 'attach subscriptions' do
       let(:action_class) { ::Actions::Katello::Host::AttachSubscriptions }
 
-      it 'plans' do
+      it 'plans success' do
         action = create_action action_class
         action.expects(:action_subject).with(@host)
 
@@ -31,6 +31,19 @@ module Katello::Host
                                   :quantity => 1, :pool_uuid => @pool.cp_id
         assert_action_planed_with action, Actions::Candlepin::Consumer::AttachSubscription, :uuid => @host.subscription_facet.uuid,
                                           :quantity => 2, :pool_uuid => @pool.cp_id
+      end
+
+      it 'plans failure' do
+        action = create_action action_class
+        action.expects(:action_subject).with(@host)
+
+        @host.expects(:subscription_facet).returns(nil)
+
+        pools_with_quantities = []
+
+        assert_raises RuntimeError do
+          plan_action action, @host, pools_with_quantities
+        end
       end
     end
   end


### PR DESCRIPTION
…rror message

Issue => Attach bulk subscription api is giving following error -
Internal Service Error (ISE)
NoMethodError: undefined method `candlepin_consumer' for nil:NilClass

Fix=> returning useful error message. 