### PR TITLE
Fixes #30907 - Pulp 3 Docker proxy syncing does not work

### DIFF
--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -8,6 +8,10 @@ module Katello
           repo.container_repository_name
         end
 
+        def partial_repo_path
+          ''
+        end
+
         def remote_options
           options = {url: root.url, upstream_name: root.docker_upstream_name}
           if root.docker_tags_whitelist&.any?

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -110,8 +110,11 @@ module Katello
         api.remotes_list(name: backend_object_name).first
       end
 
-      def sync
-        repository_sync_url_data = api.class.repository_sync_url_class.new(remote: remote_href, mirror: true)
+      def sync(options = {})
+        sync_params = repo_service.sync_url_params(options)
+        sync_params[:remote] = remote_href
+        sync_params[:mirror] = true
+        repository_sync_url_data = api.class.repository_sync_url_class.new(sync_params)
         [api.repositories_api.sync(repository_href, repository_sync_url_data)]
       end
 
@@ -152,6 +155,7 @@ module Katello
         dist_params[:publication] = options[:publication] if options[:publication]
         dist_params[:repository_version] = version_href if options[:use_repository_version]
         dist_options = distribution_options(path, dist_params)
+        dist_options.delete(:content_guard) if repo_service.repo.content_type == "docker"
         if (distro = repo_service.lookup_distributions(base_path: path).first) ||
           (distro = repo_service.lookup_distributions(name: "#{backend_object_name}").first)
           # update dist

--- a/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
@@ -1,0 +1,49 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    module Pulp3
+      class DockerRepositoryMirrorTest < ActiveSupport::TestCase
+        include Katello::Pulp3Support
+
+        def setup
+          @primary = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          @repo = katello_repositories(:pulp3_docker_1)
+          @repo_service = ::Katello::Pulp3::Repository::Docker.new(@repo, @primary)
+          @repo_mirror = ::Katello::Pulp3::RepositoryMirror.new(@repo_service)
+        end
+
+        def test_sync
+          @repo_mirror.stubs(:remote_href).returns("remote_href")
+          @repo_mirror.stubs(:repository_href).returns("repository_href")
+          sync_url = @repo_service.api.class.repository_sync_url_class.new(remote: "remote_href", mirror: true)
+          PulpContainerClient::RepositorySyncURL.expects(:new).with(remote: "remote_href", mirror: true).once.returns(sync_url)
+          PulpContainerClient::RepositoriesContainerApi.any_instance.expects(:sync).once.with("repository_href", sync_url)
+          @repo_mirror.sync(optimize: "test", skip_types: "another test")
+        end
+
+        def test_refresh_distributions_update_dist
+          mock_distribution = "distro"
+          mock_distribution.expects(:pulp_href).once.returns("pulp_href")
+          @repo_service.stubs(:lookup_distributions).returns([mock_distribution])
+          PulpContainerClient::DistributionsContainerApi.any_instance.expects(:partial_update).with("pulp_href", {})
+          @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
+        end
+
+        def test_refresh_distributions_create_dist
+          @repo_service.stubs(:lookup_distributions).returns([])
+          @repo_service.stubs(:relative_path).returns("mock relative_path")
+          distribution_data = "mock distribution_data"
+          PulpContainerClient::ContainerContainerDistribution.expects(:new).with(
+          {
+            :base_path => "mock relative_path",
+            :name => "Default_Organization-Cabinet-pulp3_Docker_1"
+          }).returns(distribution_data)
+          PulpContainerClient::DistributionsContainerApi.any_instance.expects(:create).with(distribution_data)
+          @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes issues with Docker proxy syncing.

To test:
1) Set up a content-enabled smart proxy with Pulp 3
2) Sync some Docker content to that proxy.  This will fail without my PR
3) Check that the content was actually synced via the Pulp 3 API or by looking in the Pulp database