### PR TITLE
Fixes #30664 - add installable models for host

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -78,6 +78,18 @@ module Katello
         host.applicable_rpms.where(name: package).order(:version_sortable).limit(1).pluck(:nvra).first
       end
 
+      def host_installable_errata_ids(host)
+        host.installable_errata.map(&:errata_id)
+      end
+
+      def host_installable_errata_filtered(host, filter = '')
+        host.installable_errata.includes(:cves).search_for(filter)
+      end
+
+      def host_latest_installable_rpm_version(host, package)
+        host.installable_rpms.where(name: package).order(:version_sortable).limit(1).pluck(:nvra).first
+      end
+
       def load_pools(search: '', includes: nil)
         load_resource(klass: Pool.readable, search: search, permission: nil, includes: includes)
       end

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -30,7 +30,9 @@ module Katello
         has_one :content_source, :through => :content_facet
         has_many :content_facet_errata, :through => :content_facet, :class_name => 'Katello::ContentFacetErratum'
         has_many :applicable_errata, :through => :content_facet_errata, :source => :erratum
+        has_many :installable_errata, :through => :content_facet_errata, :source => :erratum
         has_many :applicable_rpms, :through => :content_facet
+        has_many :installable_rpms, :through => :content_facet
         has_many :applicable_module_streams, :through => :content_facet
 
         scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view
@@ -38,10 +40,11 @@ module Katello
         scoped_search :relation => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
         scoped_search :relation => :content_facet, :on => :lifecycle_environment_id, :rename => :lifecycle_environment_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
         scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :applicable_errata, :complete_value => true, :ext_method => :find_by_applicable_errata, :only_explicit => true
-        scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
+        scoped_search :relation => :installable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
         scoped_search :relation => :applicable_errata, :on => :issued, :rename => :applicable_errata_issued, :complete_value => true, :only_explicit => true
+        scoped_search :relation => :installable_errata, :on => :issued, :rename => :installable_errata_issued, :complete_value => true, :only_explicit => true
         scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :applicable_rpms, :complete_value => true, :ext_method => :find_by_applicable_rpms, :only_explicit => true
-        scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
+        scoped_search :relation => :installable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
 
         # preserve options set by facets framework, but add new :reject_if statement
@@ -63,7 +66,8 @@ module Katello
           property :content_view, 'ContentView', desc: 'Returns content view associated with the host'
           property :lifecycle_environment, 'KTEnvironment', desc: 'Returns lifecycle environment object associated with the host'
           property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source for the host'
-          property :applicable_errata, array_of: 'Erratum', desc: 'Returns Smart Proxy object as the content source for the host'
+          property :applicable_errata, array_of: 'Erratum', desc: 'Returns applicable erratum for the host'
+          property :installable_errata, array_of: 'Erratum', desc: 'Returns installable erratum for the host'
         end
       end
 
@@ -124,5 +128,5 @@ module Katello
 end
 
 class ::Host::Managed::Jail < Safemode::Jail
-  allow :content_view, :lifecycle_environment, :content_source, :applicable_errata
+  allow :applicable_errata, :content_source, :content_view, :lifecycle_environment, :installable_errata
 end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -15,12 +15,14 @@ module Katello
 
       has_many :content_facet_errata, :class_name => "Katello::ContentFacetErratum", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_errata, :through => :content_facet_errata, :class_name => "Katello::Erratum", :source => :erratum
+      has_many :installable_errata, :through => :content_facet_errata, :class_name => "Katello::Erratum", :source => :erratum
 
       has_many :content_facet_repositories, :class_name => "Katello::ContentFacetRepository", :dependent => :destroy, :inverse_of => :content_facet
       has_many :bound_repositories, :through => :content_facet_repositories, :class_name => "Katello::Repository", :source => :repository
 
       has_many :content_facet_applicable_rpms, :class_name => "Katello::ContentFacetApplicableRpm", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_rpms, :through => :content_facet_applicable_rpms, :class_name => "Katello::Rpm", :source => :rpm
+      has_many :installable_rpms, :through => :content_facet_applicable_rpms, :class_name => "Katello::Rpm", :source => :rpm
 
       has_many :content_facet_applicable_module_streams, :class_name => "Katello::ContentFacetApplicableModuleStream", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_module_streams, :through => :content_facet_applicable_module_streams, :class_name => "Katello::ModuleStream", :source => :module_stream


### PR DESCRIPTION
added new `installable_errata` and `installable_rpms` models for Report Templates that needs purely `installable` report data.