### PR TITLE
Fixes #30462 - Upload large file from UI

### DIFF
--- a/app/lib/actions/pulp3/repository/upload_file.rb
+++ b/app/lib/actions/pulp3/repository/upload_file.rb
@@ -25,7 +25,7 @@ module Actions
                 filechunk.flush
                 actual_chunk_size = File.size(filechunk)
                 response = uploads_api.update(upload_href, content_range(offset, offset + actual_chunk_size - 1, total_size), filechunk)
-                offset += actual_chunk_size - 1
+                offset += actual_chunk_size
               ensure
                 filechunk.close
                 filechunk.unlink


### PR DESCRIPTION
**To test:**
Create a file repo and upload a file of size >~ 5 Mb
**Without change:**
Upload fails with sha256 checksum failure.
**With Change:**
Upload should succeed for large files.