### PR TITLE
Refs #30791 - demonstrate tabs addition to the new host details page

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import EmptyPage from 'foremanReact/components/common/EmptyState/EmptyStatePattern';
+
+const contentTab = () => (
+  <EmptyPage
+    icon="cloud-security"
+    header="WIP Content"
+    description="This is a demonstration for adding content to the new host details page"
+  />
+);
+
+export default contentTab;

--- a/webpack/components/extensions/HostDetails/Tabs/SubscriptionTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/SubscriptionTab.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import EmptyPage from 'foremanReact/components/common/EmptyState/EmptyStatePattern';
+
+const SubscriptionTab = () => (
+  <EmptyPage
+    icon="enterprise"
+    header="WIP Subscription"
+    description="This is a demo for adding content to the new host details page"
+  />
+);
+
+export default SubscriptionTab;

--- a/webpack/fills_index.js
+++ b/webpack/fills_index.js
@@ -3,8 +3,12 @@ import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
 import { registerReducer } from 'foremanReact/common/MountingService';
 
 import SystemStatuses from './components/extensions/about';
+import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
+import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import extendReducer from './components/extensions/reducers';
 
 registerReducer('katelloExtends', extendReducer);
 
 addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
+addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content-tab" />, 100);
+addGlobalFill('host-details-page-tabs', 'Subscription', <SubscriptionTab key="subscription-tab" />, 2000);


### PR DESCRIPTION
This PR demonstrates how to extend the experimental host details page and shows how to add tabs from katello
![https___192 168 122 21_experimental_hosts_adele-segur example tst](https://user-images.githubusercontent.com/11807069/93147987-6500d900-f6fb-11ea-8899-c6118434887c.gif)
