### PR TITLE
Fixes #30452 - Improve errata status reporting

### DIFF
--- a/app/models/katello/errata_status.rb
+++ b/app/models/katello/errata_status.rb
@@ -9,17 +9,28 @@ module Katello
       N_("Errata")
     end
 
+    def errata_status_installable
+      @installable ||= Setting[:errata_status_installable]
+    end
+
+    def profiles_reporter_package_name
+      if host.content_facet.host_tools_installed?
+        Katello::Host::ContentFacet::HOST_TOOLS_PACKAGE_NAME
+      else
+        Katello::Host::ContentFacet::SUBSCRIPTION_MANAGER_PACKAGE_NAME
+      end
+    end
+
     def to_label(_options = {})
-      installable = Setting[:errata_status_installable]
       case status
       when NEEDED_SECURITY_ERRATA
-        installable ? N_("Security errata installable") : N_("Security errata applicable")
+        errata_status_installable ? N_("Security errata installable") : N_("Security errata applicable")
       when NEEDED_ERRATA
-        installable ? N_("Non-security errata installable") : N_("Non-security errata applicable")
+        errata_status_installable ? N_("Non-security errata installable") : N_("Non-security errata applicable")
       when UP_TO_DATE
         N_("All errata applied")
       when UNKNOWN
-        N_("Could not calculate errata status, ensure host is registered and the katello-host-tools package is installed")
+        N_("No installed packages and/or enabled repositories have been reported by %s." % profiles_reporter_package_name)
       else
         N_("Unknown errata status")
       end
@@ -41,19 +52,17 @@ module Katello
     end
 
     def to_status(_options = {})
-      return UNKNOWN if host.content_facet.nil?
-
-      if Setting[:errata_status_installable]
-        errata = host.content_facet.try(:installable_errata)
-      else
-        errata = host.content_facet.try(:applicable_errata)
-      end
+      errata = if errata_status_installable
+                 host.content_facet.try(:installable_errata)
+               else
+                 host.content_facet.try(:applicable_errata)
+               end
 
       if errata.security.any?
         NEEDED_SECURITY_ERRATA
       elsif errata.any?
         NEEDED_ERRATA
-      elsif host.content_facet.bound_repositories.empty?
+      elsif host.installed_packages.empty? || host.content_facet.bound_repositories.empty?
         UNKNOWN
       else
         UP_TO_DATE

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -5,6 +5,9 @@ module Katello
       self.table_name = 'katello_content_facets'
       include Facets::Base
 
+      HOST_TOOLS_PACKAGE_NAME = 'katello-host-tools'.freeze
+      SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze
+
       belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_content_facets
       belongs_to :content_view, :inverse_of => :content_facets, :class_name => "Katello::ContentView"
       belongs_to :lifecycle_environment, :inverse_of => :content_facets, :class_name => "Katello::KTEnvironment"
@@ -225,6 +228,10 @@ module Katello
 
       def tracer_installed?
         self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => 'katello-host-tools-tracer').any?
+      end
+
+      def host_tools_installed?
+        host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => HOST_TOOLS_PACKAGE_NAME).any?
       end
 
       def update_errata_status

--- a/lib/katello/tasks/unify_hosts.rake
+++ b/lib/katello/tasks/unify_hosts.rake
@@ -122,6 +122,7 @@ namespace :katello do
 
       if content_facet
         content_facet.host = provisioning_host
+        provisioning_host.content_facet = content_facet
         content_facet.save!
         content_facet.update_errata_status
       end

--- a/test/models/errata_status_test.rb
+++ b/test/models/errata_status_test.rb
@@ -5,6 +5,7 @@ module Katello
     let(:security_errata) { katello_errata(:security) }
     let(:bugfix_errata) { katello_errata(:bugfix) }
     let(:repo) { katello_repositories(:rhel_6_x86_64) }
+    let(:installed_package) { Katello::InstalledPackage.create(name: 'test-package', nvrea: 'test-package-1.0.x86_64', nvra: 'test-package-1.0.x86_64') }
 
     let(:host) do
       FactoryBot.create(:host, :with_content, :content_view => katello_content_views(:library_dev_view),
@@ -29,20 +30,46 @@ module Katello
 
     def test_to_status_non_security
       host.content_facet.applicable_errata << bugfix_errata
+
       assert_equal Katello::ErrataStatus::NEEDED_ERRATA, status.to_status
+
+      status.refresh!
+      assert_equal "Non-security errata applicable", status.to_label
     end
 
     def test_to_status_no_repos
+      host.installed_packages << installed_package
+
+      status.refresh!
+
+      assert_empty host.content_facet.bound_repositories
       assert_equal Katello::ErrataStatus::UNKNOWN, status.to_status
+      assert_match(/enabled repositories/, status.to_label)
+    end
+
+    def test_to_status_no_packages
+      host.content_facet.bound_repositories << repo
+
+      status.refresh!
+
+      assert_empty host.installed_packages
+      assert_equal Katello::ErrataStatus::UNKNOWN, status.to_status
+      assert_match(/installed packages/, status.to_label)
     end
 
     def test_to_status_repos_no_errata
       host.content_facet.bound_repositories << repo
+      host.installed_packages << installed_package
+
       assert_equal Katello::ErrataStatus::UP_TO_DATE, status.to_status
+      assert_equal "All errata applied", status.to_label
     end
 
     def test_no_content_facet
-      assert_equal Katello::ErrataStatus::UNKNOWN, FactoryBot.build(:host).get_status(Katello::ErrataStatus).to_status
+      host.content_facet.destroy
+      host.reload
+
+      refute status.relevant?
     end
 
     def test_to_global
@@ -54,9 +81,11 @@ module Katello
       Setting['errata_status_installable'] = true
       host.content_facet.bound_repositories << repo
       host.content_facet.applicable_errata << bugfix_errata
-      ::Katello::Host::ContentFacet.any_instance.expects(:installable_errata).returns(Erratum.where("0=1"))
+      host.installed_packages << installed_package
+      host.content_facet.expects(:installable_errata).returns(Erratum.none)
 
       assert_equal Katello::ErrataStatus::UP_TO_DATE, status.to_status
+      assert_equal "All errata applied", status.to_label
     end
   end
 end


### PR DESCRIPTION
I've seen a few threads on discourse that have questioned the Errata Status messaging. This PR aims to clarify that messaging by separating out the cases:
 - host is unregistered
 - no package information reported
 - no enabled repo information reported


https://community.theforeman.org/t/strange-behaviour-with-host-status-and-the-sync-fixing-my-issue-but-then-showing-zero-packages/19673