### PR TITLE
Fixes #30676 - Extend Global registration endpoint

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -280,6 +280,9 @@ Foreman::Plugin.register :katello do
   extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/pulp_info'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/host_collections'
 
+  # Extend Global Registration endpoint
+  extend_allowed_registration_vars :activation_key
+
   extend_page "smart_proxies/show" do |cx|
     cx.add_pagelet :details_content,
                    :name => _('Storage'),


### PR DESCRIPTION
- Requires https://github.com/theforeman/foreman/pull/7859
- PR is part of the [Simple & automatic host registration WF](https://projects.theforeman.org/issues/30440) task
- How to test:
GET `/register?organization_id=1&activation_key=one_two_three`
`@activation_key` variable is set and has value from request.