### PR TITLE
Fixes #30488 - Make download_concurrency configurable

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -43,6 +43,7 @@ module Katello
       param :docker_upstream_name, String, :desc => N_("Name of the upstream docker repository")
       param :docker_tags_whitelist, Array, :desc => N_("Comma separated list of tags to sync for Container Image repository")
       param :download_policy, ["immediate", "on_demand", "background"], :desc => N_("download policy for yum repos (either 'immediate', 'on_demand', or 'background (deprecated)')")
+      param :download_concurrency, :number, :desc => N_("Used to determine download concurrency of the repository in pulp3. Use value less than 20. Defaults to 10")
       param :mirror_on_sync, :bool, :desc => N_("true if this repository when synced has to be mirrored from the source and stale rpms removed")
       param :verify_ssl_on_sync, :bool, :desc => N_("if true, Katello will verify the upstream url's SSL certifcates are signed by a trusted CA")
       param :upstream_username, String, :desc => N_("Username of the upstream repository user used for authentication")
@@ -464,7 +465,7 @@ module Katello
     end
 
     def repository_params
-      keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username,
+      keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username, :download_concurrency,
               :ostree_upstream_sync_depth, :ostree_upstream_sync_policy, :auto_enabled,
               :deb_releases, :deb_components, :deb_architectures, :description, :http_proxy_policy, :http_proxy_id,
               {:ignorable_content => []}

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -159,7 +159,7 @@ module Katello
 
     delegate :product, :redhat?, :custom?, :to => :root
     delegate :yum?, :docker?, :puppet?, :deb?, :file?, :ostree?, :ansible_collection?, :to => :root
-    delegate :name, :label, :docker_upstream_name, :url, :to => :root
+    delegate :name, :label, :docker_upstream_name, :url, :download_concurrency, :to => :root
 
     delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :arch, :label, :url, :unprotected,
              :content_type, :product_id, :checksum_type, :docker_upstream_name, :mirror_on_sync, :"mirror_on_sync?",

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -288,7 +288,7 @@ module Katello
     def pulp_update_needed?
       changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
                                  upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignorable_content
-                                 ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id http_proxy_policy http_proxy_id)
+                                 ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id http_proxy_policy http_proxy_id download_concurrency)
       changeable_attributes += %w(name container_repository_name docker_tags_whitelist) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
       changeable_attributes += %w(ansible_collection_requirements) if ansible_collection?

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -294,6 +294,7 @@ module Katello
           proxy_url: root.http_proxy&.full_url
         }
         remote_options[:url] = root.url unless root.url.blank?
+        remote_options[:download_concurrency] = root.download_concurrency unless root.download_concurrency.blank?
         if root.upstream_username && root.upstream_password
           remote_options.merge!(username: root.upstream_username,
                                password: root.upstream_password)

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -119,6 +119,7 @@ module Katello
         remote_options = {
           name: backend_object_name
         }
+        remote_options.merge!({download_concurrency: repo.download_concurrency}) if repo.download_concurrency
         remote_options.merge!(ssl_remote_options)
       end
 

--- a/db/migrate/20200820145217_add_download_concurrency_to_katello_root_repositories.rb
+++ b/db/migrate/20200820145217_add_download_concurrency_to_katello_root_repositories.rb
@@ -1,0 +1,5 @@
+class AddDownloadConcurrencyToKatelloRootRepositories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_root_repositories, :download_concurrency, :integer
+  end
+end


### PR DESCRIPTION
The current default download concurrency is 20 for pulp3. With this change, https://github.com/pulp/pulpcore/pull/832 the new default is 10. This Katello change exposes that as a field on remotes so we can configure it on katello repos if needed.
To test:
1. Create a repo
2. Check the remote in pulp 
curl --cert /etc/pki/katello/certs/pulp-client.crt --key /etc/pki/katello/private/pulp-client.key https://`hostname`/pulp/api/v3/remotes/rpm/rpm/ | python -m json.tool
3. Verify that the remote is created with the default value.
4. Open to suggestions on this part. To change the concurrency and propagate change to pulp, go to console.
```
repo = Katello::Repository.find(_id_) 
repo.root.update!(:download_concurrency=>15)
smart_proxy = SmartProxy.pulp_master
repo.backend_service(smart_proxy).update_remote

```
5. Re-sync the repo. Verify it succeeds with updated value.
