### PR TITLE
Fixes #30752 - support sles token via url param

### DIFF
--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -8,11 +8,17 @@ module Katello
         include Katello::Util::PulpcoreContentFilters
 
         def remote_options
-          if root.url.blank?
-            common_remote_options.merge(url: nil, policy: root.download_policy)
-          else
-            common_remote_options.merge(policy: root.download_policy)
-          end
+          url, sles_token = extract_sles_token
+          options = common_remote_options
+          options.merge!(sles_auth_token: sles_token) if sles_token
+          options.merge!(url: url, policy: root.download_policy)
+        end
+
+        def extract_sles_token
+          uri = URI(root.url)
+          query = uri.query
+          uri.query = nil
+          [uri.to_s, query]
         end
 
         def skip_types

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    module Pulp3
+      class Repository
+        class YumTest < ::ActiveSupport::TestCase
+          include RepositorySupport
+
+          def setup
+            @repo = katello_repositories(:fedora_17_x86_64)
+            @proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          end
+
+          def test_remote_options
+            @repo.root.url = "http://foo.com/bar/"
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            assert_equal "http://foo.com/bar/", service.remote_options[:url]
+            refute service.remote_options.key?(:sles_auth_token)
+
+            @repo.root.url = "http://foo.com/bar/?mytoken"
+            assert_equal "http://foo.com/bar/", service.remote_options[:url]
+            assert_equal 'mytoken', service.remote_options[:sles_auth_token]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this extends the current support for sles tokens (by putting a param
at the end like  http://url/path?token) by parsing that token and
passing it to pulp3