### PR TITLE
Fixes #30766 - Candlepin error with repo deletion during product destroy

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -7,9 +7,11 @@ module Actions
 
         # options:
         #   skip_environment_update - defaults to false. skips updating the CP environment
+        #   destroy_content - can be disabled to skip Candlepin remove_content
         def plan(repository, options = {})
           skip_environment_update = options.fetch(:skip_environment_update, false) ||
               options.fetch(:organization_destroy, false)
+          destroy_content = options.fetch(:destroy_content, true)
           action_subject(repository)
 
           unless repository.destroyable?
@@ -29,7 +31,9 @@ module Actions
             if repository.redhat?
               handle_redhat_content(repository) unless skip_environment_update
             else
-              handle_custom_content(repository) unless skip_environment_update
+              if destroy_content && !skip_environment_update
+                handle_custom_content(repository)
+              end
             end
           end
         end

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -202,6 +202,10 @@ module ::Actions::Katello::Product
       plan_action(action, product)
 
       assert_action_planed_with(action, candlepin_destroy_class, cp_id: product.cp_id, owner: product.organization.label)
+      assert_action_planed_with(action, ::Actions::Katello::Product::ContentDestroy) do |root|
+        root.first.repositories.where.not(id: root.first.repositories.first.id).empty?
+        !root.first.repositories.first.redhat?
+      end
       assert_action_planed_with(action, ::Actions::Katello::Repository::Destroy) do |repo|
         default_view_repos.include?(repo.first.id)
       end


### PR DESCRIPTION
Candlepin throws an error when multiple [remove_content](https://github.com/Katello/katello/blob/master/app/lib/actions/candlepin/product/content_remove.rb) calls happen concurrently.  To get around this, I've made the `Actions::Katello::Product::ContentDestroy` actions run sequentially before the concurrent `Actions::Katello::Repository::Destroy` actions.

To test:

1) Create a product
2) Add a few Docker repos
3) Delete the product
4) See the error in question
5) Apply my PR
6) Do 1-3 again
7) See that the product is deleted