### PR TITLE
Fixes #30427 - Update errata status after CV publish/promote

### DIFF
--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -47,6 +47,7 @@ module Actions
           ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
                                               :lifecycle_environment_id => input[:environment_id]).each do |facet|
             facet.update_applicability_counts
+            facet.update_errata_status
           end
 
           history = ::Katello::ContentViewHistory.find(input[:history_id])

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -122,6 +122,7 @@ module Actions
             ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
                                                 :lifecycle_environment_id => input[:environment_id]).each do |facet|
               facet.update_applicability_counts
+              facet.update_errata_status
             end
           end
 

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -57,9 +57,24 @@ module ::Actions::Katello::ContentView
         assert_empty Katello::Event.all
       end
     end
+
+    context 'finalize phase' do
+      it 'updates errata counts and status' do
+        content_facet = katello_content_facets(:content_facet_two)
+        action.stubs(:input).returns(
+          content_view_version_id: content_facet.content_view_version.id,
+          content_view_id: content_facet.content_view_id,
+          environment_id: content_facet.lifecycle_environment_id,
+          history_id: Katello::ContentViewHistory.first.id
+        )
+        Katello::Host::ContentFacet.any_instance.expects(:update_applicability_counts)
+        Katello::Host::ContentFacet.any_instance.expects(:update_errata_status)
+        action.finalize
+      end
+    end
   end
 
-  class PromoteToEnviroment < TestBase
+  class PromoteToEnviromentTest < TestBase
     let(:action_class) { ::Actions::Katello::ContentView::PromoteToEnvironment }
 
     let(:environment) do
@@ -75,6 +90,20 @@ module ::Actions::Katello::ContentView
       action.stubs(:task).returns(success_task)
       plan_action(action, content_view_version, environment, 'description')
       refute_empty content_view_version.history
+    end
+
+    context 'finalize phase' do
+      it 'updates errata counts and status' do
+        content_facet = katello_content_facets(:content_facet_two)
+        action.stubs(:input).returns(
+          content_view_id: content_facet.content_view_id,
+          environment_id: content_facet.lifecycle_environment_id,
+          history_id: Katello::ContentViewHistory.first.id
+        )
+        Katello::Host::ContentFacet.any_instance.expects(:update_applicability_counts)
+        Katello::Host::ContentFacet.any_instance.expects(:update_errata_status)
+        action.finalize
+      end
     end
   end
 


### PR DESCRIPTION
After a content view publish / promote, `update_applicability_counts` was run but `update_errata_status` was not.  This results in errata status and counts being out of sync.

For example, Host details page says "All errata applied", but Content Host details says there are 1 or more installable errata.  Or, Host details says "xx errata installable" while Content Host details shows a count of 0 for all errata types.

To reproduce:

1. Go to Web UI -> Administer -> Settings -> Content -> Installable errata from Content View -> Yes
1. Publish a content view containing a product and repo with errata
2. Attach this custom product to a host
3. Install the applicable (old) package on the host, making the errata 'applicable' and 'installable'
4. Verify that errata shows as installable on Content Host details page, and that Host Details shows a status 'xxx errata installable'
5. Make a filter that excludes all errata from the content view
6. Publish a new version
6. Check and compare Content Host details page with Host details page

Expected: Content Host details shows 0 installable errata; Host details shows status 'All errata applied'
Actual: Content Host details shows 0 installable errata, but Host details still shows 'xxx errata installable'

After applying the patch, publishing a new CV version without the filter should cause the errata status and counts to be in sync again.
