### PR TITLE
Fixes #30521 - require messaging classes in tests due to intermittent autoloading problems 

### DIFF
--- a/test/lib/messaging/connection_test.rb
+++ b/test/lib/messaging/connection_test.rb
@@ -1,4 +1,5 @@
 require 'katello_test_helper'
+require_relative '../../../app/lib/katello/messaging/connection'
 
 module Katello
   module Messaging

--- a/test/lib/messaging/stomp_connection_test.rb
+++ b/test/lib/messaging/stomp_connection_test.rb
@@ -1,5 +1,6 @@
 require 'katello_test_helper'
 require 'stomp'
+require_relative '../../../app/lib/katello/messaging/stomp_connection'
 
 module Katello
   module Messaging


### PR DESCRIPTION
Messaging related tests are intermittently failing as of late:

```
LoadError: Unable to autoload constant Katello::Messaging::Connection, expected /home/jenkins/workspace/katello-master-source-release/app/lib/katello/messaging/connection.rb to define it
    /home/jenkins/workspace/katello-master-source-release/test/lib/messaging/connection_test.rb:17:in `test_create' (LoadError)
/usr/local/rvm/gems/ruby-2.5.1@jenkins-katello-master-source-release-1074-1/gems/activesupport-6.0.3.2/lib/active_support/dependencies.rb:550
```

```
[2020-07-28T22:03:46.389Z] Error:

[2020-07-28T22:03:46.389Z] Katello::Messaging::StompConnectionTest#test_close:

[2020-07-28T22:03:46.389Z] LoadError: Unable to autoload constant Katello::Messaging::StompConnection, expected /home/jenkins/workspace/katello-pr-test/app/lib/katello/messaging/stomp_connection.rb to define it

[2020-07-28T22:03:46.389Z]     /home/jenkins/workspace/katello-pr-test/test/lib/messaging/stomp_connection_test.rb:16:in `setup'

[2020-07-28T22:03:46.389Z] 

[2020-07-28T22:03:46.389Z] Error:

[2020-07-28T22:03:46.389Z] Katello::Messaging::StompConnectionTest#test_running?:

[2020-07-28T22:03:46.389Z] LoadError: Unable to autoload constant Katello::Messaging::StompConnection, expected /home/jenkins/workspace/katello-pr-test/app/lib/katello/messaging/stomp_connection.rb to define it

[2020-07-28T22:03:46.389Z]     /home/jenkins/workspace/katello-pr-test/test/lib/messaging/stomp_connection_test.rb:16:in `setup'

[2020-07-28T22:03:46.389Z] 

[2020-07-28T22:03:46.389Z] Error:

[2020-07-28T22:03:46.389Z] Katello::Messaging::StompConnectionTest#test_open?:

[2020-07-28T22:03:46.389Z] LoadError: Unable to autoload constant Katello::Messaging::StompConnection, expected /home/jenkins/workspace/katello-pr-test/app/lib/katello/messaging/stomp_connection.rb to define it

[2020-07-28T22:03:46.389Z]     /home/jenkins/workspace/katello-pr-test/test/lib/messaging/stomp_connection_test.rb:16:in `setup'

[2020-07-28T22:03:46.389Z] 

[2020-07-28T22:03:46.389Z] Error:

[2020-07-28T22:03:46.389Z] Katello::Messaging::StompConnectionTest#test_subscribe:

[2020-07-28T22:03:46.389Z] LoadError: Unable to autoload constant Katello::Messaging::StompConnection, expected /home/jenkins/workspace/katello-pr-test/app/lib/katello/messaging/stomp_connection.rb to define it

[2020-07-28T22:03:46.389Z]     /home/jenkins/workspace/katello-pr-test/test/lib/messaging/stomp_connection_test.rb:16:in `setup'

[2020-07-28T22:03:46.389Z]
```

Let's see if using eager loading has any effect