### PR TITLE
Fixes #30804 - Add a default status to selectAPIStatus selector

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewSelectors.js
+++ b/webpack/scenes/ContentViews/ContentViewSelectors.js
@@ -3,10 +3,14 @@ import {
   selectAPIError,
   selectAPIResponse,
 } from 'foremanReact/redux/API/APISelectors';
+import { STATUS } from 'foremanReact/constants';
 import CONTENT_VIEWS_KEY from './ContentViewsConstants';
 
-export const selectContentViews = state => selectAPIResponse(state, CONTENT_VIEWS_KEY) || {};
+export const selectContentViews = state =>
+  selectAPIResponse(state, CONTENT_VIEWS_KEY) || {};
 
-export const selectContentViewStatus = state => selectAPIStatus(state, CONTENT_VIEWS_KEY);
+export const selectContentViewStatus = state =>
+  selectAPIStatus(state, CONTENT_VIEWS_KEY) || STATUS.PENDING;
 
-export const selectContentViewError = state => selectAPIError(state, CONTENT_VIEWS_KEY);
+export const selectContentViewError = state =>
+  selectAPIError(state, CONTENT_VIEWS_KEY);

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -3,13 +3,14 @@ import {
   selectAPIError,
   selectAPIResponse,
 } from 'foremanReact/redux/API/APISelectors';
+import { STATUS } from 'foremanReact/constants';
 import CONTENT_VIEWS_KEY from '../ContentViewsConstants';
 
 export const selectCVDetails = (state, cvId) =>
   selectAPIResponse(state, `${CONTENT_VIEWS_KEY}_${cvId}`) || {};
 
 export const selectCVDetailStatus =
-  (state, cvId) => selectAPIStatus(state, `${CONTENT_VIEWS_KEY}_${cvId}`);
+  (state, cvId) => selectAPIStatus(state, `${CONTENT_VIEWS_KEY}_${cvId}`) || STATUS.PENDING;
 
 export const selectCVDetailError =
   (state, cvId) => selectAPIError(state, `${CONTENT_VIEWS_KEY}_${cvId}`);


### PR DESCRIPTION
Following this change in foreman - https://github.com/theforeman/foreman/pull/7956 we need to add `STATUS.PENDING` value to the `selectAPIStatus` selector