### PR TITLE
Fixes #30883 - Use checked_icon helper in SCA column

### DIFF
--- a/app/views/overrides/organizations/_index_row_override.html.erb
+++ b/app/views/overrides/organizations/_index_row_override.html.erb
@@ -1,3 +1,3 @@
 <% if taxonomy.is_a?(Organization) %>
-  <td><%= taxonomy.simple_content_access? ? _("Enabled") : _("Disabled") %></td>
+  <td><%= checked_icon taxonomy.simple_content_access? %></td>
 <% end %>


### PR DESCRIPTION
On the Organizations index page:

Instead of showing the text 'Enabled' or 'Disabled', show the check icon using the `checked_icon` helper.  This is more consistent with other Foreman pages, such as Provisioning Templates.

Thanks @ares for the suggestion
![sca_checked_icon](https://user-images.githubusercontent.com/22042343/93639960-cceb4400-f9c7-11ea-8bb2-3cacc48b4f24.png)
