### PR TITLE
[CP] 3.16 Fixes #30082 - drop audit record creation when change in content_id

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -1,6 +1,6 @@
 module Katello
   class RootRepository < Katello::Model
-    audited
+    audited :except => [:content_id]
     serialize :ignorable_content
     serialize :docker_tags_whitelist
 
@@ -103,16 +103,6 @@ module Katello
       where(:http_proxy_id => http_proxy_id)
     }
     delegate :redhat?, :provider, :organization, to: :product
-
-    # Note - Audit hook added to find records based on column except associations to display audit information
-    def self.audit_hook_to_find_records(name, change, _audit)
-      if name =~ /_id$/
-        case name
-        when 'content_id'
-          Katello::Content.find_by(:cp_content_id => change)
-        end
-      end
-    end
 
     def library_instance
       repositories.in_default_view.first

--- a/db/migrate/20200610112009_remove_audits_of_root_repo_with_content_id.rb
+++ b/db/migrate/20200610112009_remove_audits_of_root_repo_with_content_id.rb
@@ -1,0 +1,9 @@
+class RemoveAuditsOfRootRepoWithContentId < ActiveRecord::Migration[6.0]
+  def change
+    audit_records = Audit.where(
+      :auditable_type => 'Katello::RootRepository',
+      :action => 'update')
+    audit_records = audit_records.reject { |ar| ar.audited_changes['content_id'].nil? }
+    audit_records.map(&:destroy!)
+  end
+end

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -775,22 +775,5 @@ module Katello
       assert_equal 'Katello::RootRepository', recent_audit.auditable_type
       assert_equal 'destroy', recent_audit.action
     end
-
-    def test_audit_hook_to_find_records_should_return_content
-      @fedora_root.save!
-      content_id = 'dummycontent-123'
-      content = FactoryBot.create(:katello_content, cp_content_id: content_id, :organization_id => @product.organization_id)
-      FactoryBot.create(:katello_product_content, content: content, product: @product)
-      @fedora_root.update!(content_id: content_id)
-      @audit_record = @fedora_root.audits.where(:action => 'update').first
-      refute_empty @audit_record.audited_changes['content_id']
-      assert_nil Katello::RootRepository.reflect_on_association('content')
-
-      content_by_audit_record = Katello::RootRepository.audit_hook_to_find_records(
-        'content_id', @audit_record.audited_changes['content_id'][1], @audit_record
-      )
-      assert content_by_audit_record, 'No content record found by method #audit_hook_to_find_records'
-      assert_equal Katello::Content, content_by_audit_record.class
-    end
   end
 end


### PR DESCRIPTION
With this commit, it will destroy existing audits of root repoitory
with content change.

(cherry picked from commit 51eb49258413867c5d65b08cec033c3c7ea23a85)