### PR TITLE
Fixes #30892 - Change Sub Watch links and SCA banner message

### DIFF
--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -4,11 +4,6 @@
 
 <% if Organization.current.blank? %>
   <p class="ca"><%= _("Please select an organization to view subscription status.") %></p>
-<% elsif Organization.current.simple_content_access?%>
-  <div class="bastion alert alert-info">
-    <span translate>This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.
-    </span>
-  </div>
 <% else %>
   <% total_count = total_host_count() %>
   <% partial_consumer_count = partial_consumer_count() %>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -1,5 +1,5 @@
 <div id="content-access-mode-banner" bst-alert="info" ng-show="simpleContentAccessEnabled">
   <span translate>
-This organization has Simple Content Access enabled. Hosts can consume from all repositories in their Content View regardless of subscription status.
+This organization has Simple Content Access enabled.  Hosts are not required to have subscriptions attached to access repositories.
   </span>
 </div>

--- a/webpack/scenes/Subscriptions/Manifest/SimpleContentAccess.js
+++ b/webpack/scenes/Subscriptions/Manifest/SimpleContentAccess.js
@@ -36,7 +36,7 @@ const SimpleContentAccess = (props) => {
               <OverlayTrigger
                 overlay={
                   <Tooltip id="sca-refresh-tooltip">
-                    {__('When Simple Content Access is enabled, hosts can consume from all repositories in their Content View regardless of subscription status.')}
+                    {__('When Simple Content Access is enabled, hosts are not required to have subscriptions attached to access repositories.')}
                   </Tooltip>
                 }
                 placement="bottom"

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -37,7 +37,7 @@ export const SUBSCRIPTIONS_CLOSE_DELETE_MODAL = 'SUBSCRIPTIONS_CLOSE_DELETE_MODA
 export const SUBSCRIPTIONS_DISABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_DISABLE_DELETE_BUTTON';
 export const SUBSCRIPTIONS_ENABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_ENABLE_DELETE_BUTTON';
 
-export const SUBSCRIPTION_WATCH_URL = 'https://cloud.redhat.com/subscriptions/rhel-sw/all';
+export const SUBSCRIPTION_WATCH_URL = 'https://access.redhat.com/articles/subscription-watch';
 
 export const MANIFEST_DELETE_TASK_LABEL = 'Actions::Katello::Organization::ManifestDelete';
 

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -267,8 +267,8 @@ class SubscriptionsPage extends Component {
               {simpleContentAccess && (
                 <Alert type="info">
                   This organization has Simple Content Access enabled.
-                  Hosts can consume from all repositories in their Content View regardless of
-                  subscription status.  <br />
+                  Hosts are not required to have subscriptions attached to access repositories.
+                  <br />
                   Learn more about your overall subscription usage at
                   {' '}<a href={SUBSCRIPTION_WATCH_URL} target="_blank" rel="noreferrer">Subscription Watch</a>.
                 </Alert>

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col, Form, FormGroup, Button, OverlayTrigger, Tooltip, Icon } from 'patternfly-react';
+import { Row, Col, Form, FormGroup, Button } from 'patternfly-react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { noop } from 'foremanReact/common/helpers';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -67,18 +67,6 @@ const SubscriptionsToolbar = ({
                 rel="noreferrer"
               >
                 {__('Subscription Watch')}
-                <OverlayTrigger
-                  overlay={
-                    <Tooltip id="sub-watch-tooltip">
-                      {__('Learn more about your overall subscription usage (opens in a new tab)')}
-                    </Tooltip>
-                  }
-                  placement="bottom"
-                  trigger={['hover', 'focus']}
-                  rootClose={false}
-                >
-                  <Icon type="pf" name="info" />
-                </OverlayTrigger>
               </a>
             }
 


### PR DESCRIPTION
On Subscriptions page,

- [x] Remove tooltip from Subscription Watch button
- [x] Change Subscription Watch button to link to https://access.redhat.com/articles/subscription-watch (don't link directly to Sub Watch, link to the doc instead)
- [x] Change link in SCA banner to point to https://access.redhat.com/articles/subscription-watch (don't link directly to Sub Watch, link to the doc instead)
* [NEW 9/2/20] Change the wording in the SCA banner to read
```
This organization has Simple Content Access enabled.  Hosts are not required to have subscriptions attached to access repositories.

```
  - [x] angular
  - [x] subscription page
  - [x] manage manifest modal
  - [x] erb
