### PR TITLE
Fixes #30592 - Show All Repo sets On SCA

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -9,14 +9,13 @@
  * @requires ActivationKey
  * @requires ContentHostsHelper
  * @requires CurrentOrganization
- * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for activation key associations.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host', 'simpleContentAccessEnabled',
-    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host, simpleContentAccessEnabled) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host',
+    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host) {
         var contentHostsNutupane, nutupaneParams, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -60,7 +59,5 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.memory = ContentHostsHelper.memory;
-
-        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -20,7 +20,8 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
 
         params = {
             id: $scope.$stateParams.activationKeyId,
-            'organization_id': CurrentOrganization
+            'organization_id': CurrentOrganization,
+            'content_access_mode_all': $scope.simpleContentAccessEnabled
         };
 
         $scope.controllerName = 'katello_products';
@@ -28,12 +29,12 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
         $scope.table = $scope.nutupane.table;
 
         $scope.contentAccessModes = {
-            contentAccessModeAll: false,
+            contentAccessModeAll: $scope.simpleContentAccessEnabled,
             contentAccessModeEnv: false
         };
         $scope.toggleFilters = function () {
             $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
+            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll || $scope.simpleContentAccessEnabled;
             $scope.nutupane.refresh();
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
@@ -9,14 +9,13 @@
  * @requires ActivationKey
  * @requires SubscriptionsHelper
  * @requires Notification
- * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the activation key subscriptions details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptionsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'Subscription', 'SubscriptionsHelper', 'Notification', 'simpleContentAccessEnabled',
-    function ($scope, $location, translate, Nutupane, ActivationKey, Subscription, SubscriptionsHelper, Notification, simpleContentAccessEnabled) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'Subscription', 'SubscriptionsHelper', 'Notification',
+    function ($scope, $location, translate, Nutupane, ActivationKey, Subscription, SubscriptionsHelper, Notification) {
         var params;
 
         params = {
@@ -33,7 +32,6 @@ angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptions
         $scope.contentNutupane.setSearchKey('subscriptionSearch');
         $scope.isRemoving = false;
         $scope.contextAdd = false;
-        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
 
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -17,7 +17,7 @@
   </div>
 
   <div data-block="filters">
-    <label class="checkbox-inline" title="{{ 'Show all Repository Sets in Organization' | translate }}">
+    <label class="checkbox-inline" title="{{ 'Show all Repository Sets in Organization' | translate }}" ng-if="!simpleContentAccessEnabled">
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
       <span translate>Show All</span>
     </label>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -10,14 +10,13 @@
  * @requires Organization
  * @requires CurrentOrganization
  * @requires CurrentHostsHelper
- * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoController',
-    ['$scope', '$q', 'translate', 'HostSubscription', 'ContentView', 'Organization', 'CurrentOrganization', 'ContentHostsHelper', 'simpleContentAccessEnabled',
-    function ($scope, $q, translate, HostSubscription, ContentView, Organization, CurrentOrganization, ContentHostsHelper, simpleContentAccessEnabled) {
+    ['$scope', '$q', 'translate', 'HostSubscription', 'ContentView', 'Organization', 'CurrentOrganization', 'ContentHostsHelper',
+    function ($scope, $q, translate, HostSubscription, ContentView, Organization, CurrentOrganization, ContentHostsHelper) {
         function doubleColonNotationToObject(dotString) {
             var doubleColonObject = {}, tempObject, parts, part, key, property;
             for (property in dotString) {
@@ -46,7 +45,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         $scope.showCVAlert = false;
         $scope.editContentView = false;
         $scope.disableEnvironmentSelection = false;
-        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.environments = [];
 
         $scope.environments = Organization.readableEnvironments({id: CurrentOrganization});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
@@ -23,7 +23,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
             'organization_id': CurrentOrganization,
             enabled: true,
             'full_result': true,
-            'include_available_content': true
+            'include_available_content': true,
+            'content_access_mode_all': $scope.simpleContentAccessEnabled
         };
 
         $scope.controllerName = 'katello_products';
@@ -31,11 +32,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
         $scope.table = $scope.nutupane.table;
 
         $scope.contentAccessModes = {
-            contentAccessModeAll: false,
+            contentAccessModeAll: $scope.simpleContentAccessEnabled,
             contentAccessModeEnv: false
         };
         $scope.toggleFilters = function () {
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
+            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll || $scope.simpleContentAccessEnabled;
             $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
             $scope.nutupane.refresh();
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
@@ -8,14 +8,13 @@
  * @requires Subscription
  * @requires SubscriptionsHelper
  * @requires Notification
- * @requires simpleContentAccessEnabled
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Subscription', 'Host', 'HostSubscription', 'SubscriptionsHelper', 'Notification', 'simpleContentAccessEnabled',
-    function ($scope, $location, translate, Nutupane, CurrentOrganization, Subscription, Host, HostSubscription, SubscriptionsHelper, Notification, simpleContentAccessEnabled) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Subscription', 'Host', 'HostSubscription', 'SubscriptionsHelper', 'Notification',
+    function ($scope, $location, translate, Nutupane, CurrentOrganization, Subscription, Host, HostSubscription, SubscriptionsHelper, Notification) {
 
         var params = {
             'organization_id': CurrentOrganization,
@@ -31,7 +30,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsCont
         $scope.nutupane.primaryOnly = true;
         $scope.isRemoving = false;
         $scope.contextAdd = false;
-        $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {
             $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
@@ -22,7 +22,7 @@
     </div>
 
     <div data-block="filters">
-      <label class="checkbox-inline" title="{{ 'Show all Repository Sets in Organization' | translate }}">
+      <label class="checkbox-inline" title="{{ 'Show all Repository Sets in Organization' | translate }}" ng-if="!simpleContentAccessEnabled">
         <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
         <span translate>Show All</span>
       </label>

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
@@ -40,13 +40,11 @@ describe('Controller: ActivationKeyAssociationsController', function() {
             ActivationKey: ActivationKey,
             Host: Host,
             ContentHostsHelper: {},
-            CurrentOrganization: 'ACME',
-            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
+            CurrentOrganization: 'ACME'
         });
     }));
 
     it('should attach a activation-key resource onto the scope', function() {
         expect($scope.activationKey).toBeDefined();
     });
-
 });

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
@@ -179,12 +179,82 @@ describe('Controller: ActivationKeyRepositorySetsController', function () {
     });
 
     describe("can toggle repository set filters", function () {
-        it("all and env toggles", function () {
+        it("all and env toggles correctly with no SCA", function () {
             $scope.contentAccessModes.contentAccessModeAll = false;
             $scope.contentAccessModes.contentAccessModeEnv = false;
+            $scope.simpleContentAccessEnabled = false;
             $scope.toggleFilters();
             expect($scope.nutupane.table.params['content_access_mode_env']).toEqual($scope.contentAccessModes.contentAccessModeEnv);
             expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
         });
+    });
+});
+
+describe('Controller: ActivationKeyRepositorySetsControllerWithSCA', function () {
+    var $scope,
+        $controller,
+        translate,
+        ActivationKey,
+        expectedTableSelection,
+        ContentOverrideHelper,
+        Notification,
+        CurrentOrganization;
+
+    beforeEach(module('Bastion.activation-keys'));
+
+    beforeEach(inject(function (_$controller_, $rootScope, $q) {
+        $controller = _$controller_;
+        $scope = $rootScope.$new();
+        $rootScope.simpleContentAccessEnabled = true;
+        translate = function (message) {
+            return message;
+        };
+
+        ActivationKey = {
+            failed: false,
+            repositorySets: function () {
+                return {
+                    $promise: $q.defer().promise
+                }
+            },
+            contentOverride: function (params, overrides, success, failure) {
+                if (this.failed) {
+                    failure({data: {}})
+                } else {
+                    success();
+                }
+            }
+        };
+
+        ContentOverrideHelper = {
+            getEnabledContentOverrides: function () {},
+            getDisabledContentOverrides: function () {},
+            getDefaultContentOverrides: function () {}
+        };
+
+        Notification = {
+            setSuccessMessage: function () {},
+            setErrorMessage: function () {}
+        };
+
+
+        $controller('ActivationKeyRepositorySetsController', {
+            $scope: $scope,
+            translate: translate,
+            ActivationKey: ActivationKey,
+            Notification: Notification,
+            ContentOverrideHelper: ContentOverrideHelper,
+            CurrentOrganization: CurrentOrganization
+        });
+
+        $scope.table = {
+            getSelected: function () {}
+        };
+
+        $scope.$stateParams.activationKeyId = 1;
+    }));
+
+    it('sets the content access mode correctly', function () {
+        expect($scope.contentAccessModes.contentAccessModeAll).toBe(true);
     });
 });

--- a/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
@@ -179,12 +179,81 @@ describe('Controller: ContentHostRepositorySetsController', function () {
     });
 
     describe("can toggle repository set filters", function () {
-        it("all and env toggles", function () {
-            $scope.contentAccessModes.contentAccessModeAll = true;
+        it("all and env toggles correctly with no SCA", function () {
+            $scope.contentAccessModes.contentAccessModeAll = false;
             $scope.contentAccessModes.contentAccessModeEnv = false;
+            $scope.simpleContentAccessEnabled = false;
             $scope.toggleFilters();
-            expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
             expect($scope.nutupane.table.params['content_access_mode_env']).toEqual($scope.contentAccessModes.contentAccessModeEnv);
+            expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
         });
+    });
+});
+
+describe('Controller: ContentHostRepositorySetsControllerWithSCA', function () {
+    var $scope,
+        $controller,
+        translate,
+        HostSubscription,
+        expectedTableSelection,
+        ContentOverrideHelper,
+        Notification,
+        CurrentOrganization;
+
+    beforeEach(module('Bastion.content-hosts'));
+
+    beforeEach(inject(function (_$controller_, $rootScope) {
+        $controller = _$controller_;
+        $scope = $rootScope.$new();
+        $scope.simpleContentAccessEnabled = true;
+        translate = function (message) {
+            return message;
+        };
+
+        HostSubscription = {
+            failed: false,
+            repositorySets: function () {
+                return {
+                    $promise: $q.defer().promise
+                }
+            },
+            contentOverride: function (params, overrides, success, failure) {
+                if (this.failed) {
+                    failure({data: {}})
+                } else {
+                    success();
+                }
+            }
+        };
+
+        ContentOverrideHelper = {
+            getEnabledContentOverrides: function () {},
+            getDisabledContentOverrides: function () {},
+            getDefaultContentOverrides: function () {}
+        };
+
+        Notification = {
+            setSuccessMessage: function () {},
+            setErrorMessage: function () {}
+        };
+
+        $controller('ContentHostRepositorySetsController', {
+            $scope: $scope,
+            translate: translate,
+            HostSubscription: HostSubscription,
+            Notification: Notification,
+            ContentOverrideHelper: ContentOverrideHelper,
+            CurrentOrganization: CurrentOrganization
+        });
+
+        $scope.table = {
+            getSelected: function () {}
+        };
+
+        $scope.$stateParams.hostId = 1;
+    }));
+
+    it('sets the content access mode correctly', function () {
+        expect($scope.contentAccessModes.contentAccessModeAll).toBe(true);
     });
 });


### PR DESCRIPTION
This commit sets the content-access-mode to all if the organization has
Simple Content Access

It also hides the show all button in both Content Host Repo Sets and AK Repo
Sets page.

This commit also removes references to duplicate
`$scope.simpleContentAccessEnabled = simpleContentAccessEnabled` strewn
across child controller. The parent controllers already have this line
and child controller must inherit from parent anyway.