### PR TITLE
Fixes #30671 - Send UI Notification when Bastion table cannot load it…

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/components/notification.service.js
+++ b/engines/bastion/app/assets/javascripts/bastion/components/notification.service.js
@@ -32,6 +32,6 @@ angular.module('Bastion.components').service("Notification", ['$interpolate', 'f
     };
 
     this.setErrorMessage = function (message, context) {
-        foreman.toastNotifications.notify({message: interpolateIfNeeded(message, context), type: 'danger'});
+        foreman.toastNotifications.notify({message: interpolateIfNeeded(message, context), type: 'error'});
     };
 }]);

--- a/engines/bastion/test/components/notification.service.test.js
+++ b/engines/bastion/test/components/notification.service.test.js
@@ -21,7 +21,7 @@ describe('Factory: Nofification', function() {
     it("provides a way to set error messages", function () {
         var message = "Everything is broken!";
         Notification.setErrorMessage(message);
-        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: message, type: 'danger'});
+        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: message, type: 'error'});
     });
 
     it("provides a way to set warning messages", function () {

--- a/engines/bastion/test/components/nutupane.factory.test.js
+++ b/engines/bastion/test/components/nutupane.factory.test.js
@@ -47,6 +47,7 @@ describe('Factory: Nutupane', function() {
 
         expectedResult = [{id: 2, value: "value2"}, {id:3, value: "value3"},
             {id: 4, value: "value4"}, {id:5, value: "value5"}];
+
         Resource = {
             queryPaged: function(params, callback) {
                 var result = {
@@ -93,12 +94,13 @@ describe('Factory: Nutupane', function() {
 
         it("providing a method to fetch records for the table", function() {
             spyOn(Resource, 'queryPaged').and.callThrough();
-            nutupane.query();
 
-            expect(Resource.queryPaged).toHaveBeenCalled();
-            expect(nutupane.table.rows.length).toBe(4);
-            angular.forEach(nutupane.table.rows, function(value, index) {
-                expect(value).toBe(expectedResult[index]);
+            nutupane.query().then(function() {
+                expect(Resource.queryPaged).toHaveBeenCalled();
+                expect(nutupane.table.rows.length).toBe(4);
+                angular.forEach(nutupane.table.rows, function(value, index) {
+                    expect(value).toBe(expectedResult[index]);
+                });
             });
         });
 
@@ -109,9 +111,10 @@ describe('Factory: Nutupane', function() {
 
             it("if paged", function () {
                 nutupane.table.params.paged = true;
-                nutupane.load();
-                expect($location.search).toHaveBeenCalledWith('page', 1);
-                expect($location.search).toHaveBeenCalledWith('per_page', 20);
+                nutupane.load().then(function() {
+                    expect($location.search).toHaveBeenCalledWith('page', 1);
+                    expect($location.search).toHaveBeenCalledWith('per_page', 20);
+                });
             });
 
             it("from existing table", function () {
@@ -130,8 +133,9 @@ describe('Factory: Nutupane', function() {
 
             it("by including a search if there is one", function () {
                 nutupane.table.searchTerm = 'hello!';
-                nutupane.load();
-                expect($location.search).toHaveBeenCalledWith('search', 'hello!');
+                nutupane.load().then(function() {
+                    expect($location.search).toHaveBeenCalledWith('search', 'hello!');
+                });
             });
 
             it("by not including a search if there isn't one", function () {
@@ -142,9 +146,10 @@ describe('Factory: Nutupane', function() {
             it("by including the sort properties if provided", function () {
                 nutupane.table.params['sort_by'] = 'name';
                 nutupane.table.params['sort_order'] = 'asc';
-                nutupane.load();
-                expect($location.search).toHaveBeenCalledWith('sortBy', 'name');
-                expect($location.search).toHaveBeenCalledWith('sortOrder', 'asc');
+                nutupane.load().then(function() {;
+                    expect($location.search).toHaveBeenCalledWith('sortBy', 'name');
+                    expect($location.search).toHaveBeenCalledWith('sortOrder', 'asc');
+                });
             });
 
             it("by not including the sort properties if provided", function () {
@@ -157,10 +162,10 @@ describe('Factory: Nutupane', function() {
         it("providing a method to refresh the table", function() {
             spyOn(Resource, 'queryPaged').and.callThrough();
 
-            nutupane.refresh();
-
-            expect(Resource.queryPaged).toHaveBeenCalled();
-            expect(nutupane.table.rows).toBe(expectedResult);
+            nutupane.refresh().then(function() {;
+                expect(Resource.queryPaged).toHaveBeenCalled();
+                expect(nutupane.table.rows).toBe(expectedResult);
+            });
         });
 
         it("provides a way to invalidate the table", function () {
@@ -430,7 +435,7 @@ describe('Factory: Nutupane', function() {
                 spyOn(Resource, 'queryPaged').and.callThrough();
                 nutupane.table.sortBy({id: "name"});
 
-                expect(Resource.queryPaged).toHaveBeenCalledWith(expectedParams, jasmine.any(Function));
+                expect(Resource.queryPaged).toHaveBeenCalledWith(expectedParams);
             });
 
             it("toggles the sort order if already sorting by that column", function() {
@@ -441,7 +446,7 @@ describe('Factory: Nutupane', function() {
                 spyOn(Resource, 'queryPaged').and.callThrough();
                 nutupane.table.sortBy({id: "name"});
 
-                expect(Resource.queryPaged).toHaveBeenCalledWith(expectedParams, jasmine.any(Function));
+                expect(Resource.queryPaged).toHaveBeenCalledWith(expectedParams);
             });
 
             it("sets the column sort order and marks it as active.", function() {
@@ -511,9 +516,10 @@ describe('Factory: Nutupane', function() {
 
         describe("when there was an error loading the resource", function() {
             beforeEach(function() {
+                spyOn(Notification, 'setErrorMessage').and.callThrough();
                 spyOn(Resource, 'customAction').and.callFake(function() {
                       return {
-                        $promise: $q.reject('internal server error')
+                        $promise: $q.reject({ data: { error: { message: 'internal server error' }}})
                       };
                 });
                 nutupane.load();
@@ -526,6 +532,10 @@ describe('Factory: Nutupane', function() {
 
             it("ensures the table is not in 'working' state", function() {
                 expect(nutupane.table.working).toBe(false);
+            });
+
+            it("sends a notification with the error message", function() {
+                expect(Notification.setErrorMessage).toHaveBeenCalledWith('internal server error');
             });
         });
     });

--- a/engines/bastion/test/test-mocks.module.js
+++ b/engines/bastion/test/test-mocks.module.js
@@ -22,7 +22,7 @@ angular.module('Bastion.test-mocks').run(['$state', '$stateParams', '$rootScope'
     }
 ]);
 
-angular.module('Bastion.test-mocks').factory('MockResource', function () {
+angular.module('Bastion.test-mocks').factory('MockResource', ['$q', function ($q) {
     function resourceGenerator() {
         var Resource, mockResource, successResponse, errorResponse;
 
@@ -100,7 +100,8 @@ angular.module('Bastion.test-mocks').factory('MockResource', function () {
                 mockResource
             ],
             total: 2,
-            subtotal: 1
+            subtotal: 1,
+            $promise: $q.defer().promise
         };
 
         Resource.get = function(params, callback) {
@@ -179,7 +180,7 @@ angular.module('Bastion.test-mocks').factory('MockResource', function () {
                 return resourceGenerator();
             }
     };
-});
+}]);
 
 angular.module('Bastion.test-mocks').factory('MockForm', function() {
     return {

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
@@ -10,7 +10,7 @@ describe('Controller: ActivationKeyRepositorySetsController', function () {
 
     beforeEach(module('Bastion.activation-keys'));
 
-    beforeEach(inject(function (_$controller_, $rootScope) {
+    beforeEach(inject(function (_$controller_, $rootScope, $q) {
         $controller = _$controller_;
         $scope = $rootScope.$new();
 
@@ -20,7 +20,11 @@ describe('Controller: ActivationKeyRepositorySetsController', function () {
 
         ActivationKey = {
             failed: false,
-            repositorySets: function () {},
+            repositorySets: function () {
+                return {
+                    $promise: $q.defer().promise
+                }
+            },
             contentOverride: function (params, overrides, success, failure) {
                 if (this.failed) {
                     failure({data: {}})

--- a/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
@@ -20,7 +20,11 @@ describe('Controller: ContentHostRepositorySetsController', function () {
 
         HostSubscription = {
             failed: false,
-            repositorySets: function () {},
+            repositorySets: function () {
+                return {
+                    $promise: $q.defer().promise
+                }
+            },
             contentOverride: function (params, overrides, success, failure) {
                 if (this.failed) {
                     failure({data: {}})

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
@@ -4,12 +4,17 @@ describe('Controller: ContentViewPuppetModuleNamesController', function() {
     beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'))
 
     beforeEach(inject(function($injector) {
+        $q = $injector.get('$q');
         $controller = $injector.get('$controller');
         ContentView = $injector.get('MockResource').$new();
         PuppetModule = $injector.get('MockResource').$new();
         PuppetModule.autocomplete = function(){return {$promise: {then: function(callback) {callback([])}}}};
 
-        ContentView.availablePuppetModuleNames = function () {};
+        ContentView.availablePuppetModuleNames = function () {
+          return {
+            $promise: $q.defer().promise
+          }
+        };
 
         $scope = $injector.get('$rootScope').$new();
         $scope.transitionTo = function () {};

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.test.js
@@ -4,10 +4,15 @@ describe('Controller: ContentViewPuppetModuleVersionsController', function() {
     beforeEach(module('Bastion.content-views', 'Bastion.test-mocks', 'Bastion.i18n'))
 
     beforeEach(inject(function($injector) {
+        $q = $injector.get('$q');
         $controller = $injector.get('$controller');
         ContentView = $injector.get('MockResource').$new();
         ContentViewPuppetModule = $injector.get('MockResource').$new();
-        ContentView.availablePuppetModules = function () {};
+        ContentView.availablePuppetModules = function () {
+          return {
+            $promise: $q.defer().promise
+          }
+        };
 
         puppetModule = {
             uuid: 'abcd',


### PR DESCRIPTION
…s resource

Looks like a very old regression. The way we were handling errors from the table resource was confusing and seemingly wrong! A simple way to test is to go to the content hosts list and search 'errata_status = foo'. Previously there'd be an error about an unhandled promise in the console, but now it's cleaned up and sends a UI notification. Since this touches a critical area, I recommend doing any action that would refresh the table (such as paging, searching) and make sure everything looks good and no errors in console.