### PR TITLE
Fixes #30725 - Server error on incremental update of empty CV

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -149,7 +149,7 @@ module Katello
       end
 
       def pulp3_support?(repository)
-        pulp3_repository_type_support?(repository.content_type)
+        repository ? pulp3_repository_type_support?(repository.try(:content_type)) : false
       end
 
       def pulp2_preferred_for_type?(repository_type)

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -75,6 +75,7 @@ module Katello
     end
 
     def test_pulp3_repository_support
+      refute @master.pulp3_support?(nil)
       refute @master.pulp3_support?(@puppet_repo)
       assert @master.pulp3_support?(@file_repo)
     end


### PR DESCRIPTION
- Create and publish an empty CV
- Try adding an errata outside the repo to the CV via inc update:
hammer -d content-view version incremental-update --content-view-version-id _CVV_ID_ --errata-ids _ERRATA_ID_