### PR TITLE
Fixes #31004 - Hypervisor update needs reporter_id

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -119,7 +119,9 @@ module Katello
     # Note that this request comes in as content-type 'text/plain' so that
     # tomcat won't parse the json.  Here we just pass the plain body through to candlepin
     def async_hypervisors_update
-      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(params[:owner], request.raw_post)
+      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(owner: params[:owner],
+                                                                       reporter_id: params[:reporter_id],
+                                                                       raw_json: request.raw_post)
       async_task(::Actions::Katello::Host::Hypervisors, nil, :task_id => task['id'])
 
       render :json => task

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -53,8 +53,8 @@ module Katello
             JSON.parse(response).with_indifferent_access
           end
 
-          def async_hypervisors(owner, raw_json)
-            url = "/candlepin/hypervisors/#{owner}"
+          def async_hypervisors(owner:, reporter_id:, raw_json:)
+            url = "/candlepin/hypervisors/#{owner}?reporter_id=#{reporter_id}"
             headers = self.default_headers
             headers['content-type'] = 'text/plain'
             response = self.post(url, raw_json, headers)

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -75,7 +75,8 @@ module Katello::Host
       host_names_expected = ["virt-who-2e78f643-1d2f-45d1-b191-d931147cbde1-#{org.id}", "virt-who-261c4dca-702f-42b3-b8ef-2a72b77f7ec2-#{org.id}"]
 
       assert_equal 0, org.hosts.count
-      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(org_label, data.to_json)
+      reporter_id = 100
+      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(owner: org_label, reporter_id: reporter_id, raw_json: data.to_json)
       action = ForemanTasks.sync_task(::Actions::Katello::Host::Hypervisors, nil, task_id: task['id'])
 
       assert_equal 'success', action.result
@@ -92,13 +93,13 @@ module Katello::Host
       create_org(org_label)
       org = Organization.find_by(label: org_label)
       host_names_expected = ["virt-who-more-useful-identifier-#{org.id}", "virt-who-261c4dca-702f-42b3-b8ef-2a72b77f7ec2-#{org.id}"]
-
-      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(org_label, data.to_json)
+      reporter_id = 100
+      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(owner: org_label, reporter_id: reporter_id, raw_json: data.to_json)
       ForemanTasks.sync_task(::Actions::Katello::Host::Hypervisors, nil, task_id: task['id'])
 
       # Change hypervisor ID
       data[:hypervisors].first[:hypervisorId][:hypervisorId] = "more_useful_identifier"
-      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(org_label, data.to_json)
+      task = Katello::Resources::Candlepin::Consumer.async_hypervisors(owner: org_label, reporter_id: reporter_id, raw_json: data.to_json)
       action = ForemanTasks.sync_task(::Actions::Katello::Host::Hypervisors, nil, task_id: task['id'])
 
       consumers = ::Katello::Resources::Candlepin::Consumer.get('owner' => org_label, :include_only => [:uuid])

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -263,14 +263,20 @@ module Katello
 
     describe "async_hypervisors_update" do
       it "hypervisors_update" do
-        Katello::Resources::Candlepin::Consumer.expects(:async_hypervisors).returns('id' => 'foo')
+        owner = @organization.label
+        reporter_id = 100
+        env = 'dev/dev'
+        Katello::Resources::Candlepin::Consumer.expects(:async_hypervisors).returns('id' => 'foo').with do |params|
+          assert_equal params[:owner], owner
+          assert_equal params[:reporter_id], reporter_id
+        end
 
         assert_async_task(::Actions::Katello::Host::Hypervisors) do |params, options|
           assert_nil params
           assert_equal options, :task_id => 'foo'
         end
 
-        post(:async_hypervisors_update, :params => {:owner => @organization.label, :env => 'dev/dev'})
+        post(:async_hypervisors_update, :params => {owner: owner, reporter_id: reporter_id, env: env})
         assert_response 200
       end
     end

--- a/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/altered_hypervisor_id.yml
+++ b/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/altered_hypervisor_id.yml
@@ -12,9 +12,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="Yw24Dd63PZQMaBYnPxlJbxPAcoym4qx4Ji0vWKA0Jzw",
-        oauth_signature="%2BmOOWglt7R5CjX4qkCTsVlGPIns%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557896", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="5tZxrDCa88W1PWf0AWxtL6d25v6Py2Z3iyBPsx3o",
+        oauth_signature="ps9mWgrBwiAINqAuI1gatq%2FVX%2Bk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044006", oauth_version="1.0"
       Cp-User:
       - foreman_admin
       Accept-Encoding:
@@ -27,25 +27,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 0d343860-5b11-4b90-90be-30b6c239a577
+      - 4c56fb59-509a-488c-9fab-87b10fe58205
       X-Version:
-      - 3.1.10-1
-      - 3.1.10-1
+      - 3.1.16-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:56 GMT
+      - Wed, 07 Oct 2020 04:13:26 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIGFsdGVy
         ZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IGNvdWxkIG5vdCBiZSBmb3VuZC4iLCJy
-        ZXF1ZXN0VXVpZCI6IjBkMzQzODYwLTViMTEtNGI5MC05MGJlLTMwYjZjMjM5
-        YTU3NyJ9
+        ZXF1ZXN0VXVpZCI6IjRjNTZmYjU5LTUwOWEtNDg4Yy05ZmFiLTg3YjEwZmU1
+        ODIwNSJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:56 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:26 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/
@@ -61,9 +61,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="4giXmOHVW9hIp1XoLI6CyOXl1HmWFAiVlAsrgom0I", oauth_signature="2xV9Cc1kbOwK%2BVV2gBfjmnTOM2s%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557896", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="CoKE7gFSRtLTYWw7cbtVS0vLyJz8p8ZVW4rY15bU", oauth_signature="IlweQL4rrh3CFgQ%2Foe87rEDhvmE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044007", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -82,21 +82,21 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - '0938ce41-0a3a-446d-a265-0b6ff2cc9ae9'
+      - 070d22f9-5821-489b-bacf-f87422592927
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:56 GMT
+      - Wed, 07 Oct 2020 04:13:26 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTYrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZGM2NzAwMTEiLCJrZXkiOiJhbHRlcmVkX2h5cGVy
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjcrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOTQ0ZjAwMmYiLCJrZXkiOiJhbHRlcmVkX2h5cGVy
         dmlzb3JfaWRfdGVzdCIsImRpc3BsYXlOYW1lIjoiYWx0ZXJlZF9oeXBlcnZp
         c29yX2lkX3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZp
         eCI6Ii9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdC8kZW52IiwiZGVmYXVs
@@ -107,7 +107,7 @@ http_interactions:
         bnRpdGxlbWVudCIsImxhc3RSZWZyZXNoZWQiOm51bGwsImhyZWYiOiIvb3du
         ZXJzL2FsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0In0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:56 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:27 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/altered_hypervisor_id_test/environments
@@ -122,9 +122,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="1AVimahGhVv3jgMPHg6AtMMM0OuN6Gu7uNTW3dmkUY", oauth_signature="o7UtLMBS9shaGnpCuFbH9tWedCA%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557896", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="EClcaVCxDQqhsKVxhiW2ovc7OHWSJUpaoVDr3eUSQ", oauth_signature="tsmqsEQmmniswOxq4sXFJEN%2BqZw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044007", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -143,28 +143,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 6f522255-5b0a-49ec-a335-db6bdc8984ff
+      - 9bd09460-4a2e-45dd-87cd-f11a0335da8a
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:56 GMT
+      - Wed, 07 Oct 2020 04:13:26 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTYrMDAwMCIsImlkIjoiNGEwYTNmNmQ1
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjcrMDAwMCIsImlkIjoiNGEwYTNmNmQ1
         NmE0Mjg5ZjNiYjA3ZTU3MjFjYzNjN2EiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4
-        ZDEwMTcxZGQ2ZGRjNjcwMDExIiwia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29y
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1
+        YWQwMTc1MDE0Mzk0NGYwMDJmIiwia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29y
         X2lkX3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9p
         ZF90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lk
         X3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:56 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:27 GMT
 - request:
     method: get
     uri: https://localhost:8443/candlepin/owners/altered_hypervisor_id_test/uebercert
@@ -177,9 +177,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="jO1T3WRlL3cucmseZQCxUGoVHe2IUa9cO8Q4Rb1Ew",
-        oauth_signature="h8UVDTWp8lB1uRVhAzJ82lVsC%2Bs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557896", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="kjvnkylEY7v1AWQks8lJsqqrVQ3Abnn61tcC8Qg5M",
+        oauth_signature="51lXAxsElNAtZdXLITgbS9Yo21o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044007", oauth_version="1.0"
       Cp-User:
       - foreman_admin
       Accept-Encoding:
@@ -192,25 +192,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 641bead1-0744-492c-9352-51b53fdf558a
+      - 7d686ab4-d031-4d38-bd5e-3136443a2c37
       X-Version:
-      - 3.1.10-1
-      - 3.1.10-1
+      - 3.1.16-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:56 GMT
+      - Wed, 07 Oct 2020 04:13:26 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IGFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IHdhcyBub3QgZm91bmQuIFBs
-        ZWFzZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiI2NDFiZWFkMS0w
-        NzQ0LTQ5MmMtOTM1Mi01MWI1M2ZkZjU1OGEifQ==
+        ZWFzZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiI3ZDY4NmFiNC1k
+        MDMxLTRkMzgtYmQ1ZS0zMTM2NDQzYTJjMzcifQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:56 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:27 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/altered_hypervisor_id_test/uebercert
@@ -225,9 +225,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="kgTIiJSP36AL63uxJ2VVkvL7P6QQOzEZoSd75gVY", oauth_signature="cwgEfLs4WJdDlopgZD853oKVVLs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557896", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="5ZpftuSf4o8Dqs2QTM5eIQHTdV5uirxyIRWqSeJHA", oauth_signature="tDIKdEnBeHO45xAzEViLpUG4Urw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044007", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -246,168 +246,176 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - fe38c5a3-4212-4d1c-b44e-85b5411475d3
+      - 9364f530-af21-4f37-b27d-1ce1f22f1ec0
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:29 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZGYyNTAwMTMiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS1FJQkFBS0NBZ0VBd3AwTDN2WGVt
-        WWoySGFrQ3VxNTNhR05PMWpwMDdlNUt2Y1hMelpxaDUzKzZiY3lMXG5na0h3
-        WGNZeEdUWDROQ2NFcWlweFlBbm5VdmJHQzQ2UEMxb1Uram5nTkJUZWE1SzR5
-        WnYvODhwSnY2QVlPR2pmXG5HdXpwYkNRb2xuU0xXWm8rUjdxMUNOTkxkWGhv
-        RDNkOEdIaVU5OUpTTmZxd29kR0hiS0l5Y3FPa2piUFpWc3FtXG5ya1p0UDJR
-        VmhCNUovbkNPRnVLMm9NWGNjS0RoeEdvNmFkNC9wdEV1S1lkTis4NEdDSlQx
-        ZE8vN05lR1I0TUpLXG5WWjgvK0RJZkd0SEp3STcrQWFaM2FBWHVhQWdWcEQ5
-        S3NmK0Rrc3NkNitqVU9POGFqRUJUc2pOa2h0dUJ3cXg3XG5UTXBQYmhpUDlQ
-        ODgvaHVKTVZqdmhhOHZKUkkySFlEZWtxZ3JQWDQ2UkJRNFNYWVB3THNDalIx
-        K3RPc3dJUTNBXG5wWTkxZVowWUMzRnhPbEV0R1Q1U0NPblV3SjZuODVQcStl
-        VkE1bUFRdVhaZm5aL3k4eGlaOENXeVpFTWNVSUxoXG5lcnR0b0lOMlR2UVhj
-        N0hmcXJXN0FINjFJTk1BY0xnWHY4VmtJd2kyVlVqcFZPTkFHYlB3MEt5aGJi
-        MnBxeXRCXG5LM1pFekRGVVRyd3dKS3oxa2RHOHhtOU9tYUJaMGxkbGkvNDZC
-        ZWs0bzcwVjYrR29yL2ZtODNGU3RNbWpGdDJnXG5PclJHNXVWSEp3bG41cHQw
-        NmhpRXZSRHB5N1RuNWNpdjJEQjU1V2RoM0h1NTdQeFBoUkMrdElSQWdvYU1Z
-        VWE5XG5MM0ZZN1NEZEdxeHVBbzNIQzBpT0t2T3plVUU3UlNEZFJsUVpGR3hz
-        ZGNVRmRybE9wSGc5NStQS2syTUNBd0VBXG5BUUtDQWdCT1R5bE9yenJDSnlW
-        NXE5OW9SUG5SYkZ4MXdaSDVoN0JWaW5qR285bFFNTXBRa2tUMHhobTFjaUdo
-        XG5sbURvZzJiU0hqLyt1QjEzK2NxWkxlVUxXVlVsbHhKTGdyWTVMUkhrTmp5
-        WTJhWXhVSGRPZzR4NjVpZkxGd1dwXG4vUDF4c2FvcjdNb1o0Z1AwSWQ0bGt4
-        dkJNUXdvYUY0aVVGeXcwSUlneVdkcFQ4WFFLelZpUWlzdDV6TGdsaUkrXG5S
-        bjNadjJxOWRMNnVGTS91Rmg2aWpXZ3gzM2RYWmNhZ2VVeDg3VnJxS3g1Vnpw
-        Y1VDRTlOMUlCYTBiakk0MG8yXG4zWUhFVlFXS25uUmZ6RHN4YTBkaUR3Rzhm
-        Q2R5Y3Y3NFJYalg3QWFQdHZhMnR3MVZZcEJsU0VoWkR2TkZSdWJ1XG5XNklz
-        VWVJemxDalZiemVXUUN5OFZIVzdKNlkxNUREZHY1MGlUOWJlbk91VDJuNHhW
-        OHh4UTZjbC85elJ2elJUXG5MWHl5RjFnMDFQY0J4UzRhdG5HditCQ29LZlVi
-        UUwvbjZDTFdOU21BeHRieU4yYzRxU1RnYnRBa3NXN09PZ25IXG4wR3VUQWMx
-        MFF5N3pldm9WL0dMUExXWEVRcW9ZL0srbWNxVHFCZ2VkR0pBQmhjMEtOU2d4
-        UTF2VVRTYzFVTHZGXG5QSG5DTXBteG5JbHlNWTkydTUyaHZ5SXBqTjdNZnhQ
-        UXNldkxtS1NIVllUQVZ0VU1RK2FiVVlBVnFaeThGRFFzXG5kYlp4cjlyMEYy
-        YVg5Zlk4RFY4bk1pZXFlVG5zUE9qamIrQXFENXFsOVIyT2lLNTUrVE1Mb0ls
-        WkxGQnVjMG53XG5rUVRma1pLS0ltRVB0SFNTUWNFVVYyemdTYmQ5NmY1REx4
-        Q2hucUxVL2hvUlhYVi9xUUtDQVFFQS9iSGFGd2RoXG4yV1IzeEVjcEl6Rmsx
-        MXRzclVVOWg4enZEV00wc1VqMEJRMVFLV2ZiVXdHTnVyZ1ZZUFFoaGpDKzhW
-        NTVwNDNNXG5rU3hXT2Z3WGJQQmJDMHBRV3dSZ0h3TDNkcmZCTzhtWXUwTHF2
-        dGYvSmFHWnlsWmUyVHZGQUozNXJmSEdWNStVXG5EM09McW5JVmpBMENRQzdp
-        RFI0bDdaOEttY0hORkhqcndyVUZLa0t2Q2w5YVRmLy9abUZ5cU1hMlV5STZL
-        TWNwXG5kN3lIU0tjWWNtbWtZcnVaT1dpdUpiSGY0SUt0NFFqdlhabEEwR0xo
-        VEQrdHJKVE9zYS9WUVJFTWE2QlozVkduXG5LcjhWRUU4WjRDNHRvTVVpaE9D
-        TmN2OGhRNE9jVzZMbkJmblU2NlIxbEZlUHV3SjA4OE5nYkFwRXFmRTBkeTZy
-        XG50UGFkYmp1d3pjT3NWd0tDQVFFQXhHSENRWUU1OWt4REpxV2pUMFhBak5r
-        clpEd2lxTGd2SFg3U1owYUVtYjVXXG5xblpnMS9saFJLUDZ1UFpiaTJ5aStT
-        QW5GNE5KeXFRSTV3dW1LVFQ1U01ZNnR4V2k1QkJZQlkwSlVNbXhBMU1uXG4y
-        V3dJSW1EREEwSlpGVytueUpyb1g2N3lxQTlWL3RFc3FIblk0ZzZoRXdxUHNS
-        U1IrK2E1a0g2ZHBrbnE1QzBjXG4yV0lnTit4d1loOUxDKzBzTDRucW1WWXFK
-        dmMvOHRqeW4wOEZLUGhHWlhXRll4cWVaSkJMQitrSkZZeDlueHBZXG5EZmVZ
-        L21UWDhBRkV6Tk5Ld05rUU5qYkxZN1dKVVdxajVxZzk1czFCWmVpL2RKYmQ2
-        WStVTkN1K0pNalBrdGtNXG5mcVVpQ09QMU1KRjJYYStOd1dLQk1PeHFUbEVH
-        WUdXZkxZSkdGRWZwMVFLQ0FRRUE1TEVjemtHalhWc0o4Ky9LXG5ENldKSi9H
-        TWFDM1FwOGgvZm12OXBnc0Rua0pBRHZOR2JPOHJtalF6WVhEeGY0d1Z0SFBi
-        NnNVU3NaTnNMMTBtXG5xTmVLMndTa3AwZXNkb2d3Rjk3UjNGbUF5dDRweXR2
-        ZmIwYmI0ZUEySkZHUzUxbUJKK0taVDRmVTZwRFlTRkFMXG5TSEs1b3E0Z3JI
-        Nk81a1BHUkpERmxEemxHbUlnUTlaVkFGNndnenZRT2JTQ3JjNWpzVkZiYUVN
-        UkNKVDB4dk9LXG5RQ2tuUExHc0VHcGpBaXYwaXVpQ1lpZXh6NGhGT3hUSHov
-        cGZUd0hkeWFPZDg4ZXdrSnkrSlpwanZVNy9aL0pHXG5leVpsajFYbUppNWVs
-        Rm1VM00yWmQ2bkQ1RWt3UFRQRm9uSEVhV3B2andhQ3R5SVNmN2VsK2dJaVcw
-        RXM3Wi8xXG5ZNmVPaFFLQ0FRRUF2ZkxJMEU5TVh4MDR2b0xzU1Zyd2VjdjlH
-        b0RJRFdYSnZML1VoNncveWUyL0tqWkNTZVNlXG4zcU8xZVg1ZzRhVDhwZmNo
-        bUs2V2kzaktXNkI2NGRTcFltaktsaGhKYkVzYXVKUElkT29CVzNQdFVYSWJG
-        QlYvXG55d0U3NVc0UVhncm54TlVWUk5WQW1xNThnYUVKMU8zTmd2dHVMUnYy
-        Y0M2bFFrd1Y5S2YrbVNIQmk4cEwyNHZJXG4wRC93ZU9LNUlHcElEblMzWk9V
-        Mlo1RE1iS2NrR0pLOGxKcHRvSVE0dkpDTTRtUFhNNDZtVzJSQjA1Q3YzVEJ4
-        XG5aV1gweENHRFpyRU42MEpvekZMbE5XanVpOFlqeWNDekJ2MXZZamdqQVN5
-        dGJ5RDRVK0FnVnF1MldERWxrRy9kXG4wMUovcVBLTExJZzQ2YmRpdzhtL1h6
-        SXNHdnF0Q2lUYzJRS0NBUUFGbm5iYVd0VGxJWnZrVHVGTEtBbFRUSE4vXG55
-        TEg1T1pJUnE3Rk85UVd6ZmJVVjNTSU5QUi83ekJsODV0cTNXUlByMTRUc1hi
-        dVNmdmZUMmI0dEZjdE1YbDJsXG4yc1ByalIxdnppWjhXbENjNVBjd09NVDRG
-        UHVPWWZGR3BjL1JZNTVkdmU4WVZEaE5HNzRXQzNHdVJvZ2xCVE1TXG5Qbjlh
-        TDhPZ0RubjFBSTJWT2czWEsvUlVQRFVYN0R2QlE0WXdaODRtRTV0K3RFdHBK
-        ZXNZaGl4RVd4U2VCdXR5XG5rNjFFeXlISVdPSkFGQkZtQzdSOXNka2JRSlZX
-        RE5iTWRNS3NOZXI5enFWWXNOaVc4WTZVUkdCZFljMDlHYzFHXG4vSWxad0Mx
-        RHdRcEl3WUlhSTdPMmM1REJUWEUycjBIU3VCcCtGVVhRRHREYjM3a1FkTk5o
-        a2hIMytZc3dcbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
-        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIY1RDQ0Js
-        bWdBd0lCQWdJSUs2SVdKWU82NU0wd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWIxYzAwMzEiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKSndJQkFBS0NBZ0VBdnZ5UDkycTJj
+        OTIvaVV0WVBtWXo1d0ovUGlUZkRBZWZ2UXFWcnMzZjY5eU1CSmNEXG5XTXJU
+        cEIwZktmZkhsRGkxMy9kQjFyb1NwR0gyYlJiWGFDK3YxZjRaRWx6ekxlVXNz
+        ZTB0QlhCa25mTFkvRU5LXG42akgzbXAyWG9Yb3l3N2RDZHJVdjZHRnZJS3Vt
+        ejdkY2NubFpJZGRaeGNHOUwzcVF5T1IwOXpPSEc1OS9wWXFyXG5OSmV5Y2lm
+        aTZlU3J3NDk5Y3NWTDk0MjI5djNqSzQ0VnhjcjJrSDdzbitBT3o1Rk1pbEFB
+        U1ByMks4bEFRQnRhXG5mOVhWVjVqclFtL2VEVXJBWFdyZVFFS3pFZG4zb05s
+        OC9kcm9WZlA3cVJsWDVoUWdOZHRSeGNyUFdXaVZHNC9KXG5XQjk1ZGE2eW4x
+        WStVTGpiR0VRL0NUOUJFVFdwcU5EUHh4MTVDV3J3MEdhWXo2N09mcUdoQWVJ
+        QVhIUEx5YmFOXG4xN0o1SDNyUVFHVDVuTHYvbW1MbzNvVmVLaXNjNzRMVzk1
+        aGQvNHlCM3dqOHdoRjJUR1FWa205aVZWamZpR3JwXG43NElmZm5UUGlHeDhM
+        endSMWx3UkY3ME1wdlROWnRQZktDRllpWXF3Tm5XWS82MWQwU3NoTzh2V3F1
+        K3o2WUltXG5Fa1hiZjhEeHhEVzUzcFdXQkFvSzN3TGN0dnYxLzdhaHJZY2t4
+        cFY4NDNoRkxNdGxyWGpzeXF4T0tUeVByelZCXG42S1I0RFdGMy9raVYwYjFN
+        bFIxbExIR0tTMnlXR3FGNmhzY1RNR3crdllXeGJraDBKNSttZ0ZCOTlrNWJm
+        QmlHXG5ad0NOR1pYY1dRaEFkcmpKUmNQRkZmZ2xmSDN3VGprMSswZnVZRlc0
+        WVhUTFZHTUhoSDlXaFBCQ2FhTUNBd0VBXG5BUUtDQWdCc3hsQUFySWlKNlV3
+        RG1DUUVOaFZ0aHVDTnRsWks5YlNtNkhaai91Ri81amJoRGxsYm92bHpTUnJN
+        XG52bEN2UExWcGY5dkJ2bXlMcnplNDNmK0ZXVk9lWDRCTUV5QjFqVWN0ZDFY
+        aStTWjFSekVLVEJGSTNYaVdXUmRaXG5ZczJ5NXBjMklPL09QR0FjaldjT2V2
+        SnVTR3JaZVZ1cDVEUXA3SGExMUZoQnl0a3loRjhoRzU5eTdzczFkVDRwXG4x
+        SkYzYWl3YXlBQUNXSFpTcWp0T1BUaHRWTEdsam9TYWNmUTlpQlc5Mk42d3Np
+        NnV0WXFnZUhQTXh5OGhHdmt5XG45NS9TbGphRmZpNWpEeG9LR3NpTWxoSTRT
+        d3QwbU9kR1lpYkw1YjZLcmdVZXorblVsRm9JUHBhQVdEekhKOTZZXG5IWGlV
+        WlJSejk3cW5PNTJGZmJqSmExUkxwWitmSDIyR2xQMTJIa0V4TVhFUEpxNXFp
+        bzU2QXQ4NmRXcDZrU2d1XG5VbmtReTdRRmZjcGtCSDR2dGd3NWQ3OUdrd096
+        aXJLZGlpWUc1MzRudEJXQWk3d0NwTnZaR2FCa2ovdmtJS0pOXG5HanFXcXpI
+        d1RxQVJoL1prcndiazUwU3BHM2ZVSXNaTVAyajdtVlFNdGUzL0NQUnYxUllv
+        dEVIbVJIeTVQVFhOXG5Ed3JQbi9sRE5CaW53MU1SQ0hqdDA4eHU3b1FqcW5u
+        Y1hZYnJwa3YvdHlIMnY3TlJIc0RHaXZ4RWFaaENBM0s4XG5KYk5CUVBUV1BO
+        d3BJaURaL0txaFpNelAyOTNvN3VwNWZLZlFXSys0Mkk4WGYza1JRajh1OEFu
+        bHhUOFFZbTBLXG4vbmRSR0dqUitFTTFxYUJpbi9NYnlIVDIvM1dyYnpiRWJs
+        blQ4dlk0QUo0NHVHR3lvUUtDQVFFQTVyVGp6L2NnXG5xenBxbXQva0hjSkpM
+        UjFPeVVqODRLU1dkc3R1cFcvNTlIaTlRczhIYkZaNkNmTTlmNXhET3BRUmFy
+        QTA1YUJrXG42dmZ0UEhLQVJBclpacm9rNmNZNWhFeEFLQ1k2RFNielp3dXVv
+        dGJ3cC9rNkZsRGpvOUVnSmczYXh6eXQyTUZJXG5acjVlVTM3aVR2aHBEWHFu
+        Uk1WNFdyZ3IxOFFVR0lJM0E5cFo3V1JsTTgrYjhVeVFMU1dLT21JbXZmUTR0
+        Ti9WXG4zclFmc0w1NFBqZjg4UDJNNGJxMWJjOGRiU1NsNEszVW1FcXdvVlJn
+        eDRLZU81UVcvYm41cHVRa0NFQnBXQWdKXG5pN2kyRHdQa2NIQW5jWDE2MUha
+        TkFycmdlYUxDZjNibmFCcW9HYW1RS0RrUDV4dC9qV29lNzRqdzU2VDB1dEVi
+        XG5oQXRqdWpFUXdxYnUrUUtDQVFFQTAremZocnU1ZnVZWWlQREQxdjhlcEF2
+        Sys4enJCMWp5QWduWDQ1QUljY004XG4yNFJRRDgrU0NHcjZVS1NSNjhqNjI5
+        VjU3bkdUcWpsb2doZWJLb0JOcFNZMlJQcjAycFZJY2tpNkNJaTFGM3FJXG5q
+        OElXUE5lSVVod1ZJcUQrQ1RHL2QzVE5aRUJzcDBMcDROL2tHdVEwZzAxZWlQ
+        ZXRMS3ZDUEtxbDFaYVYwR25nXG5NODQzQWRwclAzeDRLUGh2cDkvek5hSzF0
+        cTlqczFGZXl5VmhIQWY3NmpqZWFrZHZGczN5eTd0ZExTa1ZSWEtLXG51UWpz
+        REVqcDUvWHhYMThnOW5IUk1qZjIvYjFHdUpiV0VUNzdhUHlXbGpHOUxod28r
+        ZTc5ZU9vZHBtTHVzUExNXG41ZmxhcmlicFlrd05CSXBCa3QzODJKSzRnVStS
+        TUhMcEVzdnRlU2hZZXdLQ0FRQU5jWjhRNEZyRC81eDB0L1ZJXG5FcWxHK3Iw
+        N2w0Zzg0dnB0bzc4bjN0V1cvRzR5OVhOK1NhL0U0cXJEdyt4YS9vUGhUckZX
+        YkRsVlErdE1LWFAyXG5BeGZXRjZUTkJxTVZaWWdianRhMUszN2xrMVd5NFlt
+        V2tEeGxUb05sYVd0UkxGK0NXclBhdkxDbVpCT0ZGQkRGXG4vMDNIM2t6ZkFn
+        N1lZb0VUaXJhTkV4RjNwUUsyaGJJc0NiNFJtcCtRTWU3VEppTVIwS2g1U2Mz
+        aHMyZGhXa2dSXG5nQnU2UTF3eFR6c0JVaDlwMjhmYXh1WnJsWGFqZ0JJL3Jn
+        bmdlT202RVZ0TjhWOTBKNlM3MzRRRzQxV2duRjUwXG5ldVNoaFdsaDloN1l1
+        T0VaMVhVMkRreS8wVVhZY1B3WWkvSzBTZkx0MzdBN3p5UVNxNWNqUjhvdHNL
+        ZzRFbUhpXG5wZTJwQW9JQkFGYmVrZ0c0a2FEaTBNdlJaWFdMdmhPZ2dlUVZh
+        NEhuZzh3eUhMeTdIYnNFUEwzK3pwS3Nrei9BXG5HanRVT2p4Y2RmZ0cyYVJV
+        Q2lPTXhMb08weHZvMitzR2J0aDN4a2FUU3M4TjRMUCsxYng2RGVCZnZwM1Ir
+        NThzXG53NzBlSVFQRDBLZzJ5THAvYmdwaDgxeXFhZVpjQk9xTm5HS29vK1Bi
+        eEJMNklHQWRDZXdVZWtMQ0ZPbzlqaGpIXG4vTGxPblBaRFpuNWw0L2F1amov
+        QzZ3aDZtZ1BUZ2YvUXI5c0F6UmliOHhwd0F4R3Y5WGd5SzRzTmpUUzc3cVdX
+        XG51d3BOQkVZQkFhK0VJVXFCZTZ2T3FKRUpNQ1VvNU5GTU1pL2tleWQ0UDQ2
+        QTZRWjdKenlCU2x3NmltRTRzaElJXG4rbzBSM3k5RXI1QlhGQ3B0WXlabzlB
+        RXdkbmRqZ21FQ2dnRUFmQnF6ZUpXR2FGbGN6WTFuNm1RYWw4TDlzWUhIXG44
+        Qy9lTkZHYXBBSU5tQSsraDBCNkFMczYycGg0ZU9YbXY0OEZ4MEJEQnlWZWNY
+        SHBxQ3dXSE9Sd0JCR3IzOXpEXG5QRVk0V2o5aUoyZUt2WkJjMnlGK2pFZGtW
+        VDNXbW92VC9vNFlyKzRQZDFuVkdpRlJwQU1tcm51a0MrTFZsWEJQXG5OYmdm
+        cWF3UU1CY0psaGV6bG1jUVhMMEZramxBSTV5dENxY3dUMVBSUERhU0JDUVZB
+        TkZqUTlURGJrZnZ2bXdWXG40YW84cVNMQnN5RkgrWXNLYW9RRzl0cWtZdnpV
+        ejEzYnFURVBCN0RnTGZscnRNK3pwY3JQdEwxUGZPdkdFMWlSXG5KOEQ4WFdT
+        MndoNkFBaU15L3FyVE1pRU00MDZGMUsrUVdTVTBTdnZEQ1BLVzllOFVIODZ1
+        YkE1c3NBPT1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlJY1RDQ0Js
+        bWdBd0lCQWdJSVpPa1diY3FYKzNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
         eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
         SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
         Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReElq
-        QWdCZ05WXG5CQU1NR1dSbGRtVnNMbUpoYkcxdmNtRXVaWGhoYlhCc1pTNWpi
-        MjB3SGhjTk1qQXdOVEEwTURJd05EVTJXaGNOXG5ORGt4TWpBeE1UTXdNREF3
+        QWdCZ05WXG5CQU1NR1d4aGJXSmtZUzV6Y0dGeWRHRXVaWGhoYlhCc1pTNWpi
+        MjB3SGhjTk1qQXhNREEzTURReE16STNXaGNOXG5ORGt4TWpBeE1UTXdNREF3
         V2pBbE1TTXdJUVlEVlFRS0RCcGhiSFJsY21Wa1gyaDVjR1Z5ZG1semIzSmZh
         V1JmXG5kR1Z6ZERDQ0FpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBREND
-        QWdvQ2dnSUJBTUtkQzk3MTNwbUk5aDJwXG5BcnF1ZDJoalR0WTZkTzN1U3Iz
-        Rnk4MmFvZWQvdW0zTWk0SkI4RjNHTVJrMStEUW5CS29xY1dBSjUxTDJ4Z3VP
-        XG5qd3RhRlBvNTREUVUzbXVTdU1tYi8vUEtTYitnR0RobzN4cnM2V3drS0pa
-        MGkxbWFQa2U2dFFqVFMzVjRhQTkzXG5mQmg0bFBmU1VqWDZzS0hSaDJ5aU1u
-        S2pwSTJ6MlZiS3BxNUdiVDlrRllRZVNmNXdqaGJpdHFERjNIQ2c0Y1JxXG5P
-        bW5lUDZiUkxpbUhUZnZPQmdpVTlYVHYrelhoa2VEQ1NsV2ZQL2d5SHhyUnlj
-        Q08vZ0dtZDJnRjdtZ0lGYVEvXG5TckgvZzVMTEhldm8xRGp2R294QVU3SXpa
-        SWJiZ2NLc2UwektUMjRZai9UL1BQNGJpVEZZNzRXdkx5VVNOaDJBXG4zcEtv
-        S3oxK09rUVVPRWwyRDhDN0FvMGRmclRyTUNFTndLV1BkWG1kR0F0eGNUcFJM
-        UmsrVWdqcDFNQ2VwL09UXG42dm5sUU9aZ0VMbDJYNTJmOHZNWW1mQWxzbVJE
-        SEZDQzRYcTdiYUNEZGs3MEYzT3gzNnExdXdCK3RTRFRBSEM0XG5GNy9GWkNN
-        SXRsVkk2VlRqUUJtejhOQ3NvVzI5cWFzclFTdDJSTXd4VkU2OE1DU3M5WkhS
-        dk1adlRwbWdXZEpYXG5aWXYrT2dYcE9LTzlGZXZocUsvMzV2TnhVclRKb3hi
-        ZG9EcTBSdWJsUnljSlorYWJkT29ZaEwwUTZjdTA1K1hJXG5yOWd3ZWVWbllk
-        eDd1ZXo4VDRVUXZyU0VRSUtHakdGR3ZTOXhXTzBnM1Jxc2JnS054d3RJamly
-        enMzbEJPMFVnXG4zVVpVR1JSc2JIWEZCWGE1VHFSNFBlZmp5cE5qQWdNQkFB
+        QWdvQ2dnSUJBTDc4ai9kcXRuUGR2NGxMXG5XRDVtTStjQ2Z6NGszd3dIbjcw
+        S2xhN04zK3ZjakFTWEExakswNlFkSHluM3g1UTR0ZC8zUWRhNkVxUmg5bTBX
+        XG4xMmd2cjlYK0dSSmM4eTNsTExIdExRVndaSjN5MlB4RFN1b3g5NXFkbDZG
+        Nk1zTzNRbmExTCtoaGJ5Q3JwcyszXG5YSEo1V1NIWFdjWEJ2Uzk2a01qa2RQ
+        Y3poeHVmZjZXS3F6U1hzbkluNHVua3E4T1BmWExGUy9lTnR2Yjk0eXVPXG5G
+        Y1hLOXBCKzdKL2dEcytSVElwUUFFajY5aXZKUUVBYlduL1YxVmVZNjBKdjNn
+        MUt3RjFxM2tCQ3N4SFo5NkRaXG5mUDNhNkZYeis2a1pWK1lVSURYYlVjWEt6
+        MWxvbFJ1UHlWZ2ZlWFd1c3A5V1BsQzQyeGhFUHdrL1FSRTFxYWpRXG56OGNk
+        ZVFscThOQm1tTSt1em42aG9RSGlBRnh6eThtMmpkZXllUjk2MEVCaytaeTcv
+        NXBpNk42Rlhpb3JITytDXG4xdmVZWGYrTWdkOEkvTUlSZGt4a0ZaSnZZbFZZ
+        MzRocTZlK0NIMzUwejRoc2ZDODhFZFpjRVJlOURLYjB6V2JUXG4zeWdoV0lt
+        S3NEWjFtUCt0WGRFcklUdkwxcXJ2cyttQ0poSkYyMy9BOGNRMXVkNlZsZ1FL
+        Q3Q4QzNMYjc5ZisyXG5vYTJISk1hVmZPTjRSU3pMWmExNDdNcXNUaWs4ajY4
+        MVFlaWtlQTFoZC81SWxkRzlUSlVkWlN4eGlrdHNsaHFoXG5lb2JIRXpCc1By
+        MkZzVzVJZENlZnBvQlFmZlpPVzN3WWhtY0FqUm1WM0ZrSVFIYTR5VVhEeFJY
+        NEpYeDk4RTQ1XG5OZnRIN21CVnVHRjB5MVJqQjRSL1ZvVHdRbW1qQWdNQkFB
         R2pnZ05ETUlJRFB6QU9CZ05WSFE4QkFmOEVCQU1DXG5CTEF3RXdZRFZSMGxC
         QXd3Q2dZSUt3WUJCUVVIQXdJd0NRWURWUjBUQkFJd0FEQVJCZ2xnaGtnQmh2
-        aENBUUVFXG5CQU1DQmFBd0hRWURWUjBPQkJZRUZKTlpVUGZ6VWN2cE5DVEl2
-        YUFhNktwUFBkRTlNQjhHQTFVZEl3UVlNQmFBXG5GQlBzaXBlVXpXOVFESnFm
-        Zk9VeGZMdkhnSG96TUQ0R0VDc0dBUVFCa2dnSkFhNmQ2N2U2SXdFRUtnd29Z
+        aENBUUVFXG5CQU1DQmFBd0hRWURWUjBPQkJZRUZEalRwWmRsSVE2dUwvZWdC
+        ZjRjTHN1SXJpZlpNQjhHQTFVZEl3UVlNQmFBXG5GSCtDN2wvMzJDR2NFeGgy
+        eWlNdW5Wb0RXYlMvTUQ0R0VDc0dBUVFCa2dnSkFhN1FpbzZxVVFFRUtnd29Z
         V3gwXG5aWEpsWkY5b2VYQmxjblpwYzI5eVgybGtYM1JsYzNSZmRXVmlaWEpm
-        Y0hKdlpIVmpkREFXQmhBckJnRUVBWklJXG5DUUd1bmV1M3VpTURCQUlNQURB
-        V0JoQXJCZ0VFQVpJSUNRR3VuZXUzdWlNQ0JBSU1BREFXQmhBckJnRUVBWklJ
-        XG5DUUd1bmV1M3VpTUZCQUlNQURBWkJoQXJCZ0VFQVpJSUNRS3VuZXUzdWlR
-        QkJBVU1BM2wxYlRBa0JoRXJCZ0VFXG5BWklJQ1FLdW5ldTN1aVFCQVFRUERB
-        MTFaV0psY2w5amIyNTBaVzUwTURJR0VTc0dBUVFCa2dnSkFxNmQ2N2U2XG5K
-        QUVDQkIwTUd6RTFPRGcxTlRjNE9UWTVPVFZmZFdWaVpYSmZZMjl1ZEdWdWRE
-        QWRCaEVyQmdFRUFaSUlDUUt1XG5uZXUzdWlRQkJRUUlEQVpEZFhOMGIyMHdN
-        Z1lSS3dZQkJBR1NDQWtDcnAzcnQ3b2tBUVlFSFF3YkwyRnNkR1Z5XG5aV1Jm
-        YUhsd1pYSjJhWE52Y2w5cFpGOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxNmQ2
-        N2U2SkFFSEJBSU1BREFZXG5CaEVyQmdFRUFaSUlDUUt1bmV1M3VpUUJDQVFE
+        Y0hKdlpIVmpkREFXQmhBckJnRUVBWklJXG5DUUd1MElxT3FsRURCQUlNQURB
+        V0JoQXJCZ0VFQVpJSUNRR3UwSXFPcWxFQ0JBSU1BREFXQmhBckJnRUVBWklJ
+        XG5DUUd1MElxT3FsRUZCQUlNQURBWkJoQXJCZ0VFQVpJSUNRS3UwSXFPcWxN
+        QkJBVU1BM2wxYlRBa0JoRXJCZ0VFXG5BWklJQ1FLdTBJcU9xbE1CQVFRUERB
+        MTFaV0psY2w5amIyNTBaVzUwTURJR0VTc0dBUVFCa2dnSkFxN1FpbzZxXG5V
+        d0VDQkIwTUd6RTJNREl3TkRRd01EYzNOakZmZFdWaVpYSmZZMjl1ZEdWdWRE
+        QWRCaEVyQmdFRUFaSUlDUUt1XG4wSXFPcWxNQkJRUUlEQVpEZFhOMGIyMHdN
+        Z1lSS3dZQkJBR1NDQWtDcnRDS2pxcFRBUVlFSFF3YkwyRnNkR1Z5XG5aV1Jm
+        YUhsd1pYSjJhWE52Y2w5cFpGOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxN1Fp
+        bzZxVXdFSEJBSU1BREFZXG5CaEVyQmdFRUFaSUlDUUt1MElxT3FsTUJDQVFE
         REFFeE1EZ0dDaXNHQVFRQmtnZ0pCQUVFS2d3b1lXeDBaWEpsXG5aRjlvZVhC
         bGNuWnBjMjl5WDJsa1gzUmxjM1JmZFdWaVpYSmZjSEp2WkhWamREQVFCZ29y
         QmdFRUFaSUlDUVFDXG5CQUlNQURBZEJnb3JCZ0VFQVpJSUNRUURCQThNRFRF
-        MU9EZzFOVGM0T1RZNU9UVXdFUVlLS3dZQkJBR1NDQWtFXG5CUVFEREFFeE1D
-        UUdDaXNHQVFRQmtnZ0pCQVlFRmd3VU1qQXlNQzB3TlMwd05GUXdNam93TkRv
-        MU5sb3dKQVlLXG5Ld1lCQkFHU0NBa0VCd1FXREJReU1EUTVMVEV5TFRBeFZE
+        Mk1ESXdORFF3TURjM05qRXdFUVlLS3dZQkJBR1NDQWtFXG5CUVFEREFFeE1D
+        UUdDaXNHQVFRQmtnZ0pCQVlFRmd3VU1qQXlNQzB4TUMwd04xUXdORG94TXpv
+        eU4xb3dKQVlLXG5Ld1lCQkFHU0NBa0VCd1FXREJReU1EUTVMVEV5TFRBeFZE
         RXpPakF3T2pBd1dqQVJCZ29yQmdFRUFaSUlDUVFNXG5CQU1NQVRBd0VBWUtL
         d1lCQkFHU0NBa0VDZ1FDREFBd0VBWUtLd1lCQkFHU0NBa0VEUVFDREFBd0VR
         WUtLd1lCXG5CQUdTQ0FrRURnUUREQUV3TUJFR0Npc0dBUVFCa2dnSkJBc0VB
         d3dCTVRBUUJnb3JCZ0VFQVpJSUNRVUJCQUlNXG5BREFOQmdrcWhraUc5dzBC
-        QVFzRkFBT0NBUUVBczQvdWoreDkrRW12S3drVXRwZEhPcTRQd3FMTEtiWktF
-        d2ZVXG5XanA3SDBkSCtiQXdrS2JrSnhPUkNaN0hicGphci9abTRwcjBZYlhC
-        dW5reU44dVVDb3RuUTdiWHhIbWp0Q3FJXG5haDN1dVp6UC92NkdsNW9tRDg3
-        NjdLL09FVjhBRVQzZkx1Sk9TZDBSRXhpdDdlMHNiTEI5cnBQSnZZcUUyR3gv
-        XG5Pc1hxdDJ4d2lRWXJNL0dYYUVrWVJGNGFHbTI1R09IRnI5SmpFTWVydmhm
-        c0VQbkNyd0JTSTlSdFN2bDZ4NThQXG5QRHZTZUY3NDJIMTV2WkhWaktVTW9B
-        a1RqdEN2TFUzL3ZFaDhjR0R1Y3lneVZWVTBITjJic1lELy84Wkh1UEhhXG5N
-        ODZDVUkwRm04MTZveWZ1Z0QwcVJSSGdObTZUakRxUjFpSUpzMEllTHRQSDZO
-        N3BmZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJpYWwi
-        OnsiY3JlYXRlZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTYrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDIwLTA1LTA0VDAyOjA0OjU2KzAwMDAiLCJpZCI6MzE0NDA5OTg0
-        MDIzNzY5MjEwOSwic2VyaWFsIjozMTQ0MDk5ODQwMjM3NjkyMTA5LCJleHBp
-        cmF0aW9uIjoiMjA0OS0xMi0wMVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVk
-        IjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhm
-        YWE3NzFkZDY4ZDEwMTcxZGQ2ZGRjNjcwMDExIiwia2V5IjoiYWx0ZXJlZF9o
-        eXBlcnZpc29yX2lkX3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImFsdGVyZWRfaHlw
-        ZXJ2aXNvcl9pZF90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvYWx0ZXJlZF9oeXBl
-        cnZpc29yX2lkX3Rlc3QifX0=
+        QVFzRkFBT0NBZ0VBcGtub0JNZDFVWklGQzZqRHFmOTJaSWRWanVEeGRpbHZ6
+        L0Q2XG5ON0NFV0ZHbThwYkJXeHFqdVZ0WlJZUDl6dnUza3pnNVFiYmRpVDdC
+        dTAwR0pNeGdocDNqdmpPL3E5UDc4L3JGXG5Cb2xzdVBHU3pvS25yUGVsbGdR
+        bU44M01SMUZsN3N3cHJhemdkOEtZMDM2Q3hYRDMydk5RVkNDNHY3R3dEWndL
+        XG5BZkRHellsY1VHbXUvMjZ0Yk80QmtjWmZuaWtYeU9zTkxOalFWREZqN3Fz
+        cHR5b0tORjY1d2hBQ3BnOG9JQXQ2XG55Um43SVI5aFE2ZVNNUFJ4WTU3V2Ju
+        WFZ0M3pkN0xyRDFDRTB1QU5jaUc4ZnRzQjBWM3BDREdyb282ZzlyOTdFXG40
+        ZmFtNmJSTllNYkRQSWxxVWRmd0RPbjZwd0o1cTlGRGJIbThLY0JOaTBjbEhY
+        alEwT0EwNGZGYjljNlVwOWVPXG5Rd0h4UndISXkxQUUzL24rV3FhVllEdGZl
+        UzQ4YUI3ZERvRjhNcXQyajRmRWFuRzVvRVY5TkdGelpSZ3lST3lxXG4xbXhy
+        K1liUEJJdW02YVFvMUF4cEhPN3l4eWhNT0U0NXpYN0llTUJyc0s4SEswQjUz
+        aWFFem55YU1wL2cxcHZiXG5MMWhXN1E0cjRKTlZoU2lzTjV5WElya1hVZklq
+        Y1A1K0p0Y3ZZVXV6aGJMM2FuOHVYUDFWcDRNUHN0ZmhpRS9lXG5XekdxT0VT
+        ZG9WZHJuSHoydmpYNGU4TnVXa0F3VVcvOVVsbDNZS2xFbWZqUTBKS2hvWHpy
+        NlpUQWRXWW4wdVpoXG51RGlDT2ZZdnUxSEp2S0RQdWNOR25wdC9wMVN5TDdJ
+        TWU3T2VxQkRnRE1IYzlMb042TzVNOWVIZGdWSUdjVTlSXG5zMFpydE9JPVxu
+        LS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIiwic2VyaWFsIjp7ImNyZWF0
+        ZWQiOiIyMDIwLTEwLTA3VDA0OjEzOjI3KzAwMDAiLCJ1cGRhdGVkIjoiMjAy
+        MC0xMC0wN1QwNDoxMzoyNyswMDAwIiwiaWQiOjcyNzEzNjc3MzQxNzI1ODA3
+        MjMsInNlcmlhbCI6NzI3MTM2NzczNDE3MjU4MDcyMywiZXhwaXJhdGlvbiI6
+        IjIwNDktMTItMDFUMTM6MDA6MDArMDAwMCIsImNvbGxlY3RlZCI6ZmFsc2Us
+        InJldm9rZWQiOmZhbHNlfSwib3duZXIiOnsiaWQiOiI0MDI4ZmE2NTc0ZmVh
+        NWFkMDE3NTAxNDM5NDRmMDAyZiIsImtleSI6ImFsdGVyZWRfaHlwZXJ2aXNv
+        cl9pZF90ZXN0IiwiZGlzcGxheU5hbWUiOiJhbHRlcmVkX2h5cGVydmlzb3Jf
+        aWRfdGVzdCIsImhyZWYiOiIvb3duZXJzL2FsdGVyZWRfaHlwZXJ2aXNvcl9p
+        ZF90ZXN0In19
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:57 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:29 GMT
 - request:
     method: post
-    uri: https://localhost:8443/candlepin/hypervisors/altered_hypervisor_id_test
+    uri: https://localhost:8443/candlepin/hypervisors/altered_hypervisor_id_test?reporter_id=100
     body:
       encoding: UTF-8
       base64_string: |
@@ -433,9 +441,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="FmrMYmYSlTkheiE5Tx5zvGAQPYR9V7IbY6Gzpc", oauth_signature="0N9McNjAVRAYv%2FZzcWF%2BHYyh%2BTE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557897", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="HnpME7VRmda6YaIBm9qiHMehB36kLnnamnZUxn5PRo", oauth_signature="3XSGrYV7SPlbmfgo%2Bk4w32K%2FWqg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044009", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -454,33 +462,33 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 0076e4a3-72e4-4f4b-a357-c496ed34dcc6
+      - 7bde9e58-315c-4829-a3e7-6f09ebe794b4
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:29 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZGZiZjAwMTQiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWI5ZTAwMzIiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
         eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjpudWxsLCJwcmluY2lwYWwiOiJmb3Jl
-        bWFuX2FkbWluIiwic3RhdGUiOiJRVUVVRUQiLCJwcmV2aW91c1N0YXRlIjoi
-        Q1JFQVRFRCIsInN0YXJ0VGltZSI6bnVsbCwiZW5kVGltZSI6bnVsbCwiYXR0
-        ZW1wdHMiOjAsIm1heEF0dGVtcHRzIjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMv
-        NDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZGZiZjAwMTQiLCJyZXN1bHREYXRh
-        IjpudWxsLCJrZXkiOiJIeXBlcnZpc29yVXBkYXRlSm9iIn0=
+        bWFuX2FkbWluIiwic3RhdGUiOiJDUkVBVEVEIiwicHJldmlvdXNTdGF0ZSI6
+        IkNSRUFURUQiLCJzdGFydFRpbWUiOm51bGwsImVuZFRpbWUiOm51bGwsImF0
+        dGVtcHRzIjowLCJtYXhBdHRlbXB0cyI6MSwic3RhdHVzUGF0aCI6Ii9qb2Jz
+        LzQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0MzliOWUwMDMyIiwicmVzdWx0RGF0
+        YSI6bnVsbCwia2V5IjoiSHlwZXJ2aXNvclVwZGF0ZUpvYiJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:57 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:29 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/jobs/4028faa771dd68d10171dd6ddfbf0014?result_data=true
+    uri: https://localhost:8443/candlepin/jobs/4028fa6574fea5ad017501439b9e0032?result_data=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -490,9 +498,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="xYzIYuIBFi1ukGVMWxD2uGXPl2EXcphKIZPC1g8Ug4",
-        oauth_signature="Dvl3rZWv%2Bt6xxHU%2B6GmrsZL3ufY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="xWt45WCVTJUFK0EkgjhULddGQ2oPhrNEUT6YQhwTY4M",
+        oauth_signature="K%2F07cbedRAi0BULRnpsWSuBcVg0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044009", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -509,41 +517,41 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - aa060d55-1769-4e25-aa51-df0d59a95dc2
+      - bcc1a899-3587-48f3-9b90-0240d7d3137f
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:29 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZGZiZjAwMTQiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoiZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWI5ZTAwMzIiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
+        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoibGFtYmRhLnNwYXJ0YS5leGFtcGxl
         LmNvbSIsInByaW5jaXBhbCI6ImZvcmVtYW5fYWRtaW4iLCJzdGF0ZSI6IkZJ
         TklTSEVEIiwicHJldmlvdXNTdGF0ZSI6IlJVTk5JTkciLCJzdGFydFRpbWUi
-        OiIyMDIwLTA1LTA0VDAyOjA0OjU3KzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0w
-        NS0wNFQwMjowNDo1NyswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
-        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhYTc3MWRkNjhkMTAxNzFk
-        ZDZkZGZiZjAwMTQiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOlt7InV1aWQi
-        OiJiNTUyOTc3Yy1hMWNjLTQ2MGUtYjU5My1iZjRhM2VhOThhYmQiLCJuYW1l
+        OiIyMDIwLTEwLTA3VDA0OjEzOjI5KzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0x
+        MC0wN1QwNDoxMzoyOSswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
+        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhNjU3NGZlYTVhZDAxNzUw
+        MTQzOWI5ZTAwMzIiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOlt7InV1aWQi
+        OiIxMDJlOTg2MC0zYzRlLTRmYjQtODQ1Yy0wODA0ODUxYWNjZDEiLCJuYW1l
         IjoiZGlzdGFudGhvc3QiLCJvd25lciI6eyJrZXkiOiJhbHRlcmVkX2h5cGVy
-        dmlzb3JfaWRfdGVzdCJ9fSx7InV1aWQiOiI1ODI2NGMxMy04OGZlLTQzNmUt
-        OWI1Yi1kZmVmZDI5MjA0ZmYiLCJuYW1lIjoibG9jYWxob3N0Iiwib3duZXIi
+        dmlzb3JfaWRfdGVzdCJ9fSx7InV1aWQiOiI5YzRkZWMxYy05YWMyLTRkY2It
+        OTFhYi0yYWI0YmVlZGM0YzMiLCJuYW1lIjoibG9jYWxob3N0Iiwib3duZXIi
         Onsia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QifX1dLCJ1cGRh
         dGVkIjpbXSwidW5jaGFuZ2VkIjpbXSwiZmFpbGVkVXBkYXRlIjpbXX0sImtl
         eSI6Ikh5cGVydmlzb3JVcGRhdGVKb2IifQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:58 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:29 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/b552977c-a1cc-460e-b593-bf4a3ea98abd
+    uri: https://localhost:8443/candlepin/consumers/102e9860-3c4e-4fb4-845c-0804851accd1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -553,9 +561,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="5OEgpremH8Un8kjaz37Qe1ggeY3bICdkcACa0dNETc",
-        oauth_signature="HRijiei7wULYqcWnK%2F3myndCbH4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="JriKeGLJWEuclprvAcDJH2YynZ87JbdhB6f95yrcy0",
+        oauth_signature="4H2G52VACk1xmowflzIte2pWphA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044009", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -572,50 +580,50 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e45c1668-686e-4fa9-b81b-a702fb50821d
+      - dbebf3f5-eb35-480d-99ee-2288b6e1c53f
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:29 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTA0ZTAwMTUiLCJ1dWlkIjoiYjU1Mjk3N2MtYTFj
-        Yy00NjBlLWI1OTMtYmY0YTNlYTk4YWJkIiwibmFtZSI6ImRpc3RhbnRob3N0
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWJlNTAwMzMiLCJ1dWlkIjoiMTAyZTk4NjAtM2M0
+        ZS00ZmI0LTg0NWMtMDgwNDg1MWFjY2QxIiwibmFtZSI6ImRpc3RhbnRob3N0
         IiwidXNlcm5hbWUiOiJmb3JlbWFuX2FkbWluIiwiZW50aXRsZW1lbnRTdGF0
         dXMiOm51bGwsInNlcnZpY2VMZXZlbCI6IiIsInJvbGUiOiIiLCJ1c2FnZSI6
         IiIsImFkZE9ucyI6W10sInN5c3RlbVB1cnBvc2VTdGF0dXMiOm51bGwsIm93
-        bmVyIjp7ImlkIjoiNDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZGM2NzAwMTEi
+        bmVyIjp7ImlkIjoiNDAyOGZhNjU3NGZlYTVhZDAxNzUwMTQzOTQ0ZjAwMmYi
         LCJrZXkiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImRpc3BsYXlO
         YW1lIjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJocmVmIjoiL293
         bmVycy9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9LCJlbnZpcm9ubWVu
         dCI6bnVsbCwiZW50aXRsZW1lbnRDb3VudCI6MCwiZmFjdHMiOnsiaHlwZXJ2
         aXNvci50eXBlIjoiVk13YXJlIEVTWGkiLCJjcHUuY3B1X3NvY2tldChzKSI6
         IjEiLCJoeXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCJ9LCJsYXN0Q2hlY2tp
-        biI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImluc3RhbGxlZFByb2R1
+        biI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImluc3RhbGxlZFByb2R1
         Y3RzIjpbXSwiY2FuQWN0aXZhdGUiOmZhbHNlLCJjYXBhYmlsaXRpZXMiOltd
-        LCJoeXBlcnZpc29ySWQiOnsiY3JlYXRlZCI6IjIwMjAtMDUtMDRUMDI6MDQ6
-        NTcrMDAwMCIsInVwZGF0ZWQiOiIyMDIwLTA1LTA0VDAyOjA0OjU3KzAwMDAi
-        LCJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGUwNGUwMDE3IiwiaHlw
+        LCJoeXBlcnZpc29ySWQiOnsiY3JlYXRlZCI6IjIwMjAtMTAtMDdUMDQ6MTM6
+        MjkrMDAwMCIsInVwZGF0ZWQiOiIyMDIwLTEwLTA3VDA0OjEzOjI5KzAwMDAi
+        LCJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0MzliZTYwMDM1IiwiaHlw
         ZXJ2aXNvcklkIjoiMjYxYzRkY2EtNzAyZi00MmIzLWI4ZWYtMmE3MmI3N2Y3
-        ZWMyIiwicmVwb3J0ZXJJZCI6bnVsbH0sImNvbnRlbnRUYWdzIjpbXSwiYXV0
-        b2hlYWwiOnRydWUsImFubm90YXRpb25zIjpudWxsLCJjb250ZW50QWNjZXNz
-        TW9kZSI6bnVsbCwidHlwZSI6eyJpZCI6IjEwMDQiLCJsYWJlbCI6Imh5cGVy
-        dmlzb3IiLCJtYW5pZmVzdCI6ZmFsc2V9LCJndWVzdElkcyI6W10sImhyZWYi
-        OiIvY29uc3VtZXJzL2I1NTI5NzdjLWExY2MtNDYwZS1iNTkzLWJmNGEzZWE5
-        OGFiZCIsInJlbGVhc2VWZXIiOnsicmVsZWFzZVZlciI6bnVsbH0sImlkQ2Vy
-        dCI6bnVsbH0=
+        ZWMyIiwicmVwb3J0ZXJJZCI6IjEwMCJ9LCJjb250ZW50VGFncyI6W10sImF1
+        dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFjY2Vz
+        c01vZGUiOm51bGwsInR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJoeXBl
+        cnZpc29yIiwibWFuaWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJocmVm
+        IjoiL2NvbnN1bWVycy8xMDJlOTg2MC0zYzRlLTRmYjQtODQ1Yy0wODA0ODUx
+        YWNjZDEiLCJyZWxlYXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJpZENl
+        cnQiOm51bGx9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:58 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:29 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/58264c13-88fe-436e-9b5b-dfefd29204ff
+    uri: https://localhost:8443/candlepin/consumers/9c4dec1c-9ac2-4dcb-91ab-2ab4beedc4c3
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -625,9 +633,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="XQHkm0OFuY6SknehzOMpRM7xYpoW2j86dG2MBr9k",
-        oauth_signature="pJeg73G7RiYcdSsbQBJNydeP%2FxQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="2LOeFUVzuhj0Fe1tuAxELOb86t3qnSUZXojQti1do",
+        oauth_signature="0hG%2BdiutO963W9fKta3u138MINI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044009", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -644,50 +652,50 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 259e0efd-95eb-4bb2-b919-6c2e3ab3b119
+      - e34084ce-b473-4ab7-aa1d-d3f35114e34f
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:29 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTBhNTAwMTgiLCJ1dWlkIjoiNTgyNjRjMTMtODhm
-        ZS00MzZlLTliNWItZGZlZmQyOTIwNGZmIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWM0YzAwMzYiLCJ1dWlkIjoiOWM0ZGVjMWMtOWFj
+        Mi00ZGNiLTkxYWItMmFiNGJlZWRjNGMzIiwibmFtZSI6ImxvY2FsaG9zdCIs
         InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
         IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjoiIiwidXNhZ2UiOiIi
         LCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxsLCJvd25l
-        ciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGRjNjcwMDExIiwi
+        ciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0Mzk0NGYwMDJmIiwi
         a2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJkaXNwbGF5TmFt
         ZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiaHJlZiI6Ii9vd25l
         cnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QifSwiZW52aXJvbm1lbnQi
         Om51bGwsImVudGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5cGVydmlz
         b3IudHlwZSI6IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQocykiOiIx
         IiwiZG1pLnN5c3RlbS51dWlkIjoiYWJjZGUtZmdoamlnaiIsImh5cGVydmlz
-        b3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAyMC0wNS0w
-        NFQwMjowNDo1NyswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltdLCJjYW5B
+        b3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAyMC0xMC0w
+        N1QwNDoxMzoyOSswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltdLCJjYW5B
         Y3RpdmF0ZSI6ZmFsc2UsImNhcGFiaWxpdGllcyI6W10sImh5cGVydmlzb3JJ
-        ZCI6eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBk
-        YXRlZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImlkIjoiNDAyOGZh
-        YTc3MWRkNjhkMTAxNzFkZDZkZTBhNzAwMWEiLCJoeXBlcnZpc29ySWQiOiIy
+        ZCI6eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBk
+        YXRlZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImlkIjoiNDAyOGZh
+        NjU3NGZlYTVhZDAxNzUwMTQzOWM0ZDAwMzgiLCJoeXBlcnZpc29ySWQiOiIy
         ZTc4ZjY0My0xZDJmLTQ1ZDEtYjE5MS1kOTMxMTQ3Y2JkZTEiLCJyZXBvcnRl
-        cklkIjpudWxsfSwiY29udGVudFRhZ3MiOltdLCJhdXRvaGVhbCI6dHJ1ZSwi
-        YW5ub3RhdGlvbnMiOm51bGwsImNvbnRlbnRBY2Nlc3NNb2RlIjpudWxsLCJ0
-        eXBlIjp7ImlkIjoiMTAwNCIsImxhYmVsIjoiaHlwZXJ2aXNvciIsIm1hbmlm
-        ZXN0IjpmYWxzZX0sImd1ZXN0SWRzIjpbXSwiaHJlZiI6Ii9jb25zdW1lcnMv
-        NTgyNjRjMTMtODhmZS00MzZlLTliNWItZGZlZmQyOTIwNGZmIiwicmVsZWFz
-        ZVZlciI6eyJyZWxlYXNlVmVyIjpudWxsfSwiaWRDZXJ0IjpudWxsfQ==
+        cklkIjoiMTAwIn0sImNvbnRlbnRUYWdzIjpbXSwiYXV0b2hlYWwiOnRydWUs
+        ImFubm90YXRpb25zIjpudWxsLCJjb250ZW50QWNjZXNzTW9kZSI6bnVsbCwi
+        dHlwZSI6eyJpZCI6IjEwMDQiLCJsYWJlbCI6Imh5cGVydmlzb3IiLCJtYW5p
+        ZmVzdCI6ZmFsc2V9LCJndWVzdElkcyI6W10sImhyZWYiOiIvY29uc3VtZXJz
+        LzljNGRlYzFjLTlhYzItNGRjYi05MWFiLTJhYjRiZWVkYzRjMyIsInJlbGVh
+        c2VWZXIiOnsicmVsZWFzZVZlciI6bnVsbH0sImlkQ2VydCI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:58 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:29 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/b552977c-a1cc-460e-b593-bf4a3ea98abd/guests
+    uri: https://localhost:8443/candlepin/consumers/102e9860-3c4e-4fb4-845c-0804851accd1/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -697,9 +705,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="uQvZyjhvMSFaJko4R4iOxxRBwwsBg9Pr2mvALEZZX0",
-        oauth_signature="ij0bwipO23H9uT25V99wjxtEvH4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="hAfUlDGzQbeUHhsRgbTsvKCv0OxtQfRMPVMB7BBk0W8",
+        oauth_signature="4X01yt0%2FNNATOcOdyDYWLf94qhg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044010", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -716,25 +724,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - a4ad2669-3fdb-4dc8-9409-dec7cacce10f
+      - 524d09f7-f128-4cb6-926f-78fe51293d16
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:57 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:58 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:30 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/58264c13-88fe-436e-9b5b-dfefd29204ff/guests
+    uri: https://localhost:8443/candlepin/consumers/9c4dec1c-9ac2-4dcb-91ab-2ab4beedc4c3/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -744,9 +752,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="FwGW49P18DyEkP5yJr0VPIjRXfpsIDDHZiQeJ1Jn2pU",
-        oauth_signature="xYipm1etJKLsuy9%2FP2DC%2FxDEnco%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="AWqez4qd9zFdhuGdfeK96MJAibTk72gmMocQjyRurtg",
+        oauth_signature="QJM8uliM4ByfM7lDpyJ8SM%2BGhss%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044010", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -763,25 +771,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 59ef67ab-8648-4812-bf3b-53a01397ace7
+      - 42bb00a9-3694-419d-92e5-b0c0cf9c1282
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:58 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:30 GMT
 - request:
     method: post
-    uri: https://localhost:8443/candlepin/hypervisors/altered_hypervisor_id_test
+    uri: https://localhost:8443/candlepin/hypervisors/altered_hypervisor_id_test?reporter_id=100
     body:
       encoding: UTF-8
       base64_string: |
@@ -807,9 +815,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="v0Z1HRgbtsdVXqQUnV5PKesNab0s32cplGEuJF4spo", oauth_signature="LRNMkVQ5FykVriNNnJjGGJ28Z58%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557898", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="QGbpxnJU9xzUGAGk39qVazeTIJxBMa0pRWzjkIoH0", oauth_signature="SZQFAn8Jl6Y%2Bj%2Bect7mr97SlGx4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -828,33 +836,33 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 50073f3f-b1f4-4d60-ae22-ade878b289c9
+      - 897e2296-2075-472b-a117-d11c9d34945b
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1OSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTkrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTRmYjAwMWIiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzErMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYTIzODAwMzkiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
         eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjpudWxsLCJwcmluY2lwYWwiOiJmb3Jl
-        bWFuX2FkbWluIiwic3RhdGUiOiJRVUVVRUQiLCJwcmV2aW91c1N0YXRlIjoi
-        Q1JFQVRFRCIsInN0YXJ0VGltZSI6bnVsbCwiZW5kVGltZSI6bnVsbCwiYXR0
-        ZW1wdHMiOjAsIm1heEF0dGVtcHRzIjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMv
-        NDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZTRmYjAwMWIiLCJyZXN1bHREYXRh
-        IjpudWxsLCJrZXkiOiJIeXBlcnZpc29yVXBkYXRlSm9iIn0=
+        bWFuX2FkbWluIiwic3RhdGUiOiJDUkVBVEVEIiwicHJldmlvdXNTdGF0ZSI6
+        IkNSRUFURUQiLCJzdGFydFRpbWUiOm51bGwsImVuZFRpbWUiOm51bGwsImF0
+        dGVtcHRzIjowLCJtYXhBdHRlbXB0cyI6MSwic3RhdHVzUGF0aCI6Ii9qb2Jz
+        LzQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0M2EyMzgwMDM5IiwicmVzdWx0RGF0
+        YSI6bnVsbCwia2V5IjoiSHlwZXJ2aXNvclVwZGF0ZUpvYiJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/jobs/4028faa771dd68d10171dd6de4fb001b?result_data=true
+    uri: https://localhost:8443/candlepin/jobs/4028fa6574fea5ad01750143a2380039?result_data=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -864,9 +872,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="0KGWAbEuQvnMs7GRNsGpfWzxgkRNlEP5HeKiZzTcU",
-        oauth_signature="2PGC7t9pHn0ka2m%2FO%2BiTV20WkrI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="5oHxRw4jjB2s3nT8RS0vuvKNWupaikGdA2EUbUVNE",
+        oauth_signature="imFE5Xdyq9kkDASKj%2BUboVJMlpM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -883,41 +891,41 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 35f915d1-5f3c-404e-92d4-7aea125e1c93
+      - e7a7a755-677b-4bb2-9283-5f59c9df1199
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1OSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTkrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTRmYjAwMWIiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoiZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzErMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYTIzODAwMzkiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
+        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoibGFtYmRhLnNwYXJ0YS5leGFtcGxl
         LmNvbSIsInByaW5jaXBhbCI6ImZvcmVtYW5fYWRtaW4iLCJzdGF0ZSI6IkZJ
         TklTSEVEIiwicHJldmlvdXNTdGF0ZSI6IlJVTk5JTkciLCJzdGFydFRpbWUi
-        OiIyMDIwLTA1LTA0VDAyOjA0OjU5KzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0w
-        NS0wNFQwMjowNDo1OSswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
-        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhYTc3MWRkNjhkMTAxNzFk
-        ZDZkZTRmYjAwMWIiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOltdLCJ1cGRh
-        dGVkIjpbeyJ1dWlkIjoiNTgyNjRjMTMtODhmZS00MzZlLTliNWItZGZlZmQy
-        OTIwNGZmIiwibmFtZSI6ImxvY2FsaG9zdCIsIm93bmVyIjp7ImtleSI6ImFs
+        OiIyMDIwLTEwLTA3VDA0OjEzOjMxKzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0x
+        MC0wN1QwNDoxMzozMSswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
+        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhNjU3NGZlYTVhZDAxNzUw
+        MTQzYTIzODAwMzkiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOltdLCJ1cGRh
+        dGVkIjpbeyJ1dWlkIjoiOWM0ZGVjMWMtOWFjMi00ZGNiLTkxYWItMmFiNGJl
+        ZWRjNGMzIiwibmFtZSI6ImxvY2FsaG9zdCIsIm93bmVyIjp7ImtleSI6ImFs
         dGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0In19XSwidW5jaGFuZ2VkIjpbeyJ1
-        dWlkIjoiYjU1Mjk3N2MtYTFjYy00NjBlLWI1OTMtYmY0YTNlYTk4YWJkIiwi
+        dWlkIjoiMTAyZTk4NjAtM2M0ZS00ZmI0LTg0NWMtMDgwNDg1MWFjY2QxIiwi
         bmFtZSI6ImRpc3RhbnRob3N0Iiwib3duZXIiOnsia2V5IjoiYWx0ZXJlZF9o
         eXBlcnZpc29yX2lkX3Rlc3QifX1dLCJmYWlsZWRVcGRhdGUiOltdfSwia2V5
         IjoiSHlwZXJ2aXNvclVwZGF0ZUpvYiJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/58264c13-88fe-436e-9b5b-dfefd29204ff
+    uri: https://localhost:8443/candlepin/consumers/9c4dec1c-9ac2-4dcb-91ab-2ab4beedc4c3
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -927,9 +935,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="CGlqcPFXwHiX2Pl8E2Hhd48FXZLDbzWnlCnh6x2s1Js",
-        oauth_signature="gncBVZF7Il1Cf1TighyObpx5QcA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="eXjcTzGpocZHPwBKtR9m31hdGh1E6dT2XEv5lvBIJE4",
+        oauth_signature="PFDK4vXMm6qnhjmb5tBregYohRE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -946,50 +954,50 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 4d3b1143-19a9-4eff-90ec-26e7e114454d
+      - 4aaedae8-9e10-4612-a606-2d2a93332fee
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTkrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTBhNTAwMTgiLCJ1dWlkIjoiNTgyNjRjMTMtODhm
-        ZS00MzZlLTliNWItZGZlZmQyOTIwNGZmIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzErMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWM0YzAwMzYiLCJ1dWlkIjoiOWM0ZGVjMWMtOWFj
+        Mi00ZGNiLTkxYWItMmFiNGJlZWRjNGMzIiwibmFtZSI6ImxvY2FsaG9zdCIs
         InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
         IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjoiIiwidXNhZ2UiOiIi
         LCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxsLCJvd25l
-        ciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGRjNjcwMDExIiwi
+        ciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0Mzk0NGYwMDJmIiwi
         a2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJkaXNwbGF5TmFt
         ZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiaHJlZiI6Ii9vd25l
         cnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QifSwiZW52aXJvbm1lbnQi
         Om51bGwsImVudGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5cGVydmlz
         b3IudHlwZSI6IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQocykiOiIx
         IiwiZG1pLnN5c3RlbS51dWlkIjoiYWJjZGUtZmdoamlnaiIsImh5cGVydmlz
-        b3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAyMC0wNS0w
-        NFQwMjowNDo1OSswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltdLCJjYW5B
+        b3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAyMC0xMC0w
+        N1QwNDoxMzozMSswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltdLCJjYW5B
         Y3RpdmF0ZSI6ZmFsc2UsImNhcGFiaWxpdGllcyI6W10sImh5cGVydmlzb3JJ
-        ZCI6eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBk
-        YXRlZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTkrMDAwMCIsImlkIjoiNDAyOGZh
-        YTc3MWRkNjhkMTAxNzFkZDZkZTBhNzAwMWEiLCJoeXBlcnZpc29ySWQiOiJt
-        b3JlX3VzZWZ1bF9pZGVudGlmaWVyIiwicmVwb3J0ZXJJZCI6bnVsbH0sImNv
-        bnRlbnRUYWdzIjpbXSwiYXV0b2hlYWwiOnRydWUsImFubm90YXRpb25zIjpu
-        dWxsLCJjb250ZW50QWNjZXNzTW9kZSI6bnVsbCwidHlwZSI6eyJpZCI6IjEw
-        MDQiLCJsYWJlbCI6Imh5cGVydmlzb3IiLCJtYW5pZmVzdCI6ZmFsc2V9LCJn
-        dWVzdElkcyI6W10sImhyZWYiOiIvY29uc3VtZXJzLzU4MjY0YzEzLTg4ZmUt
-        NDM2ZS05YjViLWRmZWZkMjkyMDRmZiIsInJlbGVhc2VWZXIiOnsicmVsZWFz
-        ZVZlciI6bnVsbH0sImlkQ2VydCI6bnVsbH0=
+        ZCI6eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBk
+        YXRlZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzErMDAwMCIsImlkIjoiNDAyOGZh
+        NjU3NGZlYTVhZDAxNzUwMTQzOWM0ZDAwMzgiLCJoeXBlcnZpc29ySWQiOiJt
+        b3JlX3VzZWZ1bF9pZGVudGlmaWVyIiwicmVwb3J0ZXJJZCI6IjEwMCJ9LCJj
+        b250ZW50VGFncyI6W10sImF1dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9ucyI6
+        bnVsbCwiY29udGVudEFjY2Vzc01vZGUiOm51bGwsInR5cGUiOnsiaWQiOiIx
+        MDA0IiwibGFiZWwiOiJoeXBlcnZpc29yIiwibWFuaWZlc3QiOmZhbHNlfSwi
+        Z3Vlc3RJZHMiOltdLCJocmVmIjoiL2NvbnN1bWVycy85YzRkZWMxYy05YWMy
+        LTRkY2ItOTFhYi0yYWI0YmVlZGM0YzMiLCJyZWxlYXNlVmVyIjp7InJlbGVh
+        c2VWZXIiOm51bGx9LCJpZENlcnQiOm51bGx9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/b552977c-a1cc-460e-b593-bf4a3ea98abd
+    uri: https://localhost:8443/candlepin/consumers/102e9860-3c4e-4fb4-845c-0804851accd1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -999,9 +1007,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="rVGuyHlazu8nj0CkDyCK06dyMb0IvVrCWzebnxI8",
-        oauth_signature="KGcYa%2FdJ4FaUgpMfyKtNbwMOuOU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="w93W9BWhWPO7HLR6gWHaqKLUoMAEfAdrrUSggIfuY",
+        oauth_signature="4Czr5Tnm8uUlQocRiSnWjTf7dIc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1018,50 +1026,50 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - df3c5e8a-9179-4ac0-bdbd-0e0cc3d3f51a
+      - 93ef4248-48ae-475b-a88a-d99cd4cf5c48
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTkrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZTA0ZTAwMTUiLCJ1dWlkIjoiYjU1Mjk3N2MtYTFj
-        Yy00NjBlLWI1OTMtYmY0YTNlYTk4YWJkIiwibmFtZSI6ImRpc3RhbnRob3N0
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzoyOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzErMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzOWJlNTAwMzMiLCJ1dWlkIjoiMTAyZTk4NjAtM2M0
+        ZS00ZmI0LTg0NWMtMDgwNDg1MWFjY2QxIiwibmFtZSI6ImRpc3RhbnRob3N0
         IiwidXNlcm5hbWUiOiJmb3JlbWFuX2FkbWluIiwiZW50aXRsZW1lbnRTdGF0
         dXMiOm51bGwsInNlcnZpY2VMZXZlbCI6IiIsInJvbGUiOiIiLCJ1c2FnZSI6
         IiIsImFkZE9ucyI6W10sInN5c3RlbVB1cnBvc2VTdGF0dXMiOm51bGwsIm93
-        bmVyIjp7ImlkIjoiNDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZGM2NzAwMTEi
+        bmVyIjp7ImlkIjoiNDAyOGZhNjU3NGZlYTVhZDAxNzUwMTQzOTQ0ZjAwMmYi
         LCJrZXkiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImRpc3BsYXlO
         YW1lIjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJocmVmIjoiL293
         bmVycy9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9LCJlbnZpcm9ubWVu
         dCI6bnVsbCwiZW50aXRsZW1lbnRDb3VudCI6MCwiZmFjdHMiOnsiaHlwZXJ2
         aXNvci50eXBlIjoiVk13YXJlIEVTWGkiLCJjcHUuY3B1X3NvY2tldChzKSI6
         IjEiLCJoeXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCJ9LCJsYXN0Q2hlY2tp
-        biI6IjIwMjAtMDUtMDRUMDI6MDQ6NTcrMDAwMCIsImluc3RhbGxlZFByb2R1
+        biI6IjIwMjAtMTAtMDdUMDQ6MTM6MjkrMDAwMCIsImluc3RhbGxlZFByb2R1
         Y3RzIjpbXSwiY2FuQWN0aXZhdGUiOmZhbHNlLCJjYXBhYmlsaXRpZXMiOltd
-        LCJoeXBlcnZpc29ySWQiOnsiY3JlYXRlZCI6IjIwMjAtMDUtMDRUMDI6MDQ6
-        NTcrMDAwMCIsInVwZGF0ZWQiOiIyMDIwLTA1LTA0VDAyOjA0OjU3KzAwMDAi
-        LCJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGUwNGUwMDE3IiwiaHlw
+        LCJoeXBlcnZpc29ySWQiOnsiY3JlYXRlZCI6IjIwMjAtMTAtMDdUMDQ6MTM6
+        MjkrMDAwMCIsInVwZGF0ZWQiOiIyMDIwLTEwLTA3VDA0OjEzOjI5KzAwMDAi
+        LCJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0MzliZTYwMDM1IiwiaHlw
         ZXJ2aXNvcklkIjoiMjYxYzRkY2EtNzAyZi00MmIzLWI4ZWYtMmE3MmI3N2Y3
-        ZWMyIiwicmVwb3J0ZXJJZCI6bnVsbH0sImNvbnRlbnRUYWdzIjpbXSwiYXV0
-        b2hlYWwiOnRydWUsImFubm90YXRpb25zIjpudWxsLCJjb250ZW50QWNjZXNz
-        TW9kZSI6bnVsbCwidHlwZSI6eyJpZCI6IjEwMDQiLCJsYWJlbCI6Imh5cGVy
-        dmlzb3IiLCJtYW5pZmVzdCI6ZmFsc2V9LCJndWVzdElkcyI6W10sImhyZWYi
-        OiIvY29uc3VtZXJzL2I1NTI5NzdjLWExY2MtNDYwZS1iNTkzLWJmNGEzZWE5
-        OGFiZCIsInJlbGVhc2VWZXIiOnsicmVsZWFzZVZlciI6bnVsbH0sImlkQ2Vy
-        dCI6bnVsbH0=
+        ZWMyIiwicmVwb3J0ZXJJZCI6IjEwMCJ9LCJjb250ZW50VGFncyI6W10sImF1
+        dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFjY2Vz
+        c01vZGUiOm51bGwsInR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJoeXBl
+        cnZpc29yIiwibWFuaWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJocmVm
+        IjoiL2NvbnN1bWVycy8xMDJlOTg2MC0zYzRlLTRmYjQtODQ1Yy0wODA0ODUx
+        YWNjZDEiLCJyZWxlYXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJpZENl
+        cnQiOm51bGx9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/b552977c-a1cc-460e-b593-bf4a3ea98abd/guests
+    uri: https://localhost:8443/candlepin/consumers/102e9860-3c4e-4fb4-845c-0804851accd1/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1071,9 +1079,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="EuO1Ppr8Lv08uZ9YuiE0aLn681llui9qRimcoGDPY",
-        oauth_signature="YF1%2FvYy31hAly3fCSU6cmzk59G4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="VjzALHxYVWnA24jZoJMKlJmWkG6Ghl3dWICQp6zYWk0",
+        oauth_signature="w2t9jDzbY1n4uUu5R%2BsSF8muR70%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1090,25 +1098,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e06fc3d2-e211-43ed-9a05-31d992036ef1
+      - 07f0a03d-835f-4495-afc9-ee5d2710402d
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/58264c13-88fe-436e-9b5b-dfefd29204ff/guests
+    uri: https://localhost:8443/candlepin/consumers/9c4dec1c-9ac2-4dcb-91ab-2ab4beedc4c3/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,9 +1126,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="zUYuOf5lhUyOvuVmCmWjB2CmLYvJxxZyEcPf79mCXa0",
-        oauth_signature="iLj9Xl5pF%2BpholWuINhC8xk%2BQ54%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="FoFGKxkyZrUSofKGSQ7znZgtfh5gk7KdKH4sAcOCYyA",
+        oauth_signature="CRAltjtBZtcL6qfYsZV8iFmKU6g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1137,22 +1145,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 289cac93-11a9-4dc5-86cd-9c91e8fc2161
+      - e6441011-c368-434f-acd1-ea847eb76b6b
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:58 GMT
+      - Wed, 07 Oct 2020 04:13:30 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 - request:
     method: get
     uri: https://localhost:8443/candlepin/consumers/?include=uuid&owner=altered_hypervisor_id_test&page=1&per_page=1000
@@ -1165,9 +1173,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="MPbMacUNi0kWBWKo6UyqVKdnMEqpNNz7FbG2Kh2VI",
-        oauth_signature="vkDRxMGAVtdtdFygryunsRZScWI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557899", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="IciHJhxSw8P4HZepj5BBXVHofnxAGB5QFdxdP6c1Ac",
+        oauth_signature="an1BXM7pxIs4f7aO0mIUZ8MH52Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044011", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1184,27 +1192,27 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - a33a3f4c-2c9d-43e6-942a-bd0e1d823394
+      - 965a79cf-fb92-4af5-80c9-a52f021dac1e
       Link:
-      - <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&owner=altered_hypervisor_id_test&per_page=1000&include=uuid&page=1>;
-        rel="first"; title="first"; type="application/json", <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&owner=altered_hypervisor_id_test&per_page=1000&include=uuid&page=1>;
+      - <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&per_page=1000&include=uuid&owner=altered_hypervisor_id_test&page=1>;
+        rel="first"; title="first"; type="application/json", <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&per_page=1000&include=uuid&owner=altered_hypervisor_id_test&page=1>;
         rel="last"; title="last"; type="application/json"
       X-Total-Count:
       - '2'
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:59 GMT
+      - Wed, 07 Oct 2020 04:13:31 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        W3sidXVpZCI6IjU4MjY0YzEzLTg4ZmUtNDM2ZS05YjViLWRmZWZkMjkyMDRm
-        ZiJ9LHsidXVpZCI6ImI1NTI5NzdjLWExY2MtNDYwZS1iNTkzLWJmNGEzZWE5
-        OGFiZCJ9XQ==
+        W3sidXVpZCI6IjljNGRlYzFjLTlhYzItNGRjYi05MWFiLTJhYjRiZWVkYzRj
+        MyJ9LHsidXVpZCI6IjEwMmU5ODYwLTNjNGUtNGZiNC04NDVjLTA4MDQ4NTFh
+        Y2NkMSJ9XQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:59 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:31 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/duplicate_hostname.yml
+++ b/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/duplicate_hostname.yml
@@ -12,9 +12,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="Vau4z1wJaSpJFocLMFnwmiPrlwDZU4yd3IXDXM1lto",
-        oauth_signature="4tIrHT4MacpT7Uyqy0sZ3Sr3mfM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557892", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="tZgLpZIEG6SS7iVLy7yqlVOI9xOoVqi8tJGTD6oRpE",
+        oauth_signature="w6cNnWDbRbDDh7lztD56WJITgEQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044012", oauth_version="1.0"
       Cp-User:
       - foreman_admin
       Accept-Encoding:
@@ -27,25 +27,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 6b3233c0-b3c9-42e5-bb87-af170b96e849
+      - 63148e03-b7e2-44fe-bbb1-0e075d5c8d25
       X-Version:
-      - 3.1.10-1
-      - 3.1.10-1
+      - 3.1.16-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:52 GMT
+      - Wed, 07 Oct 2020 04:13:31 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIGR1cGxp
         Y2F0ZV9ob3N0bmFtZV90ZXN0IGNvdWxkIG5vdCBiZSBmb3VuZC4iLCJyZXF1
-        ZXN0VXVpZCI6IjZiMzIzM2MwLWIzYzktNDJlNS1iYjg3LWFmMTcwYjk2ZTg0
-        OSJ9
+        ZXN0VXVpZCI6IjYzMTQ4ZTAzLWI3ZTItNDRmZS1iYmIxLTBlMDc1ZDVjOGQy
+        NSJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:52 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:32 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/
@@ -61,9 +61,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="oPS6EjkpjTN7lrv4BCC32WK4k7fVYK9pbtvItE2I8sM", oauth_signature="2po%2FOTf5nwlflLpgxLMN2aJTfNk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557893", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="d5waZVlqicDJuCZWxbodoOnIbSdrYsaqUrKxXAQ", oauth_signature="nO6kx803kohswhEdZEPqUk0aJZc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044012", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -82,21 +82,21 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 2d4e0a91-d85f-4e6b-9094-42431e95cd62
+      - fa2930e6-2ea7-4720-977b-bbad98b692b5
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:52 GMT
+      - Wed, 07 Oct 2020 04:13:32 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1MyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTMrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkY2VlMDAwMDciLCJrZXkiOiJkdXBsaWNhdGVfaG9z
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzIrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYThjZTAwM2EiLCJrZXkiOiJkdXBsaWNhdGVfaG9z
         dG5hbWVfdGVzdCIsImRpc3BsYXlOYW1lIjoiZHVwbGljYXRlX2hvc3RuYW1l
         X3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZpeCI6Ii9k
         dXBsaWNhdGVfaG9zdG5hbWVfdGVzdC8kZW52IiwiZGVmYXVsdFNlcnZpY2VM
@@ -107,7 +107,7 @@ http_interactions:
         dCIsImxhc3RSZWZyZXNoZWQiOm51bGwsImhyZWYiOiIvb3duZXJzL2R1cGxp
         Y2F0ZV9ob3N0bmFtZV90ZXN0In0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:53 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:32 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/duplicate_hostname_test/environments
@@ -122,9 +122,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="o1WS4TpSBmFODKI4i4TV8RCwEl4DNi26bnZQuh7E", oauth_signature="TJJeWbJBynzP%2F7FX9VHUTVAiXF4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557893", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="xTgJezt4iFCeZx3pHo8kOMUmwMIYJeUyhvMsIlzHuFc", oauth_signature="dEoPt%2BJPbty3%2Ba7oweDl1tEg%2BBU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044012", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -143,28 +143,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 3329b7de-eeeb-43e8-ba86-048fd625e32b
+      - efac0f27-eda4-4e61-adb4-08e2cb6c50e3
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:52 GMT
+      - Wed, 07 Oct 2020 04:13:32 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1MyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTMrMDAwMCIsImlkIjoiZTZlYjc3OTU3
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzIrMDAwMCIsImlkIjoiZTZlYjc3OTU3
         NTE1NmZiN2RiYWZhMjIyZTE1MWQ4YTciLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4
-        ZDEwMTcxZGQ2ZGNlZTAwMDA3Iiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1l
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1
+        YWQwMTc1MDE0M2E4Y2UwMDNhIiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1l
         X3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0
         IiwiaHJlZiI6Ii9vd25lcnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QifSwi
         ZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:53 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:32 GMT
 - request:
     method: get
     uri: https://localhost:8443/candlepin/owners/duplicate_hostname_test/uebercert
@@ -177,9 +177,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="S2PEk75EtUelSTjIpBOy4y7LB8LyKyE7oFmDbL9Kfg",
-        oauth_signature="zxnXn8ti56LocTXlSRc2x0EU1Ic%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557893", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="dqJALfJdjMhJB3wni32dcrWluXqUPupudEGawf5T7o",
+        oauth_signature="r5l28dOk%2Bzf5AQNQVyNO6IH0Mw8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044012", oauth_version="1.0"
       Cp-User:
       - foreman_admin
       Accept-Encoding:
@@ -192,25 +192,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - b7d4e3a9-f265-46fc-b1f3-91152f90a5b8
+      - 632a7f52-c16b-41d0-921b-7bc4b0f75c5c
       X-Version:
-      - 3.1.10-1
-      - 3.1.10-1
+      - 3.1.16-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:52 GMT
+      - Wed, 07 Oct 2020 04:13:32 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IGR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IHdhcyBub3QgZm91bmQuIFBsZWFz
-        ZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiJiN2Q0ZTNhOS1mMjY1
-        LTQ2ZmMtYjFmMy05MTE1MmY5MGE1YjgifQ==
+        ZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiI2MzJhN2Y1Mi1jMTZi
+        LTQxZDAtOTIxYi03YmM0YjBmNzVjNWMifQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:53 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:32 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/duplicate_hostname_test/uebercert
@@ -225,9 +225,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="ssssmtJzQQGgjcwRasbUZ7ny6FoIEJ76eFnXgf1uU", oauth_signature="maPXKOLF2QRFYGEgJfX%2F9UyMCmk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557893", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="tTzVVrwpKyi3APYKmVNvTRgvMLfkVeXgWfICOBKQ", oauth_signature="ffQJ973xZYdFOkwhb8QeK%2BhHsSI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044012", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -246,167 +246,175 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 2cac2c62-da5a-4b53-a6bb-e9f56afc20c5
+      - 53404279-fe14-4f69-bb8b-dbfe1695f2d3
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:54 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1MyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDE3NjAwMDkiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS0FJQkFBS0NBZ0VBeHF2REZ2M2p5
-        Z2hISlVxWmFDU3I5aGRoNE05Ty9WRi9kYWlVRWxPK0JuUkprSHU4XG5XQjZq
-        WXAvZlpQMmNWaE55ckc5K2kxWGVLT05TY0trT1BRclVrQlhkY0NCcGU3bVN6
-        OWo0QUJ0Z3IrVTFPaGp2XG4yVVhGZS9KR3VQYUNiY29xaTJ5eStGQldINGtB
-        VkEvVVd1ZTBtUnFIZTdMSmVkT04yWXI3YlUzSEE5WTBZbGh5XG4wQ3NHOEZY
-        KzliUHZrSksyeFA5UEZDaFBYY1IrNE9xSEdZNmVxazV4UTdzZk85WW91NXpS
-        QWJDblhkVmNnWTBlXG5UNVE3SlUxM3ZucUJEb1RGN2s2T3lkUDJEbVoxVk5G
-        NGNzWWZOZ05RNEtzQ09uUjNxaDhsM0lpMSszT3ZrTmViXG5oWkxTMjF6Umpm
-        L2ZFYkJmeUNRMWlWYThKQVE1bUVHdXN4Y0xDc2dXQjNmVmovbnQrRzVWbTJz
-        Q1ZzTlJYM25nXG5tSGY1cFN3SnFPTmk4YW9xT2gvT2dGdFJ1NUcvblc3bldy
-        QU1nSXF6V1kwNkY2YlZWUFhsZHdVcjY1UVlVRUJZXG5XaGJSeG9TT0JSWkFS
-        WUJIZU1wSFNHb203UU04TEFLcnhlRURpdGVZYVIzYUU0OE9DRFYzMDRaZzAz
-        aVM3cTZuXG5SOWQvU1VwSWRaaS9BQ0R5cXhWNjh1TWw3YXFpN1F4UjU1Rllo
-        S2pWMXFkdTRwMmFOc3VpbTdlYVR1bDdNZ2RwXG5yUUVub1l1YVRTbFBZUXFz
-        MTd5bUZJQ1U4ZExURHZGaGxrTTVqUzZKd1o1Tm1UanJ4N29hUkhYR2ZYMlk2
-        K2JLXG5ZdW9oSkhxanUwMEhuZ3VUVTcrS2FaYWdreWtXSUhhZ2N1R01La0FS
-        T3lTRUFIVnJZQS9SYThtd0poRUNBd0VBXG5BUUtDQWdBT2hnbjZDVTk0dW9n
-        dzhyWXFSZHdJWG9jNlB3MkFPVS8vRXZiWUxDVU5KYjBuQWRTd0FIVmpSVnE0
-        XG5jRTNZZ1ExMkM2U05uUlpqbU5LekI3alJ2NVB3Z0ppeWxMd0JYbnljRXps
-        MkVJcE44WXlsbGFNYkdCMnF4UGhrXG5seWpMeSthMlVKajR6QzZ2bVgxYnA5
-        aVhXSzc4TGxOUE9LKy81elpNZS91TGJ3OG9lYVZVdHpDVmhUKzVuQi9LXG5h
-        SUFQNnBuUDV2WXAvQlJwUDI4akZDSVNQVG5lSzJQZVZyU2UxRFlnR1FPeWd1
-        NkpUb3Ezc2RCUWN2NnI2SERqXG5qT01ZWTU1d29HK1IwNXYrUzRFeVZTbmdB
-        aG5RQWdnTWxKUFNJQ2VMV1VHVVVLNDFGcXowQXI4TTBjSDJaVit3XG5hTTh1
-        NU56cnJiSDRPMDMvdUF0WjFSdG5YanpoU09yeDZXNkJ0ZnBaaTdUZHE3bTdz
-        SkVFa1dnNnBIS2l4YWFVXG42VW5VV1E2UHNuazg0WVRFYWp1UXJ4U2JWdVEz
-        RENCb25KV0V2Y1ZFaU93QUNiVURqck10Wm96OUVWcmphSFU1XG53U1FBeWJt
-        eFdTMW1WbnBlU3Y1VlMvZzViMXlvTWgvQlBBM1JtYVk2ZXI3eXNOUTZzVFRF
-        ZFhGWlFvTHJDZzhsXG5tUitEdUpKblJKRkRiV0pjbjlKdnpzQklQM0ZtY3Fk
-        LyszNy82d0xZQ2pYNWJXSCt2ZitqT2ovNVNlUkl1eHg5XG5EclIxNWhzeVFq
-        V1dnSnFLTTlvMmowYXk0OHhKeFFiZjVvdldQZi82aWdyc3duOGlvdGxwY2Zo
-        QmNlQW83UFVmXG43QlYybHViU1JYMHUwaFJqdndVOEZlTjBzRTV3WHRNMVo4
-        Qy9leVJWL1ZWRTFRTHcvUUtDQVFFQTVVekhydnhaXG40cUlxQzBCU1hsYjFh
-        NGRNanZmcDM3d2ZrVm92anVrYUFZYjNhK0ZmT2ErNnU2UnF1RnQ4dFJvMk94
-        bnpycURUXG5tMFJ4MEhldmRXZEl6SU8xTXM3T1RVMmlQZ2RzZnVxSjNlbUVB
-        dG15NktleUNJMzRlTFAzZllqR2dOaUU2V3NuXG54a3A2NzNyUGt0MDZ0V1Bw
-        QUtKUXZWSThtK1g2VWd3LytuMEdkL1dsK0paeUErQkMxUkZ6UXFNY3phUTFP
-        NDdsXG5aTndFeFZEMHoySnhWVGJHbi8zemtKQWplcWdFRm5ZT1I0MXpZd2t0
-        YlBmZ2xCbXJvWDR6eXowTEwrN1J5MkZyXG4rM1Y0NUcwM2ZaTnNlc2o1dk5t
-        M3NCeldWMXNTYTRLK0NSY1lPN3c1UGhkeVo3ajRWSXFJOCtBbVNiOVlJZElo
-        XG5iazFXam96Zksybkd4d0tDQVFFQTNjMzEzYXBKL3UxY2RybUZFOEVvci9o
-        a3dVdUlDRytUelYvOC8wTnB3SWNCXG40dGdxSHdpTHRjZXZteXhBaWRuN05n
-        aWJhUW01MmNQMEV4S1NGeHpKZXhQdXNOemVpWThBV1lPbFY1b0dXVXcyXG5X
-        VkNtSVZVVlpXZzl5REN3K0FVVGw2eUhnZ1FTalUwd2tVNklHcTlpWmJReVNS
-        Z0E0MWY3REtHb2hScENlRkFrXG5LYVlBaG0vMDc0aWFPcXF1SXlBcjlFOTNR
-        emFIZ2N5ZXB2QjV5a1hidzBTNlluNkJFeHNlanpLM25nUDhBbUlCXG5ESVE3
-        Vkw4ckZmeFJjR3BaVGhYQVkxaXU0VFFPWFQ1SDR4M09VcXNFZ2lSTlAySUlX
-        cStSL2Z3SzNlc2NYcjQyXG5zSE9hUEsrQXBZYXJRSjdpOFBwZHhST2YyTDNH
-        UFpOc2JaY21FSGwwWndLQ0FRQldrdTZ4dXNXVk0vVDcyb1UrXG42VVl3R3gx
-        a3ZXV24rN2RQZ2VXQzU2L1I4OHRuQitpVU55MGh1Nm92Z1J0TXBXRGtYNkFK
-        eHQ4ZU9IRmdiRS9xXG4yOXc0bTJIR2xSNS9RVmlJWXZVcjFoSEhuMnNnU0dH
-        c1JlU0tKbEF5QW9EbS9NVTEwSW9lTno4Rk53bkRjWEw5XG4yRmxhTXlhOS9v
-        ck5jRWRCOVVyVnY1cElVUHdvUHE4emRGb0g3SnhQSmcrR2tWOUdwVUVVQTVm
-        SXhPbG9ObkMzXG4vRXNlQ1Zoay85VCtOKzJ0V2RKeFNKR0xvblIyWi9pbXM5
-        QXZHcUlhanpPdkFKVkF1OEtxTDFZOTB0U2FLa0pSXG5QMkF0MjhPdThlVFFz
-        WktiMk43VGlNR0hYUmpoTk9mSDhjSllOeFpMbFNLd01XbERYdU0vb2I3Tmpw
-        V25yTGgyXG5BN0h4QW9JQkFHRW82MTZpVGEraUFqTHZxVit4NlVUTUpqYVdB
-        NHpPYzR3dlUvL3RZOUcyVWhrd1g2TWdkeksxXG51akxhKzVwbkppZlJOV0ta
-        cEJQRVJwSmtQQ0pydGNaNFFNS3d2YnE4TFljSXA5RHI0NFFTWW14VmE3Q0dP
-        TTBuXG5FSWswNnhCNkNNOFVBSGZ2bU1EVTQwV0RoUk5MYUdyc3VHcFVYVzg1
-        QnZ2TmhLaHBqRnh2bnFldjArTVAvOWM5XG5tM0cvZW5CZ2syQjl2dHh1Y29W
-        bFFNb1g1UUc2QUQ1VlNPQUVVajR3VHY2alZOT2ZJekZZQk9XYXR2SzBtd2NT
-        XG5kQW91Uzloc3BzM2Q5eDBuVkhONzZMbVFRT1R0alJnRkZ1R0E2Ky90b0tJ
-        RldpMUQ1RFdNVlNDT1F5MzZJdnhmXG5OWDBsSEh3NjhBQjRURGtCU0dtSXZx
-        Snk1M1duL2xrQ2dnRUJBTmc4bEo1WS9UVnVJRFBUU3FLOGd5czlpNkJOXG54
-        ZUdQOXYzMVR1NHgrQ2Z5cnd3UFh4MVZXMEludHRQU256a09tNitDQ2NaUGcy
-        MURNTnFoQm9tOEMvQjBPN3dLXG5vMWV2YVl6WHo4RkdpMEQ5UEZ1RlFaQnNX
-        Smo0VXMwZm8vSHRkOEw4cDJ0ckg2eDRrbnRVNmp4WUE4VXl4TXlHXG5oeXNQ
-        RFRYNzVERHIra0RlS2lUVnZPbmtKSFBQQW9NbXJsRTRrUDRTb0FMYVB2Y1M2
-        YVBiZlU4RndVQ250WlBEXG5qZlM3TDdMbTJSb3N4SE00a1JOeDBVbmcxLzBU
-        VzhJbVkxajltY3VrSnBvRit6ZG9kV2dENkl6djJaUjkyY0cwXG5hR2UrWllN
-        VDhMVGdkeGpYU3IvQ1ZsWTROMlJFRTZwVmFmRytrcjBaM2EwMCtBMDFNODR3
-        ZngxV0R5OD1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
-        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIWlRDQ0Jr
-        MmdBd0lCQWdJSUJZL1ZLTy8zZ2U0d0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzMrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYWQ5YTAwM2MiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKSndJQkFBS0NBZ0VBbU1uWGZFNzRh
+        SU5QV3ZnNEVmTjFFRG5HdEJ2bzQvNlJxbmI5ampjY3FySEQ0SEgwXG5RWWVm
+        a1Q2ZWQxZlFqT2k2bEphT2NYbkFBOFVyb1JZMWE4d3dHa0NrZU5mN040YS9X
+        S0NsdklZQ2JLMTY0TmZnXG5kL21qQ0pLYzNWeGNUazFaaStUVThLQ2wySHVr
+        aE1LVlhZRUxMZEs2ZGlmRjAvdVFadHQ2QTFjTUdZeEVmODhsXG5FNVZzdUJK
+        VUNiLy9ESGpwRHlwdGk5REJtTE1Yb295WFkrQXY2ZGRsTHhDOXRkaW9JRU01
+        ZTdzWTczdmtSR01uXG5BS0M1ZC91eHozczF4N1NrY3RaOXR1WHZqTjRQUTg3
+        dzdwaTlremJOenpIZGxVOTBzRzNHSTdUTmFqNEtPSGJuXG5zSG9Rc0VXQito
+        TDd6elBqNkRFSW5QSEN1cnN3bjIvdWNHUkh2VW9ZZDVURzB1QzUwYWl5QkpQ
+        cEsvdnhQaXBTXG5CMkdHNmFoRmF6d1YvNEJteUxCUTdCRXUxNGRPcDNLeWVp
+        ejNVQUxUVXo4VEVCVDNaaGJ4ZmI5MjZVSGU4RjMyXG5xYTJLTkFCbys5M0x1
+        VFJZWHRPTWd6K3hvZ29DQVZ2MmhYVGF1TjZzV2s3TWtxYWN0b3pGbFd4SmZY
+        aURJcWx0XG5vSGg2ZVR5Z0liVFJ1UlhlUXZJcFpSdU5xTVp2YnJhOS9UbVdj
+        TlphUVJLcnNYTEtUZmdsQUlJclVRNmo1L1FVXG40eFd1OVdOYXA0Rk1mVUhW
+        TW5EbGM2aThoU2VVbUNzY2ZSUEM0alJhS0N4ZzhrVVNsQW9GVzRralFOdkxy
+        V1dOXG5makEvcmZrcUR3K0FwdUhIeXkwblpZc1NQUFYwcCtNQU9Pa3grVGR5
+        MjRvMnhmZ1B1cmFlQXdQaWtyTUNBd0VBXG5BUUtDQWdCaUNGQU00SmFlYUhK
+        SVNpK2Z4UGY5bXpTVlo3cjhYdUNUNFprNjRMMnlBREZRRjQzRFpnUEtLOFY5
+        XG5pWWkwZ0xjR2s3dDlyOEsyS0pLZjN5SVRzb1hDc210VlppODRKMnNxc0pq
+        bTU0MHlzZlMvdzRPeE55bVdYSXZ0XG50RTg5cG4rb05RRTBDNytkc1dlVUQw
+        M0xHdnRUUVh5R1IycTFZeG42QlNTNmMrVzlsclIwMVRKUzZITkRmKzhQXG4r
+        bkxwUzhNdUNla1Q1clB4Q0NoSUViRXBValVyOHhwbkluUzI4dmFkRE1VYlVL
+        YmxNamI2Y2l3YVNRWDNxRFVrXG5qVWVxaFl0bWE1MXA5d3JHOWN3Umsvd2Ur
+        ejNYOFRnSWsxUTdjeW5KOGdWSjc3NUZSdDFEOFhjalVvN1dxeUtFXG5sQjJo
+        aXdmV2VXK3ZVNmZBTEU4OFhaTTk1Zm5veVQwYkh0R3hNTElTeHNGdy9FR1lx
+        MVN2UGtabjZzT284NmJxXG5XaUlqYmdJR2VYZUJZT2VhdlZiV0l5WnY1RnlF
+        NnFTSGVMeEp3Y0hXaTliQkRxaVZxZVZzVjBrZ3BmVXZ5citqXG5NbHg1a1lq
+        bXBDMURwK2d0R2JKWUZueFgvcVRUSEQya3dzZjFNM3A2ZUZZa3M1b1FxZXdM
+        eVVpUUM2QkJUWUpGXG5ISjVKdkVoZ25KdFBWUlR0TFFUVitvbDFIUXMrM3VI
+        Tm9LWFNHOTBqZ3R3Yk5iUFhXT0kyUmxUa1ZNRW1RTHczXG5oOUNQS0RFV1FH
+        MmlvWlFSakR4RDZSOGtkMndqTDBYWC92SVNJUU9tMTZpcVB2ZnpDaVFMS2M0
+        U2w5Y1h3Y3JTXG5OeklwU3V0U005YUY1M2VJK1dPb3VUa1hNcHZpMmdMUUVE
+        QTJGTWNwbXZDc09MZHFZUUtDQVFFQTJ3M25UTkh1XG5NYmN0NW5PZEk4NnRN
+        UU5JQTJkWVIxeDMrbmlSc1VHNHptVFhYclorVzhwaFZpVmU5MWJ0Q3U2eXJl
+        VXRFck5xXG44QXRobnc0WmppeFhTVWcvYmpDZXM0RDk5ZVJBL0tlU2hNNjI5
+        UW11ZmZJaVFqUkFERGtsNVFkdzN2dnNEZGkvXG5Kd2o1dlFlc2pSU1dkT1RE
+        OTVrUFN6SlpmZVk0Uk94dUIwMC9wLy8vN0gySnUrRHQ3Qy9pUitPZ245TnNq
+        aGdiXG5VQUdub1plVGVyZ1lkYmQ1T0hPUEE2ZDRzeVpSeFV4S2x4R04wcFd5
+        cmJKNkMvMmZZZzhkWXkyOHRUekczNHZoXG5ZMEhnZldYUENrbkJYSFlFZGlZ
+        Vy9hamNxUlgrODdUZ2QybW1OdVBOMnEveGhPUDNHbVN2eUJJN2d0YTlMMkQx
+        XG5JS09jL0lJZ1I2ZC91UUtDQVFFQXNvN0h4NWVzaHBEeGp1aVR2NFljOXhp
+        RFdkejVBTmVqRG9QTE9xalkydHgvXG5vbjBIMUdMeEhYQlNMSTBaNkNKbFFS
+        bFdMTzluWmtqNnJraFpZa1BvY1NMcnBSYmhMcUFERy82V2FaTTRpUjZnXG50
+        eDlSVzlMdEJpOUdIQitGWExyYms4NHV3L3hwREJQajJ0clNRQjl2UFRUcVhw
+        R2dyUDVucTRQZS96TE5weXJXXG51RGlLNC9XL0cyVmQxbnFUdlM1cGlEeFBY
+        dXRvUHh3VldMVzllaHJhaFhUMGJBRWM0UHpRbE4zU3JBTmVzL2ZBXG41L29X
+        My9HRG5KSXZqb0R6WVloUExiTXNaeUhLM1JTQ29XTGpmc0JCMW5KNDluVmQx
+        Ylp3N0I5S0JIYnE3TGhXXG5WQm1USmIxT3RaeUFKYnNJU1BVTERFZG82aGlj
+        a0dGTk1EYlpNV29qeXdLQ0FRQVJ1blpWeVVlMXpsVndxVHEyXG5neXVSSSty
+        WUc2MFJXWEo4V3ZXdm10b1NHaWMwQ3lEKzNNb3o1cUpnOGpBTkNuUjdqbWl2
+        Y3NYYzE0NzNDSFVaXG5CSTJyNktUNWpnWEtFVTU4Y0JTeVhmMkZzaFVzajdR
+        SGpXa29Zb0lzZXhPT0RhUWM1OWFhNkVmUUtQSE5VcW1zXG5ZVllyNzdmTWVo
+        NjZ2MEJ1NkFyMXlReSttb25rVnR1bmtDRnRpeTYyUnNuUmQ2S3dUTFFrYTk4
+        S0FwaEdnN1h6XG40S0phSkpjeThtZElyRzBnVXFHYmppa2JRTmh4aXB3RFlz
+        WnQ0Z0RjTnN6eUVlbUw0WGRXOEVNMWZVZGwzcTk2XG43YTB3aG55bDh6ODVH
+        RW1EaGJ3MGpSYjlreGRZcWVjbkk4WXdNeUwwaCtHU0Y2ZXBWeWZJaGRoUTQr
+        ejRvcTlxXG5IU3hCQW9JQkFHeVVzTjRwMk1zMzV2emRaOE5tM2NSUkRzY2R2
+        Zm9LSjJqVE1rbW9sYjU1cWMvNHNrTXdLNm1ZXG5QUkJFZWNXVTdQZnFYV0lU
+        NzAvZS96bnVXeFNMY1JVamhDS3ZTQjRmUmVUSEsxWm1KVklVNHV5WXlkUEo3
+        MEw4XG5pbWpkcmk2V25xSkNGbVF0NFA5c05QcElhT1IvZVJqQ1RlZFdMVnds
+        bEl0VE5NOEJhTmZJRUN5VWpibFVIbk9kXG5iN1BXZEhMdGYxVk9QNEhjSzFk
+        OVQyblRrclpuRUExcDhweWZESjJ3ZjNLWGRkNE9hbytNRUszQWdocUtkbHRH
+        XG45azUxRWd0MFpabkh4Qyt1OS9yNjF2a205bXFFcFVTdjlla0J0QjhhdzQ2
+        QzlITEVrZFdEdjFPQy9kMU1Ra25rXG5NblUvU0NsOWdjdGt2V0xsdG9lQjgv
+        dG16eXJpZllNQ2dnRUFBbSt6YVQ3aml5R0xONm5lclRuaUIrN1EvZVRKXG5B
+        MDZVcmNSenFHazdXeVhwMkdiMEVEcTREUmZDa3VmSVZJRFFBYTQzSkNXblo1
+        UVozNk9BcC9qR3R1ZFdXazB4XG5uZWtDenV2OVlXVHlZTVRiQmgxa2FTdU5x
+        aVdrS05oUHJsOU5NeXNJcHhVYUdYVE90ZGcvcGVaUGNGcHd2bUtoXG40SGxZ
+        N20rUlJqZDJHdnlhQUl3ZUtUUUZUUExEVnRsWGljOFpvVlpDMUJyb0ljb0p1
+        U3Q4emlNTVIzR1cxV2U3XG5QcjhIcXg2blBlNmVqL2FMV0dMYWNaSzd0L2th
+        elhWOWVzYldWWURrSzNIanpqZ2Q0Sk9GYlRNZURZUlphblZKXG5xaS95OXR6
+        clI3MkxVMTh6MjFFNEtNRGtTVHJIRDBQNkVYQTN3UmU1RkhQTmYvL0hoUTJH
+        YW01dUFRPT1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlJWlRDQ0Jr
+        MmdBd0lCQWdJSUd1WlF0TnB3dWtBd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
         eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
         SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
         Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReElq
-        QWdCZ05WXG5CQU1NR1dSbGRtVnNMbUpoYkcxdmNtRXVaWGhoYlhCc1pTNWpi
-        MjB3SGhjTk1qQXdOVEEwTURJd05EVXpXaGNOXG5ORGt4TWpBeE1UTXdNREF3
+        QWdCZ05WXG5CQU1NR1d4aGJXSmtZUzV6Y0dGeWRHRXVaWGhoYlhCc1pTNWpi
+        MjB3SGhjTk1qQXhNREEzTURReE16TXlXaGNOXG5ORGt4TWpBeE1UTXdNREF3
         V2pBaU1TQXdIZ1lEVlFRS0RCZGtkWEJzYVdOaGRHVmZhRzl6ZEc1aGJXVmZk
         R1Z6XG5kRENDQWlJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dJUEFEQ0NBZ29D
-        Z2dJQkFNYXJ3eGI5NDhvSVJ5VkttV2drXG5xL1lYWWVEUFR2MVJmM1dvbEJK
-        VHZnWjBTWkI3dkZnZW8yS2YzMlQ5bkZZVGNxeHZmb3RWM2lqalVuQ3BEajBL
-        XG4xSkFWM1hBZ2FYdTVrcy9ZK0FBYllLL2xOVG9ZNzlsRnhYdnlScmoyZ20z
-        S0tvdHNzdmhRVmgrSkFGUVAxRnJuXG50SmthaDN1eXlYblRqZG1LKzIxTnh3
-        UFdOR0pZY3RBckJ2QlYvdld6NzVDU3RzVC9UeFFvVDEzRWZ1RHFoeG1PXG5u
-        cXBPY1VPN0h6dldLTHVjMFFHd3AxM1ZYSUdOSGsrVU95Vk5kNzU2Z1E2RXhl
-        NU9qc25UOWc1bWRWVFJlSExHXG5IellEVU9DckFqcDBkNm9mSmR5SXRmdHpy
-        NURYbTRXUzB0dGMwWTMvM3hHd1g4Z2tOWWxXdkNRRU9aaEJyck1YXG5Dd3JJ
-        RmdkMzFZLzU3Zmh1Vlp0ckFsYkRVVjk1NEpoMythVXNDYWpqWXZHcUtqb2Z6
-        b0JiVWJ1UnY1MXU1MXF3XG5ESUNLczFtTk9oZW0xVlQxNVhjRksrdVVHRkJB
-        V0ZvVzBjYUVqZ1VXUUVXQVIzaktSMGhxSnUwRFBDd0NxOFhoXG5BNHJYbUdr
-        ZDJoT1BEZ2cxZDlPR1lOTjRrdTZ1cDBmWGYwbEtTSFdZdndBZzhxc1Zldkxq
-        SmUycW91ME1VZWVSXG5XSVNvMWRhbmJ1S2RtamJMb3B1M21rN3BleklIYWEw
-        Qko2R0xtazBwVDJFS3JOZThwaFNBbFBIUzB3N3hZWlpEXG5PWTB1aWNHZVRa
-        azQ2OGU2R2tSMXhuMTltT3ZteW1McUlTUjZvN3ROQjU0TGsxTy9pbW1Xb0pN
-        cEZpQjJvSExoXG5qQ3BBRVRza2hBQjFhMkFQMFd2SnNDWVJBZ01CQUFHamdn
+        Z2dJQkFKakoxM3hPK0dpRFQxcjRPQkh6XG5kUkE1eHJRYjZPUCtrYXAyL1k0
+        M0hLcXh3K0J4OUVHSG41RStubmRYMEl6b3VwU1dqbkY1d0FQRks2RVdOV3ZN
+        XG5NQnBBcEhqWCt6ZUd2MWlncGJ5R0FteXRldURYNEhmNW93aVNuTjFjWEU1
+        TldZdmsxUENncGRoN3BJVENsVjJCXG5DeTNTdW5ZbnhkUDdrR2JiZWdOWERC
+        bU1SSC9QSlJPVmJMZ1NWQW0vL3d4NDZROHFiWXZRd1ppekY2S01sMlBnXG5M
+        K25YWlM4UXZiWFlxQ0JET1h1N0dPOTc1RVJqSndDZ3VYZjdzYzk3TmNlMHBI
+        TFdmYmJsNzR6ZUQwUE84TzZZXG52Wk0yemM4eDNaVlBkTEJ0eGlPMHpXbytD
+        amgyNTdCNkVMQkZnZm9TKzg4ejQrZ3hDSnp4d3JxN01KOXY3bkJrXG5SNzFL
+        R0hlVXh0TGd1ZEdvc2dTVDZTdjc4VDRxVWdkaGh1bW9SV3M4RmYrQVpzaXdV
+        T3dSTHRlSFRxZHlzbm9zXG45MUFDMDFNL0V4QVU5MllXOFgyL2R1bEIzdkJk
+        OXFtdGlqUUFhUHZkeTdrMFdGN1RqSU0vc2FJS0FnRmI5b1YwXG4ycmplckZw
+        T3pKS21uTGFNeFpWc1NYMTRneUtwYmFCNGVuazhvQ0cwMGJrVjNrTHlLV1Vi
+        amFqR2IyNjJ2ZjA1XG5sbkRXV2tFU3E3Rnl5azM0SlFDQ0sxRU9vK2YwRk9N
+        VnJ2VmpXcWVCVEgxQjFUSnc1WE9vdklVbmxKZ3JISDBUXG53dUkwV2lnc1lQ
+        SkZFcFFLQlZ1SkkwRGJ5NjFsalg0d1A2MzVLZzhQZ0tiaHg4c3RKMldMRWp6
+        MWRLZmpBRGpwXG5NZmszY3R1S05zWDREN3EybmdNRDRwS3pBZ01CQUFHamdn
         TTZNSUlETmpBT0JnTlZIUThCQWY4RUJBTUNCTEF3XG5Fd1lEVlIwbEJBd3dD
         Z1lJS3dZQkJRVUhBd0l3Q1FZRFZSMFRCQUl3QURBUkJnbGdoa2dCaHZoQ0FR
-        RUVCQU1DXG5CYUF3SFFZRFZSME9CQllFRkxQTXNROVpyL0VKV0hSS09DeG11
-        K3dkbDMwdk1COEdBMVVkSXdRWU1CYUFGQlBzXG5pcGVVelc5UURKcWZmT1V4
-        Zkx2SGdIb3pNRHNHRUNzR0FRUUJrZ2dKQWE2ZDY3ZWZRd0VFSnd3bFpIVndi
+        RUVCQU1DXG5CYUF3SFFZRFZSME9CQllFRk5RWFV1SkpOSTNlbFBZdUh2WEFK
+        bW5GL1lZSk1COEdBMVVkSXdRWU1CYUFGSCtDXG43bC8zMkNHY0V4aDJ5aU11
+        blZvRFdiUy9NRHNHRUNzR0FRUUJrZ2dKQWE3UWlvN1RGd0VFSnd3bFpIVndi
         R2xqXG5ZWFJsWDJodmMzUnVZVzFsWDNSbGMzUmZkV1ZpWlhKZmNISnZaSFZq
-        ZERBV0JoQXJCZ0VFQVpJSUNRR3VuZXUzXG5uME1EQkFJTUFEQVdCaEFyQmdF
-        RUFaSUlDUUd1bmV1M24wTUNCQUlNQURBV0JoQXJCZ0VFQVpJSUNRR3VuZXUz
-        XG5uME1GQkFJTUFEQVpCaEFyQmdFRUFaSUlDUUt1bmV1M24wUUJCQVVNQTNs
-        MWJUQWtCaEVyQmdFRUFaSUlDUUt1XG5uZXUzbjBRQkFRUVBEQTExWldKbGNs
-        OWpiMjUwWlc1ME1ESUdFU3NHQVFRQmtnZ0pBcTZkNjdlZlJBRUNCQjBNXG5H
-        ekUxT0RnMU5UYzRPVE0xTnpGZmRXVmlaWEpmWTI5dWRHVnVkREFkQmhFckJn
-        RUVBWklJQ1FLdW5ldTNuMFFCXG5CUVFJREFaRGRYTjBiMjB3THdZUkt3WUJC
-        QUdTQ0FrQ3JwM3J0NTlFQVFZRUdnd1lMMlIxY0d4cFkyRjBaVjlvXG5iM04w
-        Ym1GdFpWOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxNmQ2N2VmUkFFSEJBSU1B
-        REFZQmhFckJnRUVBWklJXG5DUUt1bmV1M24wUUJDQVFEREFFeE1EVUdDaXNH
+        ZERBV0JoQXJCZ0VFQVpJSUNRR3UwSXFPXG4weGNEQkFJTUFEQVdCaEFyQmdF
+        RUFaSUlDUUd1MElxTzB4Y0NCQUlNQURBV0JoQXJCZ0VFQVpJSUNRR3UwSXFP
+        XG4weGNGQkFJTUFEQVpCaEFyQmdFRUFaSUlDUUt1MElxTzB4Z0JCQVVNQTNs
+        MWJUQWtCaEVyQmdFRUFaSUlDUUt1XG4wSXFPMHhnQkFRUVBEQTExWldKbGNs
+        OWpiMjUwWlc1ME1ESUdFU3NHQVFRQmtnZ0pBcTdRaW83VEdBRUNCQjBNXG5H
+        ekUyTURJd05EUXdNVEk1TlRGZmRXVmlaWEpmWTI5dWRHVnVkREFkQmhFckJn
+        RUVBWklJQ1FLdTBJcU8weGdCXG5CUVFJREFaRGRYTjBiMjB3THdZUkt3WUJC
+        QUdTQ0FrQ3J0Q0tqdE1ZQVFZRUdnd1lMMlIxY0d4cFkyRjBaVjlvXG5iM04w
+        Ym1GdFpWOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxN1FpbzdUR0FFSEJBSU1B
+        REFZQmhFckJnRUVBWklJXG5DUUt1MElxTzB4Z0JDQVFEREFFeE1EVUdDaXNH
         QVFRQmtnZ0pCQUVFSnd3bFpIVndiR2xqWVhSbFgyaHZjM1J1XG5ZVzFsWDNS
         bGMzUmZkV1ZpWlhKZmNISnZaSFZqZERBUUJnb3JCZ0VFQVpJSUNRUUNCQUlN
-        QURBZEJnb3JCZ0VFXG5BWklJQ1FRREJBOE1EVEUxT0RnMU5UYzRPVE0xTnpF
+        QURBZEJnb3JCZ0VFXG5BWklJQ1FRREJBOE1EVEUyTURJd05EUXdNVEk1TlRF
         d0VRWUtLd1lCQkFHU0NBa0VCUVFEREFFeE1DUUdDaXNHXG5BUVFCa2dnSkJB
-        WUVGZ3dVTWpBeU1DMHdOUzB3TkZRd01qb3dORG8xTTFvd0pBWUtLd1lCQkFH
+        WUVGZ3dVTWpBeU1DMHhNQzB3TjFRd05Eb3hNem96TWxvd0pBWUtLd1lCQkFH
         U0NBa0VCd1FXXG5EQlF5TURRNUxURXlMVEF4VkRFek9qQXdPakF3V2pBUkJn
         b3JCZ0VFQVpJSUNRUU1CQU1NQVRBd0VBWUtLd1lCXG5CQUdTQ0FrRUNnUUNE
         QUF3RUFZS0t3WUJCQUdTQ0FrRURRUUNEQUF3RVFZS0t3WUJCQUdTQ0FrRURn
         UUREQUV3XG5NQkVHQ2lzR0FRUUJrZ2dKQkFzRUF3d0JNVEFRQmdvckJnRUVB
-        WklJQ1FVQkJBSU1BREFOQmdrcWhraUc5dzBCXG5BUXNGQUFPQ0FRRUFBVFRJ
-        UGg4MDRaV2E3TDljUWpCZDVtNllCYlR5TWVyYXVhQ0xuSnMvSE5ZYUc0UWhD
-        SyszXG5BSmlVZThrdWxpR0NNZGFmRXYzR3l1U0tvNzJoK3N0OUh2emxnR2ZC
-        SlRSaVFkNWJBZVpzWERrY3JLWEpUYUdiXG5QcGwybEY4NG1LQ2dLenJra3ZR
-        ZE8zRFVFRUZrRVpKMmtuSmRKSmR6S21DTEhVQmk3QllDUGtrM0d2OHlrZXlP
-        XG5mdG1iWVJmTWtoSm1heXdkc21Oa04yTUx1YnFOcU5Vcm5PR2xxTkVrTi9C
-        TGtJYjRVMG1LelduY2hWOHhjMERoXG5qcmFRMlo3MlVPOWlTcW5LZ05BN1pj
-        NFNQK1dUQzFpYTIvc1J5TExtc1pCcm5Hd2V5Ykd3K3lIOENaOTAxckpMXG5J
-        TTJaSitMcjdJYTc3QklqUFpLVjAxd0RCVFZvYlZENm53PT1cbi0tLS0tRU5E
-        IENFUlRJRklDQVRFLS0tLS1cbiIsInNlcmlhbCI6eyJjcmVhdGVkIjoiMjAy
-        MC0wNS0wNFQwMjowNDo1MyswMDAwIiwidXBkYXRlZCI6IjIwMjAtMDUtMDRU
-        MDI6MDQ6NTMrMDAwMCIsImlkIjo0MDA3NzMyNjM2NjA2NDY4OTQsInNlcmlh
-        bCI6NDAwNzczMjYzNjYwNjQ2ODk0LCJleHBpcmF0aW9uIjoiMjA0OS0xMi0w
-        MVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2b2tlZCI6
-        ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2
-        ZGNlZTAwMDA3Iiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJk
-        aXNwbGF5TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiaHJlZiI6
-        Ii9vd25lcnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QifX0=
+        WklJQ1FVQkJBSU1BREFOQmdrcWhraUc5dzBCXG5BUXNGQUFPQ0FnRUFhcEtI
+        eTk5YjB0TUhuV0hjSTdJZUt1UU16cU9Yc2pteld4bERkUE5KL0dqa2NENlhr
+        RHdkXG5oMnRyOEE5UGo4Q1NMVXltSEVYMnpVUmExdFEvRmY5MXZwMXBzcFNw
+        ZGhhVTI5ZEp1QjNKRi9HcmFjdzhhUWZaXG5hRnM1SHRaR2lwejc4SklpczN0
+        NStOVHdvNldPQTZXbnhWenozVkYrKzd2aVdza1pMYmpaSTI0VWM1UEZzd0ZL
+        XG5pNllyeE1FZk5VRTZLYlQwazVjUlcvd0tOMlZvU2UzWnpuOUg4a2pUNjdE
+        aytqc1dTZ2MyQUdWRzd3ZUkzaC9RXG51MjZFcWdKZXVIekV6QkMrdTB0VEdt
+        Q29nQU54WG0wK2JjSm1mdlRtN21GcWEwOGVkT1dPaDZ1N2I2Z0lweXorXG5B
+        eWZVQ1FOYzJVZFFHckRvYVFLYmVTV2pRblZlWTg0YXFza1VYVWNNZE5wOVFB
+        dUFCSG54SlA5NHVMTkxZOHFRXG55cEhsb2ZGTk9idHpYeXYvaUtJWW9lTlRq
+        QkIxdERjaWM5WVRIZ3hjdUhqcXJaMGhHN0NmRE9NQ2lHRFBvNHBNXG5CVjRK
+        L3RRNnhXMXpTSTdnb0hwc3BMNnIxZHVRQURzSGd1TGhXazRPVG1VTno5VHFE
+        aTEwUTZKekdsTjhoWndIXG5WRFBuOVJ1N0NDOFMvL0c4NUJ1TFJHWE1VNnhO
+        a1R4MndNaDFZRnd1WmF3ZzByR0dwQlFvbXRnMFNBcnYvRFQzXG5YYlVTaldl
+        NXpMcGo3Vlhua2p2dWdrNGlCQUd0YUZaYmMxQWQvSS9ZQlFQQUR5V0QzWlRP
+        dzE4cDNCeWp5cWRWXG5Qdk84MFl5ajh3QnZzeE5MdUw1aVBjd3hrcUFOUS9O
+        aXQ1Z25vSzR2U0QyWGQ1MVBVejc2K29NPVxuLS0tLS1FTkQgQ0VSVElGSUNB
+        VEUtLS0tLVxuIiwic2VyaWFsIjp7ImNyZWF0ZWQiOiIyMDIwLTEwLTA3VDA0
+        OjEzOjMyKzAwMDAiLCJ1cGRhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozMisw
+        MDAwIiwiaWQiOjE5MzgzMjU0MjczMTg3MzMzNzYsInNlcmlhbCI6MTkzODMy
+        NTQyNzMxODczMzM3NiwiZXhwaXJhdGlvbiI6IjIwNDktMTItMDFUMTM6MDA6
+        MDArMDAwMCIsImNvbGxlY3RlZCI6ZmFsc2UsInJldm9rZWQiOmZhbHNlfSwi
+        b3duZXIiOnsiaWQiOiI0MDI4ZmE2NTc0ZmVhNWFkMDE3NTAxNDNhOGNlMDAz
+        YSIsImtleSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiZGlzcGxheU5h
+        bWUiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsImhyZWYiOiIvb3duZXJz
+        L2R1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0In19
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:33 GMT
 - request:
     method: post
-    uri: https://localhost:8443/candlepin/hypervisors/duplicate_hostname_test
+    uri: https://localhost:8443/candlepin/hypervisors/duplicate_hostname_test?reporter_id=100
     body:
       encoding: UTF-8
       base64_string: |
@@ -431,9 +439,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro",
-        oauth_nonce="4dtiG0Hf3JUI7lkxVtmZWnN3kLyZaohM2mJxJI2vc", oauth_signature="%2FUT5LjK1C8TujBiPO8qR8M31XdQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1588557894", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa",
+        oauth_nonce="LXZi4zPH13TVsmV6lD5VjaxIT1CgDIlDktZctu1r7A", oauth_signature="8kHNd54okE3VykJYncEndtk0oic%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -452,33 +460,33 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 524cfaa3-7198-418f-83e2-35696d8a0f0f
+      - 78dc5398-5b3b-425e-b1e3-c274f3ba1c0f
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:54 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDI3MjAwMGEiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzQrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYWUwODAwM2QiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
         eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjpudWxsLCJwcmluY2lwYWwiOiJmb3Jl
-        bWFuX2FkbWluIiwic3RhdGUiOiJRVUVVRUQiLCJwcmV2aW91c1N0YXRlIjoi
-        Q1JFQVRFRCIsInN0YXJ0VGltZSI6bnVsbCwiZW5kVGltZSI6bnVsbCwiYXR0
-        ZW1wdHMiOjAsIm1heEF0dGVtcHRzIjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMv
-        NDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZDI3MjAwMGEiLCJyZXN1bHREYXRh
-        IjpudWxsLCJrZXkiOiJIeXBlcnZpc29yVXBkYXRlSm9iIn0=
+        bWFuX2FkbWluIiwic3RhdGUiOiJDUkVBVEVEIiwicHJldmlvdXNTdGF0ZSI6
+        IkNSRUFURUQiLCJzdGFydFRpbWUiOm51bGwsImVuZFRpbWUiOm51bGwsImF0
+        dGVtcHRzIjowLCJtYXhBdHRlbXB0cyI6MSwic3RhdHVzUGF0aCI6Ii9qb2Jz
+        LzQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0M2FlMDgwMDNkIiwicmVzdWx0RGF0
+        YSI6bnVsbCwia2V5IjoiSHlwZXJ2aXNvclVwZGF0ZUpvYiJ9
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/jobs/4028faa771dd68d10171dd6dd272000a?result_data=true
+    uri: https://localhost:8443/candlepin/jobs/4028fa6574fea5ad01750143ae08003d?result_data=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -488,9 +496,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="XnVb0w17MaUp9NYG8lmdOFCztniiLK0JEymGZCKlf0",
-        oauth_signature="tKPB%2BhKdN6F2W6XWdxs0WUHy71w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557894", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="fXSOwRY8Sl0Mvt9mP3S4p77dywRLfJSCH3kd114eB0A",
+        oauth_signature="gaxecEGVj39ZKotfStsFu7Br57o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -507,97 +515,41 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7623f9e3-ed71-4b8a-9029-dea427c51e45
+      - e618698e-fc3f-4c42-af59-2ddf45fd77c7
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:54 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDI3MjAwMGEiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoiZGV2ZWwuYmFsbW9yYS5leGFtcGxl
-        LmNvbSIsInByaW5jaXBhbCI6ImZvcmVtYW5fYWRtaW4iLCJzdGF0ZSI6IlJV
-        Tk5JTkciLCJwcmV2aW91c1N0YXRlIjoiUVVFVUVEIiwic3RhcnRUaW1lIjoi
-        MjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwiZW5kVGltZSI6bnVsbCwiYXR0
-        ZW1wdHMiOjEsIm1heEF0dGVtcHRzIjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMv
-        NDAyOGZhYTc3MWRkNjhkMTAxNzFkZDZkZDI3MjAwMGEiLCJyZXN1bHREYXRh
-        IjpudWxsLCJrZXkiOiJIeXBlcnZpc29yVXBkYXRlSm9iIn0=
-    http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
-- request:
-    method: get
-    uri: https://localhost:8443/candlepin/jobs/4028faa771dd68d10171dd6dd272000a?result_data=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="nwlf8NZjZWcCyOHqPoOm6g75hann6dNPZQPF2Rywc",
-        oauth_signature="bauqg505MeTkfixa%2BO8RWHkWoU8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557894", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 0465b65b-6116-457b-94d9-85d075f3714f
-      X-Version:
-      - 3.1.10-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 04 May 2020 02:04:54 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDI3MjAwMGEiLCJuYW1lIjoiaHlwZXJ2aXNvcl91
-        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoiZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoiZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzQrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYWUwODAwM2QiLCJuYW1lIjoiSHlwZXJ2aXNvciBV
+        cGRhdGUiLCJncm91cCI6bnVsbCwib3JpZ2luIjoibGFtYmRhLnNwYXJ0YS5l
+        eGFtcGxlLmNvbSIsImV4ZWN1dG9yIjoibGFtYmRhLnNwYXJ0YS5leGFtcGxl
         LmNvbSIsInByaW5jaXBhbCI6ImZvcmVtYW5fYWRtaW4iLCJzdGF0ZSI6IkZJ
         TklTSEVEIiwicHJldmlvdXNTdGF0ZSI6IlJVTk5JTkciLCJzdGFydFRpbWUi
-        OiIyMDIwLTA1LTA0VDAyOjA0OjU0KzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0w
-        NS0wNFQwMjowNDo1NCswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
-        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhYTc3MWRkNjhkMTAxNzFk
-        ZDZkZDI3MjAwMGEiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOlt7InV1aWQi
-        OiJiYjUzNTdmNy1lNDczLTQ5YmYtODE4Ni00YTMyOThhMTZkNzYiLCJuYW1l
+        OiIyMDIwLTEwLTA3VDA0OjEzOjM0KzAwMDAiLCJlbmRUaW1lIjoiMjAyMC0x
+        MC0wN1QwNDoxMzozNCswMDAwIiwiYXR0ZW1wdHMiOjEsIm1heEF0dGVtcHRz
+        IjoxLCJzdGF0dXNQYXRoIjoiL2pvYnMvNDAyOGZhNjU3NGZlYTVhZDAxNzUw
+        MTQzYWUwODAwM2QiLCJyZXN1bHREYXRhIjp7ImNyZWF0ZWQiOlt7InV1aWQi
+        OiI5OTg4YjJhNS0wYjAyLTQxYjktOWNmNi1kZDYyZmJjZGMwNDUiLCJuYW1l
         IjoibG9jYWxob3N0Iiwib3duZXIiOnsia2V5IjoiZHVwbGljYXRlX2hvc3Ru
-        YW1lX3Rlc3QifX0seyJ1dWlkIjoiZjJjZDUwNGEtNGQ5My00Mjc2LTk5NGIt
-        NzBkMThhMjgzNzVkIiwibmFtZSI6ImxvY2FsaG9zdCIsIm93bmVyIjp7Imtl
+        YW1lX3Rlc3QifX0seyJ1dWlkIjoiY2MzMzczMTUtMDVmMC00YTAxLThkN2Yt
+        NGJjNzU5Y2EyNjlmIiwibmFtZSI6ImxvY2FsaG9zdCIsIm93bmVyIjp7Imtl
         eSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0In19XSwidXBkYXRlZCI6W10s
         InVuY2hhbmdlZCI6W10sImZhaWxlZFVwZGF0ZSI6W119LCJrZXkiOiJIeXBl
         cnZpc29yVXBkYXRlSm9iIn0=
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/bb5357f7-e473-49bf-8186-4a3298a16d76
+    uri: https://localhost:8443/candlepin/consumers/9988b2a5-0b02-41b9-9cf6-dd62fbcdc045
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -607,9 +559,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="9S77YcWNdRfkGtTCrmm3sRpnfBCVYDFm8gsqCO3Mz4",
-        oauth_signature="6HgDVWHNDMydqO0%2BuTZmTxl4ROo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557894", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="9bQUbMYz86gKQSn67Io1hZ1TrhUWD6ay1iaZ7brsU",
+        oauth_signature="MaUUKH6Ey0iDm1SLmPvDV6dMcBE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -626,49 +578,49 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9b3e8733-75c1-49b0-af65-80543a762cfb
+      - 31a689b0-4b15-4547-9f06-237632c1b86c
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:54 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDMwMzAwMGIiLCJ1dWlkIjoiYmI1MzU3ZjctZTQ3
-        My00OWJmLTgxODYtNGEzMjk4YTE2ZDc2IiwibmFtZSI6ImxvY2FsaG9zdCIs
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzQrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYWUyYTAwM2UiLCJ1dWlkIjoiOTk4OGIyYTUtMGIw
+        Mi00MWI5LTljZjYtZGQ2MmZiY2RjMDQ1IiwibmFtZSI6ImxvY2FsaG9zdCIs
         InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
         IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjoiIiwidXNhZ2UiOiIi
         LCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxsLCJvd25l
-        ciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGNlZTAwMDA3Iiwi
+        ciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0M2E4Y2UwMDNhIiwi
         a2V5IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJkaXNwbGF5TmFtZSI6
         ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvZHVw
         bGljYXRlX2hvc3RuYW1lX3Rlc3QifSwiZW52aXJvbm1lbnQiOm51bGwsImVu
         dGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5cGVydmlzb3IudHlwZSI6
         IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQocykiOiIxIiwiaHlwZXJ2
-        aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENoZWNraW4iOiIyMDIwLTA1
-        LTA0VDAyOjA0OjU0KzAwMDAiLCJpbnN0YWxsZWRQcm9kdWN0cyI6W10sImNh
+        aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENoZWNraW4iOiIyMDIwLTEw
+        LTA3VDA0OjEzOjM0KzAwMDAiLCJpbnN0YWxsZWRQcm9kdWN0cyI6W10sImNh
         bkFjdGl2YXRlIjpmYWxzZSwiY2FwYWJpbGl0aWVzIjpbXSwiaHlwZXJ2aXNv
-        cklkIjp7ImNyZWF0ZWQiOiIyMDIwLTA1LTA0VDAyOjA0OjU0KzAwMDAiLCJ1
-        cGRhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwiaWQiOiI0MDI4
-        ZmFhNzcxZGQ2OGQxMDE3MWRkNmRkMzA5MDAwZCIsImh5cGVydmlzb3JJZCI6
+        cklkIjp7ImNyZWF0ZWQiOiIyMDIwLTEwLTA3VDA0OjEzOjM0KzAwMDAiLCJ1
+        cGRhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwiaWQiOiI0MDI4
+        ZmE2NTc0ZmVhNWFkMDE3NTAxNDNhZTJiMDA0MCIsImh5cGVydmlzb3JJZCI6
         IjI2MWM0ZGNhLTcwMmYtNDJiMy1iOGVmLTJhNzJiNzdmN2VjMiIsInJlcG9y
-        dGVySWQiOm51bGx9LCJjb250ZW50VGFncyI6W10sImF1dG9oZWFsIjp0cnVl
-        LCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFjY2Vzc01vZGUiOm51bGws
-        InR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJoeXBlcnZpc29yIiwibWFu
-        aWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJocmVmIjoiL2NvbnN1bWVy
-        cy9iYjUzNTdmNy1lNDczLTQ5YmYtODE4Ni00YTMyOThhMTZkNzYiLCJyZWxl
-        YXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJpZENlcnQiOm51bGx9
+        dGVySWQiOiIxMDAifSwiY29udGVudFRhZ3MiOltdLCJhdXRvaGVhbCI6dHJ1
+        ZSwiYW5ub3RhdGlvbnMiOm51bGwsImNvbnRlbnRBY2Nlc3NNb2RlIjpudWxs
+        LCJ0eXBlIjp7ImlkIjoiMTAwNCIsImxhYmVsIjoiaHlwZXJ2aXNvciIsIm1h
+        bmlmZXN0IjpmYWxzZX0sImd1ZXN0SWRzIjpbXSwiaHJlZiI6Ii9jb25zdW1l
+        cnMvOTk4OGIyYTUtMGIwMi00MWI5LTljZjYtZGQ2MmZiY2RjMDQ1IiwicmVs
+        ZWFzZVZlciI6eyJyZWxlYXNlVmVyIjpudWxsfSwiaWRDZXJ0IjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/f2cd504a-4d93-4276-994b-70d18a28375d
+    uri: https://localhost:8443/candlepin/consumers/cc337315-05f0-4a01-8d7f-4bc759ca269f
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,9 +630,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="RwDo3PDLRC5GpcYfL9ynkVPodyWE22IwABexJXs8",
-        oauth_signature="l2zQPZGlA3N%2FoF4aTyFMYC3p9J0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557894", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="BV0z1oYeVYmPoW4N5HTBvSpQQijvw8CPHhrdBYIGsPU",
+        oauth_signature="NZYnzMVm%2FFMJ8m2fcEPXxxTcH24%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -697,49 +649,49 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 16146eb2-cf4b-492b-b3f0-e3e396578804
+      - 18faed08-15ef-459c-b88b-973a83dcdeb1
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:54 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMjAtMDUtMDRUMDI6MDQ6NTQrMDAwMCIsImlkIjoiNDAyOGZhYTc3
-        MWRkNjhkMTAxNzFkZDZkZDNhZTAwMGUiLCJ1dWlkIjoiZjJjZDUwNGEtNGQ5
-        My00Mjc2LTk5NGItNzBkMThhMjgzNzVkIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        eyJjcmVhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMjAtMTAtMDdUMDQ6MTM6MzQrMDAwMCIsImlkIjoiNDAyOGZhNjU3
+        NGZlYTVhZDAxNzUwMTQzYWU1ODAwNDEiLCJ1dWlkIjoiY2MzMzczMTUtMDVm
+        MC00YTAxLThkN2YtNGJjNzU5Y2EyNjlmIiwibmFtZSI6ImxvY2FsaG9zdCIs
         InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
         IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjoiIiwidXNhZ2UiOiIi
         LCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxsLCJvd25l
-        ciI6eyJpZCI6IjQwMjhmYWE3NzFkZDY4ZDEwMTcxZGQ2ZGNlZTAwMDA3Iiwi
+        ciI6eyJpZCI6IjQwMjhmYTY1NzRmZWE1YWQwMTc1MDE0M2E4Y2UwMDNhIiwi
         a2V5IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJkaXNwbGF5TmFtZSI6
         ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvZHVw
         bGljYXRlX2hvc3RuYW1lX3Rlc3QifSwiZW52aXJvbm1lbnQiOm51bGwsImVu
         dGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5cGVydmlzb3IudHlwZSI6
         IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQocykiOiIxIiwiaHlwZXJ2
-        aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENoZWNraW4iOiIyMDIwLTA1
-        LTA0VDAyOjA0OjU0KzAwMDAiLCJpbnN0YWxsZWRQcm9kdWN0cyI6W10sImNh
+        aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENoZWNraW4iOiIyMDIwLTEw
+        LTA3VDA0OjEzOjM0KzAwMDAiLCJpbnN0YWxsZWRQcm9kdWN0cyI6W10sImNh
         bkFjdGl2YXRlIjpmYWxzZSwiY2FwYWJpbGl0aWVzIjpbXSwiaHlwZXJ2aXNv
-        cklkIjp7ImNyZWF0ZWQiOiIyMDIwLTA1LTA0VDAyOjA0OjU0KzAwMDAiLCJ1
-        cGRhdGVkIjoiMjAyMC0wNS0wNFQwMjowNDo1NCswMDAwIiwiaWQiOiI0MDI4
-        ZmFhNzcxZGQ2OGQxMDE3MWRkNmRkM2FmMDAxMCIsImh5cGVydmlzb3JJZCI6
+        cklkIjp7ImNyZWF0ZWQiOiIyMDIwLTEwLTA3VDA0OjEzOjM0KzAwMDAiLCJ1
+        cGRhdGVkIjoiMjAyMC0xMC0wN1QwNDoxMzozNCswMDAwIiwiaWQiOiI0MDI4
+        ZmE2NTc0ZmVhNWFkMDE3NTAxNDNhZTU4MDA0MyIsImh5cGVydmlzb3JJZCI6
         IjJlNzhmNjQzLTFkMmYtNDVkMS1iMTkxLWQ5MzExNDdjYmRlMSIsInJlcG9y
-        dGVySWQiOm51bGx9LCJjb250ZW50VGFncyI6W10sImF1dG9oZWFsIjp0cnVl
-        LCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFjY2Vzc01vZGUiOm51bGws
-        InR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJoeXBlcnZpc29yIiwibWFu
-        aWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJocmVmIjoiL2NvbnN1bWVy
-        cy9mMmNkNTA0YS00ZDkzLTQyNzYtOTk0Yi03MGQxOGEyODM3NWQiLCJyZWxl
-        YXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJpZENlcnQiOm51bGx9
+        dGVySWQiOiIxMDAifSwiY29udGVudFRhZ3MiOltdLCJhdXRvaGVhbCI6dHJ1
+        ZSwiYW5ub3RhdGlvbnMiOm51bGwsImNvbnRlbnRBY2Nlc3NNb2RlIjpudWxs
+        LCJ0eXBlIjp7ImlkIjoiMTAwNCIsImxhYmVsIjoiaHlwZXJ2aXNvciIsIm1h
+        bmlmZXN0IjpmYWxzZX0sImd1ZXN0SWRzIjpbXSwiaHJlZiI6Ii9jb25zdW1l
+        cnMvY2MzMzczMTUtMDVmMC00YTAxLThkN2YtNGJjNzU5Y2EyNjlmIiwicmVs
+        ZWFzZVZlciI6eyJyZWxlYXNlVmVyIjpudWxsfSwiaWRDZXJ0IjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:54 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/bb5357f7-e473-49bf-8186-4a3298a16d76/guests
+    uri: https://localhost:8443/candlepin/consumers/9988b2a5-0b02-41b9-9cf6-dd62fbcdc045/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -749,9 +701,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="4Nc03RmLhCPhnmjJnZDwEx4BjZ2uUGKTvVWQP1gA",
-        oauth_signature="S52yea2JmNqcRiCSjms8JSI%2F6dg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557895", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="JtgaeOecUF2l11tDJanzXY47TjyYXSKgV7ajt95QuEs",
+        oauth_signature="aVA5UAzMnNtRdiZdg8OH05wAing%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -768,25 +720,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 0eacdf90-7d68-417b-829a-ce0310b26f89
+      - d1a0e561-2878-4f29-a0d4-4fbf4b1f4572
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:55 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:55 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 - request:
     method: get
-    uri: https://localhost:8443/candlepin/consumers/f2cd504a-4d93-4276-994b-70d18a28375d/guests
+    uri: https://localhost:8443/candlepin/consumers/cc337315-05f0-4a01-8d7f-4bc759ca269f/guests
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -796,9 +748,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Authorization:
-      - OAuth oauth_consumer_key="7Y5foFcBcAs5KwkNbtL4tijkyTzKvfro", oauth_nonce="Qn8cgSWdMEwaAwoJovXyEbDvQd455iPStogdURpln98",
-        oauth_signature="0OPwYNUD6m28%2Ff0fisMhFUkx55I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1588557895", oauth_version="1.0"
+      - OAuth oauth_consumer_key="wWpNfTXhdNtXKJty9WMqCNL7fXJWPECa", oauth_nonce="OUgmXCSi09KnYdMCzGXGtoQX30T7T9mRlO1RTfvz138",
+        oauth_signature="VisLxDPRqgnz3ShAqg7nPN%2FNIWM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1602044014", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -815,20 +767,20 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - a64c3bb2-02fa-4804-a398-7807508f9a45
+      - bd246682-bc3d-4ac4-ad4f-a7c7c42f27b7
       X-Version:
-      - 3.1.10-1
+      - 3.1.16-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 04 May 2020 02:04:55 GMT
+      - Wed, 07 Oct 2020 04:13:33 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 04 May 2020 02:04:55 GMT
+  recorded_at: Wed, 07 Oct 2020 04:13:34 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Virt-Who when it calls katello for a hypervisor update, send the
reporter_id parameter. This needs to be forwarded to candlepin for it
to be correctly processed.

This commit forwards the reporter-id in addition to other parameters.