### PR TITLE
Fixes #30654 - update batch logic for SP sync

### DIFF
--- a/app/lib/actions/katello/capsule_content/refresh_repos.rb
+++ b/app/lib/actions/katello/capsule_content/refresh_repos.rb
@@ -37,7 +37,7 @@ module Actions
           current_repos_on_capsule = smart_proxy_service.current_repositories(environment, content_view)
           current_repos_on_capsule_ids = current_repos_on_capsule.pluck(:id)
 
-          list_of_repos_to_sync = smart_proxy_helper.repos_available_to_capsule(environment, content_view, repository)
+          list_of_repos_to_sync = smart_proxy_helper.combined_repos_available_to_capsule(environment, content_view, repository)
           list_of_repos_to_sync.each do |repo|
             if repo.is_a?(Katello::ContentViewPuppetEnvironment)
               repo = repo.nonpersisted_repository

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -31,7 +31,7 @@ module Actions
           fail _("Action not allowed for the default smart proxy.") if smart_proxy.pulp_master?
 
           smart_proxy_helper = ::Katello::SmartProxyHelper.new(smart_proxy)
-          repositories = smart_proxy_helper.repos_available_to_capsule(environment, content_view, repository)
+          repositories = smart_proxy_helper.combined_repos_available_to_capsule(environment, content_view, repository)
 
           smart_proxy.ping_pulp if repositories.any? { |repo| !smart_proxy.pulp3_support?(repo) }
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -135,6 +135,7 @@ module Katello
     scope :in_published_environments, -> { in_content_views(Katello::ContentView.non_default).where.not(:environment_id => nil) }
     scope :order_by_root, ->(attr) { joins(:root).order("#{Katello::RootRepository.table_name}.#{attr}") }
     scope :with_content, ->(content) { joins(Katello::RepositoryTypeManager.find_content_type(content).model_class.repository_association_class.name.demodulize.underscore.pluralize.to_sym).distinct }
+    scope :by_rpm_count, -> { left_joins(:repository_rpms).group(:id).order("count(katello_repository_rpms.id) ASC") } # smallest count first
 
     scoped_search :on => :name, :relation => :root, :complete_value => true
     scoped_search :rename => :product, :on => :name, :relation => :product, :complete_value => true
@@ -592,6 +593,10 @@ module Katello
 
     def node_syncable?
       environment
+    end
+
+    def self.smart_proxy_syncable
+      where.not(:environment_id => nil)
     end
 
     def exist_for_environment?(environment, content_view, attribute = nil)

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -92,7 +92,7 @@ class Setting::Content < Setting
       self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."),
                true, N_('Check services before actions')),
       self.set('foreman_proxy_content_batch_size', N_("How many repositories should be synced concurrently on the capsule.  A smaller number may lead to longer sync times.  A larger number will increase dynflow load."),
-               25, N_('Batch size to sync repositories in.')),
+               100, N_('Batch size to sync repositories in.')),
       self.set('foreman_proxy_content_auto_sync', N_("Whether or not to auto sync the Smart Proxies after a Content View promotion."),
                true, N_('Sync Smart Proxies after Content View promotion')),
       self.set('default_download_policy', N_("Default download policy for custom repositories (either 'immediate', 'on_demand', or 'background')"), "immediate",

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -10,7 +10,7 @@ module Katello
         repo_map = {}
 
         smart_proxy_helper = ::Katello::SmartProxyHelper.new(smart_proxy)
-        katello_pulp_ids = smart_proxy_helper.repos_available_to_capsule.map(&:pulp_id)
+        katello_pulp_ids = smart_proxy_helper.combined_repos_available_to_capsule.map(&:pulp_id)
         pulp3_enabled_repo_types.each do |repo_type|
           api = repo_type.pulp3_service_class.api(smart_proxy)
           repo_map[api] = api.list_all.reject { |capsule_repo| katello_pulp_ids.include? capsule_repo.name }

--- a/app/services/katello/smart_proxy_helper.rb
+++ b/app/services/katello/smart_proxy_helper.rb
@@ -13,34 +13,31 @@ module Katello
       @smart_proxy.pulp_master?
     end
 
-    def repos_available_to_capsule(environment = nil, content_view = nil, repository = nil)
-      ret = []
-      if repository
-        environment = repository.environment
-        ret = [repository]
-      else
-        yum_repos = fetch_repos_available_to_capsule(environment, content_view) || []
-        puppet_envs = fetch_puppet_environments_available_to_capsule(environment, content_view) || []
-        ret = yum_repos + puppet_envs
-      end
+    def lifecycle_environment_check(environment = nil, repository = nil)
+      environment = repository.environment if repository
 
       if environment && !self.smart_proxy.lifecycle_environments.include?(environment)
         fail _("Lifecycle environment '%{environment}' is not attached to this capsule.") % { :environment => environment.name }
       end
-
-      ret
     end
 
-    private
+    def combined_repos_available_to_capsule(environment = nil, content_view = nil, repository = nil)
+      lifecycle_environment_check(environment, repository)
+      if repository
+        [repository]
+      else
+        repositories_available_to_capsule(environment, content_view) + puppet_environments_available_to_capsule(environment, content_view)
+      end
+    end
 
-    def fetch_repos_available_to_capsule(environments = nil, content_view = nil)
+    def repositories_available_to_capsule(environments, content_view)
       environments = @smart_proxy.lifecycle_environments if environments.nil?
       yum_repos = Katello::Repository.in_environment(environments)
       yum_repos = yum_repos.in_content_views([content_view]) if content_view
-      yum_repos.select(&:node_syncable?)
+      yum_repos.smart_proxy_syncable
     end
 
-    def fetch_puppet_environments_available_to_capsule(environments = nil, content_view = nil)
+    def puppet_environments_available_to_capsule(environments, content_view)
       environments = @smart_proxy.lifecycle_environments if environments.nil?
       puppet_environments = Katello::ContentViewPuppetEnvironment.in_environment(environments)
       puppet_environments = puppet_environments.in_content_view(content_view) if content_view

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -18,6 +18,12 @@ module Katello
       refute_empty Repository.where(:id => @repo.id)
     end
 
+    def test_by_rpm_count
+      repos = Katello::Repository.by_rpm_count
+      rpm_counts = repos.map { |r| r.rpms.count }
+      assert_equal Katello::Repository.all.map { |r| r.rpms.count }.sort, rpm_counts
+    end
+
     def test_docker_full_path
       full_path = @repo.full_path
       @repo.root.content_type = 'docker'


### PR DESCRIPTION
this updates the batch logic for smart proxy
syncs in two ways.  It adjusts the batch size default
to 100, as some users were not noticing issues previously
with 1000 repos being synced at a time.  It also sorts the repos
by rpm count, to hopefully put the larger ones at the end