### PR TITLE
Fixes #30619 - Add apt and zypper to job template install_errata_-_katello_ansible_default.erb

### DIFF
--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -14,5 +14,13 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') %>
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
+<% if @host.operatingsystem.family == 'Suse' -%>
+<% advisories = input(:errata).split(',').join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "zypper install -n -t patch #{advisories}") -%>
+<% elsif @host.operatingsystem.family == 'Debian' -%>
+<% advisories = input(:errata).split(',').map { |e| @host.debs_for_erratum(e) }.join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "apt-get -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" -y --only-upgrade install -y #{advisories}") %>
+<% else -%>
+<% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") -%>
+<% end -%>


### PR DESCRIPTION
Current version only supports installing upgrades through yum, added check and code for zypper as well as apt