### PR TITLE
Fixes #30775 - publishing large cv w/ filters fails Pulp 3 yum

### DIFF
--- a/app/lib/actions/pulp3/repository/multi_copy_content.rb
+++ b/app/lib/actions/pulp3/repository/multi_copy_content.rb
@@ -17,7 +17,7 @@ module Actions
           repo_id_map = {}
 
           input[:repo_id_map].each do |source_repo_ids, dest_repo_map|
-            repo_id_map[JSON.parse(source_repo_ids)] = dest_repo_map
+            repo_id_map[JSON.parse(source_repo_ids)] = dest_repo_map.deep_dup
           end
 
           output[:pulp_tasks] = ::Katello::Repository.find(repo_id_map.values.first[:dest_repo]).backend_service(smart_proxy).copy_content_from_mapping(repo_id_map, input)

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -3,9 +3,12 @@ require 'pulp_rpm_client'
 module Katello
   module Pulp3
     class Repository
+      # rubocop:disable Metrics/ClassLength
       class Yum < ::Katello::Pulp3::Repository
         include Katello::Util::Errata
         include Katello::Util::PulpcoreContentFilters
+
+        UNIT_LIMIT = 10_000
 
         def remote_options
           url, sles_token = extract_sles_token
@@ -110,12 +113,75 @@ module Katello
                 data.config << config
               end
             end
-            # FIXME: data's content being [] causes all content to be copied back
-            tasks << api.copy_api.copy_content(data)
+            tasks << copy_pulp_units(data)
           else
             tasks << remove_all_content_from_mapping(repo_id_map)
           end
           tasks.flatten
+        end
+
+        def copy_pulp_units(data)
+          tasks = []
+          unit_amount = 0
+          data.config.each { |repo_config| unit_amount += repo_config[:content].size }
+          if unit_amount > UNIT_LIMIT
+            tasks << copy_content_chunked(data)
+          else
+            tasks << api.copy_api.copy_content(data)
+          end
+          tasks
+        end
+
+        def copy_api_data_dup(data)
+          data_dup = PulpRpmClient::Copy.new
+          data_dup.dependency_solving = data.dependency_solving
+          data_dup.config = []
+          data.config.each do |repo_config|
+            config_hash = {
+              source_repo_version: repo_config[:source_repo_version],
+              dest_repo: repo_config[:dest_repo],
+              content: []
+            }
+            config_hash[:dest_base_version] = repo_config[:dest_base_version] if repo_config[:dest_base_version]
+            data_dup.config << config_hash
+          end
+          data_dup
+        end
+
+        def copy_content_chunked(data)
+          tasks = []
+
+          unit_copy_counter = 0
+          i = 0
+          leftover_units = data.config.first[:content].deep_dup
+
+          # Copy data and clear its content fields
+          data_dup = copy_api_data_dup(data)
+
+          while i < data_dup.config.size
+            # Copy all units within repo or only some?
+            if leftover_units.length < UNIT_LIMIT - unit_copy_counter
+              copy_amount = leftover_units.length
+            else
+              copy_amount = UNIT_LIMIT - unit_copy_counter
+            end
+
+            data_dup.config[i][:content] = leftover_units.pop(copy_amount)
+            unit_copy_counter += copy_amount
+            # Do copy call if limit is reached or if we're under the limit but on the last repo config.
+            if unit_copy_counter >= UNIT_LIMIT || (i == data_dup.config.size - 1 && leftover_units.empty?)
+              tasks << api.copy_api.copy_content(data_dup)
+              unit_copy_counter = 0
+            end
+
+            if leftover_units.empty?
+              i += 1
+              # Fetch unit list for next data config
+              leftover_units = data.config[i][:content].deep_dup unless i == data_dup.config.size
+            end
+          end
+
+          tasks
         end
 
         def remove_all_content_from_mapping(repo_id_map)

--- a/test/services/katello/pulp3/repository/yum/copy_units_test.rb
+++ b/test/services/katello/pulp3/repository/yum/copy_units_test.rb
@@ -1,0 +1,70 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class YumCopyUnitsTest < ::ActiveSupport::TestCase
+        include RepositorySupport
+
+        def setup
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @mock_smart_proxy.stubs(:pulp_master?).returns(true)
+          @repo = katello_repositories(:fedora_17_x86_64_duplicate)
+          @repo_service = @repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_copy_pulp_units_chooses_chunked_copy
+          data = PulpRpmClient::Copy.new
+          data.config = []
+
+          content = []
+          10_001.times do |i|
+            content << i
+          end
+
+          data.config << { content: content }
+          Katello::Pulp3::Repository::Yum.any_instance.expects(:copy_content_chunked).with(data).returns(true).once
+
+          @repo_service.copy_pulp_units(data)
+        end
+
+        def test_copy_pulp_units_chooses_single_copy
+          data = PulpRpmClient::Copy.new
+          data.config = []
+
+          content = []
+          3.times do |i|
+            content << i
+          end
+
+          data.config << { content: content }
+          mock_api = "test"
+          Katello::Pulp3::Api::Yum.any_instance.expects(:copy_api).returns(mock_api).once
+          mock_api.stubs(:copy_content).with(data).returns("copied")
+
+          @repo_service.copy_pulp_units(data)
+        end
+
+        def test_copy_content_chunked_limits_units_copied
+          data = PulpRpmClient::Copy.new
+          data.config = []
+
+          content = []
+          30_001.times do |i|
+            content << i
+          end
+
+          3.times { data.config << { content: content } }
+
+          mock_api = "test"
+          Katello::Pulp3::Api::Yum.any_instance.expects(:copy_api).returns(mock_api).times(10)
+          mock_api.stubs(:copy_content).returns("copied")
+
+          @repo_service.copy_content_chunked(data)
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository/yum/copy_units_test.rb
+++ b/test/services/katello/pulp3/repository/yum/copy_units_test.rb
@@ -4,6 +4,7 @@ module Katello
   module Service
     class Repository
       class YumCopyUnitsTest < ::ActiveSupport::TestCase
+        # rubocop:disable Metrics/MethodLength
         include RepositorySupport
 
         def setup
@@ -15,36 +16,45 @@ module Katello
           @repo_service = @repo.backend_service(@mock_smart_proxy)
         end
 
-        def test_copy_pulp_units_chooses_chunked_copy
+        def test_copy_api_data_dup_does_deep_copy
           data = PulpRpmClient::Copy.new
-          data.config = []
+          data.config = [
+            { source_repo_version: "a source repo",
+              dest_repo: "a dest repo",
+              content: ["1", "2", "3"],
+              dest_base_version: 0 },
+            { source_repo_version: "another source repo",
+              dest_repo: "another dest repo",
+              content: ["4", "5", "6"],
+              dest_base_version: 1 }
+          ]
+          data.dependency_solving = false
 
-          content = []
-          10_001.times do |i|
-            content << i
-          end
+          data_dup = @repo_service.copy_api_data_dup(data)
 
-          data.config << { content: content }
-          Katello::Pulp3::Repository::Yum.any_instance.expects(:copy_content_chunked).with(data).returns(true).once
-
-          @repo_service.copy_pulp_units(data)
+          refute data.equal?(data_dup)
         end
 
-        def test_copy_pulp_units_chooses_single_copy
+        def test_copy_api_data_dup_clears_content
           data = PulpRpmClient::Copy.new
-          data.config = []
+          data.config = [
+            { source_repo_version: "a source repo",
+              dest_repo: "a dest repo",
+              content: ["1", "2", "3"],
+              dest_base_version: 0 },
+            { source_repo_version: "another source repo",
+              dest_repo: "another dest repo",
+              content: ["4", "5", "6"],
+              dest_base_version: 1 }
+          ]
+          data.dependency_solving = false
 
-          content = []
-          3.times do |i|
-            content << i
-          end
+          data.config.first[:content] = []
+          data.config.second[:content] = []
 
-          data.config << { content: content }
-          mock_api = "test"
-          Katello::Pulp3::Api::Yum.any_instance.expects(:copy_api).returns(mock_api).once
-          mock_api.stubs(:copy_content).with(data).returns("copied")
+          data_dup = @repo_service.copy_api_data_dup(data)
 
-          @repo_service.copy_pulp_units(data)
+          assert_equal data, data_dup
         end
 
         def test_copy_content_chunked_limits_units_copied
@@ -52,15 +62,58 @@ module Katello
           data.config = []
 
           content = []
-          30_001.times do |i|
-            content << i
-          end
+          30_001.times { |i| content << i }
 
           3.times { data.config << { content: content } }
 
           mock_api = "test"
           Katello::Pulp3::Api::Yum.any_instance.expects(:copy_api).returns(mock_api).times(10)
           mock_api.stubs(:copy_content).returns("copied")
+
+          @repo_service.copy_content_chunked(data)
+        end
+
+        def test_copy_content_chunked_copies_correct_units
+          data = PulpRpmClient::Copy.new
+          data.config = []
+
+          mock_api = "test"
+          Katello::Pulp3::Api::Yum.any_instance.expects(:copy_api).returns(mock_api).times(4)
+
+          3.times do
+            data.config << {
+              source_repo_version: "repo version",
+              dest_repo: "dest repo",
+              content: []
+            }
+          end
+          data.config[0][:content] = (0..9_999).to_a
+          data.config[1][:content] = (10_000..19_999).to_a
+          data.config[2][:content] = (20_000..30_000).to_a
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: (0..9_999).to_a},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: (10_000..19_999).to_a},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: (20_001..30_000).to_a}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: [20_000]}]
+          end
 
           @repo_service.copy_content_chunked(data)
         end


### PR DESCRIPTION
This PR limits the amount of content units that can be copied per Pulp 3 RPM Copy API call.  This limit is being introduced because there seems to be a timeout that can occur if the request body is too large.  The extent of the timeout issue is still being tested.  Currently, the limit is set at 10,000 units.

To do the limiting, I essentially iterate over the original Pulp 3 Copy API data config and copy over unit hrefs to a new Pulp 3 Copy API data config until the limit is reached or the units in the original data config runs out.  Then, the Copy API is called and the process repeats.  I ensure that all repos are included in the call so that dependency solving works.

To test:

1) Sync a few large yum repos that have over 10K units together combined
2) Add those repos to a content view with a filter (still ensuring >10K units) and publish
3) Apply my PR
4) Publish again
5) Check that the same content was copied over
6) Try 1-5 but with over 50K content units if your environment can handle it