### PR TITLE
Fixes #31377 - Drop turbolinks override on smart proxy

### DIFF
--- a/app/overrides/disable_turbolinks_on_proxies_index.rb
+++ b/app/overrides/disable_turbolinks_on_proxies_index.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(
-  :virtual_path => 'smart_proxies/index',
-  :name => 'disable_turbolinks_on_proxies_index',
-  :set_attributes => '.proxy-show',
-  :attributes => {'data-no-turbolink' => 'true'})


### PR DESCRIPTION
Foreman has removed Turbolinks so this override serves no purpose.

I have no idea if this is correct and probably needs a Redmine, but here is a PR so I don't forget.