### PR TITLE
Fixes #30961 - End point for /export_api_usable

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -99,8 +99,9 @@ module Katello
                         :template => '../../../api/v2/content_view_version_export_histories/index')
     end
 
-    api :GET, "/content_view_versions/export_api_status", N_("true if the export api is pulp3 ready and usable")
+    api :GET, "/content_view_versions/export_api_status", N_("true if the export api is pulp3 ready and usable. This API is intended for use by hammer-cli only.")
     def export_api_status
+      ::Foreman::Deprecation.api_deprecation_warning("export_api_status is being deprecated and will be removed in a future version of Katello.")
       render json: { api_usable: SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE) }, status: :ok
     end
 

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -99,6 +99,11 @@ module Katello
                         :template => '../../../api/v2/content_view_version_export_histories/index')
     end
 
+    api :GET, "/content_view_versions/export_api_status", N_("true if the export api is pulp3 ready and usable")
+    def export_api_status
+      render json: { api_usable: SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE) }, status: :ok
+    end
+
     api :POST, "/content_view_versions/:id/export", N_("Export a content view version")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
     param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3")

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -122,6 +122,7 @@ Katello::Engine.routes.draw do
           end
           collection do
             get :export_histories
+            get :export_api_status
             get :auto_complete_search
             post :incremental_update
             post :import

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -153,7 +153,7 @@ module Katello
                          :finder_scope => :promotable_or_removable
       @plugin.permission :export_content_views,
                          {
-                           'katello/api/v2/content_view_versions' => [:export]
+                           'katello/api/v2/content_view_versions' => [:export, :export_histories, :export_api_status]
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :exportable

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -75,7 +75,7 @@ module Katello
                    'katello/api/v2/content_view_histories' => [:index, :auto_complete_search],
                    'katello/api/v2/content_view_puppet_modules' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_repositories' => [:show_all],
-                   'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search, :export_histories],
+                   'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search, :export_histories, :export_api_status],
                    'katello/api/v2/content_view_components' => [:index, :show],
                    'katello/api/v2/packages' => [:index],
                    'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search, :compare],

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -127,12 +127,35 @@ module Katello
       assert_template 'api/v2/content_view_versions/show'
     end
 
+    def test_export_api_status_true_for_pulp3
+      FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      get :export_api_status
+      assert_response :success
+      assert JSON.parse(@response.body)["api_usable"]
+    end
+
+    def test_export_api_status_false_for_pulp2
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
+      get :export_api_status
+      assert_response :success
+      refute JSON.parse(@response.body)["api_usable"]
+    end
+
     def test_export_histories_protected
       allowed_perms = [@view_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:export_histories, allowed_perms, denied_perms) do
         get :export_histories, params: { :content_view_id => @library_dev_staging_view.id }
+      end
+    end
+
+    def test_export_api_status_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:export_api_status, allowed_perms, denied_perms) do
+        get :export_api_status
       end
     end
 

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -142,7 +142,7 @@ module Katello
     end
 
     def test_export_histories_protected
-      allowed_perms = [@view_permission]
+      allowed_perms = [@view_permission, @export_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:export_histories, allowed_perms, denied_perms) do
@@ -151,7 +151,7 @@ module Katello
     end
 
     def test_export_api_status_protected
-      allowed_perms = [@view_permission]
+      allowed_perms = [@export_permission, @view_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:export_api_status, allowed_perms, denied_perms) do


### PR DESCRIPTION
This commit adds an endpoint to the content view versions controller to
verify if pulp3 yum is enabled.