### PR TITLE
Fixes #30371 - Fix timezone display on sync date field in UI

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -121,6 +121,14 @@ module Katello
       errors.add :base, _("Start Date and Time can't be blank") if self.sync_date.nil?
     end
 
+    def sync_date_sans_tz
+      if User.current.try(:timezone)
+        return self.sync_date.strftime('%a, %d %b %Y %H:%M:%S')
+      else
+        sync_date
+      end
+    end
+
     def next_sync
       return nil unless self.enabled?
       self.foreman_tasks_recurring_logic&.tasks&.order(:start_at)&.last&.start_at

--- a/app/views/katello/api/v2/sync_plans/show.json.rabl
+++ b/app/views/katello/api/v2/sync_plans/show.json.rabl
@@ -2,7 +2,8 @@ object @resource
 
 attributes :id, :organization_id
 attributes :name, :description
-attributes :interval, :next_sync, :sync_date
+attributes :interval, :next_sync
+attributes :sync_date_sans_tz => :sync_date
 attributes :created_at, :updated_at
 attributes :enabled, :foreman_tasks_recurring_logic_id
 attributes :cron_expression

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
             function updateSyncPlan(syncPlan) {
                 var syncDate;
                 if (syncPlan['sync_date']) {
-                    syncDate = new Date(syncPlan['sync_date'].replace(/\s/, 'T').replace(/\s/, ''));
+                    syncDate = new Date(syncPlan['sync_date']);
                 } else {
                     syncDate = new Date();
                 }
@@ -68,11 +68,12 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
                     syncDate = new Date(syncPlan.syncDate),
                     syncTime = new Date(syncPlan.syncTime || new Date());
 
+                var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' };
+
                 syncDate.setHours(syncTime.getHours());
                 syncDate.setMinutes(syncTime.getMinutes());
                 syncDate.setSeconds(0);
-                syncPlan['sync_date'] = syncDate.toString();
-
+                syncPlan['sync_date'] = syncDate.toLocaleString("en-US", options);
                 syncPlan.$update(function (response) {
                     updateSyncPlan(syncPlan);
                     deferred.resolve(response);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
@@ -20,7 +20,7 @@
       <dt translate>Start Date</dt>
       <dd bst-edit-custom="syncPlan.syncDate"
           formatter="date"
-          formatter-options="'medium'"
+          formatter-options="'MMMM d, y, hh:mm a'"
           on-save="save(syncPlan)"
           readonly="denied('edit_sync_plans', syncPlan)">
 


### PR DESCRIPTION
Opening this for better ideas to fix this. 

To test:
1. Create a sync plan
2. Go to Logged in user (top right corner dropdown)>  My Account
3. The default Timezone should be Browser timezone. 
4. Change it to some different timezone.
5. Refresh sync plan page. Notice the sync plan start date field does not respected this timezone.

After this change, it should display start date in the user account timezone and not the browser timezone similar to next sync date.

The problem I ran into is that while the next sync date is a react component , the start date is a bastion bst-edit-custom field and I wasn't able to make it respect account timezone over browser timezone...Hence falling back to the API. 
