### PR TITLE
Fixes #30880 - Permission support to validate 404

### DIFF
--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -185,17 +185,15 @@ module Katello
       assert_response_ids response, ids
     end
 
-    # def test_index_with_content_view_version_id_and_library
-    #   # version  = @organization.default_content_view_version
-    #   # ids = version.repositories.pluck(:library_instance_id).reject(&:blank?).uniq
-    #   ids = @view.versions.first.repositories.pluck(:library_instance_id).reject(&:blank?).uniq
-    #
-    #   response = get :index, params: { :content_view_version_id => @view.versions.first.id, :organization_id => @organization.id, :library => true }
-    #
-    #   assert_response :success
-    #   assert_template 'api/v2/repositories/index'
-    #   assert_response_ids response, ids
-    # end
+    def test_index_with_content_view_version_id_and_library
+      ids = @view.versions.first.repositories.pluck(:library_instance_id).reject(&:blank?).uniq
+
+      response = get :index, params: { :content_view_version_id => @view.versions.first.id, :organization_id => @organization.id, :library => true }
+
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+      assert_response_ids response, ids
+    end
 
     def test_index_with_library
       ids = @organization.default_content_view.versions.first.repositories.pluck(:id)
@@ -539,6 +537,15 @@ module Katello
       denied_perms = [@create_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:show, allowed_perms, denied_perms) do
+        get :show, params: { :id => @repository.id }
+      end
+    end
+
+    def test_show_protected_specific_instance
+      allowed_perms = [{:name => @read_permission, :search => "name=\"#{@repository.product.name}\"" }]
+      denied_perms = [{:name => @read_permission, :search => "name=\"#{@redhat_repository.product.name}\"" }]
+
+      assert_protected_object(:show, allowed_perms, denied_perms) do
         get :show, params: { :id => @repository.id }
       end
     end


### PR DESCRIPTION
This commit enables checking authorizing a specific instance and ensure
that it handles 404 correctly.
It also adds support for multi possible permissions for same action.
For example destroy_content_views and promote_or_remove_content_views
Either support 'removing' a content view.
This commit adds support to handle that.