### PR TITLE
Fixes #30758 - Refresh Subscription and Purpose status when toggling SCA

### DIFF
--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -40,7 +40,6 @@ module Actions
         end
 
         def finalize
-          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           subject_organization.audit_manifest_action(_('Manifest deleted'))
         end
       end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -45,7 +45,6 @@ module Actions
         end
 
         def finalize
-          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           subject_organization.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest imported'))
         end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -61,7 +61,6 @@ module Actions
 
         def finalize
           org = ::Organization.find(input[:organization_id])
-          subject_organization.clear_syspurpose_status if subject_organization.simple_content_access?(cached: false)
           org.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest refreshed'))
         end

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -5,6 +5,11 @@ module Katello
         extend OwnerResource
 
         class << self
+          def all
+            response = self.get(path, default_headers)
+            JSON.parse(response.body)
+          end
+
           # Set the contentPrefix at creation time so that the client will get
           # content only for the org it has been subscribed to
           def create(key, description)

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -228,11 +228,6 @@ module Katello
           subscriptions.select(&:expiring_soon?)
         end
 
-        def clear_syspurpose_status
-          host_purpose = HostStatus::Status.where(type: ::Katello::HostStatusManager::PURPOSE_STATUS.map(&:to_s)).where('host_id in (?)', self.hosts.pluck(:id))
-          host_purpose.destroy_all
-        end
-
         def notification_recipients_ids
           users = User.unscoped.all.find_all do |user|
             user.can?(:import_manifest) && user.can?(:view_organizations, self)

--- a/app/services/katello/candlepin/event_handler.rb
+++ b/app/services/katello/candlepin/event_handler.rb
@@ -30,6 +30,8 @@ module Katello
           reindex_subscription_status
         when /system_purpose_compliance\.created/
           reindex_purpose_status
+        when /owner_content_access_mode\.modified/
+          message_handler.handle_content_access_mode_modified
         end
       end
 

--- a/app/services/katello/host_status_manager.rb
+++ b/app/services/katello/host_status_manager.rb
@@ -16,5 +16,14 @@ module Katello
       Katello::PurposeRoleStatus,
       Katello::PurposeSlaStatus,
       Katello::PurposeUsageStatus].freeze
+
+    def self.update_subscription_status_to_sca(hosts)
+      HostStatus::Status.where(host: hosts, type: Katello::SubscriptionStatus.to_s).update(status: Katello::SubscriptionStatus::DISABLED)
+    end
+
+    def self.clear_syspurpose_status(hosts)
+      host_purpose = HostStatus::Status.where(type: ::Katello::HostStatusManager::PURPOSE_STATUS.map(&:to_s)).where('host_id in (?)', hosts.pluck(:id))
+      host_purpose.destroy_all
+    end
   end
 end

--- a/test/fixtures/candlepin_messages/owner_content_access_mode.modified.json
+++ b/test/fixtures/candlepin_messages/owner_content_access_mode.modified.json
@@ -1,0 +1,19 @@
+{
+  "id": null,
+  "type": "MODIFIED",
+  "target": "OWNER_CONTENT_ACCESS_MODE",
+  "targetName": "Empty Organization",
+  "principalStore": "{\"type\":\"trusteduser\",\"name\":\"foreman_admin\"}",
+  "timestamp": 1598992663405,
+  "entityId": "4028fac873da183e0173da1da6e20000",
+  "ownerId": "4028fac873da183e0173da1da6e20000",
+  "consumerUuid": null,
+  "referenceId": null,
+  "referenceType": null,
+  "eventData": "{\"contentAccessMode\":\"org_environment\"}",
+  "messageText": null,
+  "principal": {
+    "type": "trusteduser",
+    "name": "foreman_admin"
+  }
+}

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -26,19 +26,5 @@ module Katello
       end
       assert_equal @org.manifest_refreshed_at.to_i, current_time.to_i
     end
-
-    def test_clear_syspurpose_status
-      host = @org.hosts.first
-
-      Katello::HostStatusManager::PURPOSE_STATUS.each do |status_class|
-        HostStatus::Status.create(host: host, type: status_class.to_s)
-      end
-
-      assert_equal 5, host.host_statuses.count
-
-      @org.clear_syspurpose_status
-
-      assert_equal 0, host.host_statuses.count
-    end
   end
 end

--- a/test/services/candlepin/message_handler_test.rb
+++ b/test/services/candlepin/message_handler_test.rb
@@ -128,6 +128,19 @@ module Katello
   class OwnerContentAccessModeModifiedTest < MessageHandlerTestBase
     let(:event_name) { 'owner_content_access_mode.modified' }
 
+    def setup
+      @org = get_organization(:empty_organization)
+      Katello::Resources::Candlepin::Owner.expects(:all).returns(
+        [
+          {
+            'displayName' => @org.name,
+            'key' => @org.label
+          }
+        ]
+      )
+      super
+    end
+
     def test_sca_enabled
       Katello::HostStatusManager.expects(:clear_syspurpose_status)
       Katello::HostStatusManager.expects(:update_subscription_status_to_sca)
@@ -142,8 +155,7 @@ module Katello
       Organization.any_instance.expects(:simple_content_access?).with(cached: false)
       @handler.expects(:event_data).returns('contentAccessMode' => 'entitlement').twice
 
-      org = get_organization(:empty_organization)
-      org.hosts.joins(:subscription_facet).count.times do
+      @org.hosts.joins(:subscription_facet).count.times do
         Katello::Resources::Candlepin::Consumer.expects(:compliance)
         Katello::Resources::Candlepin::Consumer.expects(:purpose_compliance)
       end

--- a/test/services/katello/candlepin/event_handler_test.rb
+++ b/test/services/katello/candlepin/event_handler_test.rb
@@ -89,5 +89,16 @@ module Katello
         handler.handle(mymessage)
       end
     end
+
+    describe 'handles owner_content_access_mode.modified' do
+      let(:mymessage) do
+        message "owner_content_access_mode.modified"
+      end
+
+      it 'calls the right MessageHandler method' do
+        Katello::Candlepin::MessageHandler.any_instance.expects(:handle_content_access_mode_modified)
+        handler.handle(mymessage)
+      end
+    end
   end
 end

--- a/test/services/katello/host_status_manager_test.rb
+++ b/test/services/katello/host_status_manager_test.rb
@@ -1,0 +1,32 @@
+require 'katello_test_helper'
+
+module Katello
+  class HostStatusManagerTest < ActiveSupport::TestCase
+    def setup
+      @org = get_organization(:empty_organization)
+    end
+
+    def test_clear_syspurpose_status
+      host = @org.hosts.first
+
+      Katello::HostStatusManager::PURPOSE_STATUS.each do |status_class|
+        HostStatus::Status.create(host: host, type: status_class.to_s)
+      end
+
+      assert_equal 5, host.host_statuses.count
+
+      Katello::HostStatusManager.clear_syspurpose_status(@org.hosts)
+
+      assert_equal 0, host.host_statuses.count
+    end
+
+    def test_update_subscription_status_to_sca
+      host = @org.hosts.first
+      sub_status = HostStatus::Status.create(host: host, type: Katello::SubscriptionStatus.to_s, status: Katello::SubscriptionStatus::INVALID)
+
+      Katello::HostStatusManager.update_subscription_status_to_sca(@org.hosts)
+
+      assert_equal Katello::SubscriptionStatus::DISABLED, sub_status.reload.status
+    end
+  end
+end


### PR DESCRIPTION
Builds on recent work by @chris1984 (https://github.com/Katello/katello/pull/8859) to process the `owner_content_access_mode.modified` event (turns out there is one!) to:
- consolidate places where we might clear syspurpose status (any manifest action) into a single event handler
- in the same event handler, handle case of switching out of SCA mode, and recalculate host purpose + subscription status

Installer PR to prevent filtering out this new event: https://github.com/theforeman/puppet-candlepin/pull/164
You can modify /etc/candlepin/broker.xml and add this filter `(EVENT_TARGET='OWNER_CONTENT_ACCESS_MODE' and EVENT_TYPE='MODIFIED')` be sure to restart tomcat afterward

**To Test**
 - register a content host
 - import a manifest that can toggle SCA
 - observe the host sub status switch from $WHATEVER to 'Simple Content Access' and vice versa
- observe  the host purpose status switch from $WHATEVER to hidden, and vice versa