### PR TITLE
Fixes #30826 - Handle Hypervisors report containing duplicate UUIDs

### DIFF
--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -8,7 +8,9 @@ module Katello::Host
     include FactImporterIsolation
     allow_transactions_for_any_importer
 
-    before :each do
+    let(:action_class) { ::Actions::Katello::Host::Hypervisors }
+
+    def setup
       User.current = users(:admin)
       @organization = FactoryBot.build(:katello_organization)
       location = taxonomies(:location1)
@@ -42,95 +44,117 @@ module Katello::Host
       ::Katello::Resources::Candlepin::Consumer.stubs(:get_all_with_facts).returns([@consumer])
     end
 
-    let(:action_class) { ::Actions::Katello::Host::Hypervisors }
+    def test_handle_new_hypervisor
+      @host.subscription_facet.destroy!
+      @host.destroy!
 
-    describe 'Hypervisors Update' do
-      it 'new hypervisor' do
-        @host.subscription_facet.destroy!
-        @host.destroy!
+      ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).never
 
-        ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).never
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+      plan_action(action, :hypervisors => @hypervisor_results)
+      action = run_action(action)
 
-        plan_action(action, :hypervisors => @hypervisor_results)
+      assert_equal :success, action.state
+
+      @host = Host.find_by(:name => @hypervisor_name)
+      assert_not_nil @host.subscription_facet
+      assert_equal @facts['hypervisor.type'], @host.facts['hypervisor::type']
+    end
+
+    def test_update_guests_hypervisor
+      guests = []
+      original_host = FactoryBot.create(:host, :with_subscription, :content_view => @content_view,
+                                        :lifecycle_environment => @content_view_environment, :organization => @organization)
+
+      3.times do
+        guests << FactoryBot.create(:host, :with_subscription, :content_view => @content_view,
+                                    :lifecycle_environment => @content_view_environment, :organization => @organization)
+      end
+
+      guests.first.subscription_facet.update!(:hypervisor_host_id => original_host.id)
+      guests.sort!
+      guest_uuids = guests.map { |guest| { 'uuid' => guest.subscription_facet.uuid } }
+
+      # Delete :guestIds to make katello to fetch the virtual guests from Candlepin
+      @consumer.delete(:guestIds)
+      ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).once.returns(guest_uuids)
+
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+      plan_action(action, :hypervisors => @hypervisor_results)
+      action = run_action(action)
+
+      assert_equal :success, action.state
+      assert_equal guests, @host.subscription_facet.virtual_guests.sort
+    end
+
+    def test_hypervisor_duplicate_bios_uuid
+      hypervisor_results = [
+        {name: "hypervisor1.example.com", uuid: "040d7c29-5075-4173-a8e2-64ebbdef03ca", organization_label: @organization.label},
+        {name: "hypervisor2.example.com", uuid: "040d7c29-5075-4173-a8e2-64ebbdef03ca", organization_label: @organization.label}
+      ]
+      consumer = {
+        "uuid" => "040d7c29-5075-4173-a8e2-64ebbdef03ca",
+        "entitlementStatus" => nil,
+        "entitlementCount" => 0,
+        "hypervisorId" => {"hypervisorId" => "hypervisor1.example.com"},
+        "type" => {"id" => "1004", "label" => "hypervisor", "manifest" => false}
+      }
+      Katello::Resources::Candlepin::Consumer.expects(:get_all_with_facts).returns([consumer.with_indifferent_access])
+      Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).returns({})
+
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+      plan_action(action, :hypervisors => hypervisor_results)
+
+      assert_raises(StandardError) do
+        run_action(action)
+      end
+
+      assert ::Host.find_by_name("virt-who-hypervisor1.example.com-#{@organization.id}")
+      refute ::Host.find_by_name("virt-who-hypervisor2.example.com-#{@organization.id}")
+    end
+
+    def test_existing_hypervisor_no_facet
+      @host.subscription_facet.delete
+      @host.save!
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+
+      plan_action(action, :hypervisors => @hypervisor_results)
+      action = run_action(action)
+
+      assert_equal :success, action.state
+
+      @host.reload
+      assert_not_nil @host.subscription_facet
+      assert_equal @facts['hypervisor.type'], @host.facts['hypervisor::type']
+    end
+
+    def test_existing_hypervisor_renamed
+      @hypervisor_results[0][:name] = 'hypervisor.renamed'
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+
+      plan_action(action, :hypervisors => @hypervisor_results)
+      assert_difference('::Katello::Host::SubscriptionFacet.count', 0) do
         action = run_action(action)
-
-        assert_equal :success, action.state
-
-        @host = Host.find_by(:name => @hypervisor_name)
-        assert_not_nil @host.subscription_facet
-        assert_equal @facts['hypervisor.type'], @host.facts['hypervisor::type']
       end
 
-      it 'update guests hypervisor' do
-        guests = []
-        original_host = FactoryBot.create(:host, :with_subscription, :content_view => @content_view,
-                                          :lifecycle_environment => @content_view_environment, :organization => @organization)
+      assert_equal :success, action.state
+    end
 
-        3.times do
-          guests << FactoryBot.create(:host, :with_subscription, :content_view => @content_view,
-                                      :lifecycle_environment => @content_view_environment, :organization => @organization)
-        end
+    def test_existing_hypervisor_no_org
+      ::Host.any_instance.stubs(:check_host_registration).returns(true)
 
-        guests.first.subscription_facet.update!(:hypervisor_host_id => original_host.id)
-        guests.sort!
-        guest_uuids = guests.map { |guest| { 'uuid' => guest.subscription_facet.uuid } }
+      @host.organization = nil
+      @host.save!
 
-        # Delete :guestIds to make katello to fetch the virtual guests from Candlepin
-        @consumer.delete(:guestIds)
-        ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).once.returns(guest_uuids)
+      action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, :hypervisors => @hypervisor_results)
-        action = run_action(action)
-
-        assert_equal :success, action.state
-        assert_equal guests, @host.subscription_facet.virtual_guests.sort
+      plan_action(action, :hypervisors => @hypervisor_results)
+      exception = assert_raises(RuntimeError) do
+        run_action(action)
       end
 
-      it 'existing hypervisor, no facet' do
-        @host.subscription_facet.delete
-        @host.save!
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-
-        plan_action(action, :hypervisors => @hypervisor_results)
-        action = run_action(action)
-
-        assert_equal :success, action.state
-
-        @host.reload
-        assert_not_nil @host.subscription_facet
-        assert_equal @facts['hypervisor.type'], @host.facts['hypervisor::type']
-      end
-
-      it 'existing hypervisor, renamed' do
-        @hypervisor_results[0][:name] = 'hypervisor.renamed'
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-
-        plan_action(action, :hypervisors => @hypervisor_results)
-        assert_difference('::Katello::Host::SubscriptionFacet.count', 0) do
-          action = run_action(action)
-        end
-
-        assert_equal :success, action.state
-      end
-
-      it 'existing hypervisor, no org' do
-        ::Host.any_instance.stubs(:check_host_registration).returns(true)
-
-        @host.organization = nil
-        @host.save!
-
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-
-        plan_action(action, :hypervisors => @hypervisor_results)
-        exception = assert_raises(RuntimeError) do
-          run_action(action)
-        end
-
-        assert_equal "Host '#{@host.name}' does not belong to an organization", exception.message
-      end
+      assert_equal "Host '#{@host.name}' does not belong to an organization", exception.message
     end
   end
 end


### PR DESCRIPTION
A while back we adapted host registration to fail when the registering host presents the same "system.dmi.uuid" fact as some other registered system. We need to extend that functionality to virt-who hypervisors upload where we parse a report from candlepin and create hosts based on the data within it, and that's what this PR does.

To test:
 - Install virt-who directly on your physical system with yum or dnf
 - create a configuration so that virt-who can talk to your dev environment:

`/etc/virt-who.d/local.conf`
```
[myconfig]
type=fake
file=/tmp/fake.json
is_hypervisor=true
hypervisor_id=hostname
owner=Default_Organization
env=Library
rhsm_hostname=centos7-katello-devel.example.com
rhsm_prefix=/rhsm
```

Create the `/tmp/fake.json` per the above config:

```
{"hypervisors":[{"uuid":"bootp-73-131-226.example.com","guests":[{"guestId":"42216992-7a40-5701-a681-3e560a389cdd","state":1,"attributes":{"active":1,"virtWhoType":"esx"}}],"facts":{"hypervisor.type":"VMware ESXi","dmi.system.uuid":"9bff4d56-3b59-6355-ece2-e02094d27d11","cpu.cpu_socket(s)":"1","hypervisor.cluster":"virtwho-test","hypervisor.version":"6.7.0"},"name":"bootp-73-131-226.example.com"},{"uuid":"bootp-73-131-237.example.com","guests":[{"guestId":"42215992-7a40-5701-a681-3e560a489cff","state":1,"attributes":{"active":1,"virtWhoType":"esx"}}],"facts":{"hypervisor.type":"VMware ESXi","dmi.system.uuid":"9bff4d56-3b59-6355-ece2-e02094d27d11","cpu.cpu_socket(s)":"1","hypervisor.cluster":"virtwho-test","hypervisor.version":"6.7.0"},"name":"bootp-73-131-237.example.com"}]}
```

Use virt-who to upload the report to your dev env: `virt-who -c /etc/virt-who.d/local.conf -od`

Without this code change, the created task should fail with a very unhelpful error: `Validation failed: Name has already been taken`

With the code change, it will tell you about the duplicate UUIDs and which hypervisors weren't able to be created, and how to resolve the problem.