### PR TITLE
Fixes #30079 - workaround for ISE when search terms are used 

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -52,7 +52,7 @@ module Katello
         scoped_search :relation => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key
         scoped_search :relation => :activation_keys, :on => :id, :rename => :activation_key_id, :complete_value => true, :ext_method => :find_by_activation_key_id,
                       :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-        scoped_search :on => :hypervisor, :relation => :subscription_facet, :complete_value => { :true => true, :false => false }
+        scoped_search :on => :hypervisor, :relation => :subscription_facet, :complete_value => true
         scoped_search :on => :name, :relation => :hypervisor_host, :complete_value => true, :rename => :hypervisor_host, :ext_method => :find_by_hypervisor_host
         scoped_search :on => :name, :relation => :subscriptions, :rename => :subscription_name, :complete_value => true, :ext_method => :find_by_subscription_name
         scoped_search :on => :id, :relation => :pools, :rename => :subscription_id, :complete_value => true, :ext_method => :find_by_subscription_id, :only_explicit => true

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -79,7 +79,7 @@ module Katello
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :label, :complete_value => true
-    scoped_search :on => :composite, :complete_value => {true: true, false: false}
+    scoped_search :on => :composite, :complete_value => true
 
     def self.in_environment(env)
       joins(:content_view_environments).


### PR DESCRIPTION
This PR is a workaround, not the ultimate resolution, for an observed defect in the scoped_search gem. See [this issue](https://github.com/wvanbergen/scoped_search/issues/200) for details.

Once that issue is resolved, then the complete_value can be restored.