### PR TITLE
Fixes #30700 - Update trace controller to reflect correct url

### DIFF
--- a/app/controllers/katello/api/v2/host_tracer_controller.rb
+++ b/app/controllers/katello/api/v2/host_tracer_controller.rb
@@ -2,11 +2,6 @@ module Katello
   class Api::V2::HostTracerController < Api::V2::ApiController
     before_action :find_host, :only => :index
 
-    resource_description do
-      api_version 'v2'
-      api_base_url "/api"
-    end
-
     api :GET, "/hosts/:host_id/traces", N_("List services that need restarting on the host")
     param :host_id, :number, :required => true, :desc => N_("ID of the host")
     def index


### PR DESCRIPTION
Tested resolving with the UI on a single host and with the new bulk resolve action and worked fine.

Screenshot:

https://nimbusweb.me/s/share/4573692/0ohiacwydvl49ocetz0e

Also tested with a WIP hammer PR I am working on (see below) and that was able to reach the updated API correctly. 

After applying the patch, I regenerated the API docs and hammer was able to see the changes as well as the api docs in the UI.

`cd ~/foreman`
`FOREMAN_APIPIE_LANGS=en bundle exec rake apipie:cache`

Tested on a 6.8 as well to make sure there were not any regressions downstream.

#### Before:
```ruby
[ INFO 2020-08-24T19:27:22 API] PUT /api/traces/resolve
[DEBUG 2020-08-24T19:27:22 API] Params: {
    "trace_ids" => [
        [0] 63,
        [1] 52
    ]
}
[DEBUG 2020-08-24T19:27:22 API] Headers: {}
[DEBUG 2020-08-24T19:27:22 API] Using authenticator: HammerCLIForeman::Api::InteractiveBasicAuth
[ERROR 2020-08-24T19:27:25 API] 404 Not Found

15:27:34 rails.1   | 2020-08-24T15:27:34 [I|app|2113eeab] Started PUT "/api/traces/resolve" for 127.0.0.1 at 2020-08-24 15:27:34 -0400
15:27:35 rails.1   | 2020-08-24T15:27:35 [F|app|2113eeab]   
15:27:35 rails.1   |  2113eeab | ActionController::RoutingError (No route matches [PUT] "/api/traces/resolve"):
```
#### With PR:
```ruby
--[ Route 267 ]----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------Prefix            | resolve_api_traces
Verb              | PUT
URI               | /katello/api(/:api_version)/traces/resolve(.:format)
Controller#Action | katello/api/v2/host_tracer#resolve {:api_version=>/v2/}

[vagrant@hammer ~]$ hammer -d host traces resolve --trace-ids [63,52]

[ INFO 2020-08-24T17:56:11 API] PUT /katello/api/traces/resolve
[DEBUG 2020-08-24T17:56:11 API] Params: {
    "trace_ids" => [
        [0] 63,
        [1] 52
    ]
}

13:48:23 rails.1   | 2020-08-24T13:48:23 [I|app|1edef3ff] Started PUT "/katello/api/traces/resolve" for 127.0.0.1 at 2020-08-24 13:48:23 -0400
13:48:24 rails.1   | 2020-08-24T13:48:24 [I|app|1edef3ff] Processing by Katello::Api::V2::HostTracerController#resolve as JSON
13:48:24 rails.1   | 2020-08-24T13:48:24 [I|app|1edef3ff]   Parameters: {"trace_ids"=>[63, 52], "api_version"=>"v2", "host_tracer"=>{}}
13:48:24 rails.1   | 2020-08-24T13:48:24 [D|app|1edef3ff] Authenticated user admin against INTERNAL authentication source
13:48:24 rails.1   | 2020-08-24T13:48:24 [D|app|1edef3ff] Post-login processing for admin
13:48:24 rails.1   | 2020-08-24T13:48:24 [I|app|1edef3ff] Authorized user admin(Admin User)
13:48:24 rails.1   | 2020-08-24T13:48:24 [D|app|1edef3ff] Post-login processing for admin
13:48:25 rails.1   | 2020-08-24T13:48:25 [I|bac|1edef3ff] Task {label: Actions::RemoteExecution::RunHostsJob, id: 93d87f7c-ff37-4f3d-bd46-a9764b31b9bf, execution_plan_id: af643117-7710-430c-ba3f-ee7c3a08b0d8} state changed: planning 
13:48:25 rails.1   | 2020-08-24T13:48:25 [I|bac|] Task {label: Actions::RemoteExecution::RunHostsJob, id: 93d87f7c-ff37-4f3d-bd46-a9764b31b9bf, execution_plan_id: af643117-7710-430c-ba3f-ee7c3a08b0d8} state changed: planned 
13:48:25 rails.1   | 2020-08-24T13:48:25 [I|app|] Completed 200 OK in 1072ms (Views: 1.0ms | ActiveRecord: 191.7ms | Allocations: 125948)
```

Screenshot of API doc in UI:

https://nimbusweb.me/s/share/4570097/yya99xt4nbit3lh1zocl