### PR TITLE
Fixes #30745 - Add pulp_href to repositories API

### DIFF
--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -4,6 +4,7 @@ extends 'katello/api/v2/common/identifier'
 
 attributes :pulp_id => :backend_identifier
 attributes :relative_path, :container_repository_name, :full_path, :library_instance_id
+attributes :version_href, :remote_href, :publication_href
 
 glue(@object.root) do
   attributes :content_type, :url, :arch, :content_id, :auto_enabled


### PR DESCRIPTION
The original request asks for pulp_href to be made available via API. Adding the 3 pulp hrefs, version, remote and publication to the API here. 
Pulp_href of the repository is defined per repo, per content view including library. Might be confusing to get to it directly.