### PR TITLE
Fixes #30480: Cleanup orphaned root repositories

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -103,6 +103,7 @@ module Katello
       where(:http_proxy_policy => RootRepository::USE_SELECTED_HTTP_PROXY).
       where(:http_proxy_id => http_proxy_id)
     }
+    scope :orphaned, -> { where.not(id: Katello::Repository.pluck(:root_id).uniq) }
     delegate :redhat?, :provider, :organization, to: :product
 
     def library_instance


### PR DESCRIPTION
There were a few cases before where (mysteriously) orphaned root repositories were causing some trouble.  I've updated the `correct_repositories` rake task to work with Pulp 3 and remove orphaned RootRepositories (nil `library_instance`).

To test:

1) Try `rake correct_repositories` on a machine using Pulp 3
2) Create a RootRepository that has a nil `library_instance`
3) Run `rake correct_repositories` and see that the RootRepository is deleted