### PR TITLE
Fixes #30361 - shows the right Cv in Content Hosts

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -119,7 +119,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
             $scope.saveSubscriptionFacet($scope.host);
         };
 
-        $scope.contentViews = function () {
+        $scope.availableContentViews = function () {
             var deferred = $q.defer();
 
             ContentView.queryUnpaged({ 'environment_id': $scope.host.content_facet_attributes.lifecycle_environment.id}, function (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -277,7 +277,7 @@
           <div bst-edit-select="host.content_facet_attributes.content_view.name"
             readonly="denied('edit_hosts', host)"
             selector="host.content_facet_attributes.content_view.id"
-            options="contentViews()"
+            options="availableContentViews()"
             on-cancel="cancelContentViewUpdate()"
             on-save="saveContentView(host)"
             edit-trigger="editContentView">

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -110,7 +110,7 @@ describe('Controller: ContentHostDetailsInfoController', function() {
     });
 
     it('provides a method to retrieve available content views for a content host', function() {
-        var promise = $scope.contentViews();
+        var promise = $scope.availableContentViews();
 
         promise.then(function(contentViews) {
             expect(contentViews).toEqual(mockContentViews);


### PR DESCRIPTION
Prior to this commit an angular error message was raised on the content
hosts details page whenever the Content View belonging to the Content
Host was updated twice. This issue occured because a method got over
written in the scope causing angular issue

This commit resolves this be setting a better name to the contentViews
method to 'availableContentViews'