### PR TITLE
Fixes #30524 - Add content_views/:id/repositories/show_all endpoint

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -66,6 +66,7 @@ module Katello
       resource = options[:resource_class] || resource_class
       includes = options.fetch(:includes, [])
       group = options.fetch(:group, nil)
+      deterministic_order = options.fetch(:deterministic_order, "#{query.table_name}.id DESC")
       params[:full_result] = true if options[:csv]
       blank_query = resource.none
 
@@ -88,7 +89,7 @@ module Katello
       if options[:custom_sort]
         query = options[:custom_sort].call(query)
       end
-      query = query.order("#{query.table_name}.id DESC") unless group #secondary order to ensure sort is deterministic
+      query = query.order(deterministic_order) unless group #secondary order to ensure sort is deterministic
       query = query.includes(includes) if includes.length > 0
 
       if ::Foreman::Cast.to_bool(params[:full_result])

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -66,7 +66,6 @@ module Katello
       resource = options[:resource_class] || resource_class
       includes = options.fetch(:includes, [])
       group = options.fetch(:group, nil)
-      fixed_query = options.fetch(:fixed_query, false) # Use query passed in and don't re-query by ids
       params[:full_result] = true if options[:csv]
       blank_query = resource.none
 
@@ -79,11 +78,7 @@ module Katello
       total = scoped_search_total(query, group)
 
       query = query.select(:id) if query.respond_to?(:select)
-      if fixed_query
-        query = query.search_for(*search_options)
-      else
-        query = resource.search_for(*search_options).where("#{resource.table_name}.id" => query)
-      end
+      query = resource.search_for(*search_options).where("#{resource.table_name}.id" => query)
 
       query = self.final_custom_index_relation(query) if self.respond_to?(:final_custom_index_relation)
 
@@ -122,7 +117,7 @@ module Katello
       if group
         query.select(group).group(group).length
       else
-        query.size
+        query.count
       end
     end
 

--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -1,0 +1,47 @@
+module Katello
+  class Api::V2::ContentViewRepositoriesController < Api::V2::ApiController
+    # There are other Content View Repository related endpoints that are in RepositoriesController
+    include Katello::Concerns::FilteredAutoCompleteSearch
+
+    before_action :find_content_view
+    before_action :find_organization_from_cv
+
+    # content_views/:id/repositories/show_all
+    # Shows all repositories, added and available to add, for a content view
+    # Undocumented endpoint since the functionality exists in separate calls already.
+    # This was created for ease of pagination and search for the UI
+    param :id, :number, desc: N_("Content View id"), required: true
+    param :only, ["available", "added"], desc: N_("only show a subset of results, either 'available' or 'added'")
+    def show_all
+      query = Repository.readable
+      ids = []
+      ids += @organization.default_content_view.versions.first.repositories.pluck(:id) unless params[:only] == 'added'
+      added_ids = @content_view.repositories.pluck(:id)
+      if params[:only] == 'available'
+        ids -= added_ids
+      else
+        ids += added_ids
+      end
+      query = query.where(id: ids.uniq)
+      sorted_ids = query.sort_by { |repo| repo.in_content_view?(@content_view) ? 0 : 1 }.pluck(:id)
+      sorted_query = Katello::Repository.where(id: sorted_ids)
+
+      # Make sure the added content views are returned first
+      options = { resource_class: Katello::Repository,
+                  deterministic_order: "array_position(array[#{sorted_ids.join(',')}], #{Katello::Repository.table_name}.id)" }
+      repos = scoped_search(sorted_query, nil, nil, options)
+
+      respond_for_index(:collection => repos)
+    end
+
+    private
+
+    def find_content_view
+      @content_view = ContentView.find(params[:content_view_id])
+    end
+
+    def find_organization_from_cv
+      @organization = @content_view.organization
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -24,12 +24,11 @@ module Katello
         CAST (#{kcvr}.repository_id as BOOLEAN) ASC, #{krr}.name
       SQL
 
-      query = Katello::Repository.in_default_view.in_organization(@organization)
+      query = Katello::Repository.readable.in_default_view.in_organization(@organization)
       # Use custom sort to perform the join and order since we need to order by specific content_view
       # and the ORDER BY query needs access to the katello_content_view_repositories table
       custom_sort = ->(sort_query) { sort_query.joins(:root).joins(join_query).order(order_query) }
-      options = { resource_class: Katello::Repository,
-                  custom_sort: custom_sort }
+      options = { resource_class: Katello::Repository, custom_sort: custom_sort }
       repos = scoped_search(query, nil, nil, options)
 
       respond_for_index(:collection => repos)

--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -11,25 +11,10 @@ module Katello
     # Undocumented endpoint since the functionality exists in separate calls already.
     # This was created for ease of pagination and search for the UI
     param :id, :number, desc: N_("Content View id"), required: true
-    param :only, ["available", "added"], desc: N_("only show a subset of results, either 'available' or 'added'")
     def show_all
-      query = Repository.readable
-      ids = []
-      ids += @organization.default_content_view.versions.first.repositories.pluck(:id) unless params[:only] == 'added'
-      added_ids = @content_view.repositories.pluck(:id)
-      if params[:only] == 'available'
-        ids -= added_ids
-      else
-        ids += added_ids
-      end
-      query = query.where(id: ids.uniq)
-      sorted_ids = query.sort_by { |repo| repo.in_content_view?(@content_view) ? 0 : 1 }.pluck(:id)
-      sorted_query = Katello::Repository.where(id: sorted_ids)
-
-      # Make sure the added content views are returned first
-      options = { resource_class: Katello::Repository,
-                  deterministic_order: "array_position(array[#{sorted_ids.join(',')}], #{Katello::Repository.table_name}.id)" }
-      repos = scoped_search(sorted_query, nil, nil, options)
+      query = Katello::Repository.all_for_content_view(@content_view.id);
+      options = { resource_class: Katello::Repository, fixed_query: true }
+      repos = scoped_search(query, nil, nil, options)
 
       respond_for_index(:collection => repos)
     end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -870,6 +870,10 @@ module Katello
       true
     end
 
+    def in_content_view?(content_view)
+      content_view.repositories.include? self
+    end
+
     protected
 
     def unit_type_for_removal(type_class = nil)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -3,9 +3,6 @@ module Katello
   class Repository < Katello::Model
     audited
 
-    # Optional for when querying based on CV
-    attribute :added_to_content_view, :boolean, default: false
-
     #pulp uses pulp id to sync with 'yum_distributor' on the end
     PULP_ID_MAX_LENGTH = 220
 
@@ -265,38 +262,6 @@ module Katello
     def self.in_content_views(views)
       joins(:content_view_version)
         .where("#{Katello::ContentViewVersion.table_name}.content_view_id" => views.map(&:id))
-    end
-
-    def self.all_for_content_view(content_view_id)
-      kr = Katello::Repository.table_name
-      kcv = Katello::ContentView.table_name
-      kcvr = Katello::ContentViewRepository.table_name
-      select_query = <<-SQL
-        DISTINCT #{kr}.*,
-          CASE
-              WHEN #{kcvr}.content_view_id = #{content_view_id} THEN 1
-              ELSE 0
-          END AS "added_to_content_view"
-      SQL
-      from_query = "#{kr}"
-      cvr_join = <<-SQL
-        LEFT JOIN #{kcvr} ON (#{kr}.id = #{kcvr}.repository_id)
-      SQL
-      cv_join = <<-SQL
-        LEFT JOIN #{kcv} ON (#{kcvr}.content_view_id = #{kcv}.id)
-      SQL
-      where_query = <<-SQL
-        #{kcv}.id = #{content_view_id} OR #{kcv}.id IS NULL
-      SQL
-      order_query =  <<-SQL
-        "added_to_content_view" DESC, katello_repositories.id
-      SQL
-      self.select(select_query)
-          .from(from_query)
-          .joins(cvr_join)
-          .joins(cv_join)
-          .where(where_query)
-          .order(Arel.sql(order_query))
     end
 
     def self.feed_ca_cert(url)

--- a/app/views/katello/api/v2/content_view_repositories/show_all.json.rabl
+++ b/app/views/katello/api/v2/content_view_repositories/show_all.json.rabl
@@ -1,0 +1,8 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/repositories/base'
+  node(:added_to_content_view) { |repo| repo.in_content_view?(@content_view) }
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -96,7 +96,11 @@ Katello::Engine.routes.draw do
             end
           end
           api_resources :puppet_modules, :only => [:index]
-          api_resources :repositories, :only => [:index]
+          api_resources :repositories, :only => [:index] do
+            collection do
+              match '/show_all' => "content_view_repositories#show_all", :via => :get
+            end
+          end
           api_resources :content_view_versions, :only => [:index]
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -71,6 +71,7 @@ module Katello
                    'katello/api/v2/content_view_filter_rules' => [:index, :show],
                    'katello/api/v2/content_view_histories' => [:index, :auto_complete_search],
                    'katello/api/v2/content_view_puppet_modules' => [:index, :show, :auto_complete_search],
+                   'katello/api/v2/content_view_repositories' => [:show_all],
                    'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_components' => [:index, :show],
                    'katello/api/v2/packages' => [:index],

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -1,0 +1,65 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::ContentViewRepositoriesControllerTest < ActionController::TestCase
+    def setup
+      setup_controller_defaults_api
+      @view = katello_content_views(:library_view)
+      @fedora_repo = katello_repositories(:fedora_17_x86_64)
+      @fedora_dup_repo = katello_repositories(:fedora_17_x86_64_duplicate)
+    end
+
+    def test_show_all
+      get :show_all, params: { content_view_id: @view.id }
+
+      assert_response :success
+      results = JSON.parse(response.body, symbolize_names: true)[:results]
+      added_ids = results.select { |r| r[:added_to_content_view] }.pluck(:id)
+      not_added_ids = results.reject { |r| r[:added_to_content_view] }.pluck(:id)
+
+      assert results.first[:added_to_content_view] # added to content view repos should show first
+      assert_includes added_ids, @fedora_repo.id
+      assert_includes not_added_ids, @fedora_dup_repo.id
+    end
+
+    def test_show_all_search
+      get :show_all, params: { content_view_id: @view.id, search: "name = \"#{@fedora_repo.name}\"" }
+
+      assert_response :success
+      body = JSON.parse(response.body, symbolize_names: true)
+      results = body[:results]
+
+      assert_equal body[:subtotal].to_i, 2 # two repos have the same name
+      assert_equal results.length, 2
+      assert results.first[:added_to_content_view]
+      refute results.last[:added_to_content_view]
+      assert_includes results.pluck(:id), @fedora_repo.id
+    end
+
+    def test_show_only_added
+      get :show_all, params: { content_view_id: @view.id, only: "added" }
+
+      assert_response :success
+      body = JSON.parse(response.body, symbolize_names: true)
+      results = body[:results]
+
+      assert_equal body[:subtotal].to_i, 1
+      assert_equal results.length, 1
+      assert results.first[:added_to_content_view]
+      assert_equal results.first[:id], @fedora_repo.id
+    end
+
+    def test_show_only_available
+      get :show_all, params: { content_view_id: @view.id, only: "available" }
+
+      assert_response :success
+      body = JSON.parse(response.body, symbolize_names: true)
+      results = body[:results]
+
+      assert body[:subtotal].to_i > 1
+      assert results.length > 1
+      results.each { |result| refute result[:added_to_content_view], "#{result} returned the wrong value!" }
+      assert_includes results.pluck(:id), @fedora_dup_repo.id
+    end
+  end
+end

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -14,7 +14,6 @@ module Katello
 
       assert_response :success
       results = JSON.parse(response.body, symbolize_names: true)[:results]
-      byebug
       added_ids = results.select { |r| r[:added_to_content_view] }.pluck(:id)
       not_added_ids = results.reject { |r| r[:added_to_content_view] }.pluck(:id)
 
@@ -35,32 +34,6 @@ module Katello
       assert results.first[:added_to_content_view]
       refute results.last[:added_to_content_view]
       assert_includes results.pluck(:id), @fedora_repo.id
-    end
-
-    def test_show_only_added
-      get :show_all, params: { content_view_id: @view.id, only: "added" }
-
-      assert_response :success
-      body = JSON.parse(response.body, symbolize_names: true)
-      results = body[:results]
-
-      assert_equal body[:subtotal].to_i, 1
-      assert_equal results.length, 1
-      assert results.first[:added_to_content_view]
-      assert_equal results.first[:id], @fedora_repo.id
-    end
-
-    def test_show_only_available
-      get :show_all, params: { content_view_id: @view.id, only: "available" }
-
-      assert_response :success
-      body = JSON.parse(response.body, symbolize_names: true)
-      results = body[:results]
-
-      assert body[:subtotal].to_i > 1
-      assert results.length > 1
-      results.each { |result| refute result[:added_to_content_view], "#{result} returned the wrong value!" }
-      assert_includes results.pluck(:id), @fedora_dup_repo.id
     end
   end
 end

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -14,6 +14,7 @@ module Katello
 
       assert_response :success
       results = JSON.parse(response.body, symbolize_names: true)[:results]
+      byebug
       added_ids = results.select { |r| r[:added_to_content_view] }.pluck(:id)
       not_added_ids = results.reject { |r| r[:added_to_content_view] }.pluck(:id)
 

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -4,9 +4,14 @@ module Katello
   class Api::V2::ContentViewRepositoriesControllerTest < ActionController::TestCase
     def setup
       setup_controller_defaults_api
+      @organization = get_organization
       @view = katello_content_views(:library_view)
       @fedora_repo = katello_repositories(:fedora_17_x86_64)
       @fedora_dup_repo = katello_repositories(:fedora_17_x86_64_duplicate)
+      @read_permission = :view_content_views
+      @create_permission = :create_content_views
+      @update_permission = :edit_content_views
+      @destroy_permission = :destroy_content_views
     end
 
     def test_show_all
@@ -34,6 +39,15 @@ module Katello
       assert results.first[:added_to_content_view]
       refute results.last[:added_to_content_view]
       assert_includes results.pluck(:id), @fedora_repo.id
+    end
+
+    def test_show_all_protected
+      allowed_perms = [@read_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:show_all, allowed_perms, denied_perms) do
+        get :show_all, params: { content_view_id: @view.id }
+      end
     end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -754,6 +754,13 @@ module Katello
       assert repo_types_hash[::Katello::Rpm.content_type] < repo_types_hash[::Katello::Erratum.content_type]
       assert repo_types_hash[::Katello::ModuleStream.content_type] < repo_types_hash[::Katello::Erratum.content_type]
     end
+
+    def test_in_content_view
+      view = katello_content_views(:library_view)
+      rhel7 = katello_repositories(:rhel_7_no_arch)
+      assert @fedora_17_x86_64.in_content_view?(view)
+      refute rhel7.in_content_view?(view)
+    end
   end
 
   class RepositoryApplicabilityTest < RepositoryTestBase


### PR DESCRIPTION
Adds a way to see all repositories, both added and available to a content view. This is useful for the new CV UI page.