### PR TITLE
Fixed #17608 - for pulp3, enable dep solving for incremental updates

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -73,7 +73,7 @@ module Actions
 
                 unless extended_repo_mapping.empty? || unit_map.values.flatten.empty?
                   copy_action_outputs << plan_action(Pulp3::Repository::MultiCopyUnits, extended_repo_mapping, unit_map,
-                                                     dependency_solving: true).output
+                                                     dependency_solving: dep_solve).output
                 end
               end
 


### PR DESCRIPTION
This PR enables dep solving options in an incremental update for a CVV  (FOR PULP3 ONLY).

Assume that an exclusion package of "*" exists, and therefore no non-modular rpms are present in a published CVV.

Before applying this change, the default behavior:
```
vagrant@centos7-hammer-devel ~]$ hammer content-view version incremental-update --content-view-version-id=11 --errata-ids=RHEA-2012:0055 --resolve-dependencies=no
Warning: An error occured while loading module hammer_cli_foreman_remote_execution.
{"resolve_dependencies"=>false, "add_content"=>{"errata_ids"=>["RHEA-2012:0055"]}, :content_view_version_environments=>[{:content_view_version_id=>11}]}
[.....................................................................................................................] [100%]
Content View: incremental-update-pre version 1.1
Added Content:
  Errata:
        RHEA-2012:0055
  Packages:
        bear-4.1-1.noarch
        dolphin-3.10.232-1.noarch
        lion-0.4-1.noarch
        penguin-0.9.1-1.noarch
        shark-0.1-1.noarch
        tiger-1.0-4.noarch
        walrus-5.21-1.noarch
        wolf-9.4-2.noarch
```
Note that all of the dependencies for the updated rpm (walrus) were also copied.

After the PR is applied:
```
[vagrant@centos7-hammer-devel ~]$ hammer content-view version incremental-update --content-view-version-id=9 --errata-ids=RHEA-2012:0055 --resolve-dependencies=no
Warning: An error occured while loading module hammer_cli_foreman_remote_execution.
{"resolve_dependencies"=>false, "add_content"=>{"errata_ids"=>["RHEA-2012:0055"]}, :content_view_version_environments=>[{:content_view_version_id=>9}]}
[..............................................................................................................................................] [100%]
Content View: test-incremental-3 version 1.1
Added Content:
  Errata:
        RHEA-2012:0055
  Packages:
        penguin-0.9.1-1.noarch
        shark-0.1-1.noarch
        walrus-5.21-1.noarch
```
Here only the packages indicated by the errata are included in the update, and no dependencies were.
