### PR TITLE
Fixes #30702 - Regression in re-assigning host location for registered hosts

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -19,11 +19,17 @@ module Katello
         prepend Overrides
 
         def update_multiple_taxonomies(type)
-          registered_host = @hosts.detect { |host| host.subscription_facet }
-          unless registered_host.nil?
-            error _("Unregister host %s before assigning an organization") % registered_host.name
-            redirect_back_or_to hosts_path
-            return
+          if type == :organization
+            new_org_id = params.dig(type, 'id')
+
+            if new_org_id
+              registered_host = @hosts.where.not(organization_id: new_org_id).joins(:subscription_facet).first
+              if registered_host
+                error _("Unregister host %s before assigning an organization") % registered_host.name
+                redirect_back_or_to hosts_path
+                return
+              end
+            end
           end
 
           super


### PR DESCRIPTION
We recently made a change which prevented changing host Organization if it is registered in Katello. It inadvertently broke the ability to change the Location of a registered Content Host.

This change:
- restores ability to change location of registered content hosts
- prevents error from being raised when "changing" host into its current org (think about Any Org + Any Loc use case)
- avoid N+1 query in loading host subscription facets

To test: Try to break stuff while changing Org or Loc from Hosts -> All Hosts