### PR TITLE
Fixes #30479 - API to export and use pulp3

### DIFF
--- a/app/lib/actions/katello/repository/export.rb
+++ b/app/lib/actions/katello/repository/export.rb
@@ -15,7 +15,7 @@ module Actions
           end
 
           unless File.writable?(Setting['pulp_export_destination'])
-            fail ::Foreman::Exception, N_("Unable to export, 'pulp_export_destination' setting is not a writable directory.")
+            fail ::Foreman::Exception, N_("Unable to export. 'pulp_export_destination' setting is not a writable directory.")
           end
 
           repo_pulp_ids = repos.collect do |repo|

--- a/app/lib/actions/pulp3/content_view_version/create_exporter.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_exporter.rb
@@ -1,0 +1,18 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class CreateExporter < Pulp3::Abstract
+        input_format do
+          param :smart_proxy_id, Integer
+          param :content_view_version_id, Integer
+        end
+
+        def run
+          cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+          output[:exporter_data] = ::Katello::Pulp3::ContentViewVersion.new(smart_proxy: smart_proxy,
+                                                                            content_view_version: cvv).create_exporter
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/content_view_version/destroy_exporter.rb
+++ b/app/lib/actions/pulp3/content_view_version/destroy_exporter.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class DestroyExporter < Pulp3::Abstract
+        input_format do
+          param :smart_proxy_id, Integer
+          param :exporter_data, Hash
+        end
+
+        def run
+          ::Katello::Pulp3::ContentViewVersion.new(smart_proxy: smart_proxy).destroy_exporter(input[:exporter_data][:pulp_href])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/content_view_version/export.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class Export < Pulp3::AbstractAsyncTask
+        input_format do
+          param :content_view_version_id, Integer
+          param :smart_proxy_id, Integer
+          param :exporter_data, Hash
+        end
+
+        def invoke_external_task
+          cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+          ::Katello::Pulp3::ContentViewVersion.new(smart_proxy: smart_proxy,
+                                                   content_view_version: cvv).create_export(input[:exporter_data][:pulp_href])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
@@ -1,0 +1,60 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module ContentViewVersion
+        class Export < Actions::EntryAction
+          input_format do
+            param :smart_proxy_id, Integer
+            param :exporter_data, Hash
+          end
+
+          output_format do
+            param :exported_file_name, String
+            param :exported_file_checksum, String
+          end
+
+          def plan(content_view_version)
+            action_subject(content_view_version)
+            unless File.directory?(Setting['pulpcore_export_destination'])
+              fail ::Foreman::Exception, N_("Unable to export. 'pulpcore_export_destination' setting is not set to a valid directory.")
+            end
+
+            sequence do
+              smart_proxy = SmartProxy.pulp_master!
+              action_output = plan_action(::Actions::Pulp3::ContentViewVersion::CreateExporter,
+                                     content_view_version_id: content_view_version.id,
+                                     smart_proxy_id: smart_proxy.id).output
+
+              plan_action(::Actions::Pulp3::ContentViewVersion::Export,
+                                     content_view_version_id: content_view_version.id,
+                                     smart_proxy_id: smart_proxy.id,
+                                     exporter_data: action_output[:exporter_data]
+                                     )
+
+              plan_self(exporter_data: action_output[:exporter_data], smart_proxy_id: smart_proxy.id)
+
+              plan_action(::Actions::Pulp3::ContentViewVersion::DestroyExporter,
+                            smart_proxy_id: smart_proxy.id,
+                            exporter_data: action_output[:exporter_data])
+            end
+          end
+
+          def run
+            smart_proxy = ::SmartProxy.find(input[:smart_proxy_id])
+            api = ::Katello::Pulp3::Api::Core.new(smart_proxy)
+            export_data = api.export_api.list(input[:exporter_data][:pulp_href]).results.first
+            output[:exported_file_name], output[:exported_file_checksum] = export_data.output_file_info.first
+          end
+
+          def humanized_name
+            _("Export")
+          end
+
+          def rescue_strategy
+            Dynflow::Action::Rescue::Skip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -105,6 +105,8 @@ class Setting::Content < Setting
                5000, N_('Pulp Docker registry port')),
       self.set('pulp_export_destination', N_("On-disk location for exported repositories"),
                "/var/lib/pulp/katello-export", N_('Pulp export destination filepath')),
+      self.set('pulpcore_export_destination', N_("On-disk location for pulp 3 exported repositories"),
+               "/var/lib/pulp/exports", N_('Pulp 3 export destination filepath')),
       self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"),
                "/etc/pki/katello/private/pulp-client.key", N_('Pulp client key')),
       self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"),

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -58,6 +58,22 @@ module Katello
           fail NotImplementedError
         end
 
+        def exporter_api
+          PulpcoreClient::ExportersPulpApi.new(core_api_client)
+        end
+
+        def importer_api
+          PulpcoreClient::ImportersPulpApi.new(core_api_client)
+        end
+
+        def export_api
+          PulpcoreClient::ExportersCoreExportsApi.new(core_api_client)
+        end
+
+        def import_api
+          PulpcoreClient::ImportersCoreImportsApi.new(core_api_client)
+        end
+
         def orphans_api
           PulpcoreClient::OrphansApi.new(core_api_client)
         end

--- a/app/services/katello/pulp3/content_view_version.rb
+++ b/app/services/katello/pulp3/content_view_version.rb
@@ -1,0 +1,64 @@
+module Katello
+  module Pulp3
+    class ContentViewVersion
+      def initialize(smart_proxy:, content_view_version: nil)
+        @smart_proxy = smart_proxy
+        @content_view_version = content_view_version
+      end
+
+      def exporter_name
+        @content_view_version.name.gsub(/\s/, '_')
+      end
+
+      def generate_exporter_id
+        "#{@content_view_version.organization.label}_#{exporter_name}"
+      end
+
+      def generate_exporter_path
+        export_path = "#{@content_view_version.content_view}/#{@content_view_version.version}".gsub(/\s/, '_')
+        "#{@content_view_version.organization.label}/#{export_path}"
+      end
+
+      def api
+        ::Katello::Pulp3::Api::Core.new(@smart_proxy)
+      end
+
+      def repository_hrefs
+        version_hrefs.map { |href| version_href_to_repository_href(href) }.uniq
+      end
+
+      def version_hrefs
+        if @content_view_version.default?
+          @content_view_version.repositories.yum_type.pluck(:version_href).compact
+        else
+          @content_view_version.archived_repos.yum_type.pluck(:version_href).compact
+        end
+      end
+
+      def version_href_to_repository_href(version_href)
+        version_href.split("/")[0..-3].join("/") + "/"
+      end
+
+      def create_exporter(export_base_dir: Setting['pulpcore_export_destination'])
+        api.exporter_api.create(name: generate_exporter_id,
+                                path: "#{export_base_dir}/#{generate_exporter_path}",
+                                repositories: repository_hrefs)
+      end
+
+      def create_export(exporter_href)
+        [api.export_api.create(exporter_href, { versions: version_hrefs })]
+      end
+
+      def fetch_export(exporter_href)
+        api.export_api.list(exporter_href).results.first
+      end
+
+      def destroy_exporter(exporter_href)
+        export_data = fetch_export(exporter_href)
+        api.exporter_api.partial_update(exporter_href, :last_export => nil)
+        api.export_api.delete(export_data.pulp_href) unless export_data.blank?
+        api.exporter_api.delete(exporter_href)
+      end
+    end
+  end
+end

--- a/test/actions/pulp3/content_view_version/export_test.rb
+++ b/test/actions/pulp3/content_view_version/export_test.rb
@@ -1,0 +1,63 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::ContentView
+  class ExportTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:fedora_17_x86_64_duplicate)
+      @repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo = create_and_sync(@repo, @master)
+      @content_view = @repo.content_view
+      @content_view_version = @content_view.versions.last
+    end
+
+    def teardown
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+    end
+
+    def create_exporter
+      ForemanTasks.sync_task(::Actions::Pulp3::ContentViewVersion::CreateExporter, content_view_version_id: @content_view_version.id,
+                                     smart_proxy_id: @master.id).output["exporter_data"]
+    end
+
+    def delete_exporter(exporter_data)
+      ForemanTasks.sync_task(::Actions::Pulp3::ContentViewVersion::DestroyExporter, exporter_data: exporter_data,
+                               smart_proxy_id: @master.id)
+    end
+
+    def pulp3_cvv
+      ::Katello::Pulp3::ContentViewVersion.new(smart_proxy: @master, content_view_version: @content_view_version)
+    end
+
+    def test_create_exporter
+      exporter_data = create_exporter
+      assert_includes exporter_data["repositories"], pulp3_cvv.version_href_to_repository_href(@repo.version_href)
+      assert_equal exporter_data["name"], pulp3_cvv.generate_exporter_id
+      assert exporter_data["path"].end_with? pulp3_cvv.generate_exporter_path
+      delete_exporter(exporter_data)
+    end
+
+    def test_destroy_exporter
+      exporter_data = create_exporter
+      delete_exporter(exporter_data)
+
+      assert_raises(PulpcoreClient::ApiError) do
+        Katello::Pulp3::Api::Core.new(@master).exporter_api.read(exporter_data[:pulp_href])
+      end
+
+      assert_raises(PulpcoreClient::ApiError) do
+        assert_empty Katello::Pulp3::Api::Core.new(@master).export_api.list(exporter_data[:pulp_href])
+      end
+    end
+
+    def test_export
+      Actions::Pulp3::Orchestration::ContentViewVersion::Export.any_instance.expects(:action_subject).with(@content_view_version)
+      File.expects(:directory?).returns(true).at_least_once
+      output = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @content_view_version).output
+      refute_empty output[:exported_file_name]
+      refute_empty output[:exported_file_checksum]
+    end
+  end
+end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -126,7 +126,16 @@ module Katello
       assert_template 'api/v2/content_view_versions/show'
     end
 
+    def test_export_pulp3_assert_invalid_params
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3))
+
+      version = @library_dev_staging_view.versions.first
+      post :export, params: { :id => version.id, :iso_mb_size => 5, :export_to_iso => "foo"}
+      assert_response :bad_request
+    end
+
     def test_export
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
       version = @library_dev_staging_view.versions.first
       @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Export,
                                             version, false, nil, nil).returns({})
@@ -135,6 +144,7 @@ module Katello
     end
 
     def test_export_fails_on_demand
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
       ContentView.any_instance.stubs(:on_demand_repositories).returns([katello_repositories(:fedora_17_x86_64)])
       version = @library_dev_staging_view.versions.first
       post :export, params: { :id => version.id }
@@ -142,12 +152,14 @@ module Katello
     end
 
     def test_export_bad_date
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
       version = @library_dev_staging_view.versions.first
       post :export, params: { :id => version.id, :since => "a really bad date" }
       assert_response 400
     end
 
     def test_export_size_sans_iso_param
+      SmartProxy.stubs(:pulp_master).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
       version = @library_dev_staging_view.versions.first
       post :export, params: { :id => version.id, :iso_mb_size => 5 }
       assert_response 400

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/delete_repository_reference/export.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/delete_repository_reference/export.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 28 Jul 2020 18:19:51 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - text/html; charset=UTF-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '77'
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        PGgxPk5vdCBGb3VuZDwvaDE+PHA+VGhlIHJlcXVlc3RlZCByZXNvdXJjZSB3
+        YXMgbm90IGZvdW5kIG9uIHRoaXMgc2VydmVyLjwvcD4=
+    http_version: 
+  recorded_at: Tue, 28 Jul 2020 18:19:51 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/create_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/create_exporter.yml
@@ -1,0 +1,1572 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '3082'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
+        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
+        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:22 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/2ba687df-52a7-46f4-99b7-ac9abcf85926/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '452'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1OTI2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMDM6Mjg6MjIuOTUzOTAyWiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1OTI2L3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5
+        YWJjZjg1OTI2L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
+        bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
+        MH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:22 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJp
+        bGwuZmVkb3JhcGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEv
+        IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
+        ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:23 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/54162db1-8c3d-41b7-a170-cd5079d9e72f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '461'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0
+        MTYyZGIxLThjM2QtNDFiNy1hMTcwLWNkNTA3OWQ5ZTcyZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjIzLjA5MTQ5NFoiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
+        cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
+        dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
+        InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
+        YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDIwLTA5LTAxVDAzOjI4OjIzLjA5MTUxN1oiLCJkb3dubG9hZF9jb25j
+        dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
+        b2tlbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:23 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1
+        OTI2L3ZlcnNpb25zLzAvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:23 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwZGE3YmE5LWE2ZmEtNDY1
+        NC04OGMyLTM3Zjc3NmRhZWM4Mi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:23 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/50da7ba9-a6fa-4654-88c2-37f776daec82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:23 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBkYTdiYTktYTZm
+        YS00NjU0LTg4YzItMzdmNzc2ZGFlYzgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjMuMzg1MjE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyMy41NTY1NTda
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjIzLjgwNDU3NVoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGY3MGU5Njct
+        NmRmYS00NDExLWE3MWMtZjhlMDkzZjJjMmFiLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS8yYmE2ODdkZi01MmE3LTQ2ZjQtOTliNy1hYzlhYmNmODU5MjYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:23 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
+        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS8wZjcwZTk2Ny02ZGZhLTQ0MTEtYTcxYy1mOGUwOTNmMmMyYWIvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxYjAzYzdmLTEzZTYtNGYy
+        OS1iOWQ5LThlNmI4NWQxZGI5YS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:24 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/71b03c7f-13e6-4f29-b9d9-8e6b85d1db9a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '347'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzFiMDNjN2YtMTNl
+        Ni00ZjI5LWI5ZDktOGU2Yjg1ZDFkYjlhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjMuOTc0MDkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MjQuMTMzMjQw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyNC4zNzk0NTNa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8yZjNhNGFk
+        Ni1hMzMwLTQ3MDctOTgzOS02MWUzM2NmZjkwOGEvIl0sInJlc2VydmVkX3Jl
+        c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:24 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2f3a4ad6-a330-4707-9839-61e33cff908a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '313'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzJmM2E0YWQ2LWEzMzAtNDcwNy05ODM5LTYxZTMzY2ZmOTA4YS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjI0LjM2NDAwN1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
+        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
+        ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
+        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
+        YmxpY2F0aW9ucy9ycG0vcnBtLzBmNzBlOTY3LTZkZmEtNDQxMS1hNzFjLWY4
+        ZTA5M2YyYzJhYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:24 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/2ba687df-52a7-46f4-99b7-ac9abcf85926/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzU0MTYy
+        ZGIxLThjM2QtNDFiNy1hMTcwLWNkNTA3OWQ5ZTcyZi8iLCJtaXJyb3IiOnRy
+        dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:24 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlNTljODYwLTJkYjQtNGVl
+        OC1hYjVlLTRmNDcxOTEwYmQ0Ni8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:24 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/be59c860-2db4-4ee8-ab5e-4f471910bd46/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:26 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '567'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmU1OWM4NjAtMmRi
+        NC00ZWU4LWFiNWUtNGY0NzE5MTBiZDQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjQuODQ2OTAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MjUu
+        MDAyNzQ1WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyNi40
+        MDE3OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoicGFyc2luZy5hZHZpc29yaWVzIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
+        cGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzJiYTY4
+        N2RmLTUyYTctNDZmNC05OWI3LWFjOWFiY2Y4NTkyNi92ZXJzaW9ucy8xLyJd
+        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS8yYmE2ODdkZi01MmE3LTQ2ZjQtOTliNy1h
+        YzlhYmNmODU5MjYvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS81
+        NDE2MmRiMS04YzNkLTQxYjctYTE3MC1jZDUwNzlkOWU3MmYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:26 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1
+        OTI2L3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:26 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkNjhiMzI0LTE0NjEtNDkw
+        YS04OTkzLTQwMzIzNmRhNTJmNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:26 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/dd68b324-1461-490a-8993-403236da52f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGQ2OGIzMjQtMTQ2
+        MS00OTBhLTg5OTMtNDAzMjM2ZGE1MmY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjYuNjM4MDI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyNi43NTk0MzBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjI3LjEzNTc4Mloi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNzNiZWY5ODkt
+        NTg4ZS00YmY2LWE0OGUtMzdhYmJhNWY4MzIxLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS8yYmE2ODdkZi01MmE3LTQ2ZjQtOTliNy1hYzlhYmNmODU5MjYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:27 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2f3a4ad6-a330-4707-9839-61e33cff908a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83M2JlZjk4OS01ODhlLTRi
+        ZjYtYTQ4ZS0zN2FiYmE1ZjgzMjEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FkYjQyYTYyLWNjMGItNDBl
+        ZC1hZWQzLTU1NzZhODZmMmVlMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:27 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/adb42a62-cc0b-40ed-aed3-5576a86f2ee1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWRiNDJhNjItY2Mw
+        Yi00MGVkLWFlZDMtNTU3NmE4NmYyZWUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjcuMzA1MTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MjcuNDM3MTMz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyNy42NjY5MzZa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:27 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2f3a4ad6-a330-4707-9839-61e33cff908a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83M2JlZjk4OS01ODhlLTRi
+        ZjYtYTQ4ZS0zN2FiYmE1ZjgzMjEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzMGM2OGZlLTdmMTItNDdh
+        OC05MjdhLTk0MjY3MzI3OTVmZC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:27 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
+        ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        IiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yYmE2ODdkZi01MmE3LTQ2ZjQtOTliNy1hYzlhYmNmODU5MjYv
+        Il19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/exporters/core/pulp/1429a2cf-2200-4a60-9184-a415d4b080e9/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '377'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC8xNDI5YTJjZi0yMjAwLTRhNjAtOTE4NC1hNDE1ZDRiMDgwZTkvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODoyOC4wMTI2NDVaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1OTI2LyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/1429a2cf-2200-4a60-9184-a415d4b080e9/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/1429a2cf-2200-4a60-9184-a415d4b080e9/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '264'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC8xNDI5YTJjZi0yMjAwLTRhNjAtOTE4NC1hNDE1ZDRiMDgwZTkvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODoyOC4wMTI2NDVaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMmJhNjg3ZGYtNTJhNy00NmY0LTk5YjctYWM5YWJjZjg1OTI2LyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/1429a2cf-2200-4a60-9184-a415d4b080e9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/54162db1-8c3d-41b7-a170-cd5079d9e72f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyNTg3ZGM2LTM2MzMtNDMy
+        NS1iNWQwLTIyOTQ2Y2EwOWNkZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/72587dc6-3633-4325-b5d0-22946ca09cde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '337'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI1ODdkYzYtMzYz
+        My00MzI1LWI1ZDAtMjI5NDZjYTA5Y2RlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjguNDY1MjA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MjguNTk3OTY2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyOC42NTczMjRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL3JwbS9ycG0vNTQxNjJkYjEtOGMzZC00MWI3LWExNzAtY2Q1
+        MDc5ZDllNzJmLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2f3a4ad6-a330-4707-9839-61e33cff908a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzMWZkMDM0LTYzNTEtNDYy
+        Ny05NDQyLWViN2Y1MmMzZmRiMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/2ba687df-52a7-46f4-99b7-ac9abcf85926/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzN2UxYjlmLTcxN2QtNGNj
+        Yy1iOGM0LTRmYTIyZDlkOWY2MC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:28 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/037e1b9f-717d-4ccc-b8c4-4fa22d9d9f60/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '342'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDM3ZTFiOWYtNzE3
+        ZC00Y2NjLWI4YzQtNGZhMjJkOWQ5ZjYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MjguODM5MTc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MjkuMDQ3MTg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODoyOS4yMTMxMjJa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yYmE2ODdkZi01MmE3LTQ2ZjQtOTli
+        Ny1hYzlhYmNmODU5MjYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:29 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/destroy_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/destroy_exporter.yml
@@ -1,0 +1,1662 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '3082'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
+        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
+        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/3a008da7-7f09-4bee-8318-189ded9beec2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '452'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJlZWMyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMDM6Mjg6MzAuNjIyMTI2WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJlZWMyL3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5
+        ZGVkOWJlZWMyL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
+        bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
+        MH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJp
+        bGwuZmVkb3JhcGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEv
+        IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
+        ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/454fbe62-27b2-463d-a0d3-9dfb738c6068/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '461'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ1
+        NGZiZTYyLTI3YjItNDYzZC1hMGQzLTlkZmI3MzhjNjA2OC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjMwLjcxNTIwMVoiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
+        cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
+        dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
+        InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
+        YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDIwLTA5LTAxVDAzOjI4OjMwLjcxNTIxN1oiLCJkb3dubG9hZF9jb25j
+        dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
+        b2tlbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:30 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJl
+        ZWMyL3ZlcnNpb25zLzAvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlNGVlNWFkLTg4YWYtNDFj
+        ZS05YTRhLWVmYzgzODFiNDQzOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:31 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/de4ee5ad-88af-41ce-9a4a-efc8381b4438/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGU0ZWU1YWQtODhh
+        Zi00MWNlLTlhNGEtZWZjODM4MWI0NDM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzEuMDExOTM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozMS4xNDk4MjBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjMxLjM4NjA3Mloi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWViNjkyMjYt
+        YThlZS00NGJiLTljYTAtNzVkMmU4NzZiODY2LyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS8zYTAwOGRhNy03ZjA5LTRiZWUtODMxOC0xODlkZWQ5YmVlYzIvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:31 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
+        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS9hZWI2OTIyNi1hOGVlLTQ0YmItOWNhMC03NWQyZTg3NmI4NjYvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwZWVlMDVmLWI5YjYtNGIz
+        OC04OWZkLTJjNWQ4MTkwMDM0ZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:31 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/50eee05f-b9b6-4b38-89fd-2c5d8190034e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '347'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTBlZWUwNWYtYjli
+        Ni00YjM4LTg5ZmQtMmM1ZDgxOTAwMzRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzEuNTQyMDUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzEuNjcyNzU1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozMS45MjAxMzBa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS9iNzQ0Njhh
+        NC00ODZjLTRhYTctOTg2YS03ODcyM2M3MGIwMmEvIl0sInJlc2VydmVkX3Jl
+        c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:31 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/b74468a4-486c-4aa7-986a-78723c70b02a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:32 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '313'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2I3NDQ2OGE0LTQ4NmMtNGFhNy05ODZhLTc4NzIzYzcwYjAyYS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjMxLjkwNTkwNFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
+        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
+        ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
+        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
+        YmxpY2F0aW9ucy9ycG0vcnBtL2FlYjY5MjI2LWE4ZWUtNDRiYi05Y2EwLTc1
+        ZDJlODc2Yjg2Ni8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:32 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/3a008da7-7f09-4bee-8318-189ded9beec2/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ1NGZi
+        ZTYyLTI3YjItNDYzZC1hMGQzLTlkZmI3MzhjNjA2OC8iLCJtaXJyb3IiOnRy
+        dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:32 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmZDgxZWFkLWU2NTMtNGQx
+        Ny1hZDk1LTg1MjJkMTFiODkzYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:32 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/efd81ead-e653-4d17-ad95-8522d11b893a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:34 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '565'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWZkODFlYWQtZTY1
+        My00ZDE3LWFkOTUtODUyMmQxMWI4OTNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzIuMzg5NDcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzIu
+        NTI2NzE5WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozMy44
+        ODc2ODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIFBhY2thZ2VzIiwiY29kZSI6InBhcnNpbmcucGFja2FnZXMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1ZmZpeCI6
+        bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoi
+        cGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNhMDA4
+        ZGE3LTdmMDktNGJlZS04MzE4LTE4OWRlZDliZWVjMi92ZXJzaW9ucy8xLyJd
+        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS8zYTAwOGRhNy03ZjA5LTRiZWUtODMxOC0x
+        ODlkZWQ5YmVlYzIvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS80
+        NTRmYmU2Mi0yN2IyLTQ2M2QtYTBkMy05ZGZiNzM4YzYwNjgvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:34 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJl
+        ZWMyL3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:34 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzNzM1MDhlLTU4MTYtNDA0
+        Ni1hZWEyLTE5NjRkNjg2MGZhOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:34 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/c373508e-5816-4046-aea2-1964d6860fa8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:34 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzM3MzUwOGUtNTgx
+        Ni00MDQ2LWFlYTItMTk2NGQ2ODYwZmE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzQuMTIxNzEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozNC4yNjIwMjFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjM0LjYyNjkxMVoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZWZjNWQwYzMt
+        MzA2Ny00MDJmLThjZTYtNmJmNjE3YzE3MTYzLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS8zYTAwOGRhNy03ZjA5LTRiZWUtODMxOC0xODlkZWQ5YmVlYzIvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:34 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/b74468a4-486c-4aa7-986a-78723c70b02a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9lZmM1ZDBjMy0zMDY3LTQw
+        MmYtOGNlNi02YmY2MTdjMTcxNjMvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:34 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmN2Q1ODFhLWVhMjYtNDA4
+        NS05MTA0LThlNmYxMGQxNGFiMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:34 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/4f7d581a-ea26-4085-9104-8e6f10d14ab0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '317'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGY3ZDU4MWEtZWEy
+        Ni00MDg1LTkxMDQtOGU2ZjEwZDE0YWIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzQuNzUwMzg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzQuODk3NDI0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozNS4xMzA2Njha
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/b74468a4-486c-4aa7-986a-78723c70b02a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9lZmM1ZDBjMy0zMDY3LTQw
+        MmYtOGNlNi02YmY2MTdjMTcxNjMvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3ZDc5MTg3LWU1ZTItNGIz
+        ZS1hNzFiLWUxYzI2ZjRlNTRkOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
+        ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        IiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zYTAwOGRhNy03ZjA5LTRiZWUtODMxOC0xODlkZWQ5YmVlYzIv
+        Il19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '377'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC82MDg1ZDlhOC00MTYxLTRiNWEtYmVlMy0yYjNmOGI3OTc0NzQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODozNS40NzIxNjlaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJlZWMyLyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '265'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC82MDg1ZDlhOC00MTYxLTRiNWEtYmVlMy0yYjNmOGI3OTc0NzQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODozNS40NzIxNjlaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vM2EwMDhkYTctN2YwOS00YmVlLTgzMTgtMTg5ZGVkOWJlZWMyLyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/6085d9a8-4161-4b5a-bee3-2b3f8b797474/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/454fbe62-27b2-463d-a0d3-9dfb738c6068/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:35 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlZmVmN2Y4LWY4YjMtNGQ5
+        NC05MzNkLWIwN2UyODViNGQyMi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:35 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/3efef7f8-f8b3-4d94-933d-b07e285b4d22/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:36 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2VmZWY3ZjgtZjhi
+        My00ZDk0LTkzM2QtYjA3ZTI4NWI0ZDIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzUuOTM0NjA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzYuMDc5Mjc5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozNi4xMzA0MzZa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL3JwbS9ycG0vNDU0ZmJlNjItMjdiMi00NjNkLWEwZDMtOWRm
+        YjczOGM2MDY4LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:36 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/b74468a4-486c-4aa7-986a-78723c70b02a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:36 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhZDJmYWVhLWMzNGYtNDg5
+        ZS04NjExLTBiNjAzZDYzMzY5Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:36 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/3a008da7-7f09-4bee-8318-189ded9beec2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:36 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1ZDViNDdmLWFiOTItNDJm
+        NS04NjVlLTkwMmY1ZTQ2N2U1OC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:36 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/15d5b47f-ab92-42f5-865e-902f5e467e58/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:36 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '340'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTVkNWI0N2YtYWI5
+        Mi00MmY1LTg2NWUtOTAyZjVlNDY3ZTU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzYuMjkyMzQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzYuNTMwNzcy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozNi43MTE1NjRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zYTAwOGRhNy03ZjA5LTRiZWUtODMx
+        OC0xODlkZWQ5YmVlYzIvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:36 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/export.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/export.yml
@@ -1,0 +1,1800 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '3082'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
+        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
+        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxp
+        ZGl0eVxuICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUw
+        IDIwMjAgR01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6
+        MjE6NTAgMjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9y
+        dGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3Jn
+        VW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAg
+        ICAgICAgU3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQ
+        dWJsaWMgS2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAg
+        ICAgICAgIFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAg
+        ICBNb2R1bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMTox
+        MDpmZjowMToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAg
+        ICAgICAgICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6
+        ZTU6ODE6YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3
+        OmMzOmJlOmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAg
+        ICAgICAgICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5Nzpj
+        ZDo5NzoxNzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6
+        YTk6MmE6ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1Ojdh
+        Ojg0OmNmOlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5
+        OTo1NjozOTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAg
+        ICAgICAgNTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6
+        ZTI6YWU6XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMw
+        OmJlOjdiOmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAg
+        ICAgICA1YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5
+        NTo4MzpcbiAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6
+        MGI6NTY6YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAg
+        ICAgIDZlOjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVl
+        OjU4OlxuICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpk
+        OTpiMjo1NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOTc6M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6
+        YjM6XG4gICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1
+        OjdmOjk1OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAg
+        ICBhMDo0ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTpl
+        MjpcbiAgICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6
+        ZjA6OTM6YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAg
+        IDAxOjBmXG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEw
+        MDAxKVxuICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAg
+        IFg1MDl2MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBD
+        QTpUUlVFXG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAg
+        ICAgICAgICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50
+        LCBDZXJ0aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUw
+        OXYzIEV4dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMg
+        V2ViIFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0
+        aGVudGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpc
+        biAgICAgICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAg
+        ICAgIE5ldHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxs
+        byBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAg
+        IFg1MDl2MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAg
+        ICAgIDlCOkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdB
+        OjdEOkQxOjg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9T
+        VD1Ob3J0aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVP
+        cmdVbml0L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4g
+        ICAgICAgICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4
+        XG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5j
+        cnlwdGlvblxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6
+        MTY6YjA6N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpm
+        ZDo3NTpjNjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToy
+        NTpcbiAgICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1
+        OmNjOjFmOjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6
+        YzE6NzE6MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4g
+        ICAgICAgICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1
+        ZTo0Yjo5OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0
+        OjI0OjY1OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAg
+        ICAgYjk6M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6
+        OTQ6YzQ6YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1
+        Njo0YjowNDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNh
+        OjY4OmQwOmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZk
+        OmE2OjQ4OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6
+        OWI6OTk6ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYTox
+        OTplMzo5MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpj
+        NzpcbiAgICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3
+        OjQxOjNiOmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6
+        MjA6YjE6Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4g
+        ICAgICAgICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1
+        Mzo1MjpmZjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0t
+        LUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lK
+        QVAyNnZIRnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURc
+        blZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4
+        RURBT0JnTlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdW
+        c2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZR
+        UUREQ0JqWlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1O
+        dmJUQWVGdzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5U
+        QmFNSUdMTVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlk
+        R2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0Jn
+        TlZCQW9NQjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZi
+        bWwwTVNrd0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFw
+        Y2k1bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURn
+        Z0VQQURDQ0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHht
+        c1hqTmlZeGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2
+        V05mMlh6WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgx
+        ZW9UUGE5Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVL
+        dTFVRUZUS0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5D
+        ZkdyTXlnQzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFj
+        ZTJiSlhcbk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpY
+        K1Z3SE9XeGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1Rx
+        TGtLYzgvM0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFm
+        OHdcbkN3WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZC
+        d01CQmdnckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3
+        TlFZSllJWklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dc
+        blIyVnVaWEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNi
+        MHRscGlKa3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlH
+        MWdCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6
+        RUxNQWtHQTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205
+        c2FXNWhNUkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RB
+        ZExZWFJsYkd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBN
+        Q2NHQTFVRUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJY
+        QnNaUzVqYjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZB
+        QU9DQVFFQU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dC
+        L3BVdVB3b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhH
+        dHFHb0Nmb3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4
+        dkFTVUpHWHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1V
+        ampMbHU1UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVa
+        L2FaSUFnUnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0
+        bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
+        V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
+        PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:37 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:37 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:37 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:37 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:37 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:37 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/b8ce0d88-7701-4bec-a622-92a2ff0cc79f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '452'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNjNzlmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMDM6Mjg6MzguMDQwMDk0WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNjNzlmL3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJh
+        MmZmMGNjNzlmL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
+        bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
+        MH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:38 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJp
+        bGwuZmVkb3JhcGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEv
+        IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
+        ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/ab7e83cd-fa1f-409d-ace6-9595c0b372cd/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '461'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Fi
+        N2U4M2NkLWZhMWYtNDA5ZC1hY2U2LTk1OTVjMGIzNzJjZC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjM4LjE0MTMwM1oiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
+        cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
+        dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
+        InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
+        YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDIwLTA5LTAxVDAzOjI4OjM4LjE0MTMxN1oiLCJkb3dubG9hZF9jb25j
+        dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
+        b2tlbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:38 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNj
+        NzlmL3ZlcnNpb25zLzAvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkMGU0MGJkLTQ0NTctNDI3
+        MS05N2UxLTcyNjlmYTg3ODNiMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:38 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/2d0e40bd-4457-4271-97e1-7269fa8783b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:38 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '369'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQwZTQwYmQtNDQ1
+        Ny00MjcxLTk3ZTEtNzI2OWZhODc4M2IxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzguNTI0NzM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozOC42OTA5OTRa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjM4LjkzNTY5NFoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDdlNTkwNDMt
+        YTVmZC00NzJjLWE5YmYtN2RiYjI4MDA0OTVjLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS9iOGNlMGQ4OC03NzAxLTRiZWMtYTYyMi05MmEyZmYwY2M3OWYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:38 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
+        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS8wN2U1OTA0My1hNWZkLTQ3MmMtYTliZi03ZGJiMjgwMDQ5NWMvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5MzBjMDVmLWY4Y2UtNGNm
+        Mi1iNDEyLTU2YWE0NmEyM2JiYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:39 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/0930c05f-f8ce-4cf2-b412-56aa46a23bbc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '347'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDkzMGMwNWYtZjhj
+        ZS00Y2YyLWI0MTItNTZhYTQ2YTIzYmJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzkuMDc4MTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6MzkuMjA1NTIx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODozOS40NTEzMjha
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8wMzYwYWRh
+        Yi05MWYzLTRkZDktYTRlNS0wMjBjOTk1MzRhZTIvIl0sInJlc2VydmVkX3Jl
+        c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:39 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0360adab-91f3-4dd9-a4e5-020c99534ae2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '312'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzAzNjBhZGFiLTkxZjMtNGRkOS1hNGU1LTAyMGM5OTUzNGFlMi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjM5LjQzNzgwN1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
+        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
+        ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
+        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
+        YmxpY2F0aW9ucy9ycG0vcnBtLzA3ZTU5MDQzLWE1ZmQtNDcyYy1hOWJmLTdk
+        YmIyODAwNDk1Yy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:39 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/b8ce0d88-7701-4bec-a622-92a2ff0cc79f/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2FiN2U4
+        M2NkLWZhMWYtNDA5ZC1hY2U2LTk1OTVjMGIzNzJjZC8iLCJtaXJyb3IiOnRy
+        dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:39 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjNWZiM2JlLTk5YWQtNGE3
+        ZC1hZWVhLWU1Mjk5MTUyZmI5Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:39 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/1c5fb3be-99ad-4a7d-aeea-e5299152fb9f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:41 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '566'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWM1ZmIzYmUtOTlh
+        ZC00YTdkLWFlZWEtZTUyOTkxNTJmYjlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6MzkuODc0MDM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6NDAu
+        MDEyMDUxWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0MS4z
+        NjgwOTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIFBhY2thZ2VzIiwiY29kZSI6InBhcnNpbmcucGFja2FnZXMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1ZmZpeCI6
+        bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoi
+        cGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I4Y2Uw
+        ZDg4LTc3MDEtNGJlYy1hNjIyLTkyYTJmZjBjYzc5Zi92ZXJzaW9ucy8xLyJd
+        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
+        ZW1vdGVzL3JwbS9ycG0vYWI3ZTgzY2QtZmExZi00MDlkLWFjZTYtOTU5NWMw
+        YjM3MmNkLyIsIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9i
+        OGNlMGQ4OC03NzAxLTRiZWMtYTYyMi05MmEyZmYwY2M3OWYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:41 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNj
+        NzlmL3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:41 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjZjcyNzY0LWFiMTctNDll
+        Zi1iNzMwLTBhYTQ5MThmOWEzYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:41 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/fcf72764-ab17-49ef-b730-0aa4918f9a3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmNmNzI3NjQtYWIx
+        Ny00OWVmLWI3MzAtMGFhNDkxOGY5YTNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6NDEuNjAxNjA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0MS43NDA4MjJa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjQyLjEyMjcyMVoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTEzZWM1NzEt
+        ZWI3ZC00OTZlLTk3MDgtZjFmZDgxMTNhOWI2LyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS9iOGNlMGQ4OC03NzAxLTRiZWMtYTYyMi05MmEyZmYwY2M3OWYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:42 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0360adab-91f3-4dd9-a4e5-020c99534ae2/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS85MTNlYzU3MS1lYjdkLTQ5
+        NmUtOTcwOC1mMWZkODExM2E5YjYvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkZjA3NGMzLWMyNTMtNDM1
+        ZC1iMzg3LTlmYjEzOTMyZGNmYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:42 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/2df074c3-c253-435d-b387-9fb13932dcfc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '316'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmRmMDc0YzMtYzI1
+        My00MzVkLWIzODctOWZiMTM5MzJkY2ZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6NDIuMjY1MTEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6NDIuMzk0MDQ3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0Mi42MzU3MjVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:42 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0360adab-91f3-4dd9-a4e5-020c99534ae2/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
+        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS85MTNlYzU3MS1lYjdkLTQ5
+        NmUtOTcwOC1mMWZkODExM2E5YjYvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhNzg4ODQxLWQwYTYtNDI2
+        NS1hYzBiLTE2ZjQ1MTYyZTEzNS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:42 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
+        ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        IiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9iOGNlMGQ4OC03NzAxLTRiZWMtYTYyMi05MmEyZmYwY2M3OWYv
+        Il19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:43 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '377'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC84OWI1YjlhNC0yMGVkLTQ1Y2UtOWEyZS0xNThjNzdiOTA0NzgvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODo0My4wMDYwNDJaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNjNzlmLyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:43 GMT
+- request:
+    method: post
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/exports/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ2ZXJzaW9ucyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNjNzlmL3ZlcnNp
+        b25zLzEvIl19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:43 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5MmUzOTJkLWQxMGMtNGFj
+        NC1hOTM1LWQyMmQ3MTcyYTJmZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:43 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/d92e392d-d10c-4ac4-a935-d22d7172a2ff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:43 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '364'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDkyZTM5MmQtZDEw
+        Yy00YWM0LWE5MzUtZDIyZDcxNzJhMmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6NDMuMDg5NTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5leHBvcnQucHVscF9leHBv
+        cnQiLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0My4yNTM4MTla
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAzOjI4OjQzLjY5MjYwNFoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC84OWI1YjlhNC0y
+        MGVkLTQ1Y2UtOWEyZS0xNThjNzdiOTA0NzgvZXhwb3J0cy9hMmI1MjUxNy0z
+        MTQ4LTQ4N2QtYmQ4YS1kNTgwMzJjYTI5ZDMvIl0sInJlc2VydmVkX3Jlc291
+        cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2V4cG9ydGVycy9jb3JlL3B1
+        bHAvODliNWI5YTQtMjBlZC00NWNlLTlhMmUtMTU4Yzc3YjkwNDc4LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:43 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:43 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '490'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
+        ZS9wdWxwLzg5YjViOWE0LTIwZWQtNDVjZS05YTJlLTE1OGM3N2I5MDQ3OC9l
+        eHBvcnRzL2EyYjUyNTE3LTMxNDgtNDg3ZC1iZDhhLWQ1ODAzMmNhMjlkMy8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjQzLjA4NTEwNloi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5MmUzOTJkLWQxMGMtNGFj
+        NC1hOTM1LWQyMmQ3MTcyYTJmZi8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I4Y2UwZDg4LTc3
+        MDEtNGJlYy1hNjIyLTkyYTJmZjBjYzc5Zi92ZXJzaW9ucy8xLyJdLCJwYXJh
+        bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtL2I4Y2UwZDg4LTc3MDEtNGJlYy1hNjIyLTkyYTJmZjBjYzc5Zi92
+        ZXJzaW9ucy8xLyJdfSwib3V0cHV0X2ZpbGVfaW5mbyI6eyIvdmFyL2xpYi9w
+        dWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9uL0FDTUVfRGVmYXVsdF9D
+        b250ZW50Vmlldy8xLjAvZXhwb3J0LWEyYjUyNTE3LTMxNDgtNDg3ZC1iZDhh
+        LWQ1ODAzMmNhMjlkMy0yMDIwMDkwMV8wMzI4LnRhci5neiI6ImFiYzVmZmU5
+        YzM1OTdmNTAzYjE3MzM5MTI3OWNmNDUxNWNkNjhmNDE0MDVjNjUzMjlkOTY1
+        NmFmMWEwMTg4MmEiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3Jn
+        YW5pemF0aW9uL0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZXhwb3J0
+        LWEyYjUyNTE3LTMxNDgtNDg3ZC1iZDhhLWQ1ODAzMmNhMjlkMy0yMDIwMDkw
+        MV8wMzI4LXRvYy5qc29uIjoiZmRjNTNiODY1MTg0YjVhNDBkN2RlYTVjODNj
+        MjM4ODJiZmU0ZDgyODYzY2JmYmQ5YjgyODgyNjY3NDRmZGIzZiJ9fV19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:43 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '490'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
+        ZS9wdWxwLzg5YjViOWE0LTIwZWQtNDVjZS05YTJlLTE1OGM3N2I5MDQ3OC9l
+        eHBvcnRzL2EyYjUyNTE3LTMxNDgtNDg3ZC1iZDhhLWQ1ODAzMmNhMjlkMy8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAzOjI4OjQzLjA4NTEwNloi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5MmUzOTJkLWQxMGMtNGFj
+        NC1hOTM1LWQyMmQ3MTcyYTJmZi8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I4Y2UwZDg4LTc3
+        MDEtNGJlYy1hNjIyLTkyYTJmZjBjYzc5Zi92ZXJzaW9ucy8xLyJdLCJwYXJh
+        bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtL2I4Y2UwZDg4LTc3MDEtNGJlYy1hNjIyLTkyYTJmZjBjYzc5Zi92
+        ZXJzaW9ucy8xLyJdfSwib3V0cHV0X2ZpbGVfaW5mbyI6eyIvdmFyL2xpYi9w
+        dWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9uL0FDTUVfRGVmYXVsdF9D
+        b250ZW50Vmlldy8xLjAvZXhwb3J0LWEyYjUyNTE3LTMxNDgtNDg3ZC1iZDhh
+        LWQ1ODAzMmNhMjlkMy0yMDIwMDkwMV8wMzI4LnRhci5neiI6ImFiYzVmZmU5
+        YzM1OTdmNTAzYjE3MzM5MTI3OWNmNDUxNWNkNjhmNDE0MDVjNjUzMjlkOTY1
+        NmFmMWEwMTg4MmEiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3Jn
+        YW5pemF0aW9uL0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZXhwb3J0
+        LWEyYjUyNTE3LTMxNDgtNDg3ZC1iZDhhLWQ1ODAzMmNhMjlkMy0yMDIwMDkw
+        MV8wMzI4LXRvYy5qc29uIjoiZmRjNTNiODY1MTg0YjVhNDBkN2RlYTVjODNj
+        MjM4ODJiZmU0ZDgyODYzY2JmYmQ5YjgyODgyNjY3NDRmZGIzZiJ9fV19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: patch
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '264'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
+        cC84OWI1YjlhNC0yMGVkLTQ1Y2UtOWEyZS0xNThjNzdiOTA0NzgvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQwMzoyODo0My4wMDYwNDJaIiwibmFt
+        ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
+        ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
+        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMCIsInJl
+        cG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vYjhjZTBkODgtNzcwMS00YmVjLWE2MjItOTJhMmZmMGNjNzlmLyJdLCJs
+        YXN0X2V4cG9ydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/exports/a2b52517-3148-487d-bd8a-d58032ca29d3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/89b5b9a4-20ed-45ce-9a2e-158c77b90478/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/ab7e83cd-fa1f-409d-ace6-9595c0b372cd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4N2QxZDA1LWYyNTEtNDEw
+        Ni05MjJiLTFlYWZkZGZkNjQwOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/b87d1d05-f251-4106-922b-1eafddfd6408/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '339'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjg3ZDFkMDUtZjI1
+        MS00MTA2LTkyMmItMWVhZmRkZmQ2NDA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6NDQuMzI4ODcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6NDQuNDY5OTY2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0NC41MjY0MzVa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL3JwbS9ycG0vYWI3ZTgzY2QtZmExZi00MDlkLWFjZTYtOTU5
+        NWMwYjM3MmNkLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0360adab-91f3-4dd9-a4e5-020c99534ae2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliZTI0NjZjLTNkNDEtNDY0
+        MS04YTk3LTAyYzEyNTI5OGY3MC8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/b8ce0d88-7701-4bec-a622-92a2ff0cc79f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:44 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmNWUwNTlkLWZlYjktNGJj
+        YS04M2ZiLTVjNmVlNWExMzc0NS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:44 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/ef5e059d-feb9-4bca-83fb-5c6ee5a13745/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 03:28:45 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWY1ZTA1OWQtZmVi
+        OS00YmNhLTgzZmItNWM2ZWU1YTEzNzQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDM6Mjg6NDQuNzE1MTgyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDM6Mjg6NDQuOTI0MDk5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMzoyODo0NS4xMTc0OTda
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iOGNlMGQ4OC03NzAxLTRiZWMtYTYy
+        Mi05MmEyZmYwY2M3OWYvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 03:28:45 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/optimize_false.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/optimize_false.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -172,7 +172,7 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:43 GMT
 - request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -183,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:43 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:43 GMT
 - request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -228,7 +228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -262,7 +262,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -273,7 +273,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +286,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -307,7 +307,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -318,7 +318,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +331,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -352,7 +352,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +378,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/"
+      - "/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -399,18 +399,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3NWI4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjhUMTc6NTE6MDUuNjEwODAwWiIsInZl
+        cG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2JhMjA1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMDI6MTQ6NDQuMzgzOTgwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3NWI4L3ZlcnNp
+        cG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2JhMjA1L3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdj
-        ZTQzMGU3NWI4L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        b3NpdG9yaWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZm
+        NzliN2JhMjA1L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
         bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
         MH0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -426,7 +426,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -439,13 +439,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:05 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/f9270b6c-becd-4634-9751-911c98961598/"
+      - "/pulp/api/v3/remotes/rpm/rpm/11ccaec4-2f1f-49c1-9bed-bc7010f03782/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -459,19 +459,19 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y5
-        MjcwYjZjLWJlY2QtNDYzNC05NzUxLTkxMWM5ODk2MTU5OC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA4LTI4VDE3OjUxOjA1LjgwMjU1NFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzEx
+        Y2NhZWM0LTJmMWYtNDljMS05YmVkLWJjNzAxMGYwMzc4Mi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjE0OjQ0LjU0ODA5M1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
         InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
         YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIwLTA4LTI4VDE3OjUxOjA1LjgwMjU3NFoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIwLTA5LTAxVDAyOjE0OjQ0LjU0ODEwOVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
         b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:05 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -479,14 +479,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3
-        NWI4L3ZlcnNpb25zLzAvIiwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6InNo
-        YTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2Jh
+        MjA1L3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -499,7 +498,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:06 GMT
+      - Tue, 01 Sep 2020 02:14:44 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -517,13 +516,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiOTNlNGIzLTUxYzktNGFm
-        Ni1iMThkLTczYjViNTEzNTc0Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0NTIzZGIzLTM3YzgtNDMz
+        YS05ZTNlLWE5OGY1M2Y1YWE3OC8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:06 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/2b93e4b3-51c9-4af6-b18d-73b5b5135747/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/d4523db3-37c8-433a-9e3e-a98f53f5aa78/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -531,7 +530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -544,7 +543,397 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:06 GMT
+      - Tue, 01 Sep 2020 02:14:45 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDQ1MjNkYjMtMzdj
+        OC00MzNhLTllM2UtYTk4ZjUzZjVhYTc4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NDQuODg4MjA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo0NS4wNzgxNzZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAyOjE0OjQ1LjQyMDAxOVoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        NzJjMDlkNDctYjQ2NC00NWE2LWE2MGItMWFkNzRmOWNmZjllLyIsInBhcmVu
+        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
+        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGIyYjFmNDct
+        NTk3Zi00YzYzLTg1MjgtOTc5ZjY5YTBjNDA0LyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVhNi0yNmY3OWI3YmEyMDUvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:45 GMT
+- request:
+    method: post
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzJiN2Q3ZjE2LWMzZDYt
+        NDJlMi04ODgzLTU3N2QxZGMyOGRlYi8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS84YjJiMWY0Ny01OTdmLTRjNjMtODUyOC05NzlmNjlhMGM0MDQvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:45 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMzA1OTU4LWYzY2YtNDhm
+        NC1hODFmLWRmZmExMzU1ZGZlNS8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:45 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/de305958-f3cf-48f4-a81f-dffa1355dfe5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:46 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '348'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUzMDU5NTgtZjNj
+        Zi00OGY0LWE4MWYtZGZmYTEzNTVkZmU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NDUuNjU0MzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTQ6NDUuODA4OTcz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo0Ni4xMzUyMTNa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS9hMzFkNGNj
+        MS1iNmE1LTQyZGItYTQwYy0wZTJmZDk4MjkxMDIvIl0sInJlc2VydmVkX3Jl
+        c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:46 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:46 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2EzMWQ0Y2MxLWI2YTUtNDJkYi1hNDBjLTBlMmZkOTgyOTEwMi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjE0OjQ2LjExOTc3MloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1v
+        cmEuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29ycG9yYXRpb24v
+        ZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29udGVudF9ndWFy
+        ZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNt
+        LzJiN2Q3ZjE2LWMzZDYtNDJlMi04ODgzLTU3N2QxZGMyOGRlYi8iLCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
+        dWJsaWNhdGlvbnMvcnBtL3JwbS84YjJiMWY0Ny01OTdmLTRjNjMtODUyOC05
+        NzlmNjlhMGM0MDQvIn0=
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:46 GMT
+- request:
+    method: post
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzExY2Nh
+        ZWM0LTJmMWYtNDljMS05YmVkLWJjNzAxMGYwMzc4Mi8iLCJtaXJyb3IiOnRy
+        dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:47 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkODc2MzAwLWFmY2UtNGZm
+        ZS1hZmI4LTZiMmFmNmM5NWE3Yi8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:47 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8d876300-afce-4ffe-afb8-6b2af6c95a7b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:50 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '561'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGQ4NzYzMDAtYWZj
+        ZS00ZmZlLWFmYjgtNmIyYWY2Yzk1YTdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NDcuMDc4MjczWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTQ6NDcu
+        NDc3OTc0WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo0OS44
+        NDEyNDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8i
+        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
+        bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
+        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
+        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3Nv
+        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
+        ZWQgUGFja2FnZXMiLCJjb2RlIjoicGFyc2luZy5wYWNrYWdlcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjMyLCJkb25lIjozMiwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgQWR2aXNvcmllcyIsImNvZGUiOiJw
+        YXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        Ijo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY4M2Zj
+        MmY5LWFlZDktNDhkNy1hZWE2LTI2Zjc5YjdiYTIwNS92ZXJzaW9ucy8xLyJd
+        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVhNi0y
+        NmY3OWI3YmEyMDUvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8x
+        MWNjYWVjNC0yZjFmLTQ5YzEtOWJlZC1iYzcwMTBmMDM3ODIvIl19
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:50 GMT
+- request:
+    method: post
+    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2Jh
+        MjA1L3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:50 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmOTU5YjQ2LTNhNmMtNDdl
+        OC1hYmQ4LTlmMjY3YjdkMGEzNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 01 Sep 2020 02:14:50 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8f959b46-3a6c-47e8-abd8-9f267b7d0a37/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 01 Sep 2020 02:14:52 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -562,416 +951,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI5M2U0YjMtNTFj
-        OS00YWY2LWIxOGQtNzNiNWI1MTM1NzQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MDYuMjEyNTU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGY5NTliNDYtM2E2
+        Yy00N2U4LWFiZDgtOWYyNjdiN2QwYTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NTAuNTE5ODI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MTowNi4zODgzOTFa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTI4VDE3OjUxOjA2Ljc3NzQ0OFoi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo1MC44OTA2Mjha
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAyOjE0OjUyLjAxNjIyMFoi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
         MThhMDg3ODEtZGFiZS00ZmFiLWJlYjYtYTcyZGI2OWUzNjAzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTE2ZGJmNWUt
-        ZGQ3YS00YzM4LTg5ZmUtZjVjYWEyZTI3YmUzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTZlOGM3MDgt
+        ODMzMS00NWRiLTg2YjEtYzdlOTcxYjk4YTQzLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMwZC1mN2NlNDMwZTc1YjgvIl19
+        L3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVhNi0yNmY3OWI3YmEyMDUvIl19
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:06 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
-        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzJiN2Q3ZjE2LWMzZDYt
-        NDJlMi04ODgzLTU3N2QxZGMyOGRlYi8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
-        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS81MTZkYmY1ZS1kZDdhLTRjMzgtODlmZS1mNWNhYTJlMjdiZTMvIn0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:07 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0ZThiYzk5LTNkYTctNDJh
-        NC1hZmMyLWU4Y2E4NDk0YjJhNC8ifQ==
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:07 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/44e8bc99-3da7-42a4-afc2-e8ca8494b2a4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:07 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '347'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDRlOGJjOTktM2Rh
-        Ny00MmE0LWFmYzItZThjYTg0OTRiMmE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MDYuOTkyMTMyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MDcuMTg3MzI0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MTowNy42NDQ4NzBa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS9lYmUyYjUw
-        Zi1iMjlhLTQ1NGYtODRiZS1mNjU4NGRjY2RkZTQvIl0sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:07 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:07 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '313'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2ViZTJiNTBmLWIyOWEtNDU0Zi04NGJlLWY2NTg0ZGNjZGRlNC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTI4VDE3OjUxOjA3LjYxNjc0MVoiLCJi
-        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vZGV2ZWwyLmJhbG1v
-        cmEuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29ycG9yYXRpb24v
-        ZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29udGVudF9ndWFy
-        ZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNt
-        LzJiN2Q3ZjE2LWMzZDYtNDJlMi04ODgzLTU3N2QxZGMyOGRlYi8iLCJuYW1l
-        IjoiMl9kdXBsaWNhdGUiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
-        dWJsaWNhdGlvbnMvcnBtL3JwbS81MTZkYmY1ZS1kZDdhLTRjMzgtODlmZS1m
-        NWNhYTJlMjdiZTMvIn0=
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:07 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y5Mjcw
-        YjZjLWJlY2QtNDYzNC05NzUxLTkxMWM5ODk2MTU5OC8iLCJtaXJyb3IiOnRy
-        dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:08 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - POST, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlOTFjNmVmLTc3OTMtNDQ5
-        ZC1hN2Q3LTI4ZTE0ZjBiZmIwMC8ifQ==
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8e91c6ef-7793-449d-a7d7-28e14f0bfb00/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:10 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '565'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGU5MWM2ZWYtNzc5
-        My00NDlkLWE3ZDctMjhlMTRmMGJmYjAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MDguMjI1MzAwWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MDgu
-        NDcxNzAyWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToxMC40
-        MzEyNDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8i
-        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
-        bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
-        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
-        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVz
-        c2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3Nv
-        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
-        ZWQgQWR2aXNvcmllcyIsImNvZGUiOiJwYXJzaW5nLmFkdmlzb3JpZXMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJw
-        YXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        MzIsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
-        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFjNTE0
-        YzU1LTlkMTctNDMzNi05MzBkLWY3Y2U0MzBlNzViOC92ZXJzaW9ucy8xLyJd
-        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMwZC1m
-        N2NlNDMwZTc1YjgvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9m
-        OTI3MGI2Yy1iZWNkLTQ2MzQtOTc1MS05MTFjOTg5NjE1OTgvIl19
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:10 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/publications/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3
-        NWI4L3ZlcnNpb25zLzEvIiwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6InNo
-        YTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:10 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2YzM1Y2YwLTMzZGUtNGE4
-        OC1hY2NmLTQwNTJjMDYxOWI2ZS8ifQ==
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:10 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b6c35cf0-33de-4a88-accf-4052c0619b6e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 28 Aug 2020 17:51:11 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '374'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZjMzVjZjAtMzNk
-        ZS00YTg4LWFjY2YtNDA1MmMwNjE5YjZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MTAuOTEyNDMzWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToxMS4xMTkyMjRa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTI4VDE3OjUxOjExLjczNDg1OVoi
-        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        NzJjMDlkNDctYjQ2NC00NWE2LWE2MGItMWFkNzRmOWNmZjllLyIsInBhcmVu
-        dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
-        bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNmEwMGNiYTYt
-        NWY2ZS00YzRmLWFhN2YtMjg3OTU4MDczZTU4LyJdLCJyZXNlcnZlZF9yZXNv
-        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMwZC1mN2NlNDMwZTc1YjgvIl19
-    http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:11 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:52 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -979,13 +977,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS82YTAwY2JhNi01ZjZlLTRj
-        NGYtYWE3Zi0yODc5NTgwNzNlNTgvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9hNmU4YzcwOC04MzMxLTQ1
+        ZGItODZiMS1jN2U5NzFiOThhNDMvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -998,7 +996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:12 GMT
+      - Tue, 01 Sep 2020 02:14:52 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1016,13 +1014,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk0ZTZmN2I5LWFkYTEtNGIx
-        Yi05N2E0LTBhNTk5ODA0OTYwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVkOTUxMzUwLTQxZjUtNDYz
+        Ny1iYjQyLWRhODFmNmJmY2NkMy8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:12 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:52 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/94e6f7b9-ada1-4b1b-97a4-0a5998049605/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/5d951350-41f5-4637-bb42-da81f6bfccd3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1030,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1043,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:12 GMT
+      - Tue, 01 Sep 2020 02:14:53 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1057,27 +1055,27 @@ http_interactions:
       Via:
       - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '316'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTRlNmY3YjktYWRh
-        MS00YjFiLTk3YTQtMGE1OTk4MDQ5NjA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MTIuMDc0MTM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWQ5NTEzNTAtNDFm
+        NS00NjM3LWJiNDItZGE4MWY2YmZjY2QzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NTIuNTUyNDk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MTIuMjkwNjY3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToxMi43NDA2MjBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTQ6NTIuOTIyNjY2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo1My42MjQyNjha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzcyYzA5ZDQ3LWI0NjQtNDVhNi1hNjBiLTFhZDc0ZjljZmY5ZS8iLCJwYXJl
+        LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:12 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:53 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1085,13 +1083,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS82YTAwY2JhNi01ZjZlLTRj
-        NGYtYWE3Zi0yODc5NTgwNzNlNTgvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9hNmU4YzcwOC04MzMxLTQ1
+        ZGItODZiMS1jN2U5NzFiOThhNDMvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1104,7 +1102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:12 GMT
+      - Tue, 01 Sep 2020 02:14:53 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1122,13 +1120,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjY2E4NGQ0LTlkZjAtNDg0
-        MS05ZjZjLTYzMjkzOTM4ODdkOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NTg3MzMzLTdiNzQtNDZl
+        ZC1iN2FiLTlhZWViOTU4M2I0Ni8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:12 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:53 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1136,7 +1134,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,7 +1147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:54 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1170,10 +1168,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1181,7 +1179,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1194,7 +1192,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:54 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1215,10 +1213,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1226,7 +1224,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1239,7 +1237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:54 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1260,10 +1258,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1271,7 +1269,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1284,7 +1282,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:54 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1305,10 +1303,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1316,7 +1314,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1327,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:55 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1350,10 +1348,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:55 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/0/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1361,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1374,7 +1372,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:13 GMT
+      - Tue, 01 Sep 2020 02:14:55 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1395,21 +1393,21 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:13 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:55 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/sync/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y5Mjcw
-        YjZjLWJlY2QtNDYzNC05NzUxLTkxMWM5ODk2MTU5OC8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzExY2Nh
+        ZWM0LTJmMWYtNDljMS05YmVkLWJjNzAxMGYwMzc4Mi8iLCJtaXJyb3IiOnRy
         dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6ZmFsc2V9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1422,7 +1420,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:14 GMT
+      - Tue, 01 Sep 2020 02:14:56 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1440,13 +1438,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1N2I4MGRhLTkyZTktNDJh
-        MC1iYjFiLWQ0YTI5ZjViNDA2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjNmI1NDFlLWY1ZmMtNDVk
+        Yy05NzYxLTA5ODVmZTZiMGZhMy8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:14 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:56 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/a57b80da-92e9-42a0-bb1b-d4a29f5b4065/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/bc6b541e-f5fc-45dc-9761-0985fe6b0fa3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1454,7 +1452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1467,7 +1465,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:19 GMT
+      - Tue, 01 Sep 2020 02:14:59 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1485,41 +1483,41 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTU3YjgwZGEtOTJl
-        OS00MmEwLWJiMWItZDRhMjlmNWI0MDY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MTQuNDk2OTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmM2YjU0MWUtZjVm
+        Yy00NWRjLTk3NjEtMDk4NWZlNmIwZmEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NTYuOTEwMjk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MTQu
-        Njc2MDMzWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToxOS4x
-        MjEyMzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTQ6NTcu
+        MTkyMDY1WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNDo1OS40
+        MTkxMDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
         b3JrZXJzLzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
         bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
         bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
-        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNz
-        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
-        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
-        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNl
-        ZCBBZHZpc29yaWVzIiwiY29kZSI6InBhcnNpbmcuYWR2aXNvcmllcyIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6
-        bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6InBh
-        cnNpbmcucGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoz
-        MiwiZG9uZSI6MzIsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
+        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBBZHZp
+        c29yaWVzIiwiY29kZSI6InBhcnNpbmcuYWR2aXNvcmllcyIsInN0YXRlIjoi
+        Y29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6InBhcnNpbmcu
+        cGFja2FnZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9u
+        ZSI6MzIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2Np
+        YXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51
+        bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
         cyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFjNTE0YzU1LTlkMTctNDMzNi05
-        MzBkLWY3Y2U0MzBlNzViOC8iLCIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0v
-        cnBtL2Y5MjcwYjZjLWJlY2QtNDYzNC05NzUxLTkxMWM5ODk2MTU5OC8iXX0=
+        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY4M2ZjMmY5LWFlZDktNDhkNy1h
+        ZWE2LTI2Zjc5YjdiYTIwNS8iLCIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0v
+        cnBtLzExY2NhZWM0LTJmMWYtNDljMS05YmVkLWJjNzAxMGYwMzc4Mi8iXX0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:19 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:59 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1527,7 +1525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1540,7 +1538,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:19 GMT
+      - Tue, 01 Sep 2020 02:14:59 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1559,18 +1557,18 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3NWI4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMjhUMTc6NTE6MDUuNjEwODAwWiIsInZl
+        cG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2JhMjA1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMDI6MTQ6NDQuMzgzOTgwWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3NWI4L3ZlcnNp
+        cG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2JhMjA1L3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdj
-        ZTQzMGU3NWI4L3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        b3NpdG9yaWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZm
+        NzliN2JhMjA1L3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
         bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
         MH0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:19 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:59 GMT
 - request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -1578,14 +1576,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3
-        NWI4L3ZlcnNpb25zLzEvIiwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6InNo
-        YTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2Jh
+        MjA1L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1598,7 +1595,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:19 GMT
+      - Tue, 01 Sep 2020 02:14:59 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1616,13 +1613,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyOWE0YmExLWU4MzAtNDhl
-        NC1hMjY1LTIxNmQyYzIwZmQwMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxOTdkOTUzLTM0NGMtNDI5
+        ZC1hYzI1LTQwMjRhOWFhZGU2YS8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:19 GMT
+  recorded_at: Tue, 01 Sep 2020 02:14:59 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/929a4ba1-e830-48e4-a265-216d2c20fd03/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/f197d953-344c-429d-ac25-4024a9aade6a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1630,7 +1627,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1643,7 +1640,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:20 GMT
+      - Tue, 01 Sep 2020 02:15:01 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1657,29 +1654,29 @@ http_interactions:
       Via:
       - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '373'
+      - '376'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTI5YTRiYTEtZTgz
-        MC00OGU0LWEyNjUtMjE2ZDJjMjBmZDAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MTkuNDMxNzQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjE5N2Q5NTMtMzQ0
+        Yy00MjlkLWFjMjUtNDAyNGE5YWFkZTZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTQ6NTkuODg0ODc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToxOS42OTM5MTha
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTI4VDE3OjUxOjIwLjM0NjIwOVoi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNTowMC4yNDc4MTNa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAyOjE1OjAxLjU5MTI5Nloi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        MThhMDg3ODEtZGFiZS00ZmFiLWJlYjYtYTcyZGI2OWUzNjAzLyIsInBhcmVu
+        NzJjMDlkNDctYjQ2NC00NWE2LWE2MGItMWFkNzRmOWNmZjllLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzRlNmI1N2Mt
-        ZDU0Yi00YjQxLWI1Y2QtODA1YTAzYmE2MmVmLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDAzMTI3NWQt
+        MjYwZC00ZjQ4LWE0ZDQtYWEzZGExNzg5NTk5LyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMwZC1mN2NlNDMwZTc1YjgvIl19
+        L3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVhNi0yNmY3OWI3YmEyMDUvIl19
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:20 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:01 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1687,13 +1684,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jNGU2YjU3Yy1kNTRiLTRi
-        NDEtYjVjZC04MDVhMDNiYTYyZWYvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMDMxMjc1ZC0yNjBkLTRm
+        NDgtYTRkNC1hYTNkYTE3ODk1OTkvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1706,7 +1703,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:20 GMT
+      - Tue, 01 Sep 2020 02:15:02 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1724,13 +1721,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3ZTg4NjkyLWU5Y2QtNGVk
-        Ny04ZTVkLTc4NmNlZjlmYmRjYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MzMmZlMGRhLTEwYmMtNDBi
+        Ni1iZWQ3LWM0Mzc2ZTZjOGNkZC8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:20 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:02 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/07e88692-e9cd-4ed7-8e5d-786cef9fbdcc/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/c32fe0da-10bc-40b6-bed7-c4376e6c8cdd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1738,7 +1735,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -1751,7 +1748,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:21 GMT
+      - Tue, 01 Sep 2020 02:15:03 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1765,16 +1762,16 @@ http_interactions:
       Via:
       - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '315'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDdlODg2OTItZTlj
-        ZC00ZWQ3LThlNWQtNzg2Y2VmOWZiZGNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MjAuNjA2OTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzMyZmUwZGEtMTBi
+        Yy00MGI2LWJlZDctYzQzNzZlNmM4Y2RkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTU6MDIuMzQ1MzIyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MjAuODA4MDM4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToyMS4yMDAxOTda
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTU6MDIuNjE3NjU3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNTowMy4xNDU2OTNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
@@ -1782,10 +1779,10 @@ http_interactions:
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:21 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:03 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1793,13 +1790,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jNGU2YjU3Yy1kNTRiLTRi
-        NDEtYjVjZC04MDVhMDNiYTYyZWYvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMDMxMjc1ZC0yNjBkLTRm
+        NDgtYTRkNC1hYTNkYTE3ODk1OTkvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1812,7 +1809,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:21 GMT
+      - Tue, 01 Sep 2020 02:15:03 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1830,13 +1827,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FkNjg3YmQxLTY0NzEtNGMz
-        MC1iNDVjLTZlMmNiNDRiNzEyZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjYjY4MGRiLWUxYTItNGU3
+        MS1iMmJiLTZiY2E1MGE0YmI2Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:21 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:03 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href,name,version,release,arch,epoch,summary,is_modular,rpm_sourcerpm,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1844,7 +1841,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1857,7 +1854,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:21 GMT
+      - Tue, 01 Sep 2020 02:15:04 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2145,10 +2142,10 @@ http_interactions:
         IjoidHJvdXQtMC4xMi0xLnNyYy5ycG0iLCJpc19tb2R1bGFyIjpmYWxzZX1d
         fQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:21 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/modulemds/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2156,7 +2153,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2169,7 +2166,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2190,10 +2187,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2201,7 +2198,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2214,7 +2211,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2327,10 +2324,10 @@ http_interactions:
         c3VtX3R5cGUiOiIiLCJ2ZXJzaW9uIjoiMC4xIn1dfV0sInJlZmVyZW5jZXMi
         OltdLCJyZWJvb3Rfc3VnZ2VzdGVkIjpmYWxzZX1dfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packagegroups/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2338,7 +2335,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2351,7 +2348,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2372,10 +2369,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href,name,version,release,arch,epoch,summary,location_href,pkgId&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2383,7 +2380,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2396,7 +2393,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:05 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2417,10 +2414,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/versions/1/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2428,7 +2425,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2441,7 +2438,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2462,7 +2459,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:06 GMT
 - request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -2470,14 +2467,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWM1MTRjNTUtOWQxNy00MzM2LTkzMGQtZjdjZTQzMGU3
-        NWI4L3ZlcnNpb25zLzEvIiwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6InNo
-        YTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vNjgzZmMyZjktYWVkOS00OGQ3LWFlYTYtMjZmNzliN2Jh
+        MjA1L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2490,7 +2486,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:22 GMT
+      - Tue, 01 Sep 2020 02:15:06 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2508,13 +2504,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0YzdkNDQzLTYzNzgtNGVh
-        NC05MmM3LTU5MWYwZWZmNDUwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhNDk2MGNkLWM2ZDQtNDcz
+        OC04YWUwLTlhMmUxMDQ4MjQ5Mi8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:22 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/84c7d443-6378-4ea4-92c7-591f0eff4505/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8a4960cd-c6d4-4738-8ae0-9a2e10482492/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2522,7 +2518,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2535,7 +2531,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:23 GMT
+      - Tue, 01 Sep 2020 02:15:07 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2549,29 +2545,29 @@ http_interactions:
       Via:
       - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '375'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODRjN2Q0NDMtNjM3
-        OC00ZWE0LTkyYzctNTkxZjBlZmY0NTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MjIuODE3NDY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGE0OTYwY2QtYzZk
+        NC00NzM4LThhZTAtOWEyZTEwNDgyNDkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTU6MDYuMjAxMTc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToyMy4wMTkyNTRa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA4LTI4VDE3OjUxOjIzLjcxNDQ5Nloi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNTowNi41Mjk5NTFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDAyOjE1OjA3Ljc1MjAwMloi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
         NzJjMDlkNDctYjQ2NC00NWE2LWE2MGItMWFkNzRmOWNmZjllLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vODgyM2M2MWMt
-        ZGQxNi00OGYxLWJlNTUtMzMxNDdjNmY0MWUzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNzIzODdiYmUt
+        ZGE0Ny00NDMxLWE1ZjctZTNjNjg0YzE1MDRmLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMwZC1mN2NlNDMwZTc1YjgvIl19
+        L3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVhNi0yNmY3OWI3YmEyMDUvIl19
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:23 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:07 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2579,13 +2575,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84ODIzYzYxYy1kZDE2LTQ4
-        ZjEtYmU1NS0zMzE0N2M2ZjQxZTMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83MjM4N2JiZS1kYTQ3LTQ0
+        MzEtYTVmNy1lM2M2ODRjMTUwNGYvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2598,7 +2594,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:24 GMT
+      - Tue, 01 Sep 2020 02:15:08 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2616,13 +2612,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzOTU1YjQ5LTE1ZTMtNGY1
-        Zi04ZjBiLTg1OGRmMTA2NGNjMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwNzI3Y2MyLThjYzMtNDZk
+        Ny1iZmZjLWVkYzY5ZjNjNTk1Ny8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:24 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:08 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/23955b49-15e3-4f5f-8f0b-858df1064cc3/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/c0727cc2-8cc3-46d7-bffc-edc69f3c5957/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2630,7 +2626,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2643,7 +2639,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:24 GMT
+      - Tue, 01 Sep 2020 02:15:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2661,23 +2657,23 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjM5NTViNDktMTVl
-        My00ZjVmLThmMGItODU4ZGYxMDY0Y2MzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MjQuMDE4ODM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzA3MjdjYzItOGNj
+        My00NmQ3LWJmZmMtZWRjNjlmM2M1OTU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTU6MDguMTk2MDEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MjQuMjQyMDk1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToyNC42MzAyMTBa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTU6MDguNTg5Nzg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNTowOS4yODY3ODBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzcyYzA5ZDQ3LWI0NjQtNDVhNi1hNjBiLTFhZDc0ZjljZmY5ZS8iLCJwYXJl
+        LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:24 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:09 GMT
 - request:
     method: patch
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2685,13 +2681,13 @@ http_interactions:
         Y2VydGd1YXJkL3Joc20vMmI3ZDdmMTYtYzNkNi00MmUyLTg4ODMtNTc3ZDFk
         YzI4ZGViLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84ODIzYzYxYy1kZDE2LTQ4
-        ZjEtYmU1NS0zMzE0N2M2ZjQxZTMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83MjM4N2JiZS1kYTQ3LTQ0
+        MzEtYTVmNy1lM2M2ODRjMTUwNGYvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2704,7 +2700,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:24 GMT
+      - Tue, 01 Sep 2020 02:15:09 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2722,13 +2718,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3NThjNGQwLWM0OGUtNDdk
-        YS05MGE2LTgxMDUyZTg2MmM2ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyMWYwYTMwLWFjZWYtNGJh
+        MS1hMTRiLWFmNjMzZWNmYTM5NS8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:24 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:09 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/f9270b6c-becd-4634-9751-911c98961598/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/11ccaec4-2f1f-49c1-9bed-bc7010f03782/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2736,7 +2732,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2749,7 +2745,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:25 GMT
+      - Tue, 01 Sep 2020 02:15:10 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2767,13 +2763,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzZDU5OTE3LWZkZDMtNGY0
-        Ny04ZTg0LWIwNDZiYmQ4OTM3NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2ZjgzMWZjLTQ3MzUtNGI5
+        Yi04ODJiLTIyM2RjODE1NzcwNy8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:25 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:10 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/53d59917-fdd3-4f47-8e84-b046bbd89375/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/26f831fc-4735-4b9b-882b-223dc8157707/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2781,7 +2777,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2794,7 +2790,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:26 GMT
+      - Tue, 01 Sep 2020 02:15:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2812,24 +2808,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTNkNTk5MTctZmRk
-        My00ZjQ3LThlODQtYjA0NmJiZDg5Mzc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MjUuODAxNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjZmODMxZmMtNDcz
+        NS00YjliLTg4MmItMjIzZGM4MTU3NzA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTU6MTAuNjM1OTMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MjYuMDMwMDQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToyNi4xMTUwNjha
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTU6MTEuMTk2NjUz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNToxMS40NTY5MjRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
         LzcyYzA5ZDQ3LWI0NjQtNDVhNi1hNjBiLTFhZDc0ZjljZmY5ZS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vZjkyNzBiNmMtYmVjZC00NjM0LTk3NTEtOTEx
-        Yzk4OTYxNTk4LyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vMTFjY2FlYzQtMmYxZi00OWMxLTliZWQtYmM3
+        MDEwZjAzNzgyLyJdfQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:26 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:11 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/ebe2b50f-b29a-454f-84be-f6584dccdde4/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/a31d4cc1-b6a5-42db-a40c-0e2fd9829102/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2837,7 +2833,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2850,7 +2846,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:26 GMT
+      - Tue, 01 Sep 2020 02:15:11 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2868,13 +2864,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwNjk4MmY0LTQ3ODktNDdi
-        ZC04NWYwLTc2ZDE5NTQzMGVjZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2MGNiOTY2LWZkNmYtNDY4
+        OC04NDEwLWFjNzk4ZDUyMjZmYi8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:26 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:11 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/1c514c55-9d17-4336-930d-f7ce430e75b8/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/683fc2f9-aed9-48d7-aea6-26f79b7ba205/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2882,7 +2878,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.6.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2895,7 +2891,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:26 GMT
+      - Tue, 01 Sep 2020 02:15:12 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2913,13 +2909,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1YTEyMjMwLTg5MDItNDJm
-        MC1iNTIyLTY3NzBiOWU3ZWYwMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0OTU4OWViLTVmZmQtNDM0
+        MC05MjE3LTA4MDk2MWFhNDllZS8ifQ==
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:26 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:12 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/25a12230-8902-42f0-b522-6770b9e7ef00/
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/249589eb-5ffd-4340-9217-080961aa49ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2927,7 +2923,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.1/ruby
+      - OpenAPI-Generator/3.6.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -2940,7 +2936,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Aug 2020 17:51:27 GMT
+      - Tue, 01 Sep 2020 02:15:14 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -2954,23 +2950,23 @@ http_interactions:
       Via:
       - 1.1 devel2.balmora.example.com
       Content-Length:
-      - '343'
+      - '341'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjVhMTIyMzAtODkw
-        Mi00MmYwLWI1MjItNjc3MGI5ZTdlZjAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDgtMjhUMTc6NTE6MjYuNDI2NDU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ5NTg5ZWItNWZm
+        ZC00MzQwLTkyMTctMDgwOTYxYWE0OWVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMDFUMDI6MTU6MTIuMDk5NjQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMjhUMTc6NTE6MjYuODkzNDgw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0yOFQxNzo1MToyNy4yNDkwNjNa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMDI6MTU6MTIuODk5NDYx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQwMjoxNToxMy45MTI0NTNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzE4YTA4NzgxLWRhYmUtNGZhYi1iZWI2LWE3MmRiNjllMzYwMy8iLCJwYXJl
+        LzcyYzA5ZDQ3LWI0NjQtNDVhNi1hNjBiLTFhZDc0ZjljZmY5ZS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xYzUxNGM1NS05ZDE3LTQzMzYtOTMw
-        ZC1mN2NlNDMwZTc1YjgvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82ODNmYzJmOS1hZWQ5LTQ4ZDctYWVh
+        Ni0yNmY3OWI3YmEyMDUvIl19
     http_version: 
-  recorded_at: Fri, 28 Aug 2020 17:51:27 GMT
+  recorded_at: Tue, 01 Sep 2020 02:15:14 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This commit creates the initial functionality to export a content view
version via the pulp3 exporter.
Things in this commit
1) Exporter updates to point to the right pulp3 api
2) After generating tar you should be able to access the location in the
   foreman task.