### PR TITLE
Fixes #30522 - Hide syspurpose when org is in SCA mode

### DIFF
--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -40,6 +40,7 @@ module Actions
         end
 
         def finalize
+          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           subject_organization.audit_manifest_action(_('Manifest deleted'))
         end
       end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -45,6 +45,7 @@ module Actions
         end
 
         def finalize
+          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           subject_organization.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest imported'))
         end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -61,6 +61,7 @@ module Actions
 
         def finalize
           org = ::Organization.find(input[:organization_id])
+          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           org.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest refreshed'))
         end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -228,6 +228,11 @@ module Katello
           subscriptions.select(&:expiring_soon?)
         end
 
+        def clear_syspurpose_status
+          host_purpose = HostStatus::Status.where(type: ::Katello::HostStatusManager::PURPOSE_STATUS.map(&:to_s)).where('host_id in (?)', self.hosts.pluck(:id))
+          host_purpose.destroy_all
+        end
+
         def notification_recipients_ids
           users = User.unscoped.all.find_all do |user|
             user.can?(:import_manifest) && user.can?(:view_organizations, self)

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -35,8 +35,10 @@ module Katello
         self.owner_details['contentAccessMode']
       end
 
-      def simple_content_access?
-        content_access_mode == "org_environment"
+      def simple_content_access?(cached: true)
+        Rails.cache.fetch("#{self.label}_simple_content_access?", expires_in: 1.minute, force: !cached) do
+          content_access_mode == "org_environment"
+        end
       end
 
       def generate_debug_cert

--- a/app/models/katello/purpose_status.rb
+++ b/app/models/katello/purpose_status.rb
@@ -1,8 +1,8 @@
 module Katello
   class PurposeStatus < HostStatus::Status
-    MATCHED = 0
+    UNKNOWN = 0
     MISMATCHED = 1
-    UNKNOWN = 2
+    MATCHED = 2
     NOT_SPECIFIED = 3
 
     def self.status_map

--- a/app/services/katello/candlepin/event_handler.rb
+++ b/app/services/katello/candlepin/event_handler.rb
@@ -53,6 +53,7 @@ module Katello
 
       def reindex_purpose_status
         reindex_consumer do
+          return if subscription_facet.host.organization.simple_content_access?
           subscription_facet.update_purpose_status(role_status: message_handler.system_purpose.role_status,
                                                    usage_status: message_handler.system_purpose.usage_status,
                                                    addons_status: message_handler.system_purpose.addons_status,

--- a/app/services/katello/host_status_manager.rb
+++ b/app/services/katello/host_status_manager.rb
@@ -9,5 +9,12 @@ module Katello
       Katello::PurposeAddonsStatus,
       Katello::PurposeStatus,
       Katello::TraceStatus].freeze
+
+    PURPOSE_STATUS = [
+      Katello::PurposeStatus,
+      Katello::PurposeAddonsStatus,
+      Katello::PurposeRoleStatus,
+      Katello::PurposeSlaStatus,
+      Katello::PurposeUsageStatus].freeze
   end
 end

--- a/db/migrate/20200818192230_update_system_purpose_status.rb
+++ b/db/migrate/20200818192230_update_system_purpose_status.rb
@@ -1,0 +1,12 @@
+class UpdateSystemPurposeStatus < ActiveRecord::Migration[6.0]
+  def change
+    purpose_types = Katello::HostStatusManager::PURPOSE_STATUS.map(&:to_s)
+
+    # load both sets of host statuses and *then* update them to make sure we update the correct statuses
+    unknown_statuses = ::HostStatus::Status.where(type: purpose_types, status: 2).pluck(:id)
+    matched_statuses = ::HostStatus::Status.where(type: purpose_types, status: 0).pluck(:id)
+
+    ::HostStatus::Status.where(id: unknown_statuses).update_all(status: Katello::PurposeStatus::UNKNOWN) # 2 => 0
+    ::HostStatus::Status.where(id: matched_statuses).update_all(status: Katello::PurposeStatus::MATCHED) # 0 => 2
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
@@ -41,7 +41,7 @@ angular.module('Bastion.content-hosts').service('ContentHostsHelper',
         this.getHostPurposeStatusIcon = function (statusCode) {
             var code = parseInt(statusCode);
 
-            if (code === 0) { // matched
+            if (code === 2) { // matched
                 return 'pficon pficon-ok';
             } else if (code === 1) { // mismatched
                 return 'pficon pficon-warning-triangle-o';

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -10,13 +10,14 @@
  * @requires Organization
  * @requires CurrentOrganization
  * @requires CurrentHostsHelper
+ * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoController',
-    ['$scope', '$q', 'translate', 'HostSubscription', 'ContentView', 'Organization', 'CurrentOrganization', 'ContentHostsHelper',
-    function ($scope, $q, translate, HostSubscription, ContentView, Organization, CurrentOrganization, ContentHostsHelper) {
+    ['$scope', '$q', 'translate', 'HostSubscription', 'ContentView', 'Organization', 'CurrentOrganization', 'ContentHostsHelper', 'simpleContentAccessEnabled',
+    function ($scope, $q, translate, HostSubscription, ContentView, Organization, CurrentOrganization, ContentHostsHelper, simpleContentAccessEnabled) {
         function doubleColonNotationToObject(dotString) {
             var doubleColonObject = {}, tempObject, parts, part, key, property;
             for (property in dotString) {
@@ -45,6 +46,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         $scope.showCVAlert = false;
         $scope.editContentView = false;
         $scope.disableEnvironmentSelection = false;
+        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.environments = [];
 
         $scope.environments = Organization.readableEnvironments({id: CurrentOrganization});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -118,8 +118,8 @@
       <div style="display: inline-block"><i class="pficon-info" title="{{ 'System Purpose allows you to set the system\'s intended use on your network and improves the accuracy of auto attaching subscriptions.' | translate }}"></i></div>
 
       <dl class="dl-horizontal dl-horizontal-left">
-        <dt translate>System Purpose Status</dt>
-        <dd>
+        <dt translate ng-hide="simpleContentAccessEnabled">System Purpose Status</dt>
+        <dd ng-hide="simpleContentAccessEnabled">
           <i ng-class="getHostPurposeStatusIcon(host.purpose_status)"></i>
           {{ host.purpose_status_label }}
         </dd>

--- a/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
@@ -11,7 +11,7 @@ describe('Controller: ContentHostsController', function() {
     }));
 
     it("provides a way to get the status icon for system purpose on a host.", function() {
-        expect(ContentHostsHelper.getHostPurposeStatusIcon(0)).toBe("pficon pficon-ok");
+        expect(ContentHostsHelper.getHostPurposeStatusIcon(2)).toBe("pficon pficon-ok");
         expect(ContentHostsHelper.getHostPurposeStatusIcon(1)).toBe("pficon pficon-warning-triangle-o");
     });
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -83,7 +83,8 @@ describe('Controller: ContentHostDetailsInfoController', function() {
             Host: Host,
             ContentView: ContentView,
             Organization: Organization,
-            CurrentOrganization: 'ACME_Corporation'
+            CurrentOrganization: 'ACME_Corporation',
+            simpleContentAccessEnabled: false
         });
     }));
 

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -144,6 +144,7 @@ module ::Actions::Katello::Organization
       rhel7 = katello_repositories(:rhel_7_x86_64)
       acme_org.stubs(:owner_details).returns({})
       acme_org.products.stubs(:redhat).returns([rhel7.product])
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
       action.stubs(:rand).returns('1234')
 
       stub_action_locking!(action)
@@ -239,7 +240,7 @@ module ::Actions::Katello::Organization
       acme_org = get_organization(:empty_organization)
       rhel7 = katello_repositories(:rhel_7_x86_64)
       acme_org.products.stubs(:redhat).returns([rhel7.product])
-
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
       stub_action_locking!(action)
       plan_action(action, acme_org, '/tmp/1234.zip', false)
       assert_difference 'Audit.count', 1 do
@@ -319,6 +320,7 @@ module ::Actions::Katello::Organization
       acme_org = get_organization(:empty_organization)
       rhel7 = katello_repositories(:rhel_7_x86_64)
       acme_org.products.stubs(:redhat).returns([rhel7.product])
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
 
       stub_action_locking!(action)
       plan_action(action, acme_org)

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -26,5 +26,19 @@ module Katello
       end
       assert_equal @org.manifest_refreshed_at.to_i, current_time.to_i
     end
+
+    def test_clear_syspurpose_status
+      host = @org.hosts.first
+
+      Katello::HostStatusManager::PURPOSE_STATUS.each do |status_class|
+        HostStatus::Status.create(host: host, type: status_class.to_s)
+      end
+
+      assert_equal 5, host.host_statuses.count
+
+      @org.clear_syspurpose_status
+
+      assert_equal 0, host.host_statuses.count
+    end
   end
 end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -90,6 +90,7 @@ module Katello
     end
 
     def test_update_purpose_status
+      host.organization.stubs(:simple_content_access?).returns(false)
       subscription_facet.update_purpose_status(sla_status: :mismatched,
                                                role_status: :unknown,
                                                usage_status: :not_specified,

--- a/test/models/purpose_status_test.rb
+++ b/test/models/purpose_status_test.rb
@@ -2,12 +2,12 @@ require 'katello_test_helper'
 
 module Katello
   module PurposeStatusTests
-    def test_status_matched
-      purpose_mock = mock(purpose_method => :matched)
+    def test_status_unknown
+      purpose_mock = mock(purpose_method => :inexistent)
       Katello::Candlepin::Consumer.any_instance.expects(:system_purpose).returns(purpose_mock)
 
-      assert_equal Katello::PurposeStatus::MATCHED, status.to_status
-      assert_equal 'Matched', status.to_label
+      assert_equal Katello::PurposeStatus::UNKNOWN, status.to_status
+      assert_equal 'Unknown', status.to_label
     end
 
     def test_status_mismatched
@@ -28,13 +28,13 @@ module Katello
       assert_equal 'Not Specified', status.to_label
     end
 
-    def test_status_unknown
-      purpose_mock = mock(purpose_method => :inexistent)
+    def test_status_matched
+      purpose_mock = mock(purpose_method => :matched)
       Katello::Candlepin::Consumer.any_instance.expects(:system_purpose).returns(purpose_mock)
       status.status = status.to_status
 
-      assert_equal Katello::PurposeStatus::UNKNOWN, status.status
-      assert_equal 'Unknown', status.to_label
+      assert_equal Katello::PurposeStatus::MATCHED, status.status
+      assert_equal 'Matched', status.to_label
     end
 
     def test_status_override

--- a/test/services/katello/candlepin/event_handler_test.rb
+++ b/test/services/katello/candlepin/event_handler_test.rb
@@ -13,6 +13,7 @@ module Katello
       ::Katello::Pool.any_instance.stubs(:import_data).returns(true)
       ::Katello::Candlepin::MessageHandler.any_instance.stubs(:get_pool_by_reference_id).returns(pool_two)
       ::Katello::Candlepin::MessageHandler.any_instance.stubs(:subscription_facet).returns(subscription_facet)
+      subscription_facet.host.organization.stubs(:simple_content_access?).returns(false)
     end
 
     def message(subject, content = {})


### PR DESCRIPTION
To test,

* Snapshot your Katello environment and run

* `bundle exec rake katello:reset`

* Register 2 or more content hosts to the organization so the syspurpose status populates

* Apply patch

* Upload a manifest that has SCA enabled and check if the hosts show anything for simple content access in the all hosts and hosts - content hosts tab.

* Try to refresh a manifest as well