### PR TITLE
Fixes #30124 - Sync Management page details for Pulp3

### DIFF
--- a/app/lib/actions/pulp3/repository/presenters/content_unit_presenter.rb
+++ b/app/lib/actions/pulp3/repository/presenters/content_unit_presenter.rb
@@ -12,7 +12,7 @@ module Actions
           def humanized_details
             ret = []
             ret << _("Cancelled.") if cancelled?
-            ret << _("Total tasks: ") + ": #{finished_units}/#{total_units}"
+            ret << _("Total steps: ") + "#{finished_units}/#{total_units}"
             ret << "--------------------------------"
             progress_reports = sync_task.try(:[], 'progress_reports') || []
             progress_reports = progress_reports.sort_by { |pr| pr.try(:[], 'message') }

--- a/app/presenters/katello/sync_status_presenter.rb
+++ b/app/presenters/katello/sync_status_presenter.rb
@@ -19,6 +19,8 @@ module Katello
     def sync_progress
       return {:state => nil} unless @repo
       return empty_task(@repo) unless @task
+      display_output = @task.humanized[:output]
+      display_output = display_output.split("\n")[0] if (display_output && @repo.version_href)
       {
         :id => @repo.id,
         :product_id => @repo.product.id,
@@ -29,8 +31,8 @@ module Katello
         :start_time => format_date(@task.started_at),
         :finish_time => format_date(@task.ended_at),
         :duration => format_duration(@task.ended_at, @task.started_at),
-        :display_size => @task.humanized[:output],
-        :size => @task.humanized[:output],
+        :display_size => display_output,
+        :size => display_output,
         :is_running => @task.pending && @task.state != 'paused',
         :error_details => @task.errors
       }

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -587,7 +587,7 @@ module ::Actions::Katello::Repository
         let(:fixture_variant) { :success_file }
 
         specify do
-          assert_equal action.humanized_output, "Total tasks: : 5/5\n"\
+          assert_equal action.humanized_output, "Total steps: 5/5\n"\
                                              "--------------------------------\n"\
                                              "Associating Content: 1/1\n"\
                                              "Downloading Artifacts: 0/0\n"\
@@ -604,7 +604,7 @@ module ::Actions::Katello::Repository
         let(:fixture_variant) { :success_ansible_collection }
 
         specify do
-          assert_equal action.humanized_output, "Total tasks: : 2/2\n"\
+          assert_equal action.humanized_output, "Total steps: 2/2\n"\
                                              "--------------------------------\n"\
                                              "Downloading Collections: 1/1\n"\
                                              "Importing Collections: 1/1"
@@ -619,7 +619,7 @@ module ::Actions::Katello::Repository
         let(:fixture_variant) { :success_docker }
 
         specify do
-          assert_equal action.humanized_output, "Total tasks: : 1192/1192\n"\
+          assert_equal action.humanized_output, "Total steps: 1192/1192\n"\
                                              "--------------------------------\n"\
                                              "Associating Content: 641/641\n"\
                                              "Downloading Artifacts: 415/415\n"\
@@ -636,7 +636,7 @@ module ::Actions::Katello::Repository
         let(:fixture_variant) { :progress_units_file }
 
         specify do
-          assert_equal action.humanized_output, "Total tasks: : 15/30\n"\
+          assert_equal action.humanized_output, "Total steps: 15/30\n"\
                                              "--------------------------------\n"\
                                              "Associating Content: 5/10\n"\
                                              "Downloading Artifacts: 5/10\n"\
@@ -652,7 +652,7 @@ module ::Actions::Katello::Repository
         let(:fixture_variant) { :progress_units_ansible_collection }
 
         specify do
-          assert_equal action.humanized_output, "Total tasks: : 1/2\n"\
+          assert_equal action.humanized_output, "Total steps: 1/2\n"\
                                              "--------------------------------\n"\
                                              "Downloading Collections: 1/2"
         end


### PR DESCRIPTION
**To test:** 
Sync a repo on Pulp3:

**Pre Change:**
![pre-sync-status](https://user-images.githubusercontent.com/21146741/88558853-1b004e80-cffa-11ea-880d-8889951e337d.png)

**Post Change:**
![post-sync-status](https://user-images.githubusercontent.com/21146741/88558875-20f62f80-cffa-11ea-916c-74d952a674ae.png)
