### PR TITLE
Fixes #30904 - Global Registration - Search for @host by :uuid or :hostname

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Concerns
+    module Api::V2::RegistrationControllerExtensions
+      extend ActiveSupport::Concern
+
+      def prepare_host
+        if params['uuid']
+          @host = Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid']).host
+          @host.assign_attributes(host_params('host'))
+          @host.save!
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -216,6 +216,7 @@ module Katello
       ::Api::V2::HostsController.include Katello::Concerns::Api::V2::HostsControllerExtensions
       ::Api::V2::HostgroupsController.include Katello::Concerns::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::SmartProxiesController.include Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
+      ::Api::V2::RegistrationController.prepend Katello::Concerns::Api::V2::RegistrationControllerExtensions
 
       ::HostsController.class_eval do
         helper Katello::Concerns::HostsAndHostgroupsHelperExtensions


### PR DESCRIPTION
Extension of `RegistrationControllerExtensions` Host registration endpoint, for more information see https://github.com/theforeman/foreman/pull/8018