### PR TITLE
Fixes #30641 - CV publish fails if checksum type changes

### DIFF
--- a/app/lib/actions/katello/repository/multi_clone_contents.rb
+++ b/app/lib/actions/katello/repository/multi_clone_contents.rb
@@ -46,19 +46,15 @@ module Actions
 
           plan_action(Katello::Repository::MetadataGenerate, new_repository, metadata_options)
           unless source_repositories.first.saved_checksum_type == new_repository.saved_checksum_type
-            checksum_mapping = {}
-            repository_mapping.each do |source_repos, dest_repo|
-              checksum_mapping[dest_repo.id] = source_repos.first.saved_checksum_type
-            end
-            plan_self(:checksum_mapping => checksum_mapping)
+            plan_self(:source_checksum_type => source_repositories.first.saved_checksum_type,
+                      :target_repo_id => new_repository.id)
           end
         end
 
         def finalize
-          input[:checksum_mapping].each do |repo_id, checksum_type|
-            repository = ::Katello::Repository.find(repo_id)
-            repository.update!(saved_checksum_type: checksum_type) if (repository && checksum_type)
-          end
+          repository = ::Katello::Repository.find(input[:target_repo_id])
+          source_checksum_type = input[:source_checksum_type]
+          repository.update!(saved_checksum_type: source_checksum_type) if (repository && source_checksum_type)
         end
       end
     end

--- a/test/actions/katello/repository/multi_clone_contents_test.rb
+++ b/test/actions/katello/repository/multi_clone_contents_test.rb
@@ -1,0 +1,37 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::MultiCloneContents do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+    include ::Katello::Pulp3Support
+
+    let(:action_class) { ::Actions::Katello::Repository::MultiCloneContents }
+
+    def setup
+      get_organization #ensure we have an org label
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:fedora_17_x86_64_duplicate)
+      @repo.update!(:environment_id => nil)
+      @repo_clone = katello_repositories(:fedora_17_x86_64_dev)
+      @repo_clone.update!(:environment_id => nil)
+
+      ensure_creatable(@repo, @master)
+      create_repo(@repo, @master)
+      ensure_creatable(@repo_clone, @master)
+      create_repo(@repo_clone, @master)
+
+      @repo.reload
+
+      @repo_mapping = { [@repo] => { :dest_repo => @repo_clone, :filters => [] } }
+    end
+
+    def test_metadata_generation_with_changed_checksum_type
+      @repo.update(saved_checksum_type: "sha1")
+      @repo_clone.update(saved_checksum_type: "sha256")
+      task = ForemanTasks.sync_task(action_class, @repo_mapping, copy_contents: false)
+      assert_equal "success", task.result
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/actions/katello/repository/multi_clone_contents/metadata_generation_with_changed_checksum_type.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/repository/multi_clone_contents/metadata_generation_with_changed_checksum_type.yml
@@ -1,0 +1,2445 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '4599'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtL2ZjNzdlNTZmLTAyMzctNDVmNC04NzEzLWYxNmMx
+        OWI0MDk5OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTEzVDE3OjI1OjM1
+        LjUxNDM4N1oiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIDg3Ojk2OmQ2OmJlOmQ1OmYzOmU5OmEz
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tXG4g
+        ICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBKdWwg
+        MTUgMTM6NTI6MDUgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6
+        IEphbiAxOCAxMzo1MjowNSAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBD
+        PVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8s
+        IE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5j
+        YW5ub2xvLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVibGljIEtl
+        eSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0aG06IHJz
+        YUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5OiAoNDA5
+        NiBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAgICAgICAg
+        ICAgICAgICAgMDA6ZDU6NWU6YWU6MjI6NTM6OGE6M2Q6NTI6MGM6ZDM6MDU6
+        OWE6YWU6Y2M6XG4gICAgICAgICAgICAgICAgICAgIDI4OjQ3OmY2OmUzOmMx
+        OmY1OjZkOjg4OjNiOmFlOmMxOjNjOmYxOmY4OjA1OlxuICAgICAgICAgICAg
+        ICAgICAgICAyMjpkZDo4MzphMTozZTo0OTo5ZTo1NDowYjoyZTphNjpkMjpi
+        MjplMTo3MTpcbiAgICAgICAgICAgICAgICAgICAgYmM6YzU6ZDQ6YWY6Njk6
+        ODg6MzY6Njc6OGI6NGE6MzE6ZTM6N2I6MGQ6NGY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDI5OmVhOjE2OjhkOjg4OjYzOjgwOjMyOmE0OjBjOmZjOmM5OjU3
+        OmE3OjNmOlxuICAgICAgICAgICAgICAgICAgICAyNDpmODpkMzo5ZDphZjo2
+        MzoxODpkODoxNDo0OTozYzplNzo0MjphYzphMjpcbiAgICAgICAgICAgICAg
+        ICAgICAgODE6YzI6NGU6MjA6YTA6NWI6M2I6MzI6ZmI6MmU6YWE6ZTQ6NjA6
+        ZmE6NmU6XG4gICAgICAgICAgICAgICAgICAgIDI0OmFjOjYyOjFjOjUwOmU0
+        OjVjOjE3OjYzOjdkOmY5OmU5OjkyOmFkOmMwOlxuICAgICAgICAgICAgICAg
+        ICAgICBhODowNjoxNjo0ZTo4NzoyYjozMzozNjo4MTpiMjoyNDo5NDo5ODpm
+        NzpkMTpcbiAgICAgICAgICAgICAgICAgICAgYTk6NTE6Y2Y6ZmQ6MTI6OWQ6
+        MDg6NTQ6ZmI6NjQ6Mzc6YmY6Mjc6NTg6ZTc6XG4gICAgICAgICAgICAgICAg
+        ICAgIDNmOjg4OmYyOmZmOjE0Ojc2OjQ3Ojk3OjAyOjg5OjhiOjU5OjhmOmQ1
+        OmI1OlxuICAgICAgICAgICAgICAgICAgICBmZDowYzplYjplYjpmMjo3Mzo0
+        OTpkZjozNzo5Yjo5ZDozODplNToyZDphMTpcbiAgICAgICAgICAgICAgICAg
+        ICAgODc6YzI6MTI6NTI6ODU6NTU6ZGE6YjE6MmE6MjY6NDU6MjU6MTE6Yjg6
+        Y2Y6XG4gICAgICAgICAgICAgICAgICAgIGNkOjY3OjgwOmQzOjRlOjhkOjYy
+        OjQxOmFkOmUzOmYzOmNiOjg3OjlmOmFiOlxuICAgICAgICAgICAgICAgICAg
+        ICBlYzowMzplNjphMTo1Yzo1Mzo5MDo1ODpmZDplMzo2ODpmZjphZDpjNTox
+        OTpcbiAgICAgICAgICAgICAgICAgICAgZGQ6M2Q6YTg6NmI6Mzc6NWQ6OTk6
+        YjI6ZTk6MjM6NmE6NmU6NmM6Nzk6MTA6XG4gICAgICAgICAgICAgICAgICAg
+        IDVhOmFhOmRlOmM5OmE0Ojk5OmNmOjViOmE5OmRhOmQ2OjVlOjZkOjZiOjc1
+        OlxuICAgICAgICAgICAgICAgICAgICBhMzozZTo4Yjo4YToyNTpjMjo0ZDo4
+        Mzo2YTo5NzoxNDo3YTowMTpkYzpjZTpcbiAgICAgICAgICAgICAgICAgICAg
+        Mzg6NGE6NmM6Y2E6ZDU6MTQ6NjQ6ZGU6ZDI6MmM6ZmI6MGU6NzY6M2U6MTM6
+        XG4gICAgICAgICAgICAgICAgICAgIDQ4OjU4OjcyOjFhOjU5Ojk0OjFiOjlh
+        OmZiOmZmOjUzOmM5OjM5OjViOmYyOlxuICAgICAgICAgICAgICAgICAgICBm
+        ZjpmZDozMjoyMzpjOTpmYjpmOToyYTo1Njo5OTo0YjoyMzo1NToyNjo2Nzpc
+        biAgICAgICAgICAgICAgICAgICAgYTE6NjU6YzI6MTQ6ODQ6NDk6YmM6N2Y6
+        MmQ6YWM6MmY6NmE6MjU6YzM6ZTY6XG4gICAgICAgICAgICAgICAgICAgIGQ1
+        OjA2OjQ5OmI4OjI1OjQxOjNiOjA4OjgwOmQ1OjhhOjRlOjg0OjI0OjdiOlxu
+        ICAgICAgICAgICAgICAgICAgICAwZjplNDo3NTpkMTozZTpkMTo2NDowMjpi
+        ZToxNzo1NTplNDo5MjowZTpkZDpcbiAgICAgICAgICAgICAgICAgICAgNTU6
+        NWM6OTQ6NTc6NzA6ZTQ6ZDc6MDI6MTI6NDE6Mzk6YmU6NmQ6NGU6NDg6XG4g
+        ICAgICAgICAgICAgICAgICAgIGYwOjg3OjcwOmEzOmY3OjU1OjJlOjllOmY5
+        OmM4OjUxOjYzOmI5OmI0OjRlOlxuICAgICAgICAgICAgICAgICAgICBlMDo1
+        MToyZToxNTozNTo1Njo3Njo0ODpkNDpjMzo4YjpkNzpmYjphOTo2NjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNjc6OWY6MGY6YmY6NTg6YzQ6OTk6ZDg6Y2Y6
+        ZGM6Yjg6NzA6NTE6ZTY6ZTE6XG4gICAgICAgICAgICAgICAgICAgIDRhOmRh
+        OjZhOmQzOjM1OjRkOjlkOmE3OjVhOjA4OjBjOmZjOjBhOmVmOjZjOlxuICAg
+        ICAgICAgICAgICAgICAgICA5MDo4Zjo1Zjo0ODpmZTo5YzoyYTo2Mjo4NDo2
+        YjoyZDozYTo0NDpiYjo5YjpcbiAgICAgICAgICAgICAgICAgICAgNGI6ZGQ6
+        MDg6YzI6MjE6MjA6Njc6YWQ6Yjk6NjI6Yzc6M2Q6YjA6YTY6NWE6XG4gICAg
+        ICAgICAgICAgICAgICAgIDgzOmMyOjZiOjc0OjM4Ojk3OjNkOjVkOmI5OmEy
+        OjBmOjg2Ojk0OjRlOmJlOlxuICAgICAgICAgICAgICAgICAgICAyODpkOTox
+        NzoyNjpkODpkNToxZDpjMTpkNDphNDo3Nzo5ZDoxMjpiODowMzpcbiAgICAg
+        ICAgICAgICAgICAgICAgOTY6YTM6YzI6NmQ6ZDE6N2I6MzU6NDE6MDY6ZWY6
+        Yzk6YWI6YTg6MzE6MjM6XG4gICAgICAgICAgICAgICAgICAgIDdjOjg2OmM1
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czogXG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTogXG4gICAgICAgICAg
+        ICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhlcm1lbnQsIENl
+        cnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAgICBYNTA5djMg
+        RXh0ZW5kZWQgS2V5IFVzYWdlOiBcbiAgICAgICAgICAgICAgICBUTFMgV2Vi
+        IFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVu
+        dGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTogXG4g
+        ICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAg
+        ICBOZXRzY2FwZSBDb21tZW50OiBcbiAgICAgICAgICAgICAgICBLYXRlbGxv
+        IFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAgICAgICAg
+        WDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6IFxuICAgICAgICAgICAg
+        ICAgIDgwOkNGOjgwOkY4OjNFOjkxOjExOjE3OjI0OkNFOjlBOjdDOjhGOjY4
+        OjMzOkRDOkEzOjMxOjIzOkM3XG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOiBcbiAgICAgICAgICAgICAgICBrZXlpZDo4
+        MDpDRjo4MDpGODozRTo5MToxMToxNzoyNDpDRTo5QTo3Qzo4Rjo2ODozMzpE
+        QzpBMzozMToyMzpDN1xuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMv
+        U1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21l
+        T3JnVW5pdC9DTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4
+        YW1wbGUuY29tXG4gICAgICAgICAgICAgICAgc2VyaWFsOjg3Ojk2OkQ2OkJF
+        OkQ1OkYzOkU5OkEzXG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEy
+        NTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICAgMTI6NmI6MjI6NDc6Mjg6
+        MTU6MWI6ZGI6MTQ6ZWI6NGU6MjE6YWE6ZmM6ODE6YmY6YjM6MmU6XG4gICAg
+        ICAgICA5Njo5Mzo5ZTo5YTo3MjphYjoyMDoxZjpjYjpmZTowYjo5YjowYzoy
+        NzpiODplNTo1Yjo2OTpcbiAgICAgICAgIGYzOjU0OjgyOjRjOmNmOmFkOmRm
+        OjE5OjdhOjZkOjE0OjNmOmI0OmIzOjMyOmRiOjQyOjFiOlxuICAgICAgICAg
+        ZTE6MDE6NzM6ODc6Y2Q6ZTU6M2U6YTI6ZGM6MTY6NWY6MGM6NTA6ZWQ6ZGM6
+        MjI6M2E6ZWE6XG4gICAgICAgICBhZDoyODpkYzo3MTo5Yjo3YjpkNjpkNDpl
+        MzpmZjowNjpmNjo5Yjo4ZjozMzpmNTozMTozMjpcbiAgICAgICAgIDIxOjNj
+        OmE3OmIzOjcxOjRkOmY0OmE1OjJhOmIzOjlhOjUwOmU5OjIxOjFiOjY5OjI0
+        OmQyOlxuICAgICAgICAgNTY6ZTY6ZDE6MjE6NzQ6Zjk6ZTY6MGY6Nzg6MjU6
+        YTc6OTI6NmQ6NGE6MDY6MmY6YTg6NWU6XG4gICAgICAgICBhYzo5ZTpjZDoz
+        MDo5ZTo3YTo2NjplNTo4YTo3Yzo0MDphZjo2ZDo3NjozMjpjMjowMjo2YTpc
+        biAgICAgICAgIDJhOmM5OjQxOjI3OjgwOjFiOmYwOjliOmE5OjBlOmQ5OjFl
+        OmRmOmRkOjYyOmNkOjFmOmI3OlxuICAgICAgICAgNGE6NmY6YmY6NmQ6ZWE6
+        Mzc6NjM6M2Y6NTI6NzY6MGQ6MDU6MTQ6NmU6ZWM6YmE6NWQ6MGY6XG4gICAg
+        ICAgICA2YTo3YzoyNDo5MTplZjo1NTo0MDo4MDphZjpjNDo3OTowODoyYToz
+        MToyMzplYjo5YjoxOTpcbiAgICAgICAgIDBjOmRmOjMwOjZiOmE4Ojg1Ojc2
+        OjllOmE4OjJjOmI5OmI4OmU0OjMyOmZiOmY1OmQ2OjAwOlxuICAgICAgICAg
+        OTM6Yzk6Y2Y6OWY6NjY6ZjQ6NDQ6NzE6MWQ6MGE6NDA6ZmI6YmY6OTQ6NmY6
+        ZDE6MGQ6MmI6XG4gICAgICAgICAxZDozYzpmNjpjODo3YjpjYzplYTo2Yjpi
+        MzpjOTowZDpjYjplMDpkMTpiNzpiOTpmZjoyMTpcbiAgICAgICAgIDA5OjA0
+        OmIwOmE0OjQ0OmY4Ojg2OmFhOmVhOjEwOjNlOjU4OmI0OjIxOmU0OmZhOjFl
+        OmI4OlxuICAgICAgICAgOGY6YjY6Zjg6ZmU6MDA6NTE6ZWM6ZTA6MWM6MGQ6
+        MzE6MWE6Yzc6OWM6ZWY6ZjI6NjU6ZGM6XG4gICAgICAgICA0MzozNzpmYTo5
+        Yzo4NzozZDoxMjoxMzpiODpkZjpiZTowMjozNjo5MDpiYzo4ZjplNjo1Zjpc
+        biAgICAgICAgIGI5OjNkOjUzOmY0OjZiOmU5OmRjOjQxOmQ3OjIxOmQ3OjVh
+        OmYwOjFkOmU1OmU0OjY2OmU3OlxuICAgICAgICAgMTc6YWE6ZGE6Yzk6MjU6
+        YzQ6ZGI6MTg6Yjg6NWY6OTY6Yjc6ZjE6Zjg6NWE6Y2U6MWY6NzY6XG4gICAg
+        ICAgICAxODoxMDplMzo0Mzo5Njo2NDo3NDpmZjpmMjoyYjoxZjo4MDpjMzo1
+        YTo4NToyZjoxOToyNzpcbiAgICAgICAgIGJmOjVmOmEwOjNiOmNmOjU0OmNm
+        OjA0OjM0OmFiOjRlOmNjOjg2OjBiOjYzOjQxOjIwOmU1OlxuICAgICAgICAg
+        MDg6MTU6OTU6MTQ6MTk6MDY6ZDg6M2E6YWY6ZDc6ZjU6ZDU6ZTU6NTE6OTk6
+        ZWI6ZjM6OWY6XG4gICAgICAgICBmYjpiMDpjOTpkMTozYjozNTphYzozODpm
+        ZDoxYzoxMzo2NDo3MzozMjo1MTpjMTpiMjo2MzpcbiAgICAgICAgIDUzOjQ5
+        OjEwOmViOjllOjI5OjZmOjJjOmVlOjRhOjE3OjIwOmU2OjEzOmJhOjA0OjFm
+        OmQyOlxuICAgICAgICAgMDU6NTY6YWQ6ZDU6MjE6NWI6Zjc6MzM6ZDU6YTU6
+        NDk6MTM6OGY6ZGU6NmQ6ZDA6MjY6ZjQ6XG4gICAgICAgICBkZTo4MzphYToy
+        MTpjMDozNDpiNDpiZDowZTo2NDpkYTplZDo1ZjoyMDo1YjphZTpjODo3Yzpc
+        biAgICAgICAgIDllOjE2OjQ0OmVhOmMyOmRkOmNlOmEwOjljOmExOjQzOjc1
+        OmZiOjM1OmRjOmNmOjkzOjg4OlxuICAgICAgICAgZmQ6NGE6MzA6MGM6NjU6
+        NGI6ZDA6M2Y6M2U6YjY6NzA6YmU6MDc6YzQ6ZTI6YzM6NzM6NGI6XG4gICAg
+        ICAgICBjMTplYzo4Njo0NDo1ZDo4NTo0OToyOVxuLS0tLS1CRUdJTiBDRVJU
+        SUZJQ0FURS0tLS0tXG5NSUlIS0RDQ0JSQ2dBd0lCQWdJSkFJZVcxcjdWOCtt
+        ak1BMEdDU3FHU0liM0RRRUJDd1VBTUlHV01Rc3dDUVlEXG5WUVFHRXdKVlV6
+        RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFj
+        TUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0Jn
+        TlZCQXNNQzFOdmJXVlBjbWRWYm1sME1UUXdNZ1lEXG5WUVFEREN0alpXNTBi
+        M00zTFd0aGRHVnNiRzh0WkdWMlpXd3RNaTVqWVc1dWIyeHZMbVY0WVcxd2JH
+        VXVZMjl0XG5NQjRYRFRJd01EY3hOVEV6TlRJd05Wb1hEVE00TURFeE9ERXpO
+        VEl3TlZvd2daWXhDekFKQmdOVkJBWVRBbFZUXG5NUmN3RlFZRFZRUUlEQTVP
+        YjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ3d0hVbUZzWldsbmFERVFN
+        QTRHXG5BMVVFQ2d3SFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3d3TFUyOXRaVTl5
+        WjFWdWFYUXhOREF5QmdOVkJBTU1LMk5sXG5iblJ2Y3pjdGEyRjBaV3hzYnkx
+        a1pYWmxiQzB5TG1OaGJtNXZiRzh1WlhoaGJYQnNaUzVqYjIwd2dnSWlNQTBH
+        XG5DU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRFZYcTRpVTRv
+        OVVnelRCWnF1ekNoSDl1UEI5VzJJXG5PNjdCUFBINEJTTGRnNkUrU1o1VUN5
+        Nm0wckxoY2J6RjFLOXBpRFpuaTBveDQzc05UeW5xRm8ySVk0QXlwQXo4XG55
+        VmVuUHlUNDA1MnZZeGpZRkVrODUwS3Nvb0hDVGlDZ1d6c3kreTZxNUdENmJp
+        U3NZaHhRNUZ3WFkzMzU2Wkt0XG53S2dHRms2SEt6TTJnYklrbEpqMzBhbFJ6
+        LzBTblFoVSsyUTN2eWRZNXorSTh2OFVka2VYQW9tTFdZL1Z0ZjBNXG42K3Z5
+        YzBuZk41dWRPT1V0b1lmQ0VsS0ZWZHF4S2laRkpSRzR6ODFuZ05OT2pXSkJy
+        ZVB6eTRlZnErd0Q1cUZjXG5VNUJZL2VOby82M0ZHZDA5cUdzM1habXk2U05x
+        Ym14NUVGcXEzc21rbWM5YnFkcldYbTFyZGFNK2k0b2x3azJEXG5hcGNVZWdI
+        Y3pqaEtiTXJWRkdUZTBpejdEblkrRTBoWWNocFpsQnVhKy85VHlUbGI4di85
+        TWlQSisva3FWcGxMXG5JMVVtWjZGbHdoU0VTYngvTGF3dmFpWEQ1dFVHU2Jn
+        bFFUc0lnTldLVG9Ra2V3L2tkZEUrMFdRQ3ZoZFY1SklPXG4zVlZjbEZkdzVO
+        Y0NFa0U1dm0xT1NQQ0hjS1AzVlM2ZStjaFJZN20wVHVCUkxoVTFWblpJMU1P
+        TDEvdXBabWVmXG5ENzlZeEpuWXo5eTRjRkhtNFVyYWF0TTFUWjJuV2dnTS9B
+        cnZiSkNQWDBqK25DcGloR3N0T2tTN20wdmRDTUloXG5JR2V0dVdMSFBiQ21X
+        b1BDYTNRNGx6MWR1YUlQaHBST3ZpalpGeWJZMVIzQjFLUjNuUks0QTVhandt
+        M1JlelZCXG5CdS9KcTZneEkzeUd4UUlEQVFBQm80SUJkVENDQVhFd0RBWURW
+        UjBUQkFVd0F3RUIvekFMQmdOVkhROEVCQU1DXG5BYVl3SFFZRFZSMGxCQll3
+        RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01CRUdDV0NHU0FHRytFSUJB
+        UVFFXG5Bd0lDUkRBMUJnbGdoa2dCaHZoQ0FRMEVLQlltUzJGMFpXeHNieUJU
+        VTB3Z1ZHOXZiQ0JIWlc1bGNtRjBaV1FnXG5RMlZ5ZEdsbWFXTmhkR1V3SFFZ
+        RFZSME9CQllFRklEUGdQZytrUkVYSk02YWZJOW9NOXlqTVNQSE1JSExCZ05W
+        XG5IU01FZ2NNd2djQ0FGSURQZ1BnK2tSRVhKTTZhZkk5b005eWpNU1BIb1lH
+        Y3BJR1pNSUdXTVFzd0NRWURWUVFHXG5Fd0pWVXpFWE1CVUdBMVVFQ0F3T1Rt
+        OXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4XG5F
+        REFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNt
+        ZFZibWwwTVRRd01nWURWUVFEXG5EQ3RqWlc1MGIzTTNMV3RoZEdWc2JHOHRa
+        R1YyWld3dE1pNWpZVzV1YjJ4dkxtVjRZVzF3YkdVdVkyOXRnZ2tBXG5oNWJX
+        dnRYejZhTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBQkpySWtjb0ZSdmJG
+        T3RPSWFyOGdiK3pMcGFUXG5ucHB5cXlBZnkvNExtd3dudU9WYmFmTlVna3pQ
+        cmQ4WmVtMFVQN1N6TXR0Q0crRUJjNGZONVQ2aTNCWmZERkR0XG4zQ0k2NnEw
+        bzNIR2JlOWJVNC84RzlwdVBNL1V4TWlFOHA3TnhUZlNsS3JPYVVPa2hHMmtr
+        MGxibTBTRjArZVlQXG5lQ1dua20xS0JpK29YcXllelRDZWVtYmxpbnhBcjIx
+        Mk1zSUNhaXJKUVNlQUcvQ2JxUTdaSHQvZFlzMGZ0MHB2XG52MjNxTjJNL1Vu
+        WU5CUlJ1N0xwZEQycDhKSkh2VlVDQXI4UjVDQ294SSt1YkdRemZNR3VvaFhh
+        ZXFDeTV1T1F5XG4rL1hXQUpQSno1OW05RVJ4SFFwQSs3K1ViOUVOS3gwODlz
+        aDd6T3ByczhrTnkrRFJ0N24vSVFrRXNLUkUrSWFxXG42aEErV0xRaDVQb2V1
+        SSsyK1A0QVVlemdIQTB4R3NlYzcvSmwzRU0zK3B5SFBSSVR1TisrQWphUXZJ
+        L21YN2s5XG5VL1JyNmR4QjF5SFhXdkFkNWVSbTV4ZXEyc2tseE5zWXVGK1d0
+        L0g0V3M0ZmRoZ1E0ME9XWkhULzhpc2ZnTU5hXG5oUzhaSjc5Zm9EdlBWTThF
+        Tkt0T3pJWUxZMEVnNVFnVmxSUVpCdGc2cjlmMTFlVlJtZXZ6bi91d3lkRTdO
+        YXc0XG4vUndUWkhNeVVjR3lZMU5KRU91ZUtXOHM3a29YSU9ZVHVnUWYwZ1ZX
+        cmRVaFcvY3oxYVZKRTQvZWJkQW05TjZEXG5xaUhBTkxTOURtVGE3VjhnVzY3
+        SWZKNFdST3JDM2M2Z25LRkRkZnMxM00rVGlQMUtNQXhsUzlBL1ByWnd2Z2ZF
+        XG40c056UzhIc2hrUmRoVWtwXG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        In1dfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '250'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9mYTIzMWJhYS02ZjcyLTQxOWYtYjdlMC0zY2QwZGZlZDQxODYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0xOVQxOTozMTowOC42NTUyNzha
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9mYTIzMWJhYS02ZjcyLTQxOWYtYjdlMC0zY2QwZGZlZDQxODYv
+        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYTIzMWJhYS02ZjcyLTQxOWYtYjdl
+        MC0zY2QwZGZlZDQxODYvdmVyc2lvbnMvMS8iLCJuYW1lIjoiMl9kdXBsaWNh
+        dGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwibWV0YWRhdGFfc2lnbmluZ19zZXJ2
+        aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MH1dfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:28 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/fa231baa-6f72-419f-b7e0-3cd0dfed4186/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMGMyMGIzLThjZTQtNGMx
+        NS05ODkzLWFhNDIyNjQ2NmI4Ni8ifQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vZDRiZTQ1NTAtZWI4Yi00Yzk1LWI1Y2YtYmQ5Y2RhNGQ2NGM2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMTlUMTk6MzE6MDguODQ1ODYzWiIsIm5h
+        bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHBzOi8vamxzaGVycmlsbC5m
+        ZWRvcmFwZW9wbGUub3JnL2Zha2UtcmVwb3MvbmVlZGVkLWVycmF0YS8iLCJj
+        YV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6
+        bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        dXNlcm5hbWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjAtMDgtMTlUMTk6MzE6MDguODQ1ODk1WiIsImRvd25sb2Fk
+        X2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIiwic2xlc19h
+        dXRoX3Rva2VuIjpudWxsfV19
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:28 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/d4be4550-eb8b-4c95-b5cf-bd9cda4d64c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwYjY3OWVmLWMxMGYtNDI5
+        MC05Mzk1LTlkZmIxOTI2NjJmMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/de0c20b3-8ce4-4c15-9893-aa4226466b86/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUwYzIwYjMtOGNl
+        NC00YzE1LTk4OTMtYWE0MjI2NDY2Yjg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDgtMTlUMTk6MzI6MjguOTI1NDU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMTlUMTk6MzI6MjkuMDQzNDQ2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0xOVQxOTozMjoyOS4xMTIxNzFa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzI0ZGQ4ZWFkLWNlZDUtNDBkMC1iOGQ0LTI4MTg3YzI3MjMwYy8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYTIzMWJhYS02ZjcyLTQxOWYtYjdl
+        MC0zY2QwZGZlZDQxODYvIl19
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/a0b679ef-c10f-4290-9395-9dfb192662f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTBiNjc5ZWYtYzEw
+        Zi00MjkwLTkzOTUtOWRmYjE5MjY2MmYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDgtMTlUMTk6MzI6MjkuMDEzMjQxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMTlUMTk6MzI6MjkuMTE3MTM4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0xOVQxOTozMjoyOS4xNDk3ODRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzNkYzRhMGZkLTZhNjQtNGRjMS04NWY3LTA1OWUzZDc1Y2MyYS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL3JwbS9ycG0vZDRiZTQ1NTAtZWI4Yi00Yzk1LWI1Y2YtYmQ5
+        Y2RhNGQ2NGM2LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '4599'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtL2ZjNzdlNTZmLTAyMzctNDVmNC04NzEzLWYxNmMx
+        OWI0MDk5OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTEzVDE3OjI1OjM1
+        LjUxNDM4N1oiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIDg3Ojk2OmQ2OmJlOmQ1OmYzOmU5OmEz
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tXG4g
+        ICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBKdWwg
+        MTUgMTM6NTI6MDUgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6
+        IEphbiAxOCAxMzo1MjowNSAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBD
+        PVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8s
+        IE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5j
+        YW5ub2xvLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVibGljIEtl
+        eSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0aG06IHJz
+        YUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5OiAoNDA5
+        NiBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAgICAgICAg
+        ICAgICAgICAgMDA6ZDU6NWU6YWU6MjI6NTM6OGE6M2Q6NTI6MGM6ZDM6MDU6
+        OWE6YWU6Y2M6XG4gICAgICAgICAgICAgICAgICAgIDI4OjQ3OmY2OmUzOmMx
+        OmY1OjZkOjg4OjNiOmFlOmMxOjNjOmYxOmY4OjA1OlxuICAgICAgICAgICAg
+        ICAgICAgICAyMjpkZDo4MzphMTozZTo0OTo5ZTo1NDowYjoyZTphNjpkMjpi
+        MjplMTo3MTpcbiAgICAgICAgICAgICAgICAgICAgYmM6YzU6ZDQ6YWY6Njk6
+        ODg6MzY6Njc6OGI6NGE6MzE6ZTM6N2I6MGQ6NGY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDI5OmVhOjE2OjhkOjg4OjYzOjgwOjMyOmE0OjBjOmZjOmM5OjU3
+        OmE3OjNmOlxuICAgICAgICAgICAgICAgICAgICAyNDpmODpkMzo5ZDphZjo2
+        MzoxODpkODoxNDo0OTozYzplNzo0MjphYzphMjpcbiAgICAgICAgICAgICAg
+        ICAgICAgODE6YzI6NGU6MjA6YTA6NWI6M2I6MzI6ZmI6MmU6YWE6ZTQ6NjA6
+        ZmE6NmU6XG4gICAgICAgICAgICAgICAgICAgIDI0OmFjOjYyOjFjOjUwOmU0
+        OjVjOjE3OjYzOjdkOmY5OmU5OjkyOmFkOmMwOlxuICAgICAgICAgICAgICAg
+        ICAgICBhODowNjoxNjo0ZTo4NzoyYjozMzozNjo4MTpiMjoyNDo5NDo5ODpm
+        NzpkMTpcbiAgICAgICAgICAgICAgICAgICAgYTk6NTE6Y2Y6ZmQ6MTI6OWQ6
+        MDg6NTQ6ZmI6NjQ6Mzc6YmY6Mjc6NTg6ZTc6XG4gICAgICAgICAgICAgICAg
+        ICAgIDNmOjg4OmYyOmZmOjE0Ojc2OjQ3Ojk3OjAyOjg5OjhiOjU5OjhmOmQ1
+        OmI1OlxuICAgICAgICAgICAgICAgICAgICBmZDowYzplYjplYjpmMjo3Mzo0
+        OTpkZjozNzo5Yjo5ZDozODplNToyZDphMTpcbiAgICAgICAgICAgICAgICAg
+        ICAgODc6YzI6MTI6NTI6ODU6NTU6ZGE6YjE6MmE6MjY6NDU6MjU6MTE6Yjg6
+        Y2Y6XG4gICAgICAgICAgICAgICAgICAgIGNkOjY3OjgwOmQzOjRlOjhkOjYy
+        OjQxOmFkOmUzOmYzOmNiOjg3OjlmOmFiOlxuICAgICAgICAgICAgICAgICAg
+        ICBlYzowMzplNjphMTo1Yzo1Mzo5MDo1ODpmZDplMzo2ODpmZjphZDpjNTox
+        OTpcbiAgICAgICAgICAgICAgICAgICAgZGQ6M2Q6YTg6NmI6Mzc6NWQ6OTk6
+        YjI6ZTk6MjM6NmE6NmU6NmM6Nzk6MTA6XG4gICAgICAgICAgICAgICAgICAg
+        IDVhOmFhOmRlOmM5OmE0Ojk5OmNmOjViOmE5OmRhOmQ2OjVlOjZkOjZiOjc1
+        OlxuICAgICAgICAgICAgICAgICAgICBhMzozZTo4Yjo4YToyNTpjMjo0ZDo4
+        Mzo2YTo5NzoxNDo3YTowMTpkYzpjZTpcbiAgICAgICAgICAgICAgICAgICAg
+        Mzg6NGE6NmM6Y2E6ZDU6MTQ6NjQ6ZGU6ZDI6MmM6ZmI6MGU6NzY6M2U6MTM6
+        XG4gICAgICAgICAgICAgICAgICAgIDQ4OjU4OjcyOjFhOjU5Ojk0OjFiOjlh
+        OmZiOmZmOjUzOmM5OjM5OjViOmYyOlxuICAgICAgICAgICAgICAgICAgICBm
+        ZjpmZDozMjoyMzpjOTpmYjpmOToyYTo1Njo5OTo0YjoyMzo1NToyNjo2Nzpc
+        biAgICAgICAgICAgICAgICAgICAgYTE6NjU6YzI6MTQ6ODQ6NDk6YmM6N2Y6
+        MmQ6YWM6MmY6NmE6MjU6YzM6ZTY6XG4gICAgICAgICAgICAgICAgICAgIGQ1
+        OjA2OjQ5OmI4OjI1OjQxOjNiOjA4OjgwOmQ1OjhhOjRlOjg0OjI0OjdiOlxu
+        ICAgICAgICAgICAgICAgICAgICAwZjplNDo3NTpkMTozZTpkMTo2NDowMjpi
+        ZToxNzo1NTplNDo5MjowZTpkZDpcbiAgICAgICAgICAgICAgICAgICAgNTU6
+        NWM6OTQ6NTc6NzA6ZTQ6ZDc6MDI6MTI6NDE6Mzk6YmU6NmQ6NGU6NDg6XG4g
+        ICAgICAgICAgICAgICAgICAgIGYwOjg3OjcwOmEzOmY3OjU1OjJlOjllOmY5
+        OmM4OjUxOjYzOmI5OmI0OjRlOlxuICAgICAgICAgICAgICAgICAgICBlMDo1
+        MToyZToxNTozNTo1Njo3Njo0ODpkNDpjMzo4YjpkNzpmYjphOTo2NjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNjc6OWY6MGY6YmY6NTg6YzQ6OTk6ZDg6Y2Y6
+        ZGM6Yjg6NzA6NTE6ZTY6ZTE6XG4gICAgICAgICAgICAgICAgICAgIDRhOmRh
+        OjZhOmQzOjM1OjRkOjlkOmE3OjVhOjA4OjBjOmZjOjBhOmVmOjZjOlxuICAg
+        ICAgICAgICAgICAgICAgICA5MDo4Zjo1Zjo0ODpmZTo5YzoyYTo2Mjo4NDo2
+        YjoyZDozYTo0NDpiYjo5YjpcbiAgICAgICAgICAgICAgICAgICAgNGI6ZGQ6
+        MDg6YzI6MjE6MjA6Njc6YWQ6Yjk6NjI6Yzc6M2Q6YjA6YTY6NWE6XG4gICAg
+        ICAgICAgICAgICAgICAgIDgzOmMyOjZiOjc0OjM4Ojk3OjNkOjVkOmI5OmEy
+        OjBmOjg2Ojk0OjRlOmJlOlxuICAgICAgICAgICAgICAgICAgICAyODpkOTox
+        NzoyNjpkODpkNToxZDpjMTpkNDphNDo3Nzo5ZDoxMjpiODowMzpcbiAgICAg
+        ICAgICAgICAgICAgICAgOTY6YTM6YzI6NmQ6ZDE6N2I6MzU6NDE6MDY6ZWY6
+        Yzk6YWI6YTg6MzE6MjM6XG4gICAgICAgICAgICAgICAgICAgIDdjOjg2OmM1
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czogXG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTogXG4gICAgICAgICAg
+        ICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhlcm1lbnQsIENl
+        cnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAgICBYNTA5djMg
+        RXh0ZW5kZWQgS2V5IFVzYWdlOiBcbiAgICAgICAgICAgICAgICBUTFMgV2Vi
+        IFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVu
+        dGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTogXG4g
+        ICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAg
+        ICBOZXRzY2FwZSBDb21tZW50OiBcbiAgICAgICAgICAgICAgICBLYXRlbGxv
+        IFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAgICAgICAg
+        WDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6IFxuICAgICAgICAgICAg
+        ICAgIDgwOkNGOjgwOkY4OjNFOjkxOjExOjE3OjI0OkNFOjlBOjdDOjhGOjY4
+        OjMzOkRDOkEzOjMxOjIzOkM3XG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOiBcbiAgICAgICAgICAgICAgICBrZXlpZDo4
+        MDpDRjo4MDpGODozRTo5MToxMToxNzoyNDpDRTo5QTo3Qzo4Rjo2ODozMzpE
+        QzpBMzozMToyMzpDN1xuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMv
+        U1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21l
+        T3JnVW5pdC9DTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4
+        YW1wbGUuY29tXG4gICAgICAgICAgICAgICAgc2VyaWFsOjg3Ojk2OkQ2OkJF
+        OkQ1OkYzOkU5OkEzXG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEy
+        NTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICAgMTI6NmI6MjI6NDc6Mjg6
+        MTU6MWI6ZGI6MTQ6ZWI6NGU6MjE6YWE6ZmM6ODE6YmY6YjM6MmU6XG4gICAg
+        ICAgICA5Njo5Mzo5ZTo5YTo3MjphYjoyMDoxZjpjYjpmZTowYjo5YjowYzoy
+        NzpiODplNTo1Yjo2OTpcbiAgICAgICAgIGYzOjU0OjgyOjRjOmNmOmFkOmRm
+        OjE5OjdhOjZkOjE0OjNmOmI0OmIzOjMyOmRiOjQyOjFiOlxuICAgICAgICAg
+        ZTE6MDE6NzM6ODc6Y2Q6ZTU6M2U6YTI6ZGM6MTY6NWY6MGM6NTA6ZWQ6ZGM6
+        MjI6M2E6ZWE6XG4gICAgICAgICBhZDoyODpkYzo3MTo5Yjo3YjpkNjpkNDpl
+        MzpmZjowNjpmNjo5Yjo4ZjozMzpmNTozMTozMjpcbiAgICAgICAgIDIxOjNj
+        OmE3OmIzOjcxOjRkOmY0OmE1OjJhOmIzOjlhOjUwOmU5OjIxOjFiOjY5OjI0
+        OmQyOlxuICAgICAgICAgNTY6ZTY6ZDE6MjE6NzQ6Zjk6ZTY6MGY6Nzg6MjU6
+        YTc6OTI6NmQ6NGE6MDY6MmY6YTg6NWU6XG4gICAgICAgICBhYzo5ZTpjZDoz
+        MDo5ZTo3YTo2NjplNTo4YTo3Yzo0MDphZjo2ZDo3NjozMjpjMjowMjo2YTpc
+        biAgICAgICAgIDJhOmM5OjQxOjI3OjgwOjFiOmYwOjliOmE5OjBlOmQ5OjFl
+        OmRmOmRkOjYyOmNkOjFmOmI3OlxuICAgICAgICAgNGE6NmY6YmY6NmQ6ZWE6
+        Mzc6NjM6M2Y6NTI6NzY6MGQ6MDU6MTQ6NmU6ZWM6YmE6NWQ6MGY6XG4gICAg
+        ICAgICA2YTo3YzoyNDo5MTplZjo1NTo0MDo4MDphZjpjNDo3OTowODoyYToz
+        MToyMzplYjo5YjoxOTpcbiAgICAgICAgIDBjOmRmOjMwOjZiOmE4Ojg1Ojc2
+        OjllOmE4OjJjOmI5OmI4OmU0OjMyOmZiOmY1OmQ2OjAwOlxuICAgICAgICAg
+        OTM6Yzk6Y2Y6OWY6NjY6ZjQ6NDQ6NzE6MWQ6MGE6NDA6ZmI6YmY6OTQ6NmY6
+        ZDE6MGQ6MmI6XG4gICAgICAgICAxZDozYzpmNjpjODo3YjpjYzplYTo2Yjpi
+        MzpjOTowZDpjYjplMDpkMTpiNzpiOTpmZjoyMTpcbiAgICAgICAgIDA5OjA0
+        OmIwOmE0OjQ0OmY4Ojg2OmFhOmVhOjEwOjNlOjU4OmI0OjIxOmU0OmZhOjFl
+        OmI4OlxuICAgICAgICAgOGY6YjY6Zjg6ZmU6MDA6NTE6ZWM6ZTA6MWM6MGQ6
+        MzE6MWE6Yzc6OWM6ZWY6ZjI6NjU6ZGM6XG4gICAgICAgICA0MzozNzpmYTo5
+        Yzo4NzozZDoxMjoxMzpiODpkZjpiZTowMjozNjo5MDpiYzo4ZjplNjo1Zjpc
+        biAgICAgICAgIGI5OjNkOjUzOmY0OjZiOmU5OmRjOjQxOmQ3OjIxOmQ3OjVh
+        OmYwOjFkOmU1OmU0OjY2OmU3OlxuICAgICAgICAgMTc6YWE6ZGE6Yzk6MjU6
+        YzQ6ZGI6MTg6Yjg6NWY6OTY6Yjc6ZjE6Zjg6NWE6Y2U6MWY6NzY6XG4gICAg
+        ICAgICAxODoxMDplMzo0Mzo5Njo2NDo3NDpmZjpmMjoyYjoxZjo4MDpjMzo1
+        YTo4NToyZjoxOToyNzpcbiAgICAgICAgIGJmOjVmOmEwOjNiOmNmOjU0OmNm
+        OjA0OjM0OmFiOjRlOmNjOjg2OjBiOjYzOjQxOjIwOmU1OlxuICAgICAgICAg
+        MDg6MTU6OTU6MTQ6MTk6MDY6ZDg6M2E6YWY6ZDc6ZjU6ZDU6ZTU6NTE6OTk6
+        ZWI6ZjM6OWY6XG4gICAgICAgICBmYjpiMDpjOTpkMTozYjozNTphYzozODpm
+        ZDoxYzoxMzo2NDo3MzozMjo1MTpjMTpiMjo2MzpcbiAgICAgICAgIDUzOjQ5
+        OjEwOmViOjllOjI5OjZmOjJjOmVlOjRhOjE3OjIwOmU2OjEzOmJhOjA0OjFm
+        OmQyOlxuICAgICAgICAgMDU6NTY6YWQ6ZDU6MjE6NWI6Zjc6MzM6ZDU6YTU6
+        NDk6MTM6OGY6ZGU6NmQ6ZDA6MjY6ZjQ6XG4gICAgICAgICBkZTo4MzphYToy
+        MTpjMDozNDpiNDpiZDowZTo2NDpkYTplZDo1ZjoyMDo1YjphZTpjODo3Yzpc
+        biAgICAgICAgIDllOjE2OjQ0OmVhOmMyOmRkOmNlOmEwOjljOmExOjQzOjc1
+        OmZiOjM1OmRjOmNmOjkzOjg4OlxuICAgICAgICAgZmQ6NGE6MzA6MGM6NjU6
+        NGI6ZDA6M2Y6M2U6YjY6NzA6YmU6MDc6YzQ6ZTI6YzM6NzM6NGI6XG4gICAg
+        ICAgICBjMTplYzo4Njo0NDo1ZDo4NTo0OToyOVxuLS0tLS1CRUdJTiBDRVJU
+        SUZJQ0FURS0tLS0tXG5NSUlIS0RDQ0JSQ2dBd0lCQWdJSkFJZVcxcjdWOCtt
+        ak1BMEdDU3FHU0liM0RRRUJDd1VBTUlHV01Rc3dDUVlEXG5WUVFHRXdKVlV6
+        RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFj
+        TUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0Jn
+        TlZCQXNNQzFOdmJXVlBjbWRWYm1sME1UUXdNZ1lEXG5WUVFEREN0alpXNTBi
+        M00zTFd0aGRHVnNiRzh0WkdWMlpXd3RNaTVqWVc1dWIyeHZMbVY0WVcxd2JH
+        VXVZMjl0XG5NQjRYRFRJd01EY3hOVEV6TlRJd05Wb1hEVE00TURFeE9ERXpO
+        VEl3TlZvd2daWXhDekFKQmdOVkJBWVRBbFZUXG5NUmN3RlFZRFZRUUlEQTVP
+        YjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ3d0hVbUZzWldsbmFERVFN
+        QTRHXG5BMVVFQ2d3SFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3d3TFUyOXRaVTl5
+        WjFWdWFYUXhOREF5QmdOVkJBTU1LMk5sXG5iblJ2Y3pjdGEyRjBaV3hzYnkx
+        a1pYWmxiQzB5TG1OaGJtNXZiRzh1WlhoaGJYQnNaUzVqYjIwd2dnSWlNQTBH
+        XG5DU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRFZYcTRpVTRv
+        OVVnelRCWnF1ekNoSDl1UEI5VzJJXG5PNjdCUFBINEJTTGRnNkUrU1o1VUN5
+        Nm0wckxoY2J6RjFLOXBpRFpuaTBveDQzc05UeW5xRm8ySVk0QXlwQXo4XG55
+        VmVuUHlUNDA1MnZZeGpZRkVrODUwS3Nvb0hDVGlDZ1d6c3kreTZxNUdENmJp
+        U3NZaHhRNUZ3WFkzMzU2Wkt0XG53S2dHRms2SEt6TTJnYklrbEpqMzBhbFJ6
+        LzBTblFoVSsyUTN2eWRZNXorSTh2OFVka2VYQW9tTFdZL1Z0ZjBNXG42K3Z5
+        YzBuZk41dWRPT1V0b1lmQ0VsS0ZWZHF4S2laRkpSRzR6ODFuZ05OT2pXSkJy
+        ZVB6eTRlZnErd0Q1cUZjXG5VNUJZL2VOby82M0ZHZDA5cUdzM1habXk2U05x
+        Ym14NUVGcXEzc21rbWM5YnFkcldYbTFyZGFNK2k0b2x3azJEXG5hcGNVZWdI
+        Y3pqaEtiTXJWRkdUZTBpejdEblkrRTBoWWNocFpsQnVhKy85VHlUbGI4di85
+        TWlQSisva3FWcGxMXG5JMVVtWjZGbHdoU0VTYngvTGF3dmFpWEQ1dFVHU2Jn
+        bFFUc0lnTldLVG9Ra2V3L2tkZEUrMFdRQ3ZoZFY1SklPXG4zVlZjbEZkdzVO
+        Y0NFa0U1dm0xT1NQQ0hjS1AzVlM2ZStjaFJZN20wVHVCUkxoVTFWblpJMU1P
+        TDEvdXBabWVmXG5ENzlZeEpuWXo5eTRjRkhtNFVyYWF0TTFUWjJuV2dnTS9B
+        cnZiSkNQWDBqK25DcGloR3N0T2tTN20wdmRDTUloXG5JR2V0dVdMSFBiQ21X
+        b1BDYTNRNGx6MWR1YUlQaHBST3ZpalpGeWJZMVIzQjFLUjNuUks0QTVhandt
+        M1JlelZCXG5CdS9KcTZneEkzeUd4UUlEQVFBQm80SUJkVENDQVhFd0RBWURW
+        UjBUQkFVd0F3RUIvekFMQmdOVkhROEVCQU1DXG5BYVl3SFFZRFZSMGxCQll3
+        RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01CRUdDV0NHU0FHRytFSUJB
+        UVFFXG5Bd0lDUkRBMUJnbGdoa2dCaHZoQ0FRMEVLQlltUzJGMFpXeHNieUJU
+        VTB3Z1ZHOXZiQ0JIWlc1bGNtRjBaV1FnXG5RMlZ5ZEdsbWFXTmhkR1V3SFFZ
+        RFZSME9CQllFRklEUGdQZytrUkVYSk02YWZJOW9NOXlqTVNQSE1JSExCZ05W
+        XG5IU01FZ2NNd2djQ0FGSURQZ1BnK2tSRVhKTTZhZkk5b005eWpNU1BIb1lH
+        Y3BJR1pNSUdXTVFzd0NRWURWUVFHXG5Fd0pWVXpFWE1CVUdBMVVFQ0F3T1Rt
+        OXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4XG5F
+        REFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNt
+        ZFZibWwwTVRRd01nWURWUVFEXG5EQ3RqWlc1MGIzTTNMV3RoZEdWc2JHOHRa
+        R1YyWld3dE1pNWpZVzV1YjJ4dkxtVjRZVzF3YkdVdVkyOXRnZ2tBXG5oNWJX
+        dnRYejZhTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBQkpySWtjb0ZSdmJG
+        T3RPSWFyOGdiK3pMcGFUXG5ucHB5cXlBZnkvNExtd3dudU9WYmFmTlVna3pQ
+        cmQ4WmVtMFVQN1N6TXR0Q0crRUJjNGZONVQ2aTNCWmZERkR0XG4zQ0k2NnEw
+        bzNIR2JlOWJVNC84RzlwdVBNL1V4TWlFOHA3TnhUZlNsS3JPYVVPa2hHMmtr
+        MGxibTBTRjArZVlQXG5lQ1dua20xS0JpK29YcXllelRDZWVtYmxpbnhBcjIx
+        Mk1zSUNhaXJKUVNlQUcvQ2JxUTdaSHQvZFlzMGZ0MHB2XG52MjNxTjJNL1Vu
+        WU5CUlJ1N0xwZEQycDhKSkh2VlVDQXI4UjVDQ294SSt1YkdRemZNR3VvaFhh
+        ZXFDeTV1T1F5XG4rL1hXQUpQSno1OW05RVJ4SFFwQSs3K1ViOUVOS3gwODlz
+        aDd6T3ByczhrTnkrRFJ0N24vSVFrRXNLUkUrSWFxXG42aEErV0xRaDVQb2V1
+        SSsyK1A0QVVlemdIQTB4R3NlYzcvSmwzRU0zK3B5SFBSSVR1TisrQWphUXZJ
+        L21YN2s5XG5VL1JyNmR4QjF5SFhXdkFkNWVSbTV4ZXEyc2tseE5zWXVGK1d0
+        L0g0V3M0ZmRoZ1E0ME9XWkhULzhpc2ZnTU5hXG5oUzhaSjc5Zm9EdlBWTThF
+        Tkt0T3pJWUxZMEVnNVFnVmxSUVpCdGc2cjlmMTFlVlJtZXZ6bi91d3lkRTdO
+        YXc0XG4vUndUWkhNeVVjR3lZMU5KRU91ZUtXOHM3a29YSU9ZVHVnUWYwZ1ZX
+        cmRVaFcvY3oxYVZKRTQvZWJkQW05TjZEXG5xaUhBTkxTOURtVGE3VjhnVzY3
+        SWZKNFdST3JDM2M2Z25LRkRkZnMxM00rVGlQMUtNQXhsUzlBL1ByWnd2Z2ZF
+        XG40c056UzhIc2hrUmRoVWtwXG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        In1dfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/9a9441da-e43e-4598-81d5-2e14f53cb5c8/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '438'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vOWE5NDQxZGEtZTQzZS00NTk4LTgxZDUtMmUxNGY1M2NiNWM4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMTlUMTk6MzI6MjkuNzY1ODM0WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vOWE5NDQxZGEtZTQzZS00NTk4LTgxZDUtMmUxNGY1M2NiNWM4L3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vOWE5NDQxZGEtZTQzZS00NTk4LTgxZDUtMmUx
+        NGY1M2NiNWM4L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6
+        bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjB9
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwOi8vbXlyZXBvLmNv
+        bSIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRf
+        a2V5IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpu
+        dWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/dbbf9cc3-9d74-4f70-8b4b-87df4ea62d71/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '417'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Ri
+        YmY5Y2MzLTlkNzQtNGY3MC04YjRiLTg3ZGY0ZWE2MmQ3MS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA4LTE5VDE5OjMyOjI5Ljg4NzgwNVoiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwOi8vbXlyZXBvLmNvbSIsImNhX2Nl
+        cnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxs
+        LCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJ1c2Vy
+        bmFtZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyMC0wOC0xOVQxOTozMjoyOS44ODc4MzVaIiwiZG93bmxvYWRfY29u
+        Y3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJzbGVzX2F1dGhf
+        dG9rZW4iOm51bGx9
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:29 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '4599'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtL2ZjNzdlNTZmLTAyMzctNDVmNC04NzEzLWYxNmMx
+        OWI0MDk5OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTEzVDE3OjI1OjM1
+        LjUxNDM4N1oiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIDg3Ojk2OmQ2OmJlOmQ1OmYzOmU5OmEz
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tXG4g
+        ICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBKdWwg
+        MTUgMTM6NTI6MDUgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6
+        IEphbiAxOCAxMzo1MjowNSAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBD
+        PVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8s
+        IE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5j
+        YW5ub2xvLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVibGljIEtl
+        eSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0aG06IHJz
+        YUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5OiAoNDA5
+        NiBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAgICAgICAg
+        ICAgICAgICAgMDA6ZDU6NWU6YWU6MjI6NTM6OGE6M2Q6NTI6MGM6ZDM6MDU6
+        OWE6YWU6Y2M6XG4gICAgICAgICAgICAgICAgICAgIDI4OjQ3OmY2OmUzOmMx
+        OmY1OjZkOjg4OjNiOmFlOmMxOjNjOmYxOmY4OjA1OlxuICAgICAgICAgICAg
+        ICAgICAgICAyMjpkZDo4MzphMTozZTo0OTo5ZTo1NDowYjoyZTphNjpkMjpi
+        MjplMTo3MTpcbiAgICAgICAgICAgICAgICAgICAgYmM6YzU6ZDQ6YWY6Njk6
+        ODg6MzY6Njc6OGI6NGE6MzE6ZTM6N2I6MGQ6NGY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDI5OmVhOjE2OjhkOjg4OjYzOjgwOjMyOmE0OjBjOmZjOmM5OjU3
+        OmE3OjNmOlxuICAgICAgICAgICAgICAgICAgICAyNDpmODpkMzo5ZDphZjo2
+        MzoxODpkODoxNDo0OTozYzplNzo0MjphYzphMjpcbiAgICAgICAgICAgICAg
+        ICAgICAgODE6YzI6NGU6MjA6YTA6NWI6M2I6MzI6ZmI6MmU6YWE6ZTQ6NjA6
+        ZmE6NmU6XG4gICAgICAgICAgICAgICAgICAgIDI0OmFjOjYyOjFjOjUwOmU0
+        OjVjOjE3OjYzOjdkOmY5OmU5OjkyOmFkOmMwOlxuICAgICAgICAgICAgICAg
+        ICAgICBhODowNjoxNjo0ZTo4NzoyYjozMzozNjo4MTpiMjoyNDo5NDo5ODpm
+        NzpkMTpcbiAgICAgICAgICAgICAgICAgICAgYTk6NTE6Y2Y6ZmQ6MTI6OWQ6
+        MDg6NTQ6ZmI6NjQ6Mzc6YmY6Mjc6NTg6ZTc6XG4gICAgICAgICAgICAgICAg
+        ICAgIDNmOjg4OmYyOmZmOjE0Ojc2OjQ3Ojk3OjAyOjg5OjhiOjU5OjhmOmQ1
+        OmI1OlxuICAgICAgICAgICAgICAgICAgICBmZDowYzplYjplYjpmMjo3Mzo0
+        OTpkZjozNzo5Yjo5ZDozODplNToyZDphMTpcbiAgICAgICAgICAgICAgICAg
+        ICAgODc6YzI6MTI6NTI6ODU6NTU6ZGE6YjE6MmE6MjY6NDU6MjU6MTE6Yjg6
+        Y2Y6XG4gICAgICAgICAgICAgICAgICAgIGNkOjY3OjgwOmQzOjRlOjhkOjYy
+        OjQxOmFkOmUzOmYzOmNiOjg3OjlmOmFiOlxuICAgICAgICAgICAgICAgICAg
+        ICBlYzowMzplNjphMTo1Yzo1Mzo5MDo1ODpmZDplMzo2ODpmZjphZDpjNTox
+        OTpcbiAgICAgICAgICAgICAgICAgICAgZGQ6M2Q6YTg6NmI6Mzc6NWQ6OTk6
+        YjI6ZTk6MjM6NmE6NmU6NmM6Nzk6MTA6XG4gICAgICAgICAgICAgICAgICAg
+        IDVhOmFhOmRlOmM5OmE0Ojk5OmNmOjViOmE5OmRhOmQ2OjVlOjZkOjZiOjc1
+        OlxuICAgICAgICAgICAgICAgICAgICBhMzozZTo4Yjo4YToyNTpjMjo0ZDo4
+        Mzo2YTo5NzoxNDo3YTowMTpkYzpjZTpcbiAgICAgICAgICAgICAgICAgICAg
+        Mzg6NGE6NmM6Y2E6ZDU6MTQ6NjQ6ZGU6ZDI6MmM6ZmI6MGU6NzY6M2U6MTM6
+        XG4gICAgICAgICAgICAgICAgICAgIDQ4OjU4OjcyOjFhOjU5Ojk0OjFiOjlh
+        OmZiOmZmOjUzOmM5OjM5OjViOmYyOlxuICAgICAgICAgICAgICAgICAgICBm
+        ZjpmZDozMjoyMzpjOTpmYjpmOToyYTo1Njo5OTo0YjoyMzo1NToyNjo2Nzpc
+        biAgICAgICAgICAgICAgICAgICAgYTE6NjU6YzI6MTQ6ODQ6NDk6YmM6N2Y6
+        MmQ6YWM6MmY6NmE6MjU6YzM6ZTY6XG4gICAgICAgICAgICAgICAgICAgIGQ1
+        OjA2OjQ5OmI4OjI1OjQxOjNiOjA4OjgwOmQ1OjhhOjRlOjg0OjI0OjdiOlxu
+        ICAgICAgICAgICAgICAgICAgICAwZjplNDo3NTpkMTozZTpkMTo2NDowMjpi
+        ZToxNzo1NTplNDo5MjowZTpkZDpcbiAgICAgICAgICAgICAgICAgICAgNTU6
+        NWM6OTQ6NTc6NzA6ZTQ6ZDc6MDI6MTI6NDE6Mzk6YmU6NmQ6NGU6NDg6XG4g
+        ICAgICAgICAgICAgICAgICAgIGYwOjg3OjcwOmEzOmY3OjU1OjJlOjllOmY5
+        OmM4OjUxOjYzOmI5OmI0OjRlOlxuICAgICAgICAgICAgICAgICAgICBlMDo1
+        MToyZToxNTozNTo1Njo3Njo0ODpkNDpjMzo4YjpkNzpmYjphOTo2NjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNjc6OWY6MGY6YmY6NTg6YzQ6OTk6ZDg6Y2Y6
+        ZGM6Yjg6NzA6NTE6ZTY6ZTE6XG4gICAgICAgICAgICAgICAgICAgIDRhOmRh
+        OjZhOmQzOjM1OjRkOjlkOmE3OjVhOjA4OjBjOmZjOjBhOmVmOjZjOlxuICAg
+        ICAgICAgICAgICAgICAgICA5MDo4Zjo1Zjo0ODpmZTo5YzoyYTo2Mjo4NDo2
+        YjoyZDozYTo0NDpiYjo5YjpcbiAgICAgICAgICAgICAgICAgICAgNGI6ZGQ6
+        MDg6YzI6MjE6MjA6Njc6YWQ6Yjk6NjI6Yzc6M2Q6YjA6YTY6NWE6XG4gICAg
+        ICAgICAgICAgICAgICAgIDgzOmMyOjZiOjc0OjM4Ojk3OjNkOjVkOmI5OmEy
+        OjBmOjg2Ojk0OjRlOmJlOlxuICAgICAgICAgICAgICAgICAgICAyODpkOTox
+        NzoyNjpkODpkNToxZDpjMTpkNDphNDo3Nzo5ZDoxMjpiODowMzpcbiAgICAg
+        ICAgICAgICAgICAgICAgOTY6YTM6YzI6NmQ6ZDE6N2I6MzU6NDE6MDY6ZWY6
+        Yzk6YWI6YTg6MzE6MjM6XG4gICAgICAgICAgICAgICAgICAgIDdjOjg2OmM1
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czogXG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTogXG4gICAgICAgICAg
+        ICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhlcm1lbnQsIENl
+        cnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAgICBYNTA5djMg
+        RXh0ZW5kZWQgS2V5IFVzYWdlOiBcbiAgICAgICAgICAgICAgICBUTFMgV2Vi
+        IFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVu
+        dGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTogXG4g
+        ICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAg
+        ICBOZXRzY2FwZSBDb21tZW50OiBcbiAgICAgICAgICAgICAgICBLYXRlbGxv
+        IFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAgICAgICAg
+        WDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6IFxuICAgICAgICAgICAg
+        ICAgIDgwOkNGOjgwOkY4OjNFOjkxOjExOjE3OjI0OkNFOjlBOjdDOjhGOjY4
+        OjMzOkRDOkEzOjMxOjIzOkM3XG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOiBcbiAgICAgICAgICAgICAgICBrZXlpZDo4
+        MDpDRjo4MDpGODozRTo5MToxMToxNzoyNDpDRTo5QTo3Qzo4Rjo2ODozMzpE
+        QzpBMzozMToyMzpDN1xuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMv
+        U1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21l
+        T3JnVW5pdC9DTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4
+        YW1wbGUuY29tXG4gICAgICAgICAgICAgICAgc2VyaWFsOjg3Ojk2OkQ2OkJF
+        OkQ1OkYzOkU5OkEzXG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEy
+        NTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICAgMTI6NmI6MjI6NDc6Mjg6
+        MTU6MWI6ZGI6MTQ6ZWI6NGU6MjE6YWE6ZmM6ODE6YmY6YjM6MmU6XG4gICAg
+        ICAgICA5Njo5Mzo5ZTo5YTo3MjphYjoyMDoxZjpjYjpmZTowYjo5YjowYzoy
+        NzpiODplNTo1Yjo2OTpcbiAgICAgICAgIGYzOjU0OjgyOjRjOmNmOmFkOmRm
+        OjE5OjdhOjZkOjE0OjNmOmI0OmIzOjMyOmRiOjQyOjFiOlxuICAgICAgICAg
+        ZTE6MDE6NzM6ODc6Y2Q6ZTU6M2U6YTI6ZGM6MTY6NWY6MGM6NTA6ZWQ6ZGM6
+        MjI6M2E6ZWE6XG4gICAgICAgICBhZDoyODpkYzo3MTo5Yjo3YjpkNjpkNDpl
+        MzpmZjowNjpmNjo5Yjo4ZjozMzpmNTozMTozMjpcbiAgICAgICAgIDIxOjNj
+        OmE3OmIzOjcxOjRkOmY0OmE1OjJhOmIzOjlhOjUwOmU5OjIxOjFiOjY5OjI0
+        OmQyOlxuICAgICAgICAgNTY6ZTY6ZDE6MjE6NzQ6Zjk6ZTY6MGY6Nzg6MjU6
+        YTc6OTI6NmQ6NGE6MDY6MmY6YTg6NWU6XG4gICAgICAgICBhYzo5ZTpjZDoz
+        MDo5ZTo3YTo2NjplNTo4YTo3Yzo0MDphZjo2ZDo3NjozMjpjMjowMjo2YTpc
+        biAgICAgICAgIDJhOmM5OjQxOjI3OjgwOjFiOmYwOjliOmE5OjBlOmQ5OjFl
+        OmRmOmRkOjYyOmNkOjFmOmI3OlxuICAgICAgICAgNGE6NmY6YmY6NmQ6ZWE6
+        Mzc6NjM6M2Y6NTI6NzY6MGQ6MDU6MTQ6NmU6ZWM6YmE6NWQ6MGY6XG4gICAg
+        ICAgICA2YTo3YzoyNDo5MTplZjo1NTo0MDo4MDphZjpjNDo3OTowODoyYToz
+        MToyMzplYjo5YjoxOTpcbiAgICAgICAgIDBjOmRmOjMwOjZiOmE4Ojg1Ojc2
+        OjllOmE4OjJjOmI5OmI4OmU0OjMyOmZiOmY1OmQ2OjAwOlxuICAgICAgICAg
+        OTM6Yzk6Y2Y6OWY6NjY6ZjQ6NDQ6NzE6MWQ6MGE6NDA6ZmI6YmY6OTQ6NmY6
+        ZDE6MGQ6MmI6XG4gICAgICAgICAxZDozYzpmNjpjODo3YjpjYzplYTo2Yjpi
+        MzpjOTowZDpjYjplMDpkMTpiNzpiOTpmZjoyMTpcbiAgICAgICAgIDA5OjA0
+        OmIwOmE0OjQ0OmY4Ojg2OmFhOmVhOjEwOjNlOjU4OmI0OjIxOmU0OmZhOjFl
+        OmI4OlxuICAgICAgICAgOGY6YjY6Zjg6ZmU6MDA6NTE6ZWM6ZTA6MWM6MGQ6
+        MzE6MWE6Yzc6OWM6ZWY6ZjI6NjU6ZGM6XG4gICAgICAgICA0MzozNzpmYTo5
+        Yzo4NzozZDoxMjoxMzpiODpkZjpiZTowMjozNjo5MDpiYzo4ZjplNjo1Zjpc
+        biAgICAgICAgIGI5OjNkOjUzOmY0OjZiOmU5OmRjOjQxOmQ3OjIxOmQ3OjVh
+        OmYwOjFkOmU1OmU0OjY2OmU3OlxuICAgICAgICAgMTc6YWE6ZGE6Yzk6MjU6
+        YzQ6ZGI6MTg6Yjg6NWY6OTY6Yjc6ZjE6Zjg6NWE6Y2U6MWY6NzY6XG4gICAg
+        ICAgICAxODoxMDplMzo0Mzo5Njo2NDo3NDpmZjpmMjoyYjoxZjo4MDpjMzo1
+        YTo4NToyZjoxOToyNzpcbiAgICAgICAgIGJmOjVmOmEwOjNiOmNmOjU0OmNm
+        OjA0OjM0OmFiOjRlOmNjOjg2OjBiOjYzOjQxOjIwOmU1OlxuICAgICAgICAg
+        MDg6MTU6OTU6MTQ6MTk6MDY6ZDg6M2E6YWY6ZDc6ZjU6ZDU6ZTU6NTE6OTk6
+        ZWI6ZjM6OWY6XG4gICAgICAgICBmYjpiMDpjOTpkMTozYjozNTphYzozODpm
+        ZDoxYzoxMzo2NDo3MzozMjo1MTpjMTpiMjo2MzpcbiAgICAgICAgIDUzOjQ5
+        OjEwOmViOjllOjI5OjZmOjJjOmVlOjRhOjE3OjIwOmU2OjEzOmJhOjA0OjFm
+        OmQyOlxuICAgICAgICAgMDU6NTY6YWQ6ZDU6MjE6NWI6Zjc6MzM6ZDU6YTU6
+        NDk6MTM6OGY6ZGU6NmQ6ZDA6MjY6ZjQ6XG4gICAgICAgICBkZTo4MzphYToy
+        MTpjMDozNDpiNDpiZDowZTo2NDpkYTplZDo1ZjoyMDo1YjphZTpjODo3Yzpc
+        biAgICAgICAgIDllOjE2OjQ0OmVhOmMyOmRkOmNlOmEwOjljOmExOjQzOjc1
+        OmZiOjM1OmRjOmNmOjkzOjg4OlxuICAgICAgICAgZmQ6NGE6MzA6MGM6NjU6
+        NGI6ZDA6M2Y6M2U6YjY6NzA6YmU6MDc6YzQ6ZTI6YzM6NzM6NGI6XG4gICAg
+        ICAgICBjMTplYzo4Njo0NDo1ZDo4NTo0OToyOVxuLS0tLS1CRUdJTiBDRVJU
+        SUZJQ0FURS0tLS0tXG5NSUlIS0RDQ0JSQ2dBd0lCQWdJSkFJZVcxcjdWOCtt
+        ak1BMEdDU3FHU0liM0RRRUJDd1VBTUlHV01Rc3dDUVlEXG5WUVFHRXdKVlV6
+        RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFj
+        TUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0Jn
+        TlZCQXNNQzFOdmJXVlBjbWRWYm1sME1UUXdNZ1lEXG5WUVFEREN0alpXNTBi
+        M00zTFd0aGRHVnNiRzh0WkdWMlpXd3RNaTVqWVc1dWIyeHZMbVY0WVcxd2JH
+        VXVZMjl0XG5NQjRYRFRJd01EY3hOVEV6TlRJd05Wb1hEVE00TURFeE9ERXpO
+        VEl3TlZvd2daWXhDekFKQmdOVkJBWVRBbFZUXG5NUmN3RlFZRFZRUUlEQTVP
+        YjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ3d0hVbUZzWldsbmFERVFN
+        QTRHXG5BMVVFQ2d3SFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3d3TFUyOXRaVTl5
+        WjFWdWFYUXhOREF5QmdOVkJBTU1LMk5sXG5iblJ2Y3pjdGEyRjBaV3hzYnkx
+        a1pYWmxiQzB5TG1OaGJtNXZiRzh1WlhoaGJYQnNaUzVqYjIwd2dnSWlNQTBH
+        XG5DU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRFZYcTRpVTRv
+        OVVnelRCWnF1ekNoSDl1UEI5VzJJXG5PNjdCUFBINEJTTGRnNkUrU1o1VUN5
+        Nm0wckxoY2J6RjFLOXBpRFpuaTBveDQzc05UeW5xRm8ySVk0QXlwQXo4XG55
+        VmVuUHlUNDA1MnZZeGpZRkVrODUwS3Nvb0hDVGlDZ1d6c3kreTZxNUdENmJp
+        U3NZaHhRNUZ3WFkzMzU2Wkt0XG53S2dHRms2SEt6TTJnYklrbEpqMzBhbFJ6
+        LzBTblFoVSsyUTN2eWRZNXorSTh2OFVka2VYQW9tTFdZL1Z0ZjBNXG42K3Z5
+        YzBuZk41dWRPT1V0b1lmQ0VsS0ZWZHF4S2laRkpSRzR6ODFuZ05OT2pXSkJy
+        ZVB6eTRlZnErd0Q1cUZjXG5VNUJZL2VOby82M0ZHZDA5cUdzM1habXk2U05x
+        Ym14NUVGcXEzc21rbWM5YnFkcldYbTFyZGFNK2k0b2x3azJEXG5hcGNVZWdI
+        Y3pqaEtiTXJWRkdUZTBpejdEblkrRTBoWWNocFpsQnVhKy85VHlUbGI4di85
+        TWlQSisva3FWcGxMXG5JMVVtWjZGbHdoU0VTYngvTGF3dmFpWEQ1dFVHU2Jn
+        bFFUc0lnTldLVG9Ra2V3L2tkZEUrMFdRQ3ZoZFY1SklPXG4zVlZjbEZkdzVO
+        Y0NFa0U1dm0xT1NQQ0hjS1AzVlM2ZStjaFJZN20wVHVCUkxoVTFWblpJMU1P
+        TDEvdXBabWVmXG5ENzlZeEpuWXo5eTRjRkhtNFVyYWF0TTFUWjJuV2dnTS9B
+        cnZiSkNQWDBqK25DcGloR3N0T2tTN20wdmRDTUloXG5JR2V0dVdMSFBiQ21X
+        b1BDYTNRNGx6MWR1YUlQaHBST3ZpalpGeWJZMVIzQjFLUjNuUks0QTVhandt
+        M1JlelZCXG5CdS9KcTZneEkzeUd4UUlEQVFBQm80SUJkVENDQVhFd0RBWURW
+        UjBUQkFVd0F3RUIvekFMQmdOVkhROEVCQU1DXG5BYVl3SFFZRFZSMGxCQll3
+        RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01CRUdDV0NHU0FHRytFSUJB
+        UVFFXG5Bd0lDUkRBMUJnbGdoa2dCaHZoQ0FRMEVLQlltUzJGMFpXeHNieUJU
+        VTB3Z1ZHOXZiQ0JIWlc1bGNtRjBaV1FnXG5RMlZ5ZEdsbWFXTmhkR1V3SFFZ
+        RFZSME9CQllFRklEUGdQZytrUkVYSk02YWZJOW9NOXlqTVNQSE1JSExCZ05W
+        XG5IU01FZ2NNd2djQ0FGSURQZ1BnK2tSRVhKTTZhZkk5b005eWpNU1BIb1lH
+        Y3BJR1pNSUdXTVFzd0NRWURWUVFHXG5Fd0pWVXpFWE1CVUdBMVVFQ0F3T1Rt
+        OXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4XG5F
+        REFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNt
+        ZFZibWwwTVRRd01nWURWUVFEXG5EQ3RqWlc1MGIzTTNMV3RoZEdWc2JHOHRa
+        R1YyWld3dE1pNWpZVzV1YjJ4dkxtVjRZVzF3YkdVdVkyOXRnZ2tBXG5oNWJX
+        dnRYejZhTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBQkpySWtjb0ZSdmJG
+        T3RPSWFyOGdiK3pMcGFUXG5ucHB5cXlBZnkvNExtd3dudU9WYmFmTlVna3pQ
+        cmQ4WmVtMFVQN1N6TXR0Q0crRUJjNGZONVQ2aTNCWmZERkR0XG4zQ0k2NnEw
+        bzNIR2JlOWJVNC84RzlwdVBNL1V4TWlFOHA3TnhUZlNsS3JPYVVPa2hHMmtr
+        MGxibTBTRjArZVlQXG5lQ1dua20xS0JpK29YcXllelRDZWVtYmxpbnhBcjIx
+        Mk1zSUNhaXJKUVNlQUcvQ2JxUTdaSHQvZFlzMGZ0MHB2XG52MjNxTjJNL1Vu
+        WU5CUlJ1N0xwZEQycDhKSkh2VlVDQXI4UjVDQ294SSt1YkdRemZNR3VvaFhh
+        ZXFDeTV1T1F5XG4rL1hXQUpQSno1OW05RVJ4SFFwQSs3K1ViOUVOS3gwODlz
+        aDd6T3ByczhrTnkrRFJ0N24vSVFrRXNLUkUrSWFxXG42aEErV0xRaDVQb2V1
+        SSsyK1A0QVVlemdIQTB4R3NlYzcvSmwzRU0zK3B5SFBSSVR1TisrQWphUXZJ
+        L21YN2s5XG5VL1JyNmR4QjF5SFhXdkFkNWVSbTV4ZXEyc2tseE5zWXVGK1d0
+        L0g0V3M0ZmRoZ1E0ME9XWkhULzhpc2ZnTU5hXG5oUzhaSjc5Zm9EdlBWTThF
+        Tkt0T3pJWUxZMEVnNVFnVmxSUVpCdGc2cjlmMTFlVlJtZXZ6bi91d3lkRTdO
+        YXc0XG4vUndUWkhNeVVjR3lZMU5KRU91ZUtXOHM3a29YSU9ZVHVnUWYwZ1ZX
+        cmRVaFcvY3oxYVZKRTQvZWJkQW05TjZEXG5xaUhBTkxTOURtVGE3VjhnVzY3
+        SWZKNFdST3JDM2M2Z25LRkRkZnMxM00rVGlQMUtNQXhsUzlBL1ByWnd2Z2ZF
+        XG40c056UzhIc2hrUmRoVWtwXG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        In1dfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '243'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kYTllNDA0Yi03ZmM2LTRhNDAtOWRjNS0zZmM0YmJlNWE3NTEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMC0wOC0xOVQxOTozMDoxOS4zOTI2MTRa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kYTllNDA0Yi03ZmM2LTRhNDAtOWRjNS0zZmM0YmJlNWE3NTEv
+        dmVyc2lvbnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kYTllNDA0Yi03ZmM2LTRhNDAtOWRj
+        NS0zZmM0YmJlNWE3NTEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMiIsImRlc2Ny
+        aXB0aW9uIjpudWxsLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGws
+        InJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowfV19
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/da9e404b-7fc6-4a40-9dc5-3fc4bbe5a751/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmZGE0ZmM0LTVjY2MtNGUw
+        Mi1iYzk5LTE5MzM0ZDNmZDUwZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/6fda4fc4-5ccc-4e02-bc99-19334d3fd50d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZkYTRmYzQtNWNj
+        Yy00ZTAyLWJjOTktMTkzMzRkM2ZkNTBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDgtMTlUMTk6MzI6MzAuMTM5ODE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDgtMTlUMTk6MzI6MzAuMjY4MjE0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOC0xOVQxOTozMjozMC4zMDI3MjRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2E2NWVjMGEyLTIwMWQtNGQ4Yi04MDJhLWRmNTc0MmE5ZTg0NS8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kYTllNDA0Yi03ZmM2LTRhNDAtOWRj
+        NS0zZmM0YmJlNWE3NTEvIl19
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '4599'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtL2ZjNzdlNTZmLTAyMzctNDVmNC04NzEzLWYxNmMx
+        OWI0MDk5OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA4LTEzVDE3OjI1OjM1
+        LjUxNDM4N1oiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
+        dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
+        IE51bWJlcjpcbiAgICAgICAgICAgIDg3Ojk2OmQ2OmJlOmQ1OmYzOmU5OmEz
+        XG4gICAgU2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5
+        cHRpb25cbiAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGlu
+        YSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1j
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tXG4g
+        ICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBKdWwg
+        MTUgMTM6NTI6MDUgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6
+        IEphbiAxOCAxMzo1MjowNSAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBD
+        PVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8s
+        IE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5j
+        YW5ub2xvLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVibGljIEtl
+        eSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0aG06IHJz
+        YUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5OiAoNDA5
+        NiBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAgICAgICAg
+        ICAgICAgICAgMDA6ZDU6NWU6YWU6MjI6NTM6OGE6M2Q6NTI6MGM6ZDM6MDU6
+        OWE6YWU6Y2M6XG4gICAgICAgICAgICAgICAgICAgIDI4OjQ3OmY2OmUzOmMx
+        OmY1OjZkOjg4OjNiOmFlOmMxOjNjOmYxOmY4OjA1OlxuICAgICAgICAgICAg
+        ICAgICAgICAyMjpkZDo4MzphMTozZTo0OTo5ZTo1NDowYjoyZTphNjpkMjpi
+        MjplMTo3MTpcbiAgICAgICAgICAgICAgICAgICAgYmM6YzU6ZDQ6YWY6Njk6
+        ODg6MzY6Njc6OGI6NGE6MzE6ZTM6N2I6MGQ6NGY6XG4gICAgICAgICAgICAg
+        ICAgICAgIDI5OmVhOjE2OjhkOjg4OjYzOjgwOjMyOmE0OjBjOmZjOmM5OjU3
+        OmE3OjNmOlxuICAgICAgICAgICAgICAgICAgICAyNDpmODpkMzo5ZDphZjo2
+        MzoxODpkODoxNDo0OTozYzplNzo0MjphYzphMjpcbiAgICAgICAgICAgICAg
+        ICAgICAgODE6YzI6NGU6MjA6YTA6NWI6M2I6MzI6ZmI6MmU6YWE6ZTQ6NjA6
+        ZmE6NmU6XG4gICAgICAgICAgICAgICAgICAgIDI0OmFjOjYyOjFjOjUwOmU0
+        OjVjOjE3OjYzOjdkOmY5OmU5OjkyOmFkOmMwOlxuICAgICAgICAgICAgICAg
+        ICAgICBhODowNjoxNjo0ZTo4NzoyYjozMzozNjo4MTpiMjoyNDo5NDo5ODpm
+        NzpkMTpcbiAgICAgICAgICAgICAgICAgICAgYTk6NTE6Y2Y6ZmQ6MTI6OWQ6
+        MDg6NTQ6ZmI6NjQ6Mzc6YmY6Mjc6NTg6ZTc6XG4gICAgICAgICAgICAgICAg
+        ICAgIDNmOjg4OmYyOmZmOjE0Ojc2OjQ3Ojk3OjAyOjg5OjhiOjU5OjhmOmQ1
+        OmI1OlxuICAgICAgICAgICAgICAgICAgICBmZDowYzplYjplYjpmMjo3Mzo0
+        OTpkZjozNzo5Yjo5ZDozODplNToyZDphMTpcbiAgICAgICAgICAgICAgICAg
+        ICAgODc6YzI6MTI6NTI6ODU6NTU6ZGE6YjE6MmE6MjY6NDU6MjU6MTE6Yjg6
+        Y2Y6XG4gICAgICAgICAgICAgICAgICAgIGNkOjY3OjgwOmQzOjRlOjhkOjYy
+        OjQxOmFkOmUzOmYzOmNiOjg3OjlmOmFiOlxuICAgICAgICAgICAgICAgICAg
+        ICBlYzowMzplNjphMTo1Yzo1Mzo5MDo1ODpmZDplMzo2ODpmZjphZDpjNTox
+        OTpcbiAgICAgICAgICAgICAgICAgICAgZGQ6M2Q6YTg6NmI6Mzc6NWQ6OTk6
+        YjI6ZTk6MjM6NmE6NmU6NmM6Nzk6MTA6XG4gICAgICAgICAgICAgICAgICAg
+        IDVhOmFhOmRlOmM5OmE0Ojk5OmNmOjViOmE5OmRhOmQ2OjVlOjZkOjZiOjc1
+        OlxuICAgICAgICAgICAgICAgICAgICBhMzozZTo4Yjo4YToyNTpjMjo0ZDo4
+        Mzo2YTo5NzoxNDo3YTowMTpkYzpjZTpcbiAgICAgICAgICAgICAgICAgICAg
+        Mzg6NGE6NmM6Y2E6ZDU6MTQ6NjQ6ZGU6ZDI6MmM6ZmI6MGU6NzY6M2U6MTM6
+        XG4gICAgICAgICAgICAgICAgICAgIDQ4OjU4OjcyOjFhOjU5Ojk0OjFiOjlh
+        OmZiOmZmOjUzOmM5OjM5OjViOmYyOlxuICAgICAgICAgICAgICAgICAgICBm
+        ZjpmZDozMjoyMzpjOTpmYjpmOToyYTo1Njo5OTo0YjoyMzo1NToyNjo2Nzpc
+        biAgICAgICAgICAgICAgICAgICAgYTE6NjU6YzI6MTQ6ODQ6NDk6YmM6N2Y6
+        MmQ6YWM6MmY6NmE6MjU6YzM6ZTY6XG4gICAgICAgICAgICAgICAgICAgIGQ1
+        OjA2OjQ5OmI4OjI1OjQxOjNiOjA4OjgwOmQ1OjhhOjRlOjg0OjI0OjdiOlxu
+        ICAgICAgICAgICAgICAgICAgICAwZjplNDo3NTpkMTozZTpkMTo2NDowMjpi
+        ZToxNzo1NTplNDo5MjowZTpkZDpcbiAgICAgICAgICAgICAgICAgICAgNTU6
+        NWM6OTQ6NTc6NzA6ZTQ6ZDc6MDI6MTI6NDE6Mzk6YmU6NmQ6NGU6NDg6XG4g
+        ICAgICAgICAgICAgICAgICAgIGYwOjg3OjcwOmEzOmY3OjU1OjJlOjllOmY5
+        OmM4OjUxOjYzOmI5OmI0OjRlOlxuICAgICAgICAgICAgICAgICAgICBlMDo1
+        MToyZToxNTozNTo1Njo3Njo0ODpkNDpjMzo4YjpkNzpmYjphOTo2NjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNjc6OWY6MGY6YmY6NTg6YzQ6OTk6ZDg6Y2Y6
+        ZGM6Yjg6NzA6NTE6ZTY6ZTE6XG4gICAgICAgICAgICAgICAgICAgIDRhOmRh
+        OjZhOmQzOjM1OjRkOjlkOmE3OjVhOjA4OjBjOmZjOjBhOmVmOjZjOlxuICAg
+        ICAgICAgICAgICAgICAgICA5MDo4Zjo1Zjo0ODpmZTo5YzoyYTo2Mjo4NDo2
+        YjoyZDozYTo0NDpiYjo5YjpcbiAgICAgICAgICAgICAgICAgICAgNGI6ZGQ6
+        MDg6YzI6MjE6MjA6Njc6YWQ6Yjk6NjI6Yzc6M2Q6YjA6YTY6NWE6XG4gICAg
+        ICAgICAgICAgICAgICAgIDgzOmMyOjZiOjc0OjM4Ojk3OjNkOjVkOmI5OmEy
+        OjBmOjg2Ojk0OjRlOmJlOlxuICAgICAgICAgICAgICAgICAgICAyODpkOTox
+        NzoyNjpkODpkNToxZDpjMTpkNDphNDo3Nzo5ZDoxMjpiODowMzpcbiAgICAg
+        ICAgICAgICAgICAgICAgOTY6YTM6YzI6NmQ6ZDE6N2I6MzU6NDE6MDY6ZWY6
+        Yzk6YWI6YTg6MzE6MjM6XG4gICAgICAgICAgICAgICAgICAgIDdjOjg2OmM1
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czogXG4gICAgICAgICAgICAgICAgQ0E6VFJV
+        RVxuICAgICAgICAgICAgWDUwOXYzIEtleSBVc2FnZTogXG4gICAgICAgICAg
+        ICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhlcm1lbnQsIENl
+        cnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAgICBYNTA5djMg
+        RXh0ZW5kZWQgS2V5IFVzYWdlOiBcbiAgICAgICAgICAgICAgICBUTFMgV2Vi
+        IFNlcnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVu
+        dGljYXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTogXG4g
+        ICAgICAgICAgICAgICAgU1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAg
+        ICBOZXRzY2FwZSBDb21tZW50OiBcbiAgICAgICAgICAgICAgICBLYXRlbGxv
+        IFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAgICAgICAg
+        WDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6IFxuICAgICAgICAgICAg
+        ICAgIDgwOkNGOjgwOkY4OjNFOjkxOjExOjE3OjI0OkNFOjlBOjdDOjhGOjY4
+        OjMzOkRDOkEzOjMxOjIzOkM3XG4gICAgICAgICAgICBYNTA5djMgQXV0aG9y
+        aXR5IEtleSBJZGVudGlmaWVyOiBcbiAgICAgICAgICAgICAgICBrZXlpZDo4
+        MDpDRjo4MDpGODozRTo5MToxMToxNzoyNDpDRTo5QTo3Qzo4Rjo2ODozMzpE
+        QzpBMzozMToyMzpDN1xuICAgICAgICAgICAgICAgIERpck5hbWU6L0M9VVMv
+        U1Q9Tm9ydGggQ2Fyb2xpbmEvTD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21l
+        T3JnVW5pdC9DTj1jZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4
+        YW1wbGUuY29tXG4gICAgICAgICAgICAgICAgc2VyaWFsOjg3Ojk2OkQ2OkJF
+        OkQ1OkYzOkU5OkEzXG5cbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEy
+        NTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICAgMTI6NmI6MjI6NDc6Mjg6
+        MTU6MWI6ZGI6MTQ6ZWI6NGU6MjE6YWE6ZmM6ODE6YmY6YjM6MmU6XG4gICAg
+        ICAgICA5Njo5Mzo5ZTo5YTo3MjphYjoyMDoxZjpjYjpmZTowYjo5YjowYzoy
+        NzpiODplNTo1Yjo2OTpcbiAgICAgICAgIGYzOjU0OjgyOjRjOmNmOmFkOmRm
+        OjE5OjdhOjZkOjE0OjNmOmI0OmIzOjMyOmRiOjQyOjFiOlxuICAgICAgICAg
+        ZTE6MDE6NzM6ODc6Y2Q6ZTU6M2U6YTI6ZGM6MTY6NWY6MGM6NTA6ZWQ6ZGM6
+        MjI6M2E6ZWE6XG4gICAgICAgICBhZDoyODpkYzo3MTo5Yjo3YjpkNjpkNDpl
+        MzpmZjowNjpmNjo5Yjo4ZjozMzpmNTozMTozMjpcbiAgICAgICAgIDIxOjNj
+        OmE3OmIzOjcxOjRkOmY0OmE1OjJhOmIzOjlhOjUwOmU5OjIxOjFiOjY5OjI0
+        OmQyOlxuICAgICAgICAgNTY6ZTY6ZDE6MjE6NzQ6Zjk6ZTY6MGY6Nzg6MjU6
+        YTc6OTI6NmQ6NGE6MDY6MmY6YTg6NWU6XG4gICAgICAgICBhYzo5ZTpjZDoz
+        MDo5ZTo3YTo2NjplNTo4YTo3Yzo0MDphZjo2ZDo3NjozMjpjMjowMjo2YTpc
+        biAgICAgICAgIDJhOmM5OjQxOjI3OjgwOjFiOmYwOjliOmE5OjBlOmQ5OjFl
+        OmRmOmRkOjYyOmNkOjFmOmI3OlxuICAgICAgICAgNGE6NmY6YmY6NmQ6ZWE6
+        Mzc6NjM6M2Y6NTI6NzY6MGQ6MDU6MTQ6NmU6ZWM6YmE6NWQ6MGY6XG4gICAg
+        ICAgICA2YTo3YzoyNDo5MTplZjo1NTo0MDo4MDphZjpjNDo3OTowODoyYToz
+        MToyMzplYjo5YjoxOTpcbiAgICAgICAgIDBjOmRmOjMwOjZiOmE4Ojg1Ojc2
+        OjllOmE4OjJjOmI5OmI4OmU0OjMyOmZiOmY1OmQ2OjAwOlxuICAgICAgICAg
+        OTM6Yzk6Y2Y6OWY6NjY6ZjQ6NDQ6NzE6MWQ6MGE6NDA6ZmI6YmY6OTQ6NmY6
+        ZDE6MGQ6MmI6XG4gICAgICAgICAxZDozYzpmNjpjODo3YjpjYzplYTo2Yjpi
+        MzpjOTowZDpjYjplMDpkMTpiNzpiOTpmZjoyMTpcbiAgICAgICAgIDA5OjA0
+        OmIwOmE0OjQ0OmY4Ojg2OmFhOmVhOjEwOjNlOjU4OmI0OjIxOmU0OmZhOjFl
+        OmI4OlxuICAgICAgICAgOGY6YjY6Zjg6ZmU6MDA6NTE6ZWM6ZTA6MWM6MGQ6
+        MzE6MWE6Yzc6OWM6ZWY6ZjI6NjU6ZGM6XG4gICAgICAgICA0MzozNzpmYTo5
+        Yzo4NzozZDoxMjoxMzpiODpkZjpiZTowMjozNjo5MDpiYzo4ZjplNjo1Zjpc
+        biAgICAgICAgIGI5OjNkOjUzOmY0OjZiOmU5OmRjOjQxOmQ3OjIxOmQ3OjVh
+        OmYwOjFkOmU1OmU0OjY2OmU3OlxuICAgICAgICAgMTc6YWE6ZGE6Yzk6MjU6
+        YzQ6ZGI6MTg6Yjg6NWY6OTY6Yjc6ZjE6Zjg6NWE6Y2U6MWY6NzY6XG4gICAg
+        ICAgICAxODoxMDplMzo0Mzo5Njo2NDo3NDpmZjpmMjoyYjoxZjo4MDpjMzo1
+        YTo4NToyZjoxOToyNzpcbiAgICAgICAgIGJmOjVmOmEwOjNiOmNmOjU0OmNm
+        OjA0OjM0OmFiOjRlOmNjOjg2OjBiOjYzOjQxOjIwOmU1OlxuICAgICAgICAg
+        MDg6MTU6OTU6MTQ6MTk6MDY6ZDg6M2E6YWY6ZDc6ZjU6ZDU6ZTU6NTE6OTk6
+        ZWI6ZjM6OWY6XG4gICAgICAgICBmYjpiMDpjOTpkMTozYjozNTphYzozODpm
+        ZDoxYzoxMzo2NDo3MzozMjo1MTpjMTpiMjo2MzpcbiAgICAgICAgIDUzOjQ5
+        OjEwOmViOjllOjI5OjZmOjJjOmVlOjRhOjE3OjIwOmU2OjEzOmJhOjA0OjFm
+        OmQyOlxuICAgICAgICAgMDU6NTY6YWQ6ZDU6MjE6NWI6Zjc6MzM6ZDU6YTU6
+        NDk6MTM6OGY6ZGU6NmQ6ZDA6MjY6ZjQ6XG4gICAgICAgICBkZTo4MzphYToy
+        MTpjMDozNDpiNDpiZDowZTo2NDpkYTplZDo1ZjoyMDo1YjphZTpjODo3Yzpc
+        biAgICAgICAgIDllOjE2OjQ0OmVhOmMyOmRkOmNlOmEwOjljOmExOjQzOjc1
+        OmZiOjM1OmRjOmNmOjkzOjg4OlxuICAgICAgICAgZmQ6NGE6MzA6MGM6NjU6
+        NGI6ZDA6M2Y6M2U6YjY6NzA6YmU6MDc6YzQ6ZTI6YzM6NzM6NGI6XG4gICAg
+        ICAgICBjMTplYzo4Njo0NDo1ZDo4NTo0OToyOVxuLS0tLS1CRUdJTiBDRVJU
+        SUZJQ0FURS0tLS0tXG5NSUlIS0RDQ0JSQ2dBd0lCQWdJSkFJZVcxcjdWOCtt
+        ak1BMEdDU3FHU0liM0RRRUJDd1VBTUlHV01Rc3dDUVlEXG5WUVFHRXdKVlV6
+        RVhNQlVHQTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFj
+        TUIxSmhiR1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0Jn
+        TlZCQXNNQzFOdmJXVlBjbWRWYm1sME1UUXdNZ1lEXG5WUVFEREN0alpXNTBi
+        M00zTFd0aGRHVnNiRzh0WkdWMlpXd3RNaTVqWVc1dWIyeHZMbVY0WVcxd2JH
+        VXVZMjl0XG5NQjRYRFRJd01EY3hOVEV6TlRJd05Wb1hEVE00TURFeE9ERXpO
+        VEl3TlZvd2daWXhDekFKQmdOVkJBWVRBbFZUXG5NUmN3RlFZRFZRUUlEQTVP
+        YjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ3d0hVbUZzWldsbmFERVFN
+        QTRHXG5BMVVFQ2d3SFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3d3TFUyOXRaVTl5
+        WjFWdWFYUXhOREF5QmdOVkJBTU1LMk5sXG5iblJ2Y3pjdGEyRjBaV3hzYnkx
+        a1pYWmxiQzB5TG1OaGJtNXZiRzh1WlhoaGJYQnNaUzVqYjIwd2dnSWlNQTBH
+        XG5DU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRFZYcTRpVTRv
+        OVVnelRCWnF1ekNoSDl1UEI5VzJJXG5PNjdCUFBINEJTTGRnNkUrU1o1VUN5
+        Nm0wckxoY2J6RjFLOXBpRFpuaTBveDQzc05UeW5xRm8ySVk0QXlwQXo4XG55
+        VmVuUHlUNDA1MnZZeGpZRkVrODUwS3Nvb0hDVGlDZ1d6c3kreTZxNUdENmJp
+        U3NZaHhRNUZ3WFkzMzU2Wkt0XG53S2dHRms2SEt6TTJnYklrbEpqMzBhbFJ6
+        LzBTblFoVSsyUTN2eWRZNXorSTh2OFVka2VYQW9tTFdZL1Z0ZjBNXG42K3Z5
+        YzBuZk41dWRPT1V0b1lmQ0VsS0ZWZHF4S2laRkpSRzR6ODFuZ05OT2pXSkJy
+        ZVB6eTRlZnErd0Q1cUZjXG5VNUJZL2VOby82M0ZHZDA5cUdzM1habXk2U05x
+        Ym14NUVGcXEzc21rbWM5YnFkcldYbTFyZGFNK2k0b2x3azJEXG5hcGNVZWdI
+        Y3pqaEtiTXJWRkdUZTBpejdEblkrRTBoWWNocFpsQnVhKy85VHlUbGI4di85
+        TWlQSisva3FWcGxMXG5JMVVtWjZGbHdoU0VTYngvTGF3dmFpWEQ1dFVHU2Jn
+        bFFUc0lnTldLVG9Ra2V3L2tkZEUrMFdRQ3ZoZFY1SklPXG4zVlZjbEZkdzVO
+        Y0NFa0U1dm0xT1NQQ0hjS1AzVlM2ZStjaFJZN20wVHVCUkxoVTFWblpJMU1P
+        TDEvdXBabWVmXG5ENzlZeEpuWXo5eTRjRkhtNFVyYWF0TTFUWjJuV2dnTS9B
+        cnZiSkNQWDBqK25DcGloR3N0T2tTN20wdmRDTUloXG5JR2V0dVdMSFBiQ21X
+        b1BDYTNRNGx6MWR1YUlQaHBST3ZpalpGeWJZMVIzQjFLUjNuUks0QTVhandt
+        M1JlelZCXG5CdS9KcTZneEkzeUd4UUlEQVFBQm80SUJkVENDQVhFd0RBWURW
+        UjBUQkFVd0F3RUIvekFMQmdOVkhROEVCQU1DXG5BYVl3SFFZRFZSMGxCQll3
+        RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01CRUdDV0NHU0FHRytFSUJB
+        UVFFXG5Bd0lDUkRBMUJnbGdoa2dCaHZoQ0FRMEVLQlltUzJGMFpXeHNieUJU
+        VTB3Z1ZHOXZiQ0JIWlc1bGNtRjBaV1FnXG5RMlZ5ZEdsbWFXTmhkR1V3SFFZ
+        RFZSME9CQllFRklEUGdQZytrUkVYSk02YWZJOW9NOXlqTVNQSE1JSExCZ05W
+        XG5IU01FZ2NNd2djQ0FGSURQZ1BnK2tSRVhKTTZhZkk5b005eWpNU1BIb1lH
+        Y3BJR1pNSUdXTVFzd0NRWURWUVFHXG5Fd0pWVXpFWE1CVUdBMVVFQ0F3T1Rt
+        OXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4XG5F
+        REFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdOVkJBc01DMU52YldWUGNt
+        ZFZibWwwTVRRd01nWURWUVFEXG5EQ3RqWlc1MGIzTTNMV3RoZEdWc2JHOHRa
+        R1YyWld3dE1pNWpZVzV1YjJ4dkxtVjRZVzF3YkdVdVkyOXRnZ2tBXG5oNWJX
+        dnRYejZhTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnSUJBQkpySWtjb0ZSdmJG
+        T3RPSWFyOGdiK3pMcGFUXG5ucHB5cXlBZnkvNExtd3dudU9WYmFmTlVna3pQ
+        cmQ4WmVtMFVQN1N6TXR0Q0crRUJjNGZONVQ2aTNCWmZERkR0XG4zQ0k2NnEw
+        bzNIR2JlOWJVNC84RzlwdVBNL1V4TWlFOHA3TnhUZlNsS3JPYVVPa2hHMmtr
+        MGxibTBTRjArZVlQXG5lQ1dua20xS0JpK29YcXllelRDZWVtYmxpbnhBcjIx
+        Mk1zSUNhaXJKUVNlQUcvQ2JxUTdaSHQvZFlzMGZ0MHB2XG52MjNxTjJNL1Vu
+        WU5CUlJ1N0xwZEQycDhKSkh2VlVDQXI4UjVDQ294SSt1YkdRemZNR3VvaFhh
+        ZXFDeTV1T1F5XG4rL1hXQUpQSno1OW05RVJ4SFFwQSs3K1ViOUVOS3gwODlz
+        aDd6T3ByczhrTnkrRFJ0N24vSVFrRXNLUkUrSWFxXG42aEErV0xRaDVQb2V1
+        SSsyK1A0QVVlemdIQTB4R3NlYzcvSmwzRU0zK3B5SFBSSVR1TisrQWphUXZJ
+        L21YN2s5XG5VL1JyNmR4QjF5SFhXdkFkNWVSbTV4ZXEyc2tseE5zWXVGK1d0
+        L0g0V3M0ZmRoZ1E0ME9XWkhULzhpc2ZnTU5hXG5oUzhaSjc5Zm9EdlBWTThF
+        Tkt0T3pJWUxZMEVnNVFnVmxSUVpCdGc2cjlmMTFlVlJtZXZ6bi91d3lkRTdO
+        YXc0XG4vUndUWkhNeVVjR3lZMU5KRU91ZUtXOHM3a29YSU9ZVHVnUWYwZ1ZX
+        cmRVaFcvY3oxYVZKRTQvZWJkQW05TjZEXG5xaUhBTkxTOURtVGE3VjhnVzY3
+        SWZKNFdST3JDM2M2Z25LRkRkZnMxM00rVGlQMUtNQXhsUzlBL1ByWnd2Z2ZF
+        XG40c056UzhIc2hrUmRoVWtwXG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        In1dfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_dev_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMiJ9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:30 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '428'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNWIxMDhlZGMtNDU1OS00NjA1LTgyYTctMDgxZGFkYTI3OTIzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDgtMTlUMTk6MzI6MzAuOTIxNDc5WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNWIxMDhlZGMtNDU1OS00NjA1LTgyYTctMDgxZGFkYTI3OTIzL3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vNWIxMDhlZGMtNDU1OS00NjA1LTgyYTctMDgx
+        ZGFkYTI3OTIzL3ZlcnNpb25zLzAvIiwibmFtZSI6IjIiLCJkZXNjcmlwdGlv
+        biI6bnVsbCwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRh
+        aW5fcGFja2FnZV92ZXJzaW9ucyI6MH0=
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/packages/?arch__ne=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/modulemds/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/advisories/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/packagegroups/?fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/packages/?arch=src&fields=pulp_href&limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/content/rpm/distribution_trees/?repository_version=/pulp/api/v3/repositories/rpm/rpm/5b108edc-4559-4605-82a7-081dada27923/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Aug 2020 19:32:31 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 19 Aug 2020 19:32:31 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes untested erroneous code that was running if a user changes their repo's checksum type before publishing it in a content view.

To test:
1) Make sure you're using Pulp 3 for yum content
2) Create and sync a repo
3) Add that repo to a content view
4) Publish the content view
5) Change the repo's checksum type to sha1
6) Publish the content view again.  This will fail without my PR.