### PR TITLE
Fixes #30463 - Add description to repository update API.

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -328,6 +328,7 @@ module Katello
     api :PUT, "/repositories/:id", N_("Update a repository")
     param :id, :number, :required => true, :desc => N_("repository ID")
     param :name, String, :required => false
+    param :description, String, :desc => N_("description of the repository"), :required => false
     param_group :repo
     def update
       repo_params = repository_params

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -564,6 +564,14 @@ module Katello
       assert_template 'api/v2/repositories/show'
     end
 
+    def test_update_with_description
+      repo = katello_repositories(:busybox)
+      assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
+        attributes[:description].must_equal "katello rules"
+      end
+      put :update, params: { :id => repo.id, :description => "katello rules" }
+    end
+
     def test_update_protected
       allowed_perms = [@update_permission]
       denied_perms = [@read_permission, @create_permission, @destroy_permission]


### PR DESCRIPTION
Before Patch:

```
Actual Result:
Could not update the repository:
  Error: Unrecognized option '--description'.
  
  See: 'hammer repository update --help'.
```

With Patch:
```
[vagrant@hammer hammer-cli-katello]$ hammer repository update --name "Repo 1" --description "Updated description" --product-id 8 --organization "Default Organization"
Repository updated.
```
