### PR TITLE
Fixes #30434 - transient test failure ContentView::CapsuleSyncTest

### DIFF
--- a/app/lib/actions/katello/content_view/capsule_sync.rb
+++ b/app/lib/actions/katello/content_view/capsule_sync.rb
@@ -11,7 +11,7 @@ module Actions
             concurrence do
               smart_proxies = SmartProxy.with_environment(environment)
               unless smart_proxies.blank?
-                plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies,
+                plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies.sort,
                             :content_view_id => content_view.id, :environment_id => environment.id)
               end
             end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -343,7 +343,7 @@ module ::Actions::Katello::ContentView
 
       plan_action(action, content_view, library)
       assert_action_planned_with(action, ::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync,
-                                 [smart_proxy_service_1.smart_proxy, smart_proxy_service_2.smart_proxy],
+                                 [smart_proxy_service_1.smart_proxy, smart_proxy_service_2.smart_proxy].sort,
                                  :content_view_id => content_view.id, :environment_id => library.id)
     end
   end


### PR DESCRIPTION
Ran locally several times without hitting the issue. The sorted input should resolve the error with different order of smart proxies passed as input to the action.