### PR TITLE
Fixes #30954 - inc update fails if cvv has mixed-Pulp content

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -266,8 +266,9 @@ module Actions
           history.status = ::Katello::ContentViewHistory::SUCCESSFUL
           history.save!
 
-          unless SmartProxy.pulp_primary.pulp3_support?(version.repositories.first)
-            version.repositories.each do |repo|
+          cvv_yum_repos = version.repositories.yum_type
+          unless cvv_yum_repos.empty? || SmartProxy.pulp_primary.pulp3_support?(cvv_yum_repos.first)
+            cvv_yum_repos.each do |repo|
               SmartProxy.pulp_primary.pulp_api.extensions.send(:module_default).
                 copy(repo.library_instance.pulp_id,
                 repo.pulp_id)


### PR DESCRIPTION
Fixes the issue by limiting the repositories that need module_default copying to yum ones.

To test: incrementally update a content view version that has a Pulp 2 yum repo and a Pulp 3 non-yum repo.