### PR TITLE
Refs #29926 - Add  Simple Content Access status in Organization details

### DIFF
--- a/app/assets/javascripts/katello/organizations/index_table_change.js
+++ b/app/assets/javascripts/katello/organizations/index_table_change.js
@@ -1,0 +1,28 @@
+function addSimpleContentAccessColumn() {
+  if(organizationsCount()) {
+    const table = $('.table-fixed');
+    let row = 0;
+
+    table.find('tr').each(function() {
+      const trow = $(this);
+      if(row === 0) {
+        trow.append('<th>Simple Content Access</th>');
+      } else {
+        const orgName = trow.find('td:first').text();
+        const hiddenFieldId = orgName.split(' ').join('_');
+        const simpleContentAccess = $("input[type=hidden]#" + hiddenFieldId).val();
+        const simpleContentAccessValue = simpleContentAccess === "true" ? "Enabled" : "Disabled";
+        trow.append(`<td>${simpleContentAccessValue}</td>`);
+      }
+      row += 1;
+    });
+  }
+}
+
+function organizationsCount() {
+  return $("input[type=hidden]#show_simple_content_access_column").val() === "true";
+}
+
+$(document).on('ContentLoad', function() {
+  addSimpleContentAccessColumn();
+});

--- a/app/overrides/add_organization_attributes.rb
+++ b/app/overrides/add_organization_attributes.rb
@@ -22,3 +22,9 @@ Deface::Override.new(:virtual_path => "taxonomies/_form",
                      :name => "add_organization_attributes_on_edit",
                      :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
                      :partial => 'overrides/organizations/edit_override')
+
+# Add Simple Content Access Column to org table
+Deface::Override.new(:virtual_path => "taxonomies/index",
+                     :name => "add_organization_attributes_on_index",
+                     :insert_after => 'erb[loud]:contains(":title"):contains("Taxonomy|Name")',
+                     :partial => 'overrides/organizations/index_override')

--- a/app/views/overrides/organizations/_index_override.html.erb
+++ b/app/views/overrides/organizations/_index_override.html.erb
@@ -1,0 +1,12 @@
+<%= javascript_include_tag 'katello/organizations/index_table_change' %>
+
+<% @taxonomies.each do |taxonomy| %>
+  <% show_simple_content_access_column = true %>
+  <% if taxonomy.is_a?(Organization) %>
+    <% if show_simple_content_access_column %>
+      <%= hidden_field_tag "show_simple_content_access_column", show_simple_content_access_column  %>
+      <% show_simple_content_access_column = false %>
+    <% end %>
+    <%= hidden_field_tag taxonomy.name, taxonomy.simple_content_access?  %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Changes Done = Added simple content access column at org list page

Changes need to be done = In Organization details, Add a new section to Organization edit screen.
Show whether Simple Content Access is enabled and allow toggle.