### PR TITLE
Fixes #27398 - enable ansible collection smart proxy content sync

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -240,6 +240,8 @@ module Katello
           "iso"
         when Repository::DEB_TYPE
           "deb"
+        when Repository::ANSIBLE_COLLECTION_TYPE
+          "ansible_collection"
         end
       end
 
@@ -269,6 +271,10 @@ module Katello
 
       def deb?
         self.content_type == Repository::DEB_TYPE
+      end
+
+      def ansible_collection?
+        self.content_type == Repository::ANSIBLE_COLLECTION_TYPE
       end
 
       def published?
@@ -378,6 +384,8 @@ module Katello
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{relative_path}"
       elsif deb?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/deb/#{relative_path}/"
+      elsif ansible_collection?
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/#{relative_path}/"
       else
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}/"
       end

--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -19,6 +19,15 @@ module Katello
             name: "#{generate_backend_object_name}"
           }
         end
+
+        def partial_repo_path
+          "/pulp_ansible/galaxy/#{repo.relative_path}/api/v2/collections"
+        end
+
+        def mirror_remote_options
+          {
+          }
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -91,10 +91,11 @@ module Katello
 
       def remote_options
         base_options = common_remote_options
-        base_options.merge(url: remote_feed_url)
+        base_options.merge!(url: remote_feed_url)
         if (type_specific_options = repo_service.try(:mirror_remote_options))
-          base_options.merge(type_specific_options)
+          base_options.merge!(type_specific_options)
         end
+        base_options
       end
 
       def create_remote

--- a/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
@@ -1,0 +1,51 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    module Pulp3
+      class AnsibleCollectionRepositoryMirrorTest < ActiveSupport::TestCase
+        include Katello::Pulp3Support
+
+        def setup
+          @primary = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          @repo = katello_repositories(:pulp3_ansible_collection_1)
+          @repo_service = ::Katello::Pulp3::Repository::AnsibleCollection.new(@repo, @primary)
+          @repo_mirror = ::Katello::Pulp3::RepositoryMirror.new(@repo_service)
+        end
+
+        def test_sync
+          @repo_mirror.stubs(:remote_href).returns("remote_href")
+          @repo_mirror.stubs(:repository_href).returns("repository_href")
+          sync_url = @repo_service.api.class.repository_sync_url_class.new(remote: "remote_href", mirror: true)
+          PulpAnsibleClient::RepositorySyncURL.expects(:new).with(remote: "remote_href", mirror: true).once.returns(sync_url)
+          PulpAnsibleClient::RepositoriesAnsibleApi.any_instance.expects(:sync).once.with("repository_href", sync_url)
+          @repo_mirror.sync(optimize: "test", skip_types: "another test")
+        end
+
+        def test_refresh_distributions_update_dist
+          mock_distribution = "distro"
+          mock_distribution.expects(:pulp_href).once.returns("pulp_href")
+          @repo_service.stubs(:lookup_distributions).returns([mock_distribution])
+          PulpAnsibleClient::DistributionsAnsibleApi.any_instance.expects(:partial_update).with("pulp_href", {:content_guard => nil})
+          @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
+        end
+
+        def test_refresh_distributions_create_dist
+          @repo_service.stubs(:lookup_distributions).returns([])
+          @repo_service.stubs(:relative_path).returns("mock relative_path")
+          distribution_data = "mock distribution_data"
+          PulpAnsibleClient::AnsibleAnsibleDistribution.expects(:new).with(
+          {
+            :base_path => "mock relative_path",
+            :name => "Default_Organization-Cabinet-pulp3_Ansible_collection_1",
+            :content_guard => nil
+          }).returns(distribution_data)
+
+          PulpAnsibleClient::DistributionsAnsibleApi.any_instance.expects(:create).with(distribution_data)
+          @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository/ansible_collection/repository_mirror_options_test.rb
+++ b/test/services/katello/pulp3/repository/ansible_collection/repository_mirror_options_test.rb
@@ -1,0 +1,35 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class AnsibleCollectionRepositoryMirrorOptionsTest < ::ActiveSupport::TestCase
+        include RepositorySupport
+
+        def setup
+          create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @mock_smart_proxy.stubs(:pulp_primary?).returns(false)
+          @repo = katello_repositories(:pulp3_ansible_collection_1)
+          @repo_service = @repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_feed_url_is_prepended_with_pulp_rpm_content_path
+          pulp3_repo = Katello::Pulp3::Repository::AnsibleCollection.new(@repo, @mock_smart_proxy)
+
+          assert_equal '/pulp_ansible/galaxy/' + @repo.relative_path + '/api/v2/collections', pulp3_repo.partial_repo_path
+        end
+
+        def test_remote_options
+          @mock_smart_proxy.stubs(:download_policy).returns(SmartProxy::DOWNLOAD_INHERIT)
+          pulp3_repo = Katello::Pulp3::Repository::AnsibleCollection.new(@repo, @mock_smart_proxy)
+          Katello::Pulp3::RepositoryMirror.any_instance.expects(:ssl_remote_options).at_least_once.returns({})
+          assert_equal "Default_Organization-Cabinet-pulp3_Ansible_collection_1", pulp3_repo.with_mirror_adapter.remote_options[:name]
+          assert pulp3_repo.with_mirror_adapter.remote_options[:url].end_with?(pulp3_repo.partial_repo_path)
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository_mirror_test.rb
@@ -1,0 +1,42 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    module Pulp3
+      class TestRepositoryService
+      end
+
+      class RepositoryMirrorTest < ActiveSupport::TestCase
+        include Katello::Pulp3Support
+
+        def setup
+          @repo_service = TestRepositoryService.new
+          @repo_mirror = ::Katello::Pulp3::RepositoryMirror.new(@repo_service)
+          @repo_mirror.stubs(:common_remote_options).returns({:name => 'some_repo'})
+          @repo_mirror.stubs(:remote_feed_url).returns('/a/path/to/content')
+        end
+
+        def test_remote_options_with_mirror_remote_options
+          @repo_service.stubs(:mirror_remote_options).returns({:mirror_remote_option1 => 'an option'})
+          expected_options = {
+            :name => "some_repo",
+            :url => "/a/path/to/content",
+            :mirror_remote_option1 => "an option"
+          }
+          assert_equal expected_options, @repo_mirror.remote_options
+        end
+
+        def test_remote_options_without_mirror_options
+          @repo_mirror.stubs(:common_remote_options).returns({:name => 'some_repo'})
+          @repo_mirror.stubs(:remote_feed_url).returns('/a/path/to/content')
+          expected_options = {
+            :name => "some_repo",
+            :url => "/a/path/to/content"
+          }
+          assert_equal expected_options, @repo_mirror.remote_options
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR enables ansible collection content syncing with remote proxies.

There are a few pre-requisites to this PR.

First is to have pulp_ansible v0.4.1 installed on both the the katello host and the remote proxy.
Both the katello host and the remote proxy must have support displayed for ansible_collection under the Pulpcore section in the Smart Proxies -> Services tab.

In the Foreman config/settings.plugins.d/katello.yml *on the katello/pulp primary* ensure that:
`    :ansible_collection: true`
is present in the content types.

To support the remote proxy with reverse proxy mapping to pulpcore on the katello host, a http conf should be created *on the katello/pulp primary*, similar to:
```
ProxyPass /pulp_ansible/galaxy/ http://127.0.0.1:24817/pulp_ansible/galaxy/ retry=0
ProxyPassReverse /pulp_ansible/galaxy/ http://127.0.0.1:24817/pulp_ansible/galaxy/

ProxyPass /pulp/content/ http://localhost:24816/pulp/content/
ProxyPassReverse /pulp/content/ http://localhost:24816/pulp/content/
```
Also update the /etc/httpd/conf.d/05-foreman-ssl.conf with:
```
## Proxy rules
  ...
  ProxyPass /pulp_ansible !
  ...
```

Create a new product and repository of the ansible_collection type, using the galaxy api url such as `https://galaxy-dev.ansible.com/api/v2/collections/testing/ansible_testing_content`.

Sync that repository. You should now have content available on the katello host (but not the remote proxy... yet).

You can check that the http  configuration is correct by issuing an HTTP request for that content via the pulpcore galaxy API:
`
curl https://centos7-katello-devel-stable.example.com/pulp_ansible/galaxy/Default_Organization/Library/custom/test/test-ansible/api/v2/collections/`
And the result should be:
```
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "name": "ansible_testing_content",
      "namespace": "testing",
      "href": "https://centos7-katello-devel-stable.example.com/pulp_ansible/galaxy/Default_Organization/Library/custom/test/test-ansible/api/v2/collections/testing/ansible_testing_content/",
      "versions_url": "https://centos7-katello-devel-stable.example.com/pulp_ansible/galaxy/Default_Organization/Library/custom/test/test-ansible/api/v2/collections/testing/ansible_testing_content/versions/"
    }
  ]
}
```
You are now ready to kick off a remote proxy sync. Go to Smart Proxies -> <your remote proxy here>, click the "Synchonize" button and choose "Complete Sync".

Check the UI for the proxy by checkin the "Content" tab. Although the number of collections is not (currently) shown, if there was no previous content sync'd, you should now see a Library content view with a product present.

Check the pulpcore schema on the proxy:
```
select version, collection_id, namespace, name, repository from ansible_collectionversion;
 version |            collection_id             |   namespace    |          name           |                            repository                             
---------+--------------------------------------+----------------+-------------------------+-------------------------------------------------------------------
 4.0.6   | 548a3203-cd3f-4179-8326-9857cf6b8eb4 | testing        | ansible_testing_content | 
 4.0.4   | 548a3203-cd3f-4179-8326-9857cf6b8eb4 | testing        | ansible_testing_content | 
```
```
select * from core_content;
               pulp_id                |         pulp_created          |       pulp_last_updated       |         pulp_type          | upstream_id 
--------------------------------------+-------------------------------+-------------------------------+----------------------------+-------------
 7e55c0ee-ceff-4895-a591-1496fc37dc17 | 2020-10-13 15:26:10.711397+00 | 2020-10-13 15:26:10.744853+00 | ansible.collection_version | 
 cf4244b9-9e17-4008-b95b-9dcc1d2d34da | 2020-10-13 15:26:10.716647+00 | 2020-10-13 15:26:10.775928+00 | ansible.collection_version | 
```
```
select pulp_id, relative_path, artifact_id, content_id from core_contentartifact;
               pulp_id                |                relative_path                 |             artifact_id              |              content_id              
--------------------------------------+----------------------------------------------+--------------------------------------+--------------------------------------
 7264520d-dcac-44e2-b8c8-9baa4747dce6 | testing-ansible_testing_content-4.0.6.tar.gz | 44efa764-7f47-44f8-b6cd-032a0928632b | 7e55c0ee-ceff-4895-a591-1496fc37dc17
 ae5330ee-13da-44e3-8141-c178b3217c7b | testing-ansible_testing_content-4.0.4.tar.gz | 11ac4728-fd4e-4ef3-a398-52962be0b998 | cf4244b9-9e17-4008-b95b-9dcc1d2d34da
```


The content/artifacts should match on both the katello host and on the proxy.

Attached files from katello/pulp primary:
/etc/httpd/conf.d/[05-foreman-ssl.conf](https://github.com/Katello/katello/files/5423207/05-foreman-ssl.conf.txt)
/etc/httpd/conf.d/05-foreman-ssl.d/[pulp_ansible.conf](https://github.com/Katello/katello/files/5423215/pulp_ansible.conf.txt)

IMPORTANT for the katello master update your `/etc/pulp/settings.py`:
```
ANSIBLE_API_HOSTNAME="https://centos7-katello-devel-stable.example.com"
ANSIBLE_CONTENT_HOSTNAME="https://centos7-katello-devel-stable.example.com/pulp/content"

```