### PR TITLE
Fixes #30749 - Add /owners/:id/system_purpose to Candlepin Proxies Controller

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -26,7 +26,7 @@ module Katello
     before_action :set_organization_id, :except => [:hypervisors_update, :async_hypervisors_update]
     before_action :find_hypervisor_organization, :only => [:async_hypervisors_update, :hypervisors_update]
 
-    before_action :check_content_type, :except => :async_hypervisors_update
+    before_action :check_media_type, :except => :async_hypervisors_update
 
     prepend_before_action :convert_owner_to_organization_id, :except => [:hypervisors_update, :async_hypervisors_update], :if => lambda { params.key?(:owner) }
     prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create], :if => lambda { params.key?(:organization_id) }
@@ -480,7 +480,7 @@ module Katello
         else
           User.consumer? || ::User.current.can?(:view_organizations, self)
         end
-      when "rhsm_proxy_owner_servicelevels_path"
+      when "rhsm_proxy_owner_servicelevels_path", "rhsm_proxy_owner_system_purpose_path"
         (User.consumer? || ::User.current.can?(:view_organizations, self))
       when "rhsm_proxy_consumer_accessible_content_path", "rhsm_proxy_consumer_certificates_path",
            "rhsm_proxy_consumer_releases_path", "rhsm_proxy_certificate_serials_path",

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -21,6 +21,7 @@ Katello::Engine.routes.draw do
       match '/owners/:organization_id/environments' => 'candlepin_proxies#rhsm_index', :via => :get
       match '/owners/:organization_id/pools' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_pools_path
       match '/owners/:organization_id/servicelevels' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_servicelevels_path
+      match '/owners/:organization_id/system_purpose' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_system_purpose_path
       match '/environments/:environment_id/consumers' => 'candlepin_proxies#consumer_create', :via => :post
       match '/consumers/:id' => 'candlepin_proxies#consumer_show', :via => :get
       match '/consumers/:id' => 'candlepin_proxies#regenerate_identity_certificates', :via => :post


### PR DESCRIPTION
New versions of subscription-manager attempt to retrieve the org's system purpose values from Katello, and we need to add that endpoint to our allowlist since we proxy those requests through the candlepin.

Can be tested from a client like this:
```
curl https://centos7-katello-devel.jturel.example.com/rhsm/owners/Default_Organization/system_purpose --cert /etc/pki/consumer/cert.pem --key /etc/pki/consumer/key.pem
```

It should respond with something like:

```
{"owner":{"id":"4028fac873da183e0173da1da6e20000","key":"Default_Organization","displayName":"Default Organization","href":"/owners/Default_Organization"},"systemPurposeAttributes":{"addons":[],"roles":["","Red Hat Enterprise Linux Server"],"usage":["Development/Test","Production"],"support_level":["Standard","Self-Support"]}}
```

Previously it would be a 404!


