### PR TITLE
Fixes #30004 - Api endpoint to import an exported content

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -99,7 +99,7 @@ module Katello
                         :template => '../../../api/v2/content_view_version_export_histories/index')
     end
 
-    api :POST, "/content_view_versions/:id/export", N_("Export a content view version"), :deprecated => true
+    api :POST, "/content_view_versions/:id/export", N_("Export a content view version")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
     param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3")
     param :export_to_iso, :bool, :desc => N_("Export to ISO format. Relevant only for Pulp 2 repositories"), :required => false
@@ -140,6 +140,14 @@ module Katello
                           params[:iso_mb_size])
       end
 
+      respond_for_async :resource => task
+    end
+
+    api :POST, "/content_view_versions/import", N_("Import a content view version")
+    param :content_view_id, :number, :desc => N_("Content view identifier"), :required => true
+    param :path, String, :desc => N_("Import path"), :required => true
+    def import
+      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path])
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -15,7 +15,9 @@ module Actions
           minor = metadata[:content_view_version][:minor]
 
           if ::Katello::ContentViewVersion.where(major: major, minor: minor, content_view: content_view).exists?
-            fail _("Content View Version specified in the metadata - '%s %s.%s' has already been imported." % [content_view.name, major, minor])
+            cvv_name = "#{content_view.name} #{major}.#{minor}"
+            fail _("Content View Version specified in the metadata - '%{name}' already exists. "\
+                    "If you wish to replace the existing version, delete %{name} and try again. " % { name: cvv_name })
           end
 
           plan_action(::Actions::Katello::ContentView::Publish, content_view, '',

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -1,0 +1,34 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class Import < Actions::EntryAction
+        PULP_USER = 'pulp'.freeze
+
+        def plan(content_view, path:)
+          content_view.check_ready_to_import!
+          unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
+            fail HttpErrors::BadRequest, _("This API endpoint is only valid for Pulp 3 repositories.")
+          end
+          ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path)
+          metadata = ::Katello::Pulp3::ContentViewVersion::Import.metadata(path)
+          major = metadata[:content_view_version][:major]
+          minor = metadata[:content_view_version][:minor]
+
+          if ::Katello::ContentViewVersion.where(major: major, minor: minor, content_view: content_view).exists?
+            fail _("Content View Version specified in the metadata - '%s %s.%s' has already been imported." % [content_view.name, major, minor])
+          end
+
+          plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
+                        path: path,
+                        import_only: true,
+                        major: major,
+                        minor: minor)
+        end
+
+        def humanized_name
+          _("Import Content View Version")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/content_view_version/create_importer.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_importer.rb
@@ -1,0 +1,20 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class CreateImporter < Pulp3::Abstract
+        input_format do
+          param :smart_proxy_id, Integer
+          param :content_view_version_id, Integer
+          param :path, String
+        end
+
+        def run
+          cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+          output[:importer_data] = ::Katello::Pulp3::ContentViewVersion::Import.new(smart_proxy: smart_proxy,
+                                                                            content_view_version: cvv,
+                                                                            path: input[:path]).create_importer
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/content_view_version/destroy_importer.rb
+++ b/app/lib/actions/pulp3/content_view_version/destroy_importer.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class DestroyImporter < Pulp3::Abstract
+        input_format do
+          param :smart_proxy_id, Integer
+          param :importer_data, Hash
+        end
+
+        def run
+          ::Katello::Pulp3::ContentViewVersion::Import.new(smart_proxy: smart_proxy).destroy_importer(input[:importer_data][:pulp_href])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/content_view_version/import.rb
+++ b/app/lib/actions/pulp3/content_view_version/import.rb
@@ -1,0 +1,21 @@
+module Actions
+  module Pulp3
+    module ContentViewVersion
+      class Import < Pulp3::AbstractAsyncTask
+        input_format do
+          param :content_view_version_id, Integer
+          param :smart_proxy_id, Integer
+          param :importer_data, Hash
+          param :path, String
+        end
+
+        def invoke_external_task
+          cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+          output[:pulp_tasks] = ::Katello::Pulp3::ContentViewVersion::Import.new(smart_proxy: smart_proxy,
+                                                   content_view_version: cvv,
+                                                   path: input[:path]).create_import(input[:importer_data][:pulp_href])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
@@ -1,0 +1,25 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module ContentViewVersion
+        class CopyVersionUnitsToLibrary < Actions::EntryAction
+          def plan(content_view_version)
+            concurrence do
+              content_view_version.importable_repositories.each do |repo|
+                sequence do
+                  copy_action = plan_action(Actions::Pulp3::Repository::CopyContent, repo, SmartProxy.pulp_primary!,
+                                                    repo.library_instance,
+                                                    copy_all: true)
+                  plan_action(Actions::Pulp3::Repository::SaveVersion, repo.library_instance,
+                                tasks: copy_action.output[:pulp_tasks])
+                  plan_action(Katello::Repository::IndexContent, id: repo.library_instance_id)
+                  plan_action(Katello::Repository::MetadataGenerate, repo.library_instance, :force => true)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/import.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/import.rb
@@ -1,0 +1,41 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module ContentViewVersion
+        class Import < Actions::EntryAction
+          def plan(content_view_version, path:)
+            action_subject(content_view_version)
+            sequence do
+              smart_proxy = SmartProxy.pulp_primary!
+              importer_output = plan_action(::Actions::Pulp3::ContentViewVersion::CreateImporter,
+                                           content_view_version_id: content_view_version.id,
+                                           smart_proxy_id: smart_proxy.id,
+                                           path: path).output
+
+              import_output = plan_action(::Actions::Pulp3::ContentViewVersion::Import,
+                                           content_view_version_id: content_view_version.id,
+                                           smart_proxy_id: smart_proxy.id,
+                                           importer_data: importer_output[:importer_data],
+                                           path: path).output
+
+              plan_action(Actions::Pulp3::Repository::SaveVersions, content_view_version.importable_repositories.pluck(:id),
+                          tasks: import_output[:pulp_tasks])
+
+              plan_action(::Actions::Pulp3::ContentViewVersion::DestroyImporter,
+                            smart_proxy_id: smart_proxy.id,
+                            importer_data: importer_output[:importer_data])
+            end
+          end
+
+          def humanized_name
+            _("Import")
+          end
+
+          def rescue_strategy
+            Dynflow::Action::Rescue::Skip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/copy_content.rb
+++ b/app/lib/actions/pulp3/repository/copy_content.rb
@@ -11,7 +11,12 @@ module Actions
         def invoke_external_task
           source = ::Katello::Repository.find(input[:source_repository_id])
           target = ::Katello::Repository.find(input[:target_repository_id] || input[:target_repository])
-          output[:pulp_tasks] = target.backend_service(smart_proxy).copy_content_for_source(source, input)
+          service = target.backend_service(smart_proxy)
+          output[:pulp_tasks] = if input[:copy_all]
+                                  service.copy_all(source)
+                                else
+                                  service.copy_content_for_source(source, input)
+                                end
         end
       end
     end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -579,6 +579,12 @@ module Katello
       PuppetModule.group_by_repoid(puppet_modules.flatten)
     end
 
+    def check_ready_to_import!
+      fail _("User must be logged in.") if ::User.current.nil?
+      fail _("Cannot import a composite content view") if composite?
+      true
+    end
+
     def check_ready_to_publish!
       fail _("User must be logged in.") if ::User.current.nil?
       fail _("Cannot publish default content view") if default?

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class ContentViewVersion < Katello::Model
     include Authorization::ContentViewVersion
     include ForemanTasks::Concerns::ActionSubject
@@ -25,7 +26,7 @@ module Katello
     has_many :export_histories, :class_name => "Katello::ContentViewVersionExportHistory", :dependent => :destroy,
              :inverse_of => :content_view_version, :foreign_key => :content_view_version_id
 
-    has_many :repositories, :class_name => "Katello::Repository", :dependent => :destroy
+    has_many :repositories, :class_name => "::Katello::Repository", :dependent => :destroy
     has_many :content_view_puppet_environments, :class_name => "Katello::ContentViewPuppetEnvironment",
                                                 :dependent => :destroy
     has_one :task_status, :class_name => "Katello::TaskStatus", :as => :task_owner, :dependent => :destroy
@@ -355,6 +356,14 @@ module Katello
         end
       end
       true
+    end
+
+    def importable_repositories
+      if default?
+        repositories.yum_type
+      else
+        archived_repos.yum_type
+      end
     end
 
     def before_promote_hooks

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -2,18 +2,13 @@ module Katello
   module Pulp3
     module ContentViewVersion
       class Export
+        include ImportExportCommon
+        METADATA_FILE = "metadata.json".freeze
+
         def initialize(smart_proxy:, content_view_version: nil, destination_server: nil)
           @smart_proxy = smart_proxy
           @content_view_version = content_view_version
           @destination_server = destination_server
-        end
-
-        def exporter_name
-          @content_view_version.name.gsub(/\s/, '_')
-        end
-
-        def generate_exporter_id
-          "#{@content_view_version.organization.label}_#{exporter_name}"
         end
 
         def generate_exporter_path
@@ -25,28 +20,8 @@ module Katello
           DateTime.now.to_s.gsub(/\W/, '-')
         end
 
-        def api
-          ::Katello::Pulp3::Api::Core.new(@smart_proxy)
-        end
-
-        def repository_hrefs
-          version_hrefs.map { |href| version_href_to_repository_href(href) }.uniq
-        end
-
-        def version_hrefs
-          if @content_view_version.default?
-            @content_view_version.repositories.yum_type.pluck(:version_href).compact
-          else
-            @content_view_version.archived_repos.yum_type.pluck(:version_href).compact
-          end
-        end
-
-        def version_href_to_repository_href(version_href)
-          version_href.split("/")[0..-3].join("/") + "/"
-        end
-
         def create_exporter(export_base_dir: Setting['pulpcore_export_destination'])
-          api.exporter_api.create(name: generate_exporter_id,
+          api.exporter_api.create(name: generate_id,
                                   path: "#{export_base_dir}/#{generate_exporter_path}",
                                   repositories: repository_hrefs)
         end
@@ -64,6 +39,27 @@ module Katello
           api.exporter_api.partial_update(exporter_href, :last_export => nil)
           api.export_api.delete(export_data.pulp_href) unless export_data.blank?
           api.exporter_api.delete(exporter_href)
+        end
+
+        def generate_metadata
+          ret = { organization: @content_view_version.organization.name,
+                  repository_mapping: {},
+                  content_view: @content_view_version.content_view.name,
+                  content_view_version: {
+                    major: @content_view_version.major,
+                    minor: @content_view_version.minor
+                  }
+          }
+          repositories.each do |repo|
+            next if repo.version_href.blank?
+            pulp3_repo = fetch_repository_info(repo.version_href).name
+            ret[:repository_mapping][pulp3_repo] = {
+              repository: repo.root.name,
+              product: repo.root.product.name,
+              redhat: repo.redhat?
+            }
+          end
+          ret
         end
       end
     end

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -58,14 +58,14 @@ module Katello
             metadata_file = "#{path}/#{::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE}"
             fail _("Could not find metadata.json at '%s'." % metadata_file) unless File.exist?(metadata_file)
             fail _("Unable to read the metadata.json at '%s'." % metadata_file) unless File.readable?(metadata_file)
-            fail _("Pulp user or group unable to read content in '%s'." % path) unless pulp_user_accesible?(path)
+            fail _("Pulp user or group unable to read content in '%s'." % path) unless pulp_user_accessible?(path)
             Dir.glob("#{path}/*").each do |file|
               next if file == metadata_file
-              fail _("Pulp user or group unable to read '%s'." % file) unless pulp_user_accesible?(file)
+              fail _("Pulp user or group unable to read '%s'." % file) unless pulp_user_accessible?(file)
             end
           end
 
-          def pulp_user_accesible?(path)
+          def pulp_user_accessible?(path)
             pulp_info = fetch_pulp_user_info
             return false if pulp_info.blank?
 

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -1,0 +1,87 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class Import
+        include ImportExportCommon
+        BASEDIR = '/var/lib/pulp'.freeze
+
+        def initialize(smart_proxy:, content_view_version: nil, path: nil)
+          @smart_proxy = smart_proxy
+          @content_view_version = content_view_version
+          @path = path
+        end
+
+        def repository_mapping
+          mapping = {}
+          metadata[:repository_mapping].each do |key, value|
+            repo = @content_view_version.importable_repositories.joins(:root, :product).
+                        where("#{::Katello::Product.table_name}" => {:name => value[:product]},
+                                                  "#{::Katello::RootRepository.table_name}" => {:name => value[:repository]}).first
+            next unless repo&.version_href
+            repo_info = fetch_repository_info(repo.version_href)
+            mapping[key] = repo_info.name
+          end
+          mapping
+        end
+
+        def create_importer
+          api.importer_api.create(name: generate_id,
+                                  repo_mapping: repository_mapping)
+        end
+
+        def create_import(importer_href)
+          [api.import_api.create(importer_href, toc: "#{@path}/#{metadata[:toc]}")]
+        end
+
+        def fetch_import(importer_href)
+          api.import_api.list(importer_href).results.first
+        end
+
+        def destroy_importer(importer_href)
+          import_data = fetch_import(importer_href)
+          api.import_api.delete(import_data.pulp_href) unless import_data.blank?
+          api.importer_api.delete(importer_href)
+        end
+
+        def metadata
+          @metadata ||= self.class.metadata(@path)
+        end
+
+        class << self
+          def metadata(path)
+            JSON.parse(File.read("#{path}/#{Export::METADATA_FILE}")).with_indifferent_access
+          end
+
+          def check_permissions!(path)
+            fail _("Invalid path specified.") if path.blank? || !File.directory?(path)
+            fail _("The import path must be in a subdirectory under '%s'." % BASEDIR) unless path.starts_with?(BASEDIR)
+            metadata_file = "#{path}/#{::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE}"
+            fail _("Could not find metadata.json at '%s'." % metadata_file) unless File.exist?(metadata_file)
+            fail _("Unable to read the metadata.json at '%s'." % metadata_file) unless File.readable?(metadata_file)
+            fail _("Pulp user or group unable to read content in '%s'." % path) unless pulp_user_accesible?(path)
+            Dir.glob("#{path}/*").each do |file|
+              next if file == metadata_file
+              fail _("Pulp user or group unable to read '%s'." % file) unless pulp_user_accesible?(file)
+            end
+          end
+
+          def pulp_user_accesible?(path)
+            pulp_info = fetch_pulp_user_info
+            return false if pulp_info.blank?
+
+            stat = File.stat(path)
+            stat.gid.to_s == pulp_info.gid ||
+              stat.uid.to_s == pulp_info.uid ||
+              stat.mode.to_s(8)[-1].to_i >= 4
+          end
+
+          def fetch_pulp_user_info
+            pulp_user = nil
+            Etc.passwd { |u| pulp_user = u if u.name == 'pulp' }
+            pulp_user
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/content_view_version/import_export_common.rb
+++ b/app/services/katello/pulp3/content_view_version/import_export_common.rb
@@ -1,0 +1,44 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      module ImportExportCommon
+        def generate_name
+          @content_view_version.name.gsub(/\s/, '_')
+        end
+
+        def generate_id
+          "#{@content_view_version.organization.label}_#{generate_name}"
+        end
+
+        def api
+          ::Katello::Pulp3::Api::Core.new(@smart_proxy)
+        end
+
+        def fetch_repository_info(version_href)
+          repo_api = ::Katello::Pulp3::Api::Yum.new(@smart_proxy).repositories_api
+          repo_api.read(version_href_to_repository_href(version_href))
+        end
+
+        def repository_hrefs
+          version_hrefs.map { |href| version_href_to_repository_href(href) }.uniq
+        end
+
+        def version_hrefs
+          repositories.pluck(:version_href).compact
+        end
+
+        def repositories
+          if @content_view_version.default?
+            @content_view_version.repositories.yum_type
+          else
+            @content_view_version.archived_repos.yum_type
+          end
+        end
+
+        def version_href_to_repository_href(version_href)
+          version_href.split("/")[0..-3].join("/") + "/"
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -148,6 +148,16 @@ module Katello
           tasks
         end
 
+        def copy_all(source_repository)
+          data = PulpRpmClient::Copy.new
+          data.config = [{
+            source_repo_version: source_repository.version_href,
+            dest_repo: repository_reference.repository_href
+          }]
+
+          [api.copy_api.copy_content(data)]
+        end
+
         def remove_all_content_from_repo(repo_href)
           data = PulpRpmClient::RepositoryAddRemoveContent.new(
             remove_content_units: ['*'])
@@ -271,7 +281,6 @@ module Katello
           end
 
           filters.flatten!.compact!
-
           whitelist_ids = []
           blacklist_ids = []
           filters.each do |filter|
@@ -298,7 +307,6 @@ module Katello
             content_unit_hrefs += additional_content_hrefs(source_repository, content_unit_hrefs)
           end
           content_unit_hrefs += source_repository.srpms.pluck(:pulp_id)
-
           dependency_solving = options[:solve_dependencies] || false
           copy_units(source_repository, content_unit_hrefs.uniq, dependency_solving)
         end

--- a/app/services/katello/pulp3/task.rb
+++ b/app/services/katello/pulp3/task.rb
@@ -61,7 +61,7 @@ module Katello
       end
 
       def task_group_href
-        task_data[:task_group]
+        task_data[:task_group] || task_data[:created_resources].find { |href| href.starts_with?("/pulp/api/v3/task-groups/") }
       end
 
       def done?

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -124,6 +124,7 @@ Katello::Engine.routes.draw do
             get :export_histories
             get :auto_complete_search
             post :incremental_update
+            post :import
           end
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -140,7 +140,7 @@ module Katello
       @plugin.permission :publish_content_views,
                          {
                            'katello/api/v2/content_views' => [:publish],
-                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories]
+                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories, :import]
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :publishable

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -1,0 +1,124 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::ContentViewVersion
+  class TestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+    include Support::Actions::RemoteAction
+    include Support::ExportSupport
+    let(:action_class) do
+      ::Actions::Katello::ContentViewVersion::Import
+    end
+
+    let(:action) do
+      create_action action_class
+    end
+
+    let(:content_view) do
+      content_view_version.content_view
+    end
+
+    let(:content_view_version) do
+      katello_content_view_versions(:library_view_version_2)
+    end
+
+    def setup_proxy
+      proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
+      SmartProxy.any_instance.stubs(:pulp_primary!).returns(proxy)
+      proxy.smart_proxy_features.where(:feature_id => Feature.find_by(:name => SmartProxy::PULP_FEATURE)).delete_all
+    end
+
+    before do
+      set_user
+      SmartProxy.any_instance.stubs(:ping_pulp).returns({})
+      SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
+      SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+      ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
+      ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
+      ::Katello::Repository.any_instance.stubs(:pulp_scratchpad_checksum_type).returns(nil)
+    end
+  end
+
+  class ImportTest < TestBase
+    before do
+      setup_proxy
+    end
+
+    it 'Import should fail on importing content for an existing versions' do
+      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+      metadata = { content_view_version: { major: content_view_version.major, minor: content_view_version.minor} }
+
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
+      exception = assert_raises(RuntimeError) do
+        plan_action(action, content_view, path: import_export_dir)
+      end
+      assert_match(/has already been imported/, exception.message)
+    end
+
+    it 'Import should plan properly' do
+      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+
+      exporter = fetch_exporter(smart_proxy: SmartProxy.pulp_primary,
+                                 content_view_version: content_view_version,
+                                 destination_server: "foo")
+      metadata = exporter.generate_metadata
+      metadata[:content_view_version][:major] += 10
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
+      plan_action(action, content_view, path: import_export_dir)
+      assert_action_planned_with(action,
+                                  ::Actions::Katello::ContentView::Publish,
+                                  content_view, '',
+                                  path: import_export_dir,
+                                  import_only: true,
+                                  major: metadata[:content_view_version][:major],
+                                  minor: metadata[:content_view_version][:minor])
+    end
+
+    it 'Import should plan the full tree appropriately' do
+      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+      exporter = fetch_exporter(smart_proxy: SmartProxy.pulp_primary,
+                                 content_view_version: content_view_version,
+                                 destination_server: "foo")
+      metadata = exporter.generate_metadata
+      metadata[:content_view_version][:major] += 10
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
+      generated_cvv = nil
+      tree = plan_action_tree(action_class, content_view, path: import_export_dir)
+
+      assert_empty tree.errors
+      assert_tree_planned_steps(tree, Actions::Katello::ContentView::AddToEnvironment)
+      assert_tree_planned_steps(tree, Actions::Katello::ContentViewVersion::CreateRepos)
+      assert_tree_planned_steps(tree, Actions::Pulp3::Orchestration::ContentViewVersion::Import)
+      assert_tree_planned_steps(tree, Actions::Pulp3::Orchestration::ContentViewVersion::CopyVersionUnitsToLibrary)
+
+      assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::CreateImporter) do |input|
+        assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
+        assert_equal import_export_dir, input[:path]
+        generated_cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
+        assert_equal content_view_version.content_view.id, generated_cvv.content_view.id
+        assert_equal metadata[:content_view_version][:major], generated_cvv.major
+        assert_equal metadata[:content_view_version][:minor], generated_cvv.minor
+      end
+
+      assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::Import) do |input|
+        assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
+        assert_equal import_export_dir, input[:path]
+        assert_equal generated_cvv.id, input[:content_view_version_id]
+        refute_nil input[:importer_data]
+      end
+      assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::DestroyImporter)
+
+      assert_tree_planned_with(tree, Actions::Pulp3::Repository::CopyContent) do |input|
+        assert input[:copy_all]
+        refute_nil input[:source_repository_id]
+        refute_nil input[:target_repository_id]
+        refute_nil input[:smart_proxy_id]
+      end
+    end
+  end
+end

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -55,7 +55,7 @@ module ::Actions::Katello::ContentViewVersion
       exception = assert_raises(RuntimeError) do
         plan_action(action, content_view, path: import_export_dir)
       end
-      assert_match(/has already been imported/, exception.message)
+      assert_match(/'#{content_view_version.name}' already exists/, exception.message)
     end
 
     it 'Import should plan properly' do

--- a/test/actions/pulp3/content_view_version/export_test.rb
+++ b/test/actions/pulp3/content_view_version/export_test.rb
@@ -38,7 +38,7 @@ module ::Actions::Pulp3::ContentView
     def test_create_exporter
       exporter_data = create_exporter
       assert_includes exporter_data["repositories"], pulp3_cvv.version_href_to_repository_href(@repo.version_href)
-      assert_equal exporter_data["name"], pulp3_cvv.generate_exporter_id
+      assert_equal exporter_data["name"], pulp3_cvv.generate_id
       assert exporter_data["path"].end_with? pulp3_cvv.generate_exporter_path
       delete_exporter(exporter_data)
     end
@@ -59,6 +59,10 @@ module ::Actions::Pulp3::ContentView
     def test_export
       Actions::Pulp3::Orchestration::ContentViewVersion::Export.any_instance.expects(:action_subject).with(@content_view_version)
       File.expects(:directory?).returns(true).at_least_once
+      File.expects(:write).returns.with do |path|
+        assert path.end_with?(::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE)
+      end
+
       output = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @content_view_version, destination_server: "foo").output
       refute_empty output[:exported_file_name]
       refute_empty output[:exported_file_checksum]

--- a/test/fixtures/import-export/metadata.json
+++ b/test/fixtures/import-export/metadata.json
@@ -1,0 +1,1 @@
+{"organization":"export-30803","repository_mapping":{"katello-13926":{"repository":"katello","product":"prod","redhat":false},"misc-24524":{"repository":"misc","product":"prod","redhat":false}},"content_view":"view","content_view_version":{"major":1,"minor":0},"toc":"export-3363d8a3-4252-45b7-b82e-e4f921b788b4-20200924_1625-toc.json"}

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/create_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/create_exporter.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -37,15 +37,15 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '3082'
+      - '3079'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
-        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
-        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        L2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYtNDIyMi05MjM0LTMwZTA1
+        ODY3MTI5MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDAzOjQ3OjEx
+        LjkxMzYxNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -172,7 +172,7 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -183,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -228,7 +228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -262,7 +262,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -273,7 +273,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +286,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -307,7 +307,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -318,7 +318,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +331,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -352,7 +352,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +378,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/57380350-ff78-460d-9457-2325a297b11b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/4bc72e4c-10fc-4ad8-ab82-81e21a52f548/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -399,18 +399,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTczODAzNTAtZmY3OC00NjBkLTk0NTctMjMyNWEyOTdiMTFiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMjE6NTU6MjUuODI2MDE5WiIsInZl
+        cG0vNGJjNzJlNGMtMTBmYy00YWQ4LWFiODItODFlMjFhNTJmNTQ4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMjZUMTg6MzU6MzYuNDI5OTkzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNTczODAzNTAtZmY3OC00NjBkLTk0NTctMjMyNWEyOTdiMTFiL3ZlcnNp
+        cG0vNGJjNzJlNGMtMTBmYy00YWQ4LWFiODItODFlMjFhNTJmNTQ4L3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNTczODAzNTAtZmY3OC00NjBkLTk0NTctMjMy
-        NWEyOTdiMTFiL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        b3NpdG9yaWVzL3JwbS9ycG0vNGJjNzJlNGMtMTBmYy00YWQ4LWFiODItODFl
+        MjFhNTJmNTQ4L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
         bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
         MH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -426,7 +426,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -439,13 +439,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:25 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/f00c2337-a284-43cb-83e8-220518d25471/"
+      - "/pulp/api/v3/remotes/rpm/rpm/c0df3cb5-9846-4b92-904e-8227faddc544/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -459,19 +459,19 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Yw
-        MGMyMzM3LWEyODQtNDNjYi04M2U4LTIyMDUxOGQyNTQ3MS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjI1Ljk1OTgyMVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Mw
+        ZGYzY2I1LTk4NDYtNGI5Mi05MDRlLTgyMjdmYWRkYzU0NC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjM2LjUzNjE5MloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
         InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
         YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIwLTA5LTAxVDIxOjU1OjI1Ljk1OTgzNloiLCJkb3dubG9hZF9jb25j
+        OiIyMDIwLTA5LTI2VDE4OjM1OjM2LjUzNjIwOFoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
         b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:25 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -479,13 +479,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNTczODAzNTAtZmY3OC00NjBkLTk0NTctMjMyNWEyOTdi
-        MTFiL3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vNGJjNzJlNGMtMTBmYy00YWQ4LWFiODItODFlMjFhNTJm
+        NTQ4L3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -498,7 +498,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:26 GMT
+      - Sat, 26 Sep 2020 18:35:36 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -516,13 +516,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhNmJiNjRjLWE2ZWYtNDU5
-        Yy1iOWNiLTUyMjNmNmU1YzdhZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1MDc5MTdlLTA5NWYtNGVl
+        Yi05MzgxLWNlMDNjYzJiYTkzNS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:26 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:36 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/ea6bb64c-a6ef-459c-b9cb-5223f6e5c7ad/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/d507917e-095f-4eeb-9381-ce03cc2ba935/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -530,7 +530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -543,7 +543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:26 GMT
+      - Sat, 26 Sep 2020 18:35:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -557,26 +557,26 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '372'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWE2YmI2NGMtYTZl
-        Zi00NTljLWI5Y2ItNTIyM2Y2ZTVjN2FkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MjYuMjU4MTA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDUwNzkxN2UtMDk1
+        Zi00ZWViLTkzODEtY2UwM2NjMmJhOTM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzYuODY4MTgyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NToyNi40MzMxMDZa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjI2Ljc1MTExNloi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozNy4wNDA2NzBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjM3LjMxNjk2N1oi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        MmFkMDViNTYtMDY3NS00NTkzLThjNzYtZDJjNGM5MzhkYzk5LyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjEzNTc4Yzct
-        ZGFlNS00YWY5LTkyZjgtYzgxYTQ5YWNjODA5LyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYmFjNDhlZGIt
+        MjUyZC00YjViLWJmMDctMjdkNzMwNzI2NzEyLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS81NzM4MDM1MC1mZjc4LTQ2MGQtOTQ1Ny0yMzI1YTI5N2IxMWIvIl19
+        L3JwbS80YmM3MmU0Yy0xMGZjLTRhZDgtYWI4Mi04MWUyMWE1MmY1NDgvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:26 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:37 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -585,15 +585,15 @@ http_interactions:
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
-        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYt
+        NDIyMi05MjM0LTMwZTA1ODY3MTI5MC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
         LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS82MTM1NzhjNy1kYWU1LTRhZjktOTJmOC1jODFhNDlhY2M4MDkvIn0=
+        L3JwbS9iYWM0OGVkYi0yNTJkLTRiNWItYmYwNy0yN2Q3MzA3MjY3MTIvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -606,7 +606,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:26 GMT
+      - Sat, 26 Sep 2020 18:35:37 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -624,13 +624,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiODlkYzA1LTM3YTAtNDM1
-        YS1iYTFhLTY1YzFlNDZkZTIyNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1M2VjNjY0LTgwOTAtNDNi
+        My05NjBmLTVhYTYxYTA3MWE5Zi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:26 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:37 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/bb89dc05-37a0-435a-ba1a-65c1e46de227/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/b53ec664-8090-43b3-960f-5aa61a071a9f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -651,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:27 GMT
+      - Sat, 26 Sep 2020 18:35:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -665,28 +665,28 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '348'
+      - '349'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmI4OWRjMDUtMzdh
-        MC00MzVhLWJhMWEtNjVjMWU0NmRlMjI3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MjYuODkxMjUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjUzZWM2NjQtODA5
+        MC00M2IzLTk2MGYtNWFhNjFhMDcxYTlmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzcuNDc0NTU1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MjcuMDQ1ODUz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NToyNy4yOTU3ODla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MzcuNjM2ODky
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozNy45MzMyMDla
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8zNTExYTIz
-        MC1iZDQ2LTRmNzgtOTY2YS04MDIxMTZiMmQ1YWEvIl0sInJlc2VydmVkX3Jl
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS84YWEyMDk4
+        ZC1kOTA5LTQzYTctYTBiOC0wMThkOGU1NWFiNGMvIl0sInJlc2VydmVkX3Jl
         c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:27 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:38 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/3511a230-bd46-4f78-966a-802116b2d5aa/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/8aa2098d-d909-43a7-a0b8-018d8e55ab4c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -694,7 +694,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -707,7 +707,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:27 GMT
+      - Sat, 26 Sep 2020 18:35:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -726,33 +726,33 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzM1MTFhMjMwLWJkNDYtNGY3OC05NjZhLTgwMjExNmIyZDVhYS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjI3LjI3ODM0MloiLCJi
+        cnBtLzhhYTIwOThkLWQ5MDktNDNhNy1hMGI4LTAxOGQ4ZTU1YWI0Yy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjM3LjkxNTI2M1oiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
         YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
-        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        ZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4NjcxMjkwLyIsIm5hbWUi
         OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
-        YmxpY2F0aW9ucy9ycG0vcnBtLzYxMzU3OGM3LWRhZTUtNGFmOS05MmY4LWM4
-        MWE0OWFjYzgwOS8ifQ==
+        YmxpY2F0aW9ucy9ycG0vcnBtL2JhYzQ4ZWRiLTI1MmQtNGI1Yi1iZjA3LTI3
+        ZDczMDcyNjcxMi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:27 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:38 GMT
 - request:
     method: post
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/57380350-ff78-460d-9457-2325a297b11b/sync/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/4bc72e4c-10fc-4ad8-ab82-81e21a52f548/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2YwMGMy
-        MzM3LWEyODQtNDNjYi04M2U4LTIyMDUxOGQyNTQ3MS8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2MwZGYz
+        Y2I1LTk4NDYtNGI5Mi05MDRlLTgyMjdmYWRkYzU0NC8iLCJtaXJyb3IiOnRy
         dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -765,7 +765,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:27 GMT
+      - Sat, 26 Sep 2020 18:35:38 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -783,13 +783,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1Y2U5ZWU0LTYzN2EtNDQz
-        Ny05NzhmLTIwMWEzM2EzY2M4Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyYzc5NDg5LTVlMzYtNDA4
+        ZS05NjU4LTA2OTA3NDYxZjhlOC8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:27 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:38 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/85ce9ee4-637a-4437-978f-201a33a3cc86/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/82c79489-5e36-408e-9658-06907461f8e8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -797,7 +797,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -810,7 +810,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:29 GMT
+      - Sat, 26 Sep 2020 18:35:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -824,44 +824,44 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '565'
+      - '564'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODVjZTllZTQtNjM3
-        YS00NDM3LTk3OGYtMjAxYTMzYTNjYzg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MjcuODY0OTI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODJjNzk0ODktNWUz
+        Ni00MDhlLTk2NTgtMDY5MDc0NjFmOGU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzguNDQ0MDg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6Mjgu
-        MDEzMDY4WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NToyOS40
-        Mzk1NDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzL2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8i
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6Mzgu
+        NjEwMDAwWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozOS45
+        OTYwMzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
-        bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
-        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
-        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVz
-        c2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3Nv
-        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
-        ZWQgQWR2aXNvcmllcyIsImNvZGUiOiJwYXJzaW5nLmFkdmlzb3JpZXMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJw
-        YXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        MzIsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
-        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3Mzgw
-        MzUwLWZmNzgtNDYwZC05NDU3LTIzMjVhMjk3YjExYi92ZXJzaW9ucy8xLyJd
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoicGFyc2luZy5hZHZpc29yaWVzIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
+        cGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzRiYzcy
+        ZTRjLTEwZmMtNGFkOC1hYjgyLTgxZTIxYTUyZjU0OC92ZXJzaW9ucy8xLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS81NzM4MDM1MC1mZjc4LTQ2MGQtOTQ1Ny0y
-        MzI1YTI5N2IxMWIvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9m
-        MDBjMjMzNy1hMjg0LTQzY2ItODNlOC0yMjA1MThkMjU0NzEvIl19
+        ZW1vdGVzL3JwbS9ycG0vYzBkZjNjYjUtOTg0Ni00YjkyLTkwNGUtODIyN2Zh
+        ZGRjNTQ0LyIsIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80
+        YmM3MmU0Yy0xMGZjLTRhZDgtYWI4Mi04MWUyMWE1MmY1NDgvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:29 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:40 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -869,13 +869,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNTczODAzNTAtZmY3OC00NjBkLTk0NTctMjMyNWEyOTdi
-        MTFiL3ZlcnNpb25zLzEvIn0=
+        aWVzL3JwbS9ycG0vNGJjNzJlNGMtMTBmYy00YWQ4LWFiODItODFlMjFhNTJm
+        NTQ4L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -888,7 +888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:29 GMT
+      - Sat, 26 Sep 2020 18:35:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -906,13 +906,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzZTlmNjdlLTJiY2MtNGE1
-        YS04YWE0LWExNDk1ZmFmNzkwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5MjkyZTYzLTYwZWMtNDZk
+        OS05MTMwLTRmNGNiMzVkNjhiMS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:29 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:40 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/13e9f67e-2bcc-4a5a-8aa4-a1495faf7905/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/a9292e63-60ec-46d9-9130-4f4cb35d68b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -920,7 +920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -933,7 +933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:30 GMT
+      - Sat, 26 Sep 2020 18:35:40 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -947,43 +947,43 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '374'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTNlOWY2N2UtMmJj
-        Yy00YTVhLThhYTQtYTE0OTVmYWY3OTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MjkuNjI1Mzc3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTkyOTJlNjMtNjBl
+        Yy00NmQ5LTkxMzAtNGY0Y2IzNWQ2OGIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6NDAuMjI1OTIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NToyOS43OTQ4NTla
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjMwLjI0MTk2M1oi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTo0MC4zOTQzODNa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjQwLjg5NjEyM1oi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        ZTcyZGUxYmEtODZiOS00MDg5LWJjZGItMTAwZTFiZTgzOTYzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYzNhZDM0NGMt
-        MWYyYy00ODE2LWE4YjQtODIyMWM2ODIzNTZhLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNjI4ZDgxYzEt
+        N2E5Ny00ZWZmLWJjMDAtNzFlZTM3YzViN2UwLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS81NzM4MDM1MC1mZjc4LTQ2MGQtOTQ1Ny0yMzI1YTI5N2IxMWIvIl19
+        L3JwbS80YmM3MmU0Yy0xMGZjLTRhZDgtYWI4Mi04MWUyMWE1MmY1NDgvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:30 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:40 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/3511a230-bd46-4f78-966a-802116b2d5aa/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/8aa2098d-d909-43a7-a0b8-018d8e55ab4c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jM2FkMzQ0Yy0xZjJjLTQ4
-        MTYtYThiNC04MjIxYzY4MjM1NmEvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS82MjhkODFjMS03YTk3LTRl
+        ZmYtYmMwMC03MWVlMzdjNWI3ZTAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -996,7 +996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:30 GMT
+      - Sat, 26 Sep 2020 18:35:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1014,13 +1014,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5YTNkN2E3LTYxYzYtNGIw
-        ZS1hZWRjLTIzMmUyOGE0YmFlYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3M2VjM2Q4LWYxZDMtNGYx
+        OC04YmZlLWY5MmEwMGVmMDgwMy8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:30 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:41 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/89a3d7a7-61c6-4b0e-aedc-232e28a4baeb/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/d73ec3d8-f1d3-4f18-8bfe-f92a00ef0803/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:30 GMT
+      - Sat, 26 Sep 2020 18:35:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1059,37 +1059,37 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODlhM2Q3YTctNjFj
-        Ni00YjBlLWFlZGMtMjMyZTI4YTRiYWViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzAuMzc5MDQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDczZWMzZDgtZjFk
+        My00ZjE4LThiZmUtZjkyYTAwZWYwODAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6NDEuMDU1MTk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MzAuNTE5NDQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozMC44MzA4NTNa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6NDEuMjIzNDEz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTo0MS41MDM4MTRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        L2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:30 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:41 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/3511a230-bd46-4f78-966a-802116b2d5aa/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/8aa2098d-d909-43a7-a0b8-018d8e55ab4c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jM2FkMzQ0Yy0xZjJjLTQ4
-        MTYtYThiNC04MjIxYzY4MjM1NmEvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS82MjhkODFjMS03YTk3LTRl
+        ZmYtYmMwMC03MWVlMzdjNWI3ZTAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1102,7 +1102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:30 GMT
+      - Sat, 26 Sep 2020 18:35:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1120,10 +1120,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2YWUyMDBiLTNkMmItNDAz
-        MS05Nzg0LTZjNWJjMTdmMWIwMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4ODRmMGU3LWIyYjEtNDU4
+        MC1iYmVlLTcwOWUxMzE5ODRhZS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:30 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:41 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
@@ -1134,13 +1134,13 @@ http_interactions:
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
         cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
         L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NzM4MDM1MC1m
-        Zjc4LTQ2MGQtOTQ1Ny0yMzI1YTI5N2IxMWIvIl19
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80YmM3MmU0Yy0x
+        MGZjLTRhZDgtYWI4Mi04MWUyMWE1MmY1NDgvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1153,13 +1153,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
+      - Sat, 26 Sep 2020 18:35:41 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/53f8556e-ba74-49fe-901b-c0439a7fdc4f/"
+      - "/pulp/api/v3/exporters/core/pulp/16507865-004a-46a3-8f80-b83c97f303fa/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1174,19 +1174,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC81M2Y4NTU2ZS1iYTc0LTQ5ZmUtOTAxYi1jMDQzOWE3ZmRjNGYvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTozMS4yMTAzNjlaIiwibmFt
+        cC8xNjUwNzg2NS0wMDRhLTQ2YTMtOGY4MC1iODNjOTdmMzAzZmEvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNTo0MS44ODk2NTdaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTczODAzNTAtZmY3OC00
-        NjBkLTk0NTctMjMyNWEyOTdiMTFiLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGJjNzJlNGMtMTBmYy00
+        YWQ4LWFiODItODFlMjFhNTJmNTQ4LyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:41 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/53f8556e-ba74-49fe-901b-c0439a7fdc4f/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/16507865-004a-46a3-8f80-b83c97f303fa/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1194,7 +1194,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1207,7 +1207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
+      - Sat, 26 Sep 2020 18:35:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1228,10 +1228,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/53f8556e-ba74-49fe-901b-c0439a7fdc4f/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/16507865-004a-46a3-8f80-b83c97f303fa/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1241,7 +1241,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1254,7 +1254,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
+      - Sat, 26 Sep 2020 18:35:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1273,19 +1273,19 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC81M2Y4NTU2ZS1iYTc0LTQ5ZmUtOTAxYi1jMDQzOWE3ZmRjNGYvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTozMS4yMTAzNjlaIiwibmFt
+        cC8xNjUwNzg2NS0wMDRhLTQ2YTMtOGY4MC1iODNjOTdmMzAzZmEvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNTo0MS44ODk2NTdaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTczODAzNTAtZmY3OC00
-        NjBkLTk0NTctMjMyNWEyOTdiMTFiLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGJjNzJlNGMtMTBmYy00
+        YWQ4LWFiODItODFlMjFhNTJmNTQ4LyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/53f8556e-ba74-49fe-901b-c0439a7fdc4f/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/16507865-004a-46a3-8f80-b83c97f303fa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1293,7 +1293,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Authorization:
       - Basic Og==
       Accept-Encoding:
@@ -1306,7 +1306,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
+      - Sat, 26 Sep 2020 18:35:42 GMT
       Server:
       - gunicorn/20.0.4
       Vary:
@@ -1321,10 +1321,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/f00c2337-a284-43cb-83e8-220518d25471/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/c0df3cb5-9846-4b92-904e-8227faddc544/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1332,7 +1332,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1345,7 +1345,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
+      - Sat, 26 Sep 2020 18:35:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1363,13 +1363,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhYjEzMTM3LTRmZjAtNDE4
-        Ny1iNTljLTE1ZDczYmE0M2Q5MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzODM5NTUwLTU5NjMtNDE0
+        MS1hY2IwLWQ1YzMyYThkNGQ1NS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/4ab13137-4ff0-4187-b59c-15d73ba43d91/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/e3839550-5963-4141-acb0-d5c32a8d4d55/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1377,7 +1377,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1390,153 +1390,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:31 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 lambda.sparta.example.com
-      Content-Length:
-      - '337'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFiMTMxMzctNGZm
-        MC00MTg3LWI1OWMtMTVkNzNiYTQzZDkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzEuNjc1NjA5WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MzEuODE5NDAx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozMS44ODczMTRa
-        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
-        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
-        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vZjAwYzIzMzctYTI4NC00M2NiLTgzZTgtMjIw
-        NTE4ZDI1NDcxLyJdfQ==
-    http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:31 GMT
-- request:
-    method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/3511a230-bd46-4f78-966a-802116b2d5aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 01 Sep 2020 21:55:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 lambda.sparta.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwNjc1YzNiLTI2ZDItNDg5
-        NC05YzJmLWMyYmYyMGEwNTQzOC8ifQ==
-    http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:32 GMT
-- request:
-    method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/57380350-ff78-460d-9457-2325a297b11b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 01 Sep 2020 21:55:32 GMT
-      Server:
-      - gunicorn/20.0.4
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Via:
-      - 1.1 lambda.sparta.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4NmVmNTk0LWUyMmMtNDIw
-        ZC05NDJjLWU4NzA3ODQxYTdlYS8ifQ==
-    http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:32 GMT
-- request:
-    method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/886ef594-e22c-420d-942c-e8707841a7ea/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 01 Sep 2020 21:55:32 GMT
+      - Sat, 26 Sep 2020 18:35:42 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1554,19 +1408,165 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODg2ZWY1OTQtZTIy
-        Yy00MjBkLTk0MmMtZTg3MDc4NDFhN2VhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzIuMDgwNDI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTM4Mzk1NTAtNTk2
+        My00MTQxLWFjYjAtZDVjMzJhOGQ0ZDU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6NDIuMzQ5MDE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MzIuMzA4NzE4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozMi40OTk5NDRa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6NDIuNDg5NDYz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTo0Mi41NjgyNzNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        L2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NzM4MDM1MC1mZjc4LTQ2MGQtOTQ1
-        Ny0yMzI1YTI5N2IxMWIvIl19
+        My9yZW1vdGVzL3JwbS9ycG0vYzBkZjNjYjUtOTg0Ni00YjkyLTkwNGUtODIy
+        N2ZhZGRjNTQ0LyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:32 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/8aa2098d-d909-43a7-a0b8-018d8e55ab4c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 26 Sep 2020 18:35:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlM2M5M2I4LWVhZGMtNDcz
+        NS1hYmI3LTlmYTM0ZjVlM2ExOC8ifQ==
+    http_version: 
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
+- request:
+    method: delete
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/4bc72e4c-10fc-4ad8-ab82-81e21a52f548/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Sat, 26 Sep 2020 18:35:42 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 lambda.sparta.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxNGRlMDVjLWM3ZTYtNDE1
+        Ni05M2U5LTcwMWVjYWNiYmM1My8ifQ==
+    http_version: 
+  recorded_at: Sat, 26 Sep 2020 18:35:42 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/714de05c-c7e6-4156-93e9-701ecacbbc53/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 26 Sep 2020 18:35:43 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '342'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzE0ZGUwNWMtYzdl
+        Ni00MTU2LTkzZTktNzAxZWNhY2JiYzUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6NDIuNzgyMDkxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6NDMuMDEzOTI0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTo0My4yMTMwODZa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80YmM3MmU0Yy0xMGZjLTRhZDgtYWI4
+        Mi04MWUyMWE1MmY1NDgvIl19
+    http_version: 
+  recorded_at: Sat, 26 Sep 2020 18:35:43 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/destroy_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/destroy_exporter.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:33 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -37,15 +37,15 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '3082'
+      - '3079'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
-        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
-        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        L2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYtNDIyMi05MjM0LTMwZTA1
+        ODY3MTI5MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDAzOjQ3OjEx
+        LjkxMzYxNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -172,7 +172,7 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:33 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -183,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:33 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:33 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -228,7 +228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:33 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -262,7 +262,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:33 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -273,7 +273,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +286,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:33 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -307,7 +307,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:33 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -318,7 +318,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +331,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:33 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -352,7 +352,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:33 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +378,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:34 GMT
+      - Sat, 26 Sep 2020 18:35:16 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/61977aa2-18ff-4987-bccb-aa908bbd44fc/"
+      - "/pulp/api/v3/repositories/rpm/rpm/832895e3-93be-463e-a3d1-e1b6c0718513/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -399,18 +399,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjE5NzdhYTItMThmZi00OTg3LWJjY2ItYWE5MDhiYmQ0NGZjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMjE6NTU6MzQuMDc1MzI2WiIsInZl
+        cG0vODMyODk1ZTMtOTNiZS00NjNlLWEzZDEtZTFiNmMwNzE4NTEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMjZUMTg6MzU6MTYuODYwMTk3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNjE5NzdhYTItMThmZi00OTg3LWJjY2ItYWE5MDhiYmQ0NGZjL3ZlcnNp
+        cG0vODMyODk1ZTMtOTNiZS00NjNlLWEzZDEtZTFiNmMwNzE4NTEzL3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNjE5NzdhYTItMThmZi00OTg3LWJjY2ItYWE5
-        MDhiYmQ0NGZjL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        b3NpdG9yaWVzL3JwbS9ycG0vODMyODk1ZTMtOTNiZS00NjNlLWEzZDEtZTFi
+        NmMwNzE4NTEzL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
         bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
         MH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:34 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:16 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -426,7 +426,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -439,13 +439,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:34 GMT
+      - Sat, 26 Sep 2020 18:35:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/4658b989-a98a-4fbd-83cd-57901beeb182/"
+      - "/pulp/api/v3/remotes/rpm/rpm/cc9784ae-d3c3-4911-a5f9-b326b7fe22f1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -459,19 +459,19 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ2
-        NThiOTg5LWE5OGEtNGZiZC04M2NkLTU3OTAxYmVlYjE4Mi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjM0LjE2ODA5NVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Nj
+        OTc4NGFlLWQzYzMtNDkxMS1hNWY5LWIzMjZiN2ZlMjJmMS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjE2Ljk5ODI1MloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
         InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
         YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIwLTA5LTAxVDIxOjU1OjM0LjE2ODExMVoiLCJkb3dubG9hZF9jb25j
+        OiIyMDIwLTA5LTI2VDE4OjM1OjE2Ljk5ODI2OVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
         b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:34 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:17 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -479,13 +479,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNjE5NzdhYTItMThmZi00OTg3LWJjY2ItYWE5MDhiYmQ0
-        NGZjL3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vODMyODk1ZTMtOTNiZS00NjNlLWEzZDEtZTFiNmMwNzE4
+        NTEzL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -498,7 +498,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:34 GMT
+      - Sat, 26 Sep 2020 18:35:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -516,13 +516,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjMTlkNWVhLTMxMTAtNDhi
-        Ni1hMmU1LTA5MTA1M2ZmMjk3Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiOWMxMzU3LWNkMGYtNGQ0
+        OS05MzU4LWUyNjI5ZGU5YTc2MC8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:34 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:17 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/3c19d5ea-3110-48b6-a2e5-091053ff297b/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/db9c1357-cd0f-4d49-9358-e2629de9a760/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -530,7 +530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -543,7 +543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:34 GMT
+      - Sat, 26 Sep 2020 18:35:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -561,22 +561,22 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2MxOWQ1ZWEtMzEx
-        MC00OGI2LWEyZTUtMDkxMDUzZmYyOTdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzQuNDgyMzkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGI5YzEzNTctY2Qw
+        Zi00ZDQ5LTkzNTgtZTI2MjlkZTlhNzYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MTcuMzE3ODc4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozNC42MzQ5MjZa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjM0Ljg3ODIzNloi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToxNy40NjM0MzFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjE3Ljc1MjY3NFoi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        ZTcyZGUxYmEtODZiOS00MDg5LWJjZGItMTAwZTFiZTgzOTYzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2M2M2IwMjkt
-        NjAyYy00MTQ5LWFlNWQtYjVkODgxMWFlMTk5LyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGRhNjUyNGYt
+        MjZlMi00NmQ3LWEzMjYtNjM5MDk0YmUwMGVlLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS82MTk3N2FhMi0xOGZmLTQ5ODctYmNjYi1hYTkwOGJiZDQ0ZmMvIl19
+        L3JwbS84MzI4OTVlMy05M2JlLTQ2M2UtYTNkMS1lMWI2YzA3MTg1MTMvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:34 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:17 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -585,15 +585,15 @@ http_interactions:
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
-        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYt
+        NDIyMi05MjM0LTMwZTA1ODY3MTI5MC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
         LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8zYzYzYjAyOS02MDJjLTQxNDktYWU1ZC1iNWQ4ODExYWUxOTkvIn0=
+        L3JwbS8wZGE2NTI0Zi0yNmUyLTQ2ZDctYTMyNi02MzkwOTRiZTAwZWUvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -606,7 +606,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:35 GMT
+      - Sat, 26 Sep 2020 18:35:17 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -624,13 +624,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2MGU5NTI1LTBiYmItNDE0
-        NC05NTA3LWEyMGFhNWJkZmU4NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlMWExYTU3LTE0ZTItNDYw
+        Mi1iNjc5LTIzZmQ0OGNlYzhlMy8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:35 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:17 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/f60e9525-0bbb-4144-9507-a20aa5bdfe85/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/0e1a1a57-14e2-4602-b679-23fd48cec8e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -651,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:35 GMT
+      - Sat, 26 Sep 2020 18:35:18 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -665,28 +665,28 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '348'
+      - '347'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjYwZTk1MjUtMGJi
-        Yi00MTQ0LTk1MDctYTIwYWE1YmRmZTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzUuMDI0MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGUxYTFhNTctMTRl
+        Mi00NjAyLWI2NzktMjNmZDQ4Y2VjOGUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MTcuOTExNDA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MzUuMTc5NjQ2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozNS40NDA3ODla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MTguMDY4MTQ5
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToxOC4zNjkwNjZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        L2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8wMjk4MTY5
-        Yi05N2E0LTQ4ZDgtODZiMy0yMjZiODU3NmEwNTMvIl0sInJlc2VydmVkX3Jl
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS82MTY1ODk4
+        NS0xODJkLTQ0NzItOGU1Yy0wMWY0ZmJiMTM0ZDYvIl0sInJlc2VydmVkX3Jl
         c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:35 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:18 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0298169b-97a4-48d8-86b3-226b8576a053/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/61658985-182d-4472-8e5c-01f4fbb134d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -694,7 +694,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -707,7 +707,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:35 GMT
+      - Sat, 26 Sep 2020 18:35:18 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -721,38 +721,38 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '315'
+      - '313'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAyOTgxNjliLTk3YTQtNDhkOC04NmIzLTIyNmI4NTc2YTA1My8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjM1LjQyMzkzMFoiLCJi
+        cnBtLzYxNjU4OTg1LTE4MmQtNDQ3Mi04ZTVjLTAxZjRmYmIxMzRkNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjE4LjM1NDA1NloiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
         YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
-        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        ZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4NjcxMjkwLyIsIm5hbWUi
         OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
-        YmxpY2F0aW9ucy9ycG0vcnBtLzNjNjNiMDI5LTYwMmMtNDE0OS1hZTVkLWI1
-        ZDg4MTFhZTE5OS8ifQ==
+        YmxpY2F0aW9ucy9ycG0vcnBtLzBkYTY1MjRmLTI2ZTItNDZkNy1hMzI2LTYz
+        OTA5NGJlMDBlZS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:35 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:18 GMT
 - request:
     method: post
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/61977aa2-18ff-4987-bccb-aa908bbd44fc/sync/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/832895e3-93be-463e-a3d1-e1b6c0718513/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ2NThi
-        OTg5LWE5OGEtNGZiZC04M2NkLTU3OTAxYmVlYjE4Mi8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2NjOTc4
+        NGFlLWQzYzMtNDkxMS1hNWY5LWIzMjZiN2ZlMjJmMS8iLCJtaXJyb3IiOnRy
         dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -765,7 +765,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:35 GMT
+      - Sat, 26 Sep 2020 18:35:18 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -783,13 +783,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3MmY4YmZkLWE3YzMtNDBj
-        OS1iNDZjLTA0MjQ1MzkxNGJhOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5ZTdhOTFmLTZmMjctNGI5
+        OC1iZTBkLWYyNDM0MjNiMTk1ZS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:35 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:18 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/772f8bfd-a7c3-40c9-b46c-042453914ba8/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/b9e7a91f-6f27-4b98-be0d-f243423b195e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -797,7 +797,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -810,7 +810,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:38 GMT
+      - Sat, 26 Sep 2020 18:35:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -824,44 +824,44 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '566'
+      - '569'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzcyZjhiZmQtYTdj
-        My00MGM5LWI0NmMtMDQyNDUzOTE0YmE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzUuOTU1NDE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjllN2E5MWYtNmYy
+        Ny00Yjk4LWJlMGQtZjI0MzQyM2IxOTVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MTguODc5NDg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6MzYu
-        MTA2MTcwWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozOC4x
-        ODE4NjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8i
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MTku
+        MDI5MDg3WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyMi4w
+        MTM3OTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
-        bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
-        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
-        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVz
-        c2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3Nv
-        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
-        ZWQgQWR2aXNvcmllcyIsImNvZGUiOiJwYXJzaW5nLmFkdmlzb3JpZXMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJw
-        YXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        MzIsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
-        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYxOTc3
-        YWEyLTE4ZmYtNDk4Ny1iY2NiLWFhOTA4YmJkNDRmYy92ZXJzaW9ucy8xLyJd
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoicGFyc2luZy5hZHZpc29yaWVzIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzZWQgUGFja2FnZXMiLCJjb2RlIjoi
+        cGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMyLCJkb25lIjozMiwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzgzMjg5
+        NWUzLTkzYmUtNDYzZS1hM2QxLWUxYjZjMDcxODUxMy92ZXJzaW9ucy8xLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS82MTk3N2FhMi0xOGZmLTQ5ODctYmNjYi1h
-        YTkwOGJiZDQ0ZmMvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS80
-        NjU4Yjk4OS1hOThhLTRmYmQtODNjZC01NzkwMWJlZWIxODIvIl19
+        ZW1vdGVzL3JwbS9ycG0vY2M5Nzg0YWUtZDNjMy00OTExLWE1ZjktYjMyNmI3
+        ZmUyMmYxLyIsIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        MzI4OTVlMy05M2JlLTQ2M2UtYTNkMS1lMWI2YzA3MTg1MTMvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:38 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:22 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -869,13 +869,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vNjE5NzdhYTItMThmZi00OTg3LWJjY2ItYWE5MDhiYmQ0
-        NGZjL3ZlcnNpb25zLzEvIn0=
+        aWVzL3JwbS9ycG0vODMyODk1ZTMtOTNiZS00NjNlLWEzZDEtZTFiNmMwNzE4
+        NTEzL3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -888,7 +888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:38 GMT
+      - Sat, 26 Sep 2020 18:35:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -906,13 +906,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyZWZkNDQ0LTY5Y2UtNDkw
-        OS04ODNlLTFlNjRkMzBhZmM4OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiNGZhMGM4LTA2Y2YtNDdl
+        NC1iYTk4LTU3Njc4NWEyMWExZi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:38 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:22 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/32efd444-69ce-4909-883e-1e64d30afc89/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/bb4fa0c8-06cf-47e4-ba98-576785a21a1f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -920,7 +920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -933,7 +933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:39 GMT
+      - Sat, 26 Sep 2020 18:35:22 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -947,43 +947,43 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '374'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzJlZmQ0NDQtNjlj
-        ZS00OTA5LTg4M2UtMWU2NGQzMGFmYzg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzguNTkyNDA5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmI0ZmEwYzgtMDZj
+        Zi00N2U0LWJhOTgtNTc2Nzg1YTIxYTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjIuMzAzODg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTozOC44MDMwMDJa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjM5LjQ2MjkxMFoi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyMi40ODUwNDFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjIyLjkyOTA3M1oi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        ZTcyZGUxYmEtODZiOS00MDg5LWJjZGItMTAwZTFiZTgzOTYzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTZlNDZmNmEt
-        MzljZS00NjdlLTkxZGItZDY1MTIzOTZlZDczLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGZiMGI4ZmEt
+        YTUxNS00ZjIxLTgwNjYtY2JiOTA3Y2ZkZTAxLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS82MTk3N2FhMi0xOGZmLTQ5ODctYmNjYi1hYTkwOGJiZDQ0ZmMvIl19
+        L3JwbS84MzI4OTVlMy05M2JlLTQ2M2UtYTNkMS1lMWI2YzA3MTg1MTMvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:39 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:22 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0298169b-97a4-48d8-86b3-226b8576a053/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/61658985-182d-4472-8e5c-01f4fbb134d6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS81NmU0NmY2YS0zOWNlLTQ2
-        N2UtOTFkYi1kNjUxMjM5NmVkNzMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84ZmIwYjhmYS1hNTE1LTRm
+        MjEtODA2Ni1jYmI5MDdjZmRlMDEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -996,7 +996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:39 GMT
+      - Sat, 26 Sep 2020 18:35:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1014,13 +1014,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxOTk0ZGQ0LWIyODYtNDU0
-        OS1iNmEyLTc2ZTQ5OTE3ZTg4My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjMWRjOTQ5LWJiNmUtNDBh
+        Ny1iMzUyLTI1ODA1MzJiNzliOC8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:39 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:23 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/b1994dd4-b286-4549-b6a2-76e49917e883/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/7c1dc949-bb6e-40a7-b352-2580532b79b8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:40 GMT
+      - Sat, 26 Sep 2020 18:35:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1055,41 +1055,41 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '318'
+      - '316'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjE5OTRkZDQtYjI4
-        Ni00NTQ5LWI2YTItNzZlNDk5MTdlODgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6MzkuNzQ4NzgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2MxZGM5NDktYmI2
+        ZS00MGE3LWIzNTItMjU4MDUzMmI3OWI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjMuMDk2ODE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NDAuMDEwODk4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0MC4zNzk5NzVa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MjMuMjUxMjI3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyMy41MjM0MjFa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:40 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:23 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0298169b-97a4-48d8-86b3-226b8576a053/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/61658985-182d-4472-8e5c-01f4fbb134d6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS81NmU0NmY2YS0zOWNlLTQ2
-        N2UtOTFkYi1kNjUxMjM5NmVkNzMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84ZmIwYjhmYS1hNTE1LTRm
+        MjEtODA2Ni1jYmI5MDdjZmRlMDEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1102,7 +1102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:40 GMT
+      - Sat, 26 Sep 2020 18:35:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1120,10 +1120,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExZWE1YmIwLWY0ZmQtNDY5
-        Zi05MTc2LWY1ZGJiZDhmZWZmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNzhlZGVjLTc2MDctNDBj
+        Yy1hMDkyLTZmYmM4OTkyODM2Ny8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:40 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:23 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
@@ -1134,13 +1134,13 @@ http_interactions:
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
         cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
         L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTk3N2FhMi0x
-        OGZmLTQ5ODctYmNjYi1hYTkwOGJiZDQ0ZmMvIl19
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84MzI4OTVlMy05
+        M2JlLTQ2M2UtYTNkMS1lMWI2YzA3MTg1MTMvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1153,13 +1153,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:23 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/"
+      - "/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1174,19 +1174,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC82MTBmYTU0ZC04NzZjLTQyOWEtOTRhYS04NDVlY2UzYjIyNDEvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTo0MS4wMDU1MjdaIiwibmFt
+        cC9hYTc3MjI3My1hM2JlLTRmZjAtOTEwNy00NDhmMDQ2MWFlYzgvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNToyMy45NTU1ODJaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE5NzdhYTItMThmZi00
-        OTg3LWJjY2ItYWE5MDhiYmQ0NGZjLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODMyODk1ZTMtOTNiZS00
+        NjNlLWEzZDEtZTFiNmMwNzE4NTEzLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:23 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1194,7 +1194,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1207,7 +1207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1228,10 +1228,10 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1241,7 +1241,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1254,7 +1254,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1273,19 +1273,19 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC82MTBmYTU0ZC04NzZjLTQyOWEtOTRhYS04NDVlY2UzYjIyNDEvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTo0MS4wMDU1MjdaIiwibmFt
+        cC9hYTc3MjI3My1hM2JlLTRmZjAtOTEwNy00NDhmMDQ2MWFlYzgvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNToyMy45NTU1ODJaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE5NzdhYTItMThmZi00
-        OTg3LWJjY2ItYWE5MDhiYmQ0NGZjLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODMyODk1ZTMtOTNiZS00
+        NjNlLWEzZDEtZTFiNmMwNzE4NTEzLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1293,7 +1293,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Authorization:
       - Basic Og==
       Accept-Encoding:
@@ -1306,7 +1306,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Vary:
@@ -1321,10 +1321,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1332,7 +1332,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1345,7 +1345,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1366,10 +1366,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/610fa54d-876c-429a-94aa-845ece3b2241/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/aa772273-a3be-4ff0-9107-448f0461aec8/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1377,7 +1377,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1390,7 +1390,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1411,10 +1411,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/4658b989-a98a-4fbd-83cd-57901beeb182/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/cc9784ae-d3c3-4911-a5f9-b326b7fe22f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1422,7 +1422,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1435,7 +1435,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:41 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1453,13 +1453,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwMGI0NTE4LTg2MTQtNDgw
-        YS1iZGFjLTljZTQ4Y2FmZGFiMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1Y2NjNDI4LTUwNTEtNDZh
+        Zi1iNWU2LTZiMWUxMGIyOTM1Yi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:41 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/d00b4518-8614-480a-bdac-9ce48cafdab2/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/65ccc428-5051-46af-b5e6-6b1e10b2935b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1467,7 +1467,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1480,7 +1480,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:42 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1494,28 +1494,28 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '339'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDAwYjQ1MTgtODYx
-        NC00ODBhLWJkYWMtOWNlNDhjYWZkYWIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NDEuNzc2NTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjVjY2M0MjgtNTA1
+        MS00NmFmLWI1ZTYtNmIxZTEwYjI5MzViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjQuNDg3NjU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NDIuMDI3ODQ3
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0Mi4xMzQ0NDda
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MjQuNjQxNTc3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyNC43MDMzMTBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vNDY1OGI5ODktYTk4YS00ZmJkLTgzY2QtNTc5
-        MDFiZWViMTgyLyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vY2M5Nzg0YWUtZDNjMy00OTExLWE1ZjktYjMy
+        NmI3ZmUyMmYxLyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:42 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/0298169b-97a4-48d8-86b3-226b8576a053/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/61658985-182d-4472-8e5c-01f4fbb134d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1523,7 +1523,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1536,7 +1536,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:42 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1554,13 +1554,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5YzYzNzRlLTYwZjctNDdj
-        My1hN2IyLTZkZjUwMDNjNjZkMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4ZTY4NTRmLWZmZmItNGNk
+        NC04MGQ1LWNiMmE0NGU0ZDdkNi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:42 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/61977aa2-18ff-4987-bccb-aa908bbd44fc/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/832895e3-93be-463e-a3d1-e1b6c0718513/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1568,7 +1568,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1581,7 +1581,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:42 GMT
+      - Sat, 26 Sep 2020 18:35:24 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1599,13 +1599,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjNTJlZTRhLWJkN2MtNGQ3
-        Zi04YzliLTY1Yzk4NjMwZTA1OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1NDk1Nzg1LTcxZmYtNDg3
+        OS1hN2EzLTFkY2YzNTY1MTAxNy8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:42 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:24 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/1c52ee4a-bd7c-4d7f-8c9b-65c98630e059/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/05495785-71ff-4879-a7a3-1dcf35651017/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1613,7 +1613,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1626,7 +1626,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:43 GMT
+      - Sat, 26 Sep 2020 18:35:25 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1640,23 +1640,23 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '342'
+      - '343'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWM1MmVlNGEtYmQ3
-        Yy00ZDdmLThjOWItNjVjOTg2MzBlMDU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NDIuNDU4NjE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDU0OTU3ODUtNzFm
+        Zi00ODc5LWE3YTMtMWRjZjM1NjUxMDE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjQuODk5MjgzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NDIuODMxNjIy
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0My4yMTQzNzNa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MjUuMTQ1ODEy
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyNS4zNjUwMDda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTk3N2FhMi0xOGZmLTQ5ODctYmNj
-        Yi1hYTkwOGJiZDQ0ZmMvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84MzI4OTVlMy05M2JlLTQ2M2UtYTNk
+        MS1lMWI2YzA3MTg1MTMvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:43 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/export.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/content_view/export/export.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:44 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -37,15 +37,15 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '3082'
+      - '3079'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEtNGU0Ny05ZTYzLWQ3YWQ5
-        MTk3YzdjMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDAyOjExOjE3
-        Ljc1MTc1NFoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        L2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYtNDIyMi05MjM0LTMwZTA1
+        ODY3MTI5MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDAzOjQ3OjEx
+        LjkxMzYxNloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -172,7 +172,7 @@ http_interactions:
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9XX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:44 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -183,7 +183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,7 +196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:44 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -217,7 +217,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:44 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -228,7 +228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:44 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -262,7 +262,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:44 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -273,7 +273,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -286,7 +286,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:44 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -307,7 +307,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:44 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: get
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -318,7 +318,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +331,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:44 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -352,7 +352,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:44 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -378,13 +378,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:45 GMT
+      - Sat, 26 Sep 2020 18:35:26 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/1b733996-a457-4f7f-b36f-7430ce01b089/"
+      - "/pulp/api/v3/repositories/rpm/rpm/57039673-719d-409a-8a59-8689b357fe1b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -399,18 +399,18 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQzMGNlMDFiMDg5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjAtMDktMDFUMjE6NTU6NDUuMTUxMTkyWiIsInZl
+        cG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdmZTFiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMjZUMTg6MzU6MjYuOTUzMDQ3WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQzMGNlMDFiMDg5L3ZlcnNp
+        cG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdmZTFiL3ZlcnNp
         b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQz
-        MGNlMDFiMDg5L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        b3NpdG9yaWVzL3JwbS9ycG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4
+        OWIzNTdmZTFiL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
         bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
         MH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:45 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:26 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -426,7 +426,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -439,13 +439,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:45 GMT
+      - Sat, 26 Sep 2020 18:35:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/61ce5555-58dd-49c1-8380-fb07503eec41/"
+      - "/pulp/api/v3/remotes/rpm/rpm/44a5088b-2693-4ebe-9922-547f0229480a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -459,19 +459,19 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYx
-        Y2U1NTU1LTU4ZGQtNDljMS04MzgwLWZiMDc1MDNlZWM0MS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjQ1LjI4ODQ2N1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ0
+        YTUwODhiLTI2OTMtNGViZS05OTIyLTU0N2YwMjI5NDgwYS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjI3LjA1NTQwNFoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGws
         InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInVzZXJu
         YW1lIjpudWxsLCJwYXNzd29yZCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDIwLTA5LTAxVDIxOjU1OjQ1LjI4ODQ5N1oiLCJkb3dubG9hZF9jb25j
+        OiIyMDIwLTA5LTI2VDE4OjM1OjI3LjA1NTQyMVoiLCJkb3dubG9hZF9jb25j
         dXJyZW5jeSI6MTAsInBvbGljeSI6ImltbWVkaWF0ZSIsInNsZXNfYXV0aF90
         b2tlbiI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:45 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:27 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -479,13 +479,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQzMGNlMDFi
-        MDg5L3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdm
+        ZTFiL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -498,7 +498,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:45 GMT
+      - Sat, 26 Sep 2020 18:35:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -516,13 +516,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlNTliY2RiLWU1NmEtNDFh
-        OC1hM2U1LTI1OTlkOTAzNDYyMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyMDViYzgwLTY2YmMtNGMx
+        ZS1hNWFhLWU0MTU2YmZhOWRhMy8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:45 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:27 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/0e59bcdb-e56a-41a8-a3e5-2599d9034622/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/9205bc80-66bc-4c1e-a5aa-e4156bfa9da3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -530,7 +530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -543,7 +543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:46 GMT
+      - Sat, 26 Sep 2020 18:35:27 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -557,26 +557,26 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '372'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGU1OWJjZGItZTU2
-        YS00MWE4LWEzZTUtMjU5OWQ5MDM0NjIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NDUuNjgwNzIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTIwNWJjODAtNjZi
+        Yy00YzFlLWE1YWEtZTQxNTZiZmE5ZGEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjcuMzY3ODA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0NS44MzM0NzJa
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjQ2LjEyOTM4NVoi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyNy41MjEyMDZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjI3LjgwOTgxNloi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        MmFkMDViNTYtMDY3NS00NTkzLThjNzYtZDJjNGM5MzhkYzk5LyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMjczNzkzNTYt
-        NTMwZC00MmY4LWJhNjAtNzYwMTgyNjVjNWUzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTFiMTY1ODkt
+        ODA1NS00YjgyLWJhYjUtY2FhODE2OGU2OTI1LyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYjczMzk5Ni1hNDU3LTRmN2YtYjM2Zi03NDMwY2UwMWIwODkvIl19
+        L3JwbS81NzAzOTY3My03MTlkLTQwOWEtOGE1OS04Njg5YjM1N2ZlMWIvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:46 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:27 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -585,15 +585,15 @@ http_interactions:
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzhmYTk3MWNkLTE3MWEt
-        NGU0Ny05ZTYzLWQ3YWQ5MTk3YzdjMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
+        My9jb250ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtL2U1MDMxYWRiLTYwNGYt
+        NDIyMi05MjM0LTMwZTA1ODY3MTI5MC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUi
         LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8yNzM3OTM1Ni01MzBkLTQyZjgtYmE2MC03NjAxODI2NWM1ZTMvIn0=
+        L3JwbS85MWIxNjU4OS04MDU1LTRiODItYmFiNS1jYWE4MTY4ZTY5MjUvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -606,7 +606,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:46 GMT
+      - Sat, 26 Sep 2020 18:35:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -624,13 +624,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2NjlhNjVhLTY1YzAtNDI2
-        NC04NTg5LTFjMWZjYmM0N2JjNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkN2E3ZTk5LTNmMTMtNDc2
+        Zi04OGZhLTFjYWMzY2JhNjc1My8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:46 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:28 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/6669a65a-65c0-4264-8589-1c1fcbc47bc4/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/8d7a7e99-3f13-476f-88fa-1cac3cba6753/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -651,7 +651,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:47 GMT
+      - Sat, 26 Sep 2020 18:35:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -665,28 +665,28 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '347'
+      - '348'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjY2OWE2NWEtNjVj
-        MC00MjY0LTg1ODktMWMxZmNiYzQ3YmM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NDYuMzQ4OTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGQ3YTdlOTktM2Yx
+        My00NzZmLTg4ZmEtMWNhYzNjYmE2NzUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjcuOTcyNzA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NDYuNTE2MzEx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0Ni44ODI3MTRa
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MjguMTUwMzkx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNToyOC40MjE3Nzda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
-        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8yMzA2MjI0
-        ZS1lMGYzLTQ3YTQtODllNS0zYTNhZGVhMDkzODAvIl0sInJlc2VydmVkX3Jl
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS8xZDRjMmUz
+        NS01MTRiLTRkMzctYTdhMS1lZWVmMWE1N2I1ZWIvIl0sInJlc2VydmVkX3Jl
         c291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:47 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:28 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2306224e-e0f3-47a4-89e5-3a3adea09380/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/1d4c2e35-514b-4d37-a7a1-eeef1a57b5eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -694,7 +694,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -707,7 +707,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:47 GMT
+      - Sat, 26 Sep 2020 18:35:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -721,38 +721,38 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '312'
+      - '314'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzIzMDYyMjRlLWUwZjMtNDdhNC04OWU1LTNhM2FkZWEwOTM4MC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjQ2Ljg2MDQ1MVoiLCJi
+        cnBtLzFkNGMyZTM1LTUxNGItNGQzNy1hN2ExLWVlZWYxYTU3YjVlYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjI4LjQwNDE1MVoiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwOi8vbGFtYmRhLnNwYXJ0
         YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20v
-        OGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkxOTdjN2MwLyIsIm5hbWUi
+        ZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4NjcxMjkwLyIsIm5hbWUi
         OiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
-        YmxpY2F0aW9ucy9ycG0vcnBtLzI3Mzc5MzU2LTUzMGQtNDJmOC1iYTYwLTc2
-        MDE4MjY1YzVlMy8ifQ==
+        YmxpY2F0aW9ucy9ycG0vcnBtLzkxYjE2NTg5LTgwNTUtNGI4Mi1iYWI1LWNh
+        YTgxNjhlNjkyNS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:47 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:28 GMT
 - request:
     method: post
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/1b733996-a457-4f7f-b36f-7430ce01b089/sync/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/57039673-719d-409a-8a59-8689b357fe1b/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzYxY2U1
-        NTU1LTU4ZGQtNDljMS04MzgwLWZiMDc1MDNlZWM0MS8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ0YTUw
+        ODhiLTI2OTMtNGViZS05OTIyLTU0N2YwMjI5NDgwYS8iLCJtaXJyb3IiOnRy
         dWUsInNraXBfdHlwZXMiOltdLCJvcHRpbWl6ZSI6dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -765,7 +765,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:47 GMT
+      - Sat, 26 Sep 2020 18:35:28 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -783,13 +783,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyNTY0ZjBhLTJjNWMtNDll
-        MC1hNDhkLWU3ZTg0ODRlMTk0OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA2Nzc4NGQyLTc4ZjUtNDJi
+        ZS05M2Q2LTZkMmM4OTU2NzY3Yy8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:47 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:28 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/92564f0a-2c5c-49e0-a48d-e7e8484e1949/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/067784d2-78f5-42be-93d6-6d2c8956767c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -797,7 +797,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -810,7 +810,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:50 GMT
+      - Sat, 26 Sep 2020 18:35:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -824,44 +824,44 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '563'
+      - '566'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTI1NjRmMGEtMmM1
-        Yy00OWUwLWE0OGQtZTdlODQ4NGUxOTQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NDcuNzA4MjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDY3Nzg0ZDItNzhm
+        NS00MmJlLTkzZDYtNmQyYzg5NTY3NjdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MjguOTA0Mjc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NDcu
-        ODc4MDEzWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo0OS44
-        ODIyNzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8i
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6Mjku
+        MDY5ODIzWiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozMC40
+        MTM3MjNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93
-        bmxvYWRpbmcgTWV0YWRhdGEgRmlsZXMiLCJjb2RlIjoiZG93bmxvYWRpbmcu
-        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
-        b25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
-        IEFydGlmYWN0cyIsImNvZGUiOiJkb3dubG9hZGluZy5hcnRpZmFjdHMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZm
-        aXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
-        IiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9LHsibWVz
-        c2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3Nv
-        Y2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJz
-        ZWQgQWR2aXNvcmllcyIsImNvZGUiOiJwYXJzaW5nLmFkdmlzb3JpZXMiLCJz
-        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlBhcnNlZCBQYWNrYWdlcyIsImNvZGUiOiJw
-        YXJzaW5nLnBhY2thZ2VzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
-        MzIsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
-        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFiNzMz
-        OTk2LWE0NTctNGY3Zi1iMzZmLTc0MzBjZTAxYjA4OS92ZXJzaW9ucy8xLyJd
+        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFy
+        c2VkIFBhY2thZ2VzIiwiY29kZSI6InBhcnNpbmcucGFja2FnZXMiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1ZmZpeCI6
+        bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJjb2RlIjoi
+        cGFyc2luZy5hZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3du
+        bG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNvZGUiOiJkb3dubG9hZGluZy5t
+        ZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
+        bmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
+        QXJ0aWZhY3RzIiwiY29kZSI6ImRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29j
+        aWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3MDM5
+        NjczLTcxOWQtNDA5YS04YTU5LTg2ODliMzU3ZmUxYi92ZXJzaW9ucy8xLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS8xYjczMzk5Ni1hNDU3LTRmN2YtYjM2Zi03
-        NDMwY2UwMWIwODkvIiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS82
-        MWNlNTU1NS01OGRkLTQ5YzEtODM4MC1mYjA3NTAzZWVjNDEvIl19
+        ZW1vdGVzL3JwbS9ycG0vNDRhNTA4OGItMjY5My00ZWJlLTk5MjItNTQ3ZjAy
+        Mjk0ODBhLyIsIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81
+        NzAzOTY3My03MTlkLTQwOWEtOGE1OS04Njg5YjM1N2ZlMWIvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:50 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:30 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -869,13 +869,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQzMGNlMDFi
-        MDg5L3ZlcnNpb25zLzEvIn0=
+        aWVzL3JwbS9ycG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdm
+        ZTFiL3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -888,7 +888,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:50 GMT
+      - Sat, 26 Sep 2020 18:35:30 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -906,13 +906,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlYjZiZTcwLTBhZTYtNGVi
-        Yi1iOGI3LWI2ZWFiMmNkZjc3Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhM2VjNWVjLTZmNmEtNGEx
+        Mi1hNDY3LTRjMDU3OWIzNDIzMC8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:50 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:30 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/5eb6be70-0ae6-4ebb-b8b7-b6eab2cdf776/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/0a3ec5ec-6f6a-4a12-a467-4c0579b34230/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -920,7 +920,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -933,7 +933,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:51 GMT
+      - Sat, 26 Sep 2020 18:35:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -947,43 +947,43 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '369'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWViNmJlNzAtMGFl
-        Ni00ZWJiLWI4YjctYjZlYWIyY2RmNzc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NTAuMTc0NjY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGEzZWM1ZWMtNmY2
+        YS00YTEyLWE0NjctNGMwNTc5YjM0MjMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzAuNjAxMjk1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo1MC4zNjQ0NTha
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjUwLjk2NjEzNFoi
+        c2giLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozMC43NjIzNTVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjMxLjIzMjk3Nloi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        MmQwYmQyNzMtN2Y3ZS00YjZkLTliYzUtYzcwNWUwOTQ3OWVlLyIsInBhcmVu
+        ZTcyZGUxYmEtODZiOS00MDg5LWJjZGItMTAwZTFiZTgzOTYzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMWQ1ZDNlZmUt
-        ZGUzZS00ZTA3LTgyY2ItMTZkMmM4ZWZkOTAwLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vY2EyMDI3Yzgt
+        ZDVhNy00YzAxLWIyM2EtYzQzMDM0ZjM2ZmNjLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8xYjczMzk5Ni1hNDU3LTRmN2YtYjM2Zi03NDMwY2UwMWIwODkvIl19
+        L3JwbS81NzAzOTY3My03MTlkLTQwOWEtOGE1OS04Njg5YjM1N2ZlMWIvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:51 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:31 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2306224e-e0f3-47a4-89e5-3a3adea09380/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/1d4c2e35-514b-4d37-a7a1-eeef1a57b5eb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8xZDVkM2VmZS1kZTNlLTRl
-        MDctODJjYi0xNmQyYzhlZmQ5MDAvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jYTIwMjdjOC1kNWE3LTRj
+        MDEtYjIzYS1jNDMwMzRmMzZmY2MvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -996,7 +996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:51 GMT
+      - Sat, 26 Sep 2020 18:35:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1014,13 +1014,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwN2JlN2RkLTU5YmMtNGIz
-        Ni1iNmY3LWI1ZjdlZmU4NmI1Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzOTUzODBmLTk0YTYtNGI1
+        OS04MGI3LWRmOTYxZjE2YWM3Yi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:51 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:31 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/607be7dd-59bc-4b36-b6f7-b5f7efe86b57/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/9395380f-94a6-4b59-80b7-df961f16ac7b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:51 GMT
+      - Sat, 26 Sep 2020 18:35:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1055,41 +1055,41 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '316'
+      - '317'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjA3YmU3ZGQtNTli
-        Yy00YjM2LWI2ZjctYjVmN2VmZTg2YjU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NTEuMTg0NTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTM5NTM4MGYtOTRh
+        Ni00YjU5LTgwYjctZGY5NjFmMTZhYzdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzEuMzc5Nzg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NTEuMzgyODI4
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo1MS43NTg0MTla
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MzEuNTQ1NDM3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozMS44MTQ2MzRa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        L2U3MmRlMWJhLTg2YjktNDA4OS1iY2RiLTEwMGUxYmU4Mzk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlz
         dHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:51 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:31 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2306224e-e0f3-47a4-89e5-3a3adea09380/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/1d4c2e35-514b-4d37-a7a1-eeef1a57b5eb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vOGZhOTcxY2QtMTcxYS00ZTQ3LTllNjMtZDdhZDkx
-        OTdjN2MwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vZTUwMzFhZGItNjA0Zi00MjIyLTkyMzQtMzBlMDU4
+        NjcxMjkwLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8xZDVkM2VmZS1kZTNlLTRl
-        MDctODJjYi0xNmQyYzhlZmQ5MDAvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9jYTIwMjdjOC1kNWE3LTRj
+        MDEtYjIzYS1jNDMwMzRmMzZmY2MvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1102,7 +1102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:51 GMT
+      - Sat, 26 Sep 2020 18:35:31 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1120,10 +1120,10 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzNThkODRmLTE3MTItNDUy
-        ZC1hY2ZhLTY5NzUzMDYwOTg1Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhNWVmMWNhLTRmYmItNDIy
+        My05MWU0LWY3ZTY4ZDUxN2EzMi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:51 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:31 GMT
 - request:
     method: post
     uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/
@@ -1134,13 +1134,13 @@ http_interactions:
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
         cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
         L2Zvby9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYt
-        NzQzMGNlMDFiMDg5LyJdfQ==
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTkt
+        ODY4OWIzNTdmZTFiLyJdfQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1153,13 +1153,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:52 GMT
+      - Sat, 26 Sep 2020 18:35:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/"
+      - "/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1174,30 +1174,30 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC8xMTU5MGZhYi0xZDIwLTQ5MzctYTdjNy0xNWQxNWE3OWQxODMvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTo1Mi4zNTM5MTZaIiwibmFt
+        cC8yYWU2MjA0Yi05ZDNiLTQyYTQtYjQ2Mi02ODBhMGVkYmJjMDQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNTozMi4yMzY5NTBaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9mb28v
         ZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzFiNzMzOTk2LWE0NTctNGY3Zi1iMzZmLTc0MzBj
-        ZTAxYjA4OS8iXSwibGFzdF9leHBvcnQiOm51bGx9
+        aXRvcmllcy9ycG0vcnBtLzU3MDM5NjczLTcxOWQtNDA5YS04YTU5LTg2ODli
+        MzU3ZmUxYi8iXSwibGFzdF9leHBvcnQiOm51bGx9
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:52 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:32 GMT
 - request:
     method: post
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/exports/
     body:
       encoding: UTF-8
       base64_string: |
         eyJ2ZXJzaW9ucyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMWI3MzM5OTYtYTQ1Ny00ZjdmLWIzNmYtNzQzMGNlMDFiMDg5L3ZlcnNp
+        cG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdmZTFiL3ZlcnNp
         b25zLzEvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1210,7 +1210,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:52 GMT
+      - Sat, 26 Sep 2020 18:35:32 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1228,13 +1228,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0MTFhNWJjLWQ1MTMtNDk5
-        ZS04ZjI2LWQ4Y2U5NGU3Yjg1Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMzM2ODY4LTBmYTgtNDA2
+        NC1hMjE5LWI3ZWI1MjgyZWM0Zi8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:52 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:32 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/7411a5bc-d513-499e-8f26-d8ce94e7b856/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/60336868-0fa8-4064-a219-b7eb5282ec4f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1242,7 +1242,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1255,7 +1255,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1269,30 +1269,30 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '365'
+      - '363'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzQxMWE1YmMtZDUx
-        My00OTllLThmMjYtZDhjZTk0ZTdiODU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NTIuNDc2Nzk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjAzMzY4NjgtMGZh
+        OC00MDY0LWEyMTktYjdlYjUyODJlYzRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzIuMzI1MjQzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5leHBvcnQucHVscF9leHBv
-        cnQiLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo1Mi43NTAyODda
-        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTAxVDIxOjU1OjUzLjQ1Mjc3M1oi
+        cnQiLCJzdGFydGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozMi41NTQ4OTVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDIwLTA5LTI2VDE4OjM1OjMzLjExOTAyN1oi
         LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
-        YjIwNjdhMDMtZTc3MC00MWZjLWI1ZWQtNWE1NzM4YjkxYzIwLyIsInBhcmVu
+        ZTcyZGUxYmEtODZiOS00MDg5LWJjZGItMTAwZTFiZTgzOTYzLyIsInBhcmVu
         dF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51
         bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC8xMTU5MGZhYi0x
-        ZDIwLTQ5MzctYTdjNy0xNWQxNWE3OWQxODMvZXhwb3J0cy9mYWZlOTFlOS04
-        MjU0LTQzMmQtOGRjZi04ZTUxMmViZDI5MTIvIl0sInJlc2VydmVkX3Jlc291
+        WyIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC8yYWU2MjA0Yi05
+        ZDNiLTQyYTQtYjQ2Mi02ODBhMGVkYmJjMDQvZXhwb3J0cy8wODY5Y2Q2OS0w
+        MjFiLTQ3YWItYmM0OS01MDg2MDlkODU5MWMvIl0sInJlc2VydmVkX3Jlc291
         cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2V4cG9ydGVycy9jb3JlL3B1
-        bHAvMTE1OTBmYWItMWQyMC00OTM3LWE3YzctMTVkMTVhNzlkMTgzLyJdfQ==
+        bHAvMmFlNjIwNGItOWQzYi00MmE0LWI0NjItNjgwYTBlZGJiYzA0LyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1300,7 +1300,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1313,7 +1313,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1327,37 +1327,37 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '498'
+      - '499'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwLzExNTkwZmFiLTFkMjAtNDkzNy1hN2M3LTE1ZDE1YTc5ZDE4My9l
-        eHBvcnRzL2ZhZmU5MWU5LTgyNTQtNDMyZC04ZGNmLThlNTEyZWJkMjkxMi8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjUyLjQ3MDUyMloi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0MTFhNWJjLWQ1MTMtNDk5
-        ZS04ZjI2LWQ4Y2U5NGU3Yjg1Ni8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFiNzMzOTk2LWE0
-        NTctNGY3Zi1iMzZmLTc0MzBjZTAxYjA4OS92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwLzJhZTYyMDRiLTlkM2ItNDJhNC1iNDYyLTY4MGEwZWRiYmMwNC9l
+        eHBvcnRzLzA4NjljZDY5LTAyMWItNDdhYi1iYzQ5LTUwODYwOWQ4NTkxYy8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjMyLjMyMTIxOFoi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMzM2ODY4LTBmYTgtNDA2
+        NC1hMjE5LWI3ZWI1MjgyZWM0Zi8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3MDM5NjczLTcx
+        OWQtNDA5YS04YTU5LTg2ODliMzU3ZmUxYi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzFiNzMzOTk2LWE0NTctNGY3Zi1iMzZmLTc0MzBjZTAxYjA4OS92
+        cG0vcnBtLzU3MDM5NjczLTcxOWQtNDA5YS04YTU5LTg2ODliMzU3ZmUxYi92
         ZXJzaW9ucy8xLyJdfSwib3V0cHV0X2ZpbGVfaW5mbyI6eyIvdmFyL2xpYi9w
         dWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9uL0FDTUVfRGVmYXVsdF9D
-        b250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4cG9ydC1mYWZlOTFlOS04
-        MjU0LTQzMmQtOGRjZi04ZTUxMmViZDI5MTItMjAyMDA5MDFfMjE1NS50YXIu
-        Z3oiOiI0MDI0MWUwMTcxNGY4Yzg0MzQyMDE2ZWIxMGU5OTcxNjhjZjRmYjI0
-        NDNlNDMzYTNmMGRjYjUzYTgxY2I1ZTNjIiwiL3Zhci9saWIvcHVscC9leHBv
+        b250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4cG9ydC0wODY5Y2Q2OS0w
+        MjFiLTQ3YWItYmM0OS01MDg2MDlkODU5MWMtMjAyMDA5MjZfMTgzNS50YXIu
+        Z3oiOiI2ZmEwZTMwODZiZGIxZWNkOGZiMmZkN2IyM2Q3YTRjNzM5MDc0ZDAz
+        NjJmZTIyMGQ5OTA2YmJhN2RjNzI1NWMxIiwiL3Zhci9saWIvcHVscC9leHBv
         cnRzL0VtcHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZp
-        ZXcvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtZmFmZTkxZTktODI1NC00MzJk
-        LThkY2YtOGU1MTJlYmQyOTEyLTIwMjAwOTAxXzIxNTUtdG9jLmpzb24iOiI4
-        NWU2MzYwOTI5OGUyMDY4ZDVkNjkxNmJkMDlkOTE5NjUwM2U1MDJlZmUyNjc2
-        ZDc3OGNlNDMzZjdlZTc0NGQ1In19XX0=
+        ZXcvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtMDg2OWNkNjktMDIxYi00N2Fi
+        LWJjNDktNTA4NjA5ZDg1OTFjLTIwMjAwOTI2XzE4MzUtdG9jLmpzb24iOiI5
+        MjgwM2I1ODFiNWNkOTExMjVlODlmZjNjMTdjNmE3MGQ4ZmUyNGViNmE0NjQy
+        NGI3NmJkYTdlYmFhZjkzOGE2In19XX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/exports/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/57039673-719d-409a-8a59-8689b357fe1b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1365,7 +1365,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1378,7 +1378,61 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 lambda.sparta.example.com
+      Content-Length:
+      - '225'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdmZTFiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjAtMDktMjZUMTg6MzU6MjYuOTUzMDQ3WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4OWIzNTdmZTFiL3ZlcnNp
+        b25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vNTcwMzk2NzMtNzE5ZC00MDlhLThhNTktODY4
+        OWIzNTdmZTFiL3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJlbW90ZSI6bnVsbCwibWV0YWRhdGFfc2ln
+        bmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6
+        MH0=
+    http_version: 
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
+- request:
+    method: get
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/exports/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.6.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1392,37 +1446,37 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '498'
+      - '499'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwLzExNTkwZmFiLTFkMjAtNDkzNy1hN2M3LTE1ZDE1YTc5ZDE4My9l
-        eHBvcnRzL2ZhZmU5MWU5LTgyNTQtNDMyZC04ZGNmLThlNTEyZWJkMjkxMi8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTAxVDIxOjU1OjUyLjQ3MDUyMloi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0MTFhNWJjLWQ1MTMtNDk5
-        ZS04ZjI2LWQ4Y2U5NGU3Yjg1Ni8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzFiNzMzOTk2LWE0
-        NTctNGY3Zi1iMzZmLTc0MzBjZTAxYjA4OS92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwLzJhZTYyMDRiLTlkM2ItNDJhNC1iNDYyLTY4MGEwZWRiYmMwNC9l
+        eHBvcnRzLzA4NjljZDY5LTAyMWItNDdhYi1iYzQ5LTUwODYwOWQ4NTkxYy8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIwLTA5LTI2VDE4OjM1OjMyLjMyMTIxOFoi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwMzM2ODY4LTBmYTgtNDA2
+        NC1hMjE5LWI3ZWI1MjgyZWM0Zi8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzU3MDM5NjczLTcx
+        OWQtNDA5YS04YTU5LTg2ODliMzU3ZmUxYi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzFiNzMzOTk2LWE0NTctNGY3Zi1iMzZmLTc0MzBjZTAxYjA4OS92
+        cG0vcnBtLzU3MDM5NjczLTcxOWQtNDA5YS04YTU5LTg2ODliMzU3ZmUxYi92
         ZXJzaW9ucy8xLyJdfSwib3V0cHV0X2ZpbGVfaW5mbyI6eyIvdmFyL2xpYi9w
         dWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9uL0FDTUVfRGVmYXVsdF9D
-        b250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4cG9ydC1mYWZlOTFlOS04
-        MjU0LTQzMmQtOGRjZi04ZTUxMmViZDI5MTItMjAyMDA5MDFfMjE1NS50YXIu
-        Z3oiOiI0MDI0MWUwMTcxNGY4Yzg0MzQyMDE2ZWIxMGU5OTcxNjhjZjRmYjI0
-        NDNlNDMzYTNmMGRjYjUzYTgxY2I1ZTNjIiwiL3Zhci9saWIvcHVscC9leHBv
+        b250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4cG9ydC0wODY5Y2Q2OS0w
+        MjFiLTQ3YWItYmM0OS01MDg2MDlkODU5MWMtMjAyMDA5MjZfMTgzNS50YXIu
+        Z3oiOiI2ZmEwZTMwODZiZGIxZWNkOGZiMmZkN2IyM2Q3YTRjNzM5MDc0ZDAz
+        NjJmZTIyMGQ5OTA2YmJhN2RjNzI1NWMxIiwiL3Zhci9saWIvcHVscC9leHBv
         cnRzL0VtcHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZp
-        ZXcvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtZmFmZTkxZTktODI1NC00MzJk
-        LThkY2YtOGU1MTJlYmQyOTEyLTIwMjAwOTAxXzIxNTUtdG9jLmpzb24iOiI4
-        NWU2MzYwOTI5OGUyMDY4ZDVkNjkxNmJkMDlkOTE5NjUwM2U1MDJlZmUyNjc2
-        ZDc3OGNlNDMzZjdlZTc0NGQ1In19XX0=
+        ZXcvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtMDg2OWNkNjktMDIxYi00N2Fi
+        LWJjNDktNTA4NjA5ZDg1OTFjLTIwMjAwOTI2XzE4MzUtdG9jLmpzb24iOiI5
+        MjgwM2I1ODFiNWNkOTExMjVlODlmZjNjMTdjNmE3MGQ4ZmUyNGViNmE0NjQy
+        NGI3NmJkYTdlYmFhZjkzOGE2In19XX0=
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: patch
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1432,7 +1486,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1445,7 +1499,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1464,19 +1518,19 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC8xMTU5MGZhYi0xZDIwLTQ5MzctYTdjNy0xNWQxNWE3OWQxODMvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMC0wOS0wMVQyMTo1NTo1Mi4zNTM5MTZaIiwibmFt
+        cC8yYWU2MjA0Yi05ZDNiLTQyYTQtYjQ2Mi02ODBhMGVkYmJjMDQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMC0wOS0yNlQxODozNTozMi4yMzY5NTBaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
         cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9mb28v
         ZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzFiNzMzOTk2LWE0NTctNGY3Zi1iMzZmLTc0MzBj
-        ZTAxYjA4OS8iXSwibGFzdF9leHBvcnQiOm51bGx9
+        aXRvcmllcy9ycG0vcnBtLzU3MDM5NjczLTcxOWQtNDA5YS04YTU5LTg2ODli
+        MzU3ZmUxYi8iXSwibGFzdF9leHBvcnQiOm51bGx9
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/exports/fafe91e9-8254-432d-8dcf-8e512ebd2912/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/exports/0869cd69-021b-47ab-bc49-508609d8591c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1484,7 +1538,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Authorization:
       - Basic Og==
       Accept-Encoding:
@@ -1497,7 +1551,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Vary:
@@ -1512,10 +1566,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/11590fab-1d20-4937-a7c7-15d15a79d183/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/exporters/core/pulp/2ae6204b-9d3b-42a4-b462-680a0edbbc04/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1523,7 +1577,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Authorization:
       - Basic Og==
       Accept-Encoding:
@@ -1536,7 +1590,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:53 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Vary:
@@ -1551,10 +1605,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:53 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/61ce5555-58dd-49c1-8380-fb07503eec41/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/remotes/rpm/rpm/44a5088b-2693-4ebe-9922-547f0229480a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1562,7 +1616,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1575,7 +1629,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:54 GMT
+      - Sat, 26 Sep 2020 18:35:33 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1593,13 +1647,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZjMwZmRlLWI4NGUtNDM3
-        ZS04YjBmLTM3MzhjZjc5MjBjOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZlZjdjY2ViLWIwNjMtNGU1
+        NC1iMGRkLTAxZjZiZWM0ZjNmMS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:54 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:33 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/90f30fde-b84e-437e-8b0f-3738cf7920c8/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/fef7cceb-b063-4e54-b0dd-01f6bec4f3f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1607,7 +1661,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1620,7 +1674,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:54 GMT
+      - Sat, 26 Sep 2020 18:35:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1634,28 +1688,28 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '338'
+      - '340'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBmMzBmZGUtYjg0
-        ZS00MzdlLThiMGYtMzczOGNmNzkyMGM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NTQuMDY4MzAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmVmN2NjZWItYjA2
+        My00ZTU0LWIwZGQtMDFmNmJlYzRmM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzMuOTM1OTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NTQuMTk5MTEz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo1NC4yNjIxNjda
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MzQuMDc4Nzg3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozNC4xNjQ2ODNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        L2IyMDY3YTAzLWU3NzAtNDFmYy1iNWVkLTVhNTczOGI5MWMyMC8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZW1vdGVzL3JwbS9ycG0vNjFjZTU1NTUtNThkZC00OWMxLTgzODAtZmIw
-        NzUwM2VlYzQxLyJdfQ==
+        My9yZW1vdGVzL3JwbS9ycG0vNDRhNTA4OGItMjY5My00ZWJlLTk5MjItNTQ3
+        ZjAyMjk0ODBhLyJdfQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:54 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:34 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/2306224e-e0f3-47a4-89e5-3a3adea09380/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/distributions/rpm/rpm/1d4c2e35-514b-4d37-a7a1-eeef1a57b5eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1663,7 +1717,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1676,7 +1730,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:54 GMT
+      - Sat, 26 Sep 2020 18:35:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1694,13 +1748,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M0ZDViYTU2LTlkMzgtNDli
-        ZC1iY2YyLWYyN2M4YmEyOTBiNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2OTcwMGI2LWM4YTYtNDQ1
+        OS05Y2FiLTdmNDMxMGU2ZDYzOS8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:54 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:34 GMT
 - request:
     method: delete
-    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/1b733996-a457-4f7f-b36f-7430ce01b089/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/repositories/rpm/rpm/57039673-719d-409a-8a59-8689b357fe1b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1708,7 +1762,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.1/ruby
+      - OpenAPI-Generator/3.6.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1721,7 +1775,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:54 GMT
+      - Sat, 26 Sep 2020 18:35:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1739,13 +1793,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxZjNkZjg0LTI3M2EtNGFk
-        Mi1hMGUzLWE3OTliZjA5ZWRmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FkNWVlZWZmLTJlMDQtNGRm
+        MS1iYzBlLWY2Y2QwOGJhMGVkNC8ifQ==
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:54 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:34 GMT
 - request:
     method: get
-    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/41f3df84-273a-4ad2-a0e3-a799bf09edff/
+    uri: https://lambda.sparta.example.com/pulp/api/v3/tasks/ad5eeeff-2e04-4df1-bc0e-f6cd08ba0ed4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1753,7 +1807,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.6.0/ruby
+      - OpenAPI-Generator/3.6.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1766,7 +1820,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 01 Sep 2020 21:55:55 GMT
+      - Sat, 26 Sep 2020 18:35:34 GMT
       Server:
       - gunicorn/20.0.4
       Content-Type:
@@ -1780,23 +1834,23 @@ http_interactions:
       Via:
       - 1.1 lambda.sparta.example.com
       Content-Length:
-      - '341'
+      - '343'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDFmM2RmODQtMjcz
-        YS00YWQyLWEwZTMtYTc5OWJmMDllZGZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjAtMDktMDFUMjE6NTU6NTQuNDUyMjAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWQ1ZWVlZmYtMmUw
+        NC00ZGYxLWJjMGUtZjZjZDA4YmEwZWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjAtMDktMjZUMTg6MzU6MzQuMzc0Njc3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMDFUMjE6NTU6NTQuNzkzNjg1
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0wMVQyMTo1NTo1NC45OTc5ODJa
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMjAtMDktMjZUMTg6MzU6MzQuNjE4OTM0
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyMC0wOS0yNlQxODozNTozNC44MzQ0NjVa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzJkMGJkMjczLTdmN2UtNGI2ZC05YmM1LWM3MDVlMDk0NzllZS8iLCJwYXJl
+        LzJhZDA1YjU2LTA2NzUtNDU5My04Yzc2LWQyYzRjOTM4ZGM5OS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xYjczMzk5Ni1hNDU3LTRmN2YtYjM2
-        Zi03NDMwY2UwMWIwODkvIl19
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81NzAzOTY3My03MTlkLTQwOWEtOGE1
+        OS04Njg5YjM1N2ZlMWIvIl19
     http_version: 
-  recorded_at: Tue, 01 Sep 2020 21:55:55 GMT
+  recorded_at: Sat, 26 Sep 2020 18:35:34 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -1,0 +1,37 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      module ContentViewVersion
+        class ExportTest < ActiveSupport::TestCase
+          include Support::Actions::Fixtures
+          include FactoryBot::Syntax::Methods
+          include Support::ExportSupport
+
+          it "test metadata" do
+            proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+            SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
+            version = katello_content_view_versions(:library_view_version_2)
+            destination_server = "whereami.com"
+            export = fetch_exporter(smart_proxy: proxy,
+                                         content_view_version: version,
+                                         destination_server: destination_server)
+
+            data = export.generate_metadata
+            assert_equal data[:content_view_version][:major], version.major
+            assert_equal data[:content_view_version][:minor], version.minor
+            assert_equal data[:content_view], version.content_view.name
+
+            version_repositories = version.archived_repos.yum_type
+            data[:repository_mapping].each do |name, repo_info|
+              repo = version_repositories[name.to_i]
+              assert_equal repo_info[:repository], repo.root.name
+              assert_equal repo_info[:product], repo.root.product.name
+              assert_equal repo_info[:redhat], repo.redhat?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -1,0 +1,114 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      module ContentViewVersion
+        class ImportTest < ActiveSupport::TestCase
+          include Support::Actions::Fixtures
+
+          it "fails on blank path" do
+            exception = assert_raises(RuntimeError) do
+              ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(nil)
+            end
+            assert_match(/Invalid path/, exception.message)
+          end
+
+          it "fails if not a dir" do
+            path = __FILE__ # set it to current file path
+            exception = assert_raises(RuntimeError) do
+              ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path)
+            end
+            assert_match(/Invalid path/, exception.message)
+          end
+
+          it "fails if not a an importable basedir prefixed" do
+            path = __dir__ # current directory
+            exception = assert_raises(RuntimeError) do
+              ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path)
+            end
+            assert_match(/import path must be in a subdirectory under/, exception.message)
+          end
+
+          it "fails if not a metadata json found" do
+            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures')
+            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
+              exception = assert_raises(RuntimeError) do
+                ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir)
+              end
+              assert_match(/Could not find metadata/, exception.message)
+            end
+          end
+
+          it "fails if not able to read metadata json" do
+            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
+            File.expects(:readable?).with("#{import_export_dir}/metadata.json").returns(false)
+
+            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
+              exception = assert_raises(RuntimeError) do
+                ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir)
+              end
+              assert_match(/Unable to read the metadata/, exception.message)
+            end
+          end
+
+          it "fails if pulp user is not able to access metadata json" do
+            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accesible?).with(import_export_dir).returns(false)
+
+            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
+              exception = assert_raises(RuntimeError) do
+                ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir)
+              end
+              assert_match(/Pulp user or group unable to read content/, exception.message)
+            end
+          end
+
+          it "pulp_user_accesible returns false if no pulp user" do
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(nil)
+            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?("/tmp")
+          end
+
+          it "pulp_user_accesible returns false if no uid/gid/readable does not match" do
+            path = "/tmp"
+            stats = mock(gid: 1001, uid: 1002, mode: 1)
+            File.expects(:stat).with(path).returns(stats)
+
+            user_info = mock(gid: 1003.to_s, uid: 1004.to_s)
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
+            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+          end
+
+          it "pulp_user_accesible returns true if world readable" do
+            path = "/tmp"
+            stats = mock(gid: 1001, uid: 1002, mode: 7)
+            File.expects(:stat).with(path).returns(stats)
+
+            user_info = mock(gid: 1004.to_s, uid: 1005.to_s)
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+          end
+
+          it "pulp_user_accesible returns true if groups match" do
+            path = "/tmp"
+            stats = mock(gid: 1001)
+            File.expects(:stat).with(path).returns(stats)
+
+            user_info = mock(gid: 1001.to_s)
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+          end
+
+          it "pulp_user_accesible returns true if uids match" do
+            path = "/tmp"
+            stats = mock(gid: 1001, uid: 1002)
+            File.expects(:stat).with(path).returns(stats)
+
+            user_info = mock(gid: 1003.to_s, uid: 1002.to_s)
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -53,7 +53,7 @@ module Katello
 
           it "fails if pulp user is not able to access metadata json" do
             import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-            ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accesible?).with(import_export_dir).returns(false)
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accessible?).with(import_export_dir).returns(false)
 
             stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
               exception = assert_raises(RuntimeError) do
@@ -63,49 +63,49 @@ module Katello
             end
           end
 
-          it "pulp_user_accesible returns false if no pulp user" do
+          it "pulp_user_accessible returns false if no pulp user" do
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(nil)
-            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?("/tmp")
+            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accessible?("/tmp")
           end
 
-          it "pulp_user_accesible returns false if no uid/gid/readable does not match" do
+          it "pulp_user_accessible returns false if no uid/gid/readable does not match" do
             path = "/tmp"
             stats = mock(gid: 1001, uid: 1002, mode: 1)
             File.expects(:stat).with(path).returns(stats)
 
             user_info = mock(gid: 1003.to_s, uid: 1004.to_s)
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
-            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+            refute ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accessible?(path)
           end
 
-          it "pulp_user_accesible returns true if world readable" do
+          it "pulp_user_accessible returns true if world readable" do
             path = "/tmp"
             stats = mock(gid: 1001, uid: 1002, mode: 7)
             File.expects(:stat).with(path).returns(stats)
 
             user_info = mock(gid: 1004.to_s, uid: 1005.to_s)
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
-            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accessible?(path)
           end
 
-          it "pulp_user_accesible returns true if groups match" do
+          it "pulp_user_accessible returns true if groups match" do
             path = "/tmp"
             stats = mock(gid: 1001)
             File.expects(:stat).with(path).returns(stats)
 
             user_info = mock(gid: 1001.to_s)
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
-            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accessible?(path)
           end
 
-          it "pulp_user_accesible returns true if uids match" do
+          it "pulp_user_accessible returns true if uids match" do
             path = "/tmp"
             stats = mock(gid: 1001, uid: 1002)
             File.expects(:stat).with(path).returns(stats)
 
             user_info = mock(gid: 1003.to_s, uid: 1002.to_s)
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:fetch_pulp_user_info).returns(user_info)
-            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accesible?(path)
+            assert ::Katello::Pulp3::ContentViewVersion::Import.pulp_user_accessible?(path)
           end
         end
       end

--- a/test/support/export_support.rb
+++ b/test/support/export_support.rb
@@ -1,0 +1,22 @@
+module Support
+  module ExportSupport
+    def fetch_exporter(smart_proxy:, content_view_version:, destination_server:)
+      export = ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
+                                                                 content_view_version: content_view_version,
+                                                                 destination_server: destination_server)
+      version_repositories = content_view_version.archived_repos.yum_type
+      version_repositories.each_with_index do |repo, index|
+        repo.update!(version_href: index)
+      end
+
+      export.instance_eval do
+        @version_repositories = version_repositories
+        def fetch_repository_info(href)
+          fail _("invalid href %s" % href) unless href.to_i < @version_repositories.count
+          OpenStruct.new(name: href.to_i)
+        end
+      end
+      export
+    end
+  end
+end


### PR DESCRIPTION
This commit allows you to import an exported content view dump via api.

Changes include
1) Adding a end point in CVV Controller that accepts cotent view and
   import path
2) Modifying the publish action to handle import case.
3) Making the publish do the import instead of copy contents if
   import_only is true.
4) Actions to orchestrate the importing
5) Actions to finally update the library instance with published
   content.