### PR TITLE
Refs #29948 - Improve querying when importing SubscriptionFacetPools

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -21,6 +21,8 @@ module Katello
         lazy_accessor :available, :initializer => lambda { |_s| self.quantity_available }
 
         lazy_accessor :backend_data, :initializer => lambda { |_s| self.class.candlepin_data(self.cp_id) }
+
+        lazy_accessor :consumer_uuids, :initializer => lambda { |_s| Resources::Candlepin::Pool.consumer_uuids(self.cp_id) }
       end
     end
 
@@ -162,27 +164,20 @@ module Katello
       end
 
       def import_hosts
-        uuids = Resources::Candlepin::Pool.consumer_uuids(self.cp_id)
-
-        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where('uuid in (?)', uuids).pluck([:id, :host_id]).transpose
+        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where('uuid in (?)', consumer_uuids).pluck([:id, :host_id]).transpose
         sub_facet_ids_from_cp ||= []
         host_ids_from_cp ||= []
 
-        sub_facet_ids_from_pool_table = Katello::SubscriptionFacetPool.where(:pool_id => self.id).select(:subscription_facet_id).pluck(:subscription_facet_id)
-        host_ids_from_pool_table = Katello::Host::SubscriptionFacet.where(:id => sub_facet_ids_from_pool_table).pluck(:host_id)
+        sub_facet_ids_from_pool_table, host_ids_from_pool_table = self.subscription_facets.pluck(:id, :host_id).transpose
+        sub_facet_ids_from_pool_table ||= []
+        host_ids_from_pool_table ||= []
 
         entries_to_add = sub_facet_ids_from_cp - sub_facet_ids_from_pool_table
-        unless entries_to_add.empty?
-          ActiveRecord::Base.transaction do
-            entries_to_add.each do |sub_facet_id|
-              query = "INSERT INTO #{Katello::SubscriptionFacetPool.table_name} (pool_id, subscription_facet_id) VALUES (#{self.id}, #{sub_facet_id})"
-              ActiveRecord::Base.connection.execute(query)
-            end
-          end
-        end
+        facet_pool_data = entries_to_add.map { |sub_facet_id| { pool_id: self.id, subscription_facet_id: sub_facet_id } }
+        Katello::SubscriptionFacetPool.import(facet_pool_data) unless facet_pool_data.empty?
 
         entries_to_remove = sub_facet_ids_from_pool_table - sub_facet_ids_from_cp
-        Katello::SubscriptionFacetPool.where(:pool_id => self.id, :subscription_facet_id => entries_to_remove).delete_all
+        self.subscription_facet_pools.where(subscription_facet_id: entries_to_remove).delete_all
         self.import_audit_record(host_ids_from_pool_table, host_ids_from_cp)
       end
 

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -164,7 +164,7 @@ module Katello
       end
 
       def import_hosts
-        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where('uuid in (?)', consumer_uuids).pluck([:id, :host_id]).transpose
+        sub_facet_ids_from_cp, host_ids_from_cp = Katello::Host::SubscriptionFacet.where('uuid in (?)', consumer_uuids).pluck(:id, :host_id).transpose
         sub_facet_ids_from_cp ||= []
         host_ids_from_cp ||= []
 

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -134,6 +134,25 @@ module Katello
       assert @pool_one.subscription_facets.where(id: host.subscription_facet.id).any?
     end
 
+    def test_import_hosts_no_consumers
+      host = FactoryBot.create(:host, :with_subscription)
+      Resources::Candlepin::Pool.expects(:consumer_uuids).returns([])
+
+      @pool_one.import_hosts
+
+      refute @pool_one.subscription_facets.where(id: host.subscription_facet.id).any?
+    end
+
+    def test_import_hosts_cleanup_facet_pools
+      host = FactoryBot.create(:host, :with_subscription)
+      Resources::Candlepin::Pool.expects(:consumer_uuids).returns([])
+      facet_pool = Katello::SubscriptionFacetPool.create!(pool: @pool_one, subscription_facet: host.subscription_facet)
+
+      @pool_one.import_hosts
+
+      refute Katello::SubscriptionFacetPool.find_by_id(facet_pool.id)
+    end
+
     def test_quantity_available_unlimited
       pool = FactoryBot.build(:katello_pool, quantity: -1, consumed: 3)
       assert_equal(-1, pool.quantity_available)


### PR DESCRIPTION
See the first go-round for data-setup info: https://github.com/Katello/katello/pull/8732

I recommend doing an end-to-end test using the `katello:reimport` rake task as that's how this came back up. However, the issue raised on the bz isn't a problem in develop now due to newer rails version. ~~It would be best to test this on a 3.14 box in addition to develop per the data setup in the original PR.~~ Edit: Cole has tested this downstream (3.14) so upstream testing only is sufficient here