### PR TITLE
Fixes #30389 - Optimze false for repo syncs

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -193,8 +193,12 @@ module Katello
         ignore_404_exception { api.repositories_api.delete(href) } if href
       end
 
+      def sync_params
+        {remote: repo.remote_href, mirror: repo.root.mirror_on_sync}
+      end
+
       def sync
-        sync_url_params = {remote: repo.remote_href, mirror: repo.root.mirror_on_sync}
+        sync_url_params = sync_params
         skip_type_param = skip_types
         sync_url_params[:skip_types] = skip_type_param if skip_type_param
         repository_sync_url_data = api.class.repository_sync_url_class.new(sync_url_params)

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -31,6 +31,10 @@ module Katello
           }
         end
 
+        def sync_params
+          {remote: repo.remote_href, mirror: repo.root.mirror_on_sync, optimize: false}
+        end
+
         def mirror_remote_options
           policy = smart_proxy.download_policy
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -53,8 +53,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.0.0", "< 1.1.0"
   gem.add_dependency "pulp_ansible_client", "> 0.1", "< 0.2.0b15"
   gem.add_dependency "pulp_container_client", ">= 1.4.0", "< 1.5.0"
-  gem.add_dependency "pulp_rpm_client", ">=3.4.2", "< 3.5.0"
-  gem.add_dependency "pulp_2to3_migration_client", ">= 0.2.0b2", "< 0.3.0"
+  gem.add_dependency "pulp_rpm_client", ">=3.5.0", "< 3.6.0"
+  gem.add_dependency "pulp_2to3_migration_client", ">= 0.2.0b6", "< 0.3.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
 
   # UI


### PR DESCRIPTION
1. Create and Sync a repo with mirror set to true.
2. Re-sync the repo.
3. Contents should not get unassociated.