### PR TITLE
Fixes #31053 - Add metadata field to ContentViewExportHistory

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class Api::V2::ContentViewVersionsController < Api::V2::ApiController
     include Concerns::Api::V2::BulkHostsExtensions
     include Katello::Concerns::FilteredAutoCompleteSearch
@@ -124,9 +125,9 @@ module Katello
     api :POST, "/content_view_versions/import", N_("Import a content view version")
     param :content_view_id, :number, :desc => N_("Content view identifier"), :required => true
     param :path, String, :desc => N_("Directory containing the exported Content View Version"), :required => true
-    param :metadata, Hash, :desc => N_("If path does not contain the export metadata it must be provided."), :required => false
+    param :metadata, Hash, :desc => N_("Metadata taken from the upstream export history for this Content View Version"), :required => true
     def import
-      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path], metadata: params[:metadata])
+      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path], metadata: metadata_params)
       respond_for_async :resource => task
     end
 
@@ -356,6 +357,17 @@ module Katello
 
       async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @version, destination_server: params[:destination_server],
                                                                                                chunk_size: params[:chunk_size_mb])
+    end
+
+    def metadata_params
+      params.require(:metadata).permit(
+        :organization,
+        :content_view,
+        :repository_mapping,
+        content_view_version: [:major, :minor]
+      ).tap do |nested|
+        nested[:repository_mapping] = params[:metadata].require(:repository_mapping).permit!
+      end
     end
   end
 end

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -124,7 +124,7 @@ module Katello
     api :POST, "/content_view_versions/import", N_("Import a content view version")
     param :content_view_id, :number, :desc => N_("Content view identifier"), :required => true
     param :path, String, :desc => N_("Directory containing the exported Content View Version"), :required => true
-    param :metadata, String, :desc => N_("If path does not contain the export metadata it must be provided."), :required => false
+    param :metadata, Hash, :desc => N_("If path does not contain the export metadata it must be provided."), :required => false
     def import
       task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path], metadata: params[:metadata])
       respond_for_async :resource => task

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -364,6 +364,7 @@ module Katello
         :organization,
         :content_view,
         :repository_mapping,
+        :toc,
         content_view_version: [:major, :minor]
       ).tap do |nested|
         nested[:repository_mapping] = params[:metadata].require(:repository_mapping).permit!

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -123,9 +123,10 @@ module Katello
 
     api :POST, "/content_view_versions/import", N_("Import a content view version")
     param :content_view_id, :number, :desc => N_("Content view identifier"), :required => true
-    param :path, String, :desc => N_("Import path"), :required => true
+    param :path, String, :desc => N_("Directory containing the exported Content View Version"), :required => true
+    param :metadata, String, :desc => N_("If path does not contain the export metadata it must be provided."), :required => false
     def import
-      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path])
+      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path], metadata: params[:metadata])
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -53,7 +53,7 @@ module Actions
             if separated_repo_map[:pulp3_yum].keys.flatten.present? &&
                 SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
               if import_only
-                handle_import(version, options.slice(:path, metadata))
+                handle_import(version, options.slice(:path, :metadata))
               else
                 plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)
               end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -9,7 +9,6 @@ module Actions
         def plan(content_view, description = "", options = {})
           action_subject(content_view)
           import_only = options.fetch(:import_only, false)
-          path = options[:path]
           content_view.check_ready_to_publish! unless import_only
 
           if options[:repos_units].present?
@@ -54,7 +53,7 @@ module Actions
             if separated_repo_map[:pulp3_yum].keys.flatten.present? &&
                 SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
               if import_only
-                handle_import(version, path)
+                handle_import(version, path: options[:path], metadata: options[:metadata])
               else
                 plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)
               end
@@ -188,8 +187,8 @@ module Actions
           end
         end
 
-        def handle_import(version, path)
-          plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Import, version, path: path)
+        def handle_import(version, path:, metadata:)
+          plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Import, version, path: path, metadata: metadata)
           plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::CopyVersionUnitsToLibrary, version)
           concurrence do
             version.importable_repositories.pluck(:id).each do |id|

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -53,7 +53,7 @@ module Actions
             if separated_repo_map[:pulp3_yum].keys.flatten.present? &&
                 SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
               if import_only
-                handle_import(version, path: options[:path], metadata: options[:metadata])
+                handle_import(version, options.slice(:path, metadata))
               else
                 plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)
               end

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -10,14 +10,10 @@ module Actions
             fail ::Katello::HttpErrors::BadRequest, _("This API endpoint is only valid for Pulp 3 repositories.")
           end
           ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path, assert_metadata: metadata.nil?)
-          metadata_json = if metadata
-                            JSON.parse(metadata).with_indifferent_access
-                          else
-                            ::Katello::Pulp3::ContentViewVersion::Import.metadata(path)
-                          end
+          metadata ||= ::Katello::Pulp3::ContentViewVersion::Import.metadata(path)
 
-          major = metadata_json[:content_view_version][:major]
-          minor = metadata_json[:content_view_version][:minor]
+          major = metadata[:content_view_version][:major]
+          minor = metadata[:content_view_version][:minor]
 
           if ::Katello::ContentViewVersion.where(major: major, minor: minor, content_view: content_view).exists?
             cvv_name = "#{content_view.name} #{major}.#{minor}"

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -4,13 +4,12 @@ module Actions
       class Import < Actions::EntryAction
         PULP_USER = 'pulp'.freeze
 
-        def plan(content_view, path:, metadata: nil)
+        def plan(content_view, path:, metadata:)
           content_view.check_ready_to_import!
           unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
             fail ::Katello::HttpErrors::BadRequest, _("This API endpoint is only valid for Pulp 3 repositories.")
           end
-          ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path, assert_metadata: metadata.nil?)
-          metadata ||= ::Katello::Pulp3::ContentViewVersion::Import.metadata(path)
+          ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(path)
 
           major = metadata[:content_view_version][:major]
           minor = metadata[:content_view_version][:minor]
@@ -23,6 +22,7 @@ module Actions
 
           plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
                         path: path,
+                        metadata: metadata,
                         import_only: true,
                         major: major,
                         minor: minor)

--- a/app/lib/actions/pulp3/content_view_version/create_importer.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_importer.rb
@@ -6,13 +6,17 @@ module Actions
           param :smart_proxy_id, Integer
           param :content_view_version_id, Integer
           param :path, String
+          param :metadata, Hash
         end
 
         def run
           cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
-          output[:importer_data] = ::Katello::Pulp3::ContentViewVersion::Import.new(smart_proxy: smart_proxy,
-                                                                            content_view_version: cvv,
-                                                                            path: input[:path]).create_importer
+          output[:importer_data] = ::Katello::Pulp3::ContentViewVersion::Import.new(
+            smart_proxy: smart_proxy,
+            content_view_version: cvv,
+            path: input[:path],
+            metadata: input[:metadata]
+          ).create_importer
         end
       end
     end

--- a/app/lib/actions/pulp3/content_view_version/import.rb
+++ b/app/lib/actions/pulp3/content_view_version/import.rb
@@ -7,13 +7,17 @@ module Actions
           param :smart_proxy_id, Integer
           param :importer_data, Hash
           param :path, String
+          param :metadata, Hash
         end
 
         def invoke_external_task
           cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
-          output[:pulp_tasks] = ::Katello::Pulp3::ContentViewVersion::Import.new(smart_proxy: smart_proxy,
-                                                   content_view_version: cvv,
-                                                   path: input[:path]).create_import(input[:importer_data][:pulp_href])
+          output[:pulp_tasks] = ::Katello::Pulp3::ContentViewVersion::Import.new(
+            smart_proxy: smart_proxy,
+            content_view_version: cvv,
+            path: input[:path],
+            metadata: input[:metadata]
+          ).create_import(input[:importer_data][:pulp_href])
         end
       end
     end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
@@ -60,10 +60,12 @@ module Actions
                                                                :smart_proxy => smart_proxy).generate_metadata
             toc = Dir.glob("#{path}/*toc.json").first
             export_metadata[:toc] = File.basename(toc) if toc
-            ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: input[:content_view_version_id],
-                                                               destination_server: input[:destination_server],
-                                                               path: path,
-                                                               metadata: export_metadata)
+            ::Katello::ContentViewVersionExportHistory.create!(
+              content_view_version_id: input[:content_view_version_id],
+              destination_server: input[:destination_server],
+              path: path,
+              metadata: export_metadata
+            )
           end
 
           def humanized_name

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
@@ -54,16 +54,16 @@ module Actions
             file_name = output[:exported_file_checksum].first&.first
             path = File.dirname(file_name.to_s)
             output[:export_path] = path
-            ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: input[:content_view_version_id],
-                                                               destination_server: input[:destination_server],
-                                                               path: path)
             cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
 
             export_metadata = ::Katello::Pulp3::ContentViewVersion::Export.new(:content_view_version => cvv,
                                                                :smart_proxy => smart_proxy).generate_metadata
             toc = Dir.glob("#{path}/*toc.json").first
             export_metadata[:toc] = File.basename(toc) if toc
-            File.write("#{path}/#{::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE}", export_metadata.to_json)
+            ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: input[:content_view_version_id],
+                                                               destination_server: input[:destination_server],
+                                                               path: path,
+                                                               metadata: export_metadata)
           end
 
           def humanized_name

--- a/app/lib/actions/pulp3/orchestration/content_view_version/import.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/import.rb
@@ -3,20 +3,26 @@ module Actions
     module Orchestration
       module ContentViewVersion
         class Import < Actions::EntryAction
-          def plan(content_view_version, path:)
+          def plan(content_view_version, path:, metadata:)
             action_subject(content_view_version)
             sequence do
               smart_proxy = SmartProxy.pulp_primary!
-              importer_output = plan_action(::Actions::Pulp3::ContentViewVersion::CreateImporter,
-                                           content_view_version_id: content_view_version.id,
-                                           smart_proxy_id: smart_proxy.id,
-                                           path: path).output
+              importer_output = plan_action(
+                ::Actions::Pulp3::ContentViewVersion::CreateImporter,
+                content_view_version_id: content_view_version.id,
+                smart_proxy_id: smart_proxy.id,
+                path: path,
+                metadata: metadata
+              ).output
 
-              import_output = plan_action(::Actions::Pulp3::ContentViewVersion::Import,
-                                           content_view_version_id: content_view_version.id,
-                                           smart_proxy_id: smart_proxy.id,
-                                           importer_data: importer_output[:importer_data],
-                                           path: path).output
+              import_output = plan_action(
+                ::Actions::Pulp3::ContentViewVersion::Import,
+                content_view_version_id: content_view_version.id,
+                smart_proxy_id: smart_proxy.id,
+                importer_data: importer_output[:importer_data],
+                path: path,
+                metadata: metadata
+              ).output
 
               plan_action(Actions::Pulp3::Repository::SaveVersions, content_view_version.importable_repositories.pluck(:id),
                           tasks: import_output[:pulp_tasks])

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -7,6 +7,7 @@ module Katello
     validates :content_view_version_id, :presence => true
     validates :destination_server, :presence => true, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
     validates :metadata, :presence => true
+    serialize :metadata, Hash
 
     scope :with_organization_id, ->(organization_id) do
       where(:content_view_version_id => ContentViewVersion.with_organization_id(organization_id))

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -6,6 +6,7 @@ module Katello
     validates_lengths_from_database
     validates :content_view_version_id, :presence => true
     validates :destination_server, :presence => true, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
+    validates :metadata, :presence => true
 
     scope :with_organization_id, ->(organization_id) do
       where(:content_view_version_id => ContentViewVersion.with_organization_id(organization_id))

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -3,7 +3,6 @@ module Katello
     module ContentViewVersion
       class Export
         include ImportExportCommon
-        METADATA_FILE = "metadata.json".freeze
 
         def initialize(smart_proxy:, content_view_version: nil, destination_server: nil)
           @smart_proxy = smart_proxy

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -5,15 +5,16 @@ module Katello
         include ImportExportCommon
         BASEDIR = '/var/lib/pulp'.freeze
 
-        def initialize(smart_proxy:, content_view_version: nil, path: nil)
+        def initialize(smart_proxy:, content_view_version:, path:, metadata:)
           @smart_proxy = smart_proxy
           @content_view_version = content_view_version
           @path = path
+          @metadata = metadata
         end
 
         def repository_mapping
           mapping = {}
-          metadata[:repository_mapping].each do |key, value|
+          @metadata[:repository_mapping].each do |key, value|
             repo = @content_view_version.importable_repositories.joins(:root, :product).
                         where("#{::Katello::Product.table_name}" => {:name => value[:product]},
                                                   "#{::Katello::RootRepository.table_name}" => {:name => value[:repository]}).first
@@ -30,7 +31,7 @@ module Katello
         end
 
         def create_import(importer_href)
-          [api.import_api.create(importer_href, toc: "#{@path}/#{metadata[:toc]}")]
+          [api.import_api.create(importer_href, toc: "#{@path}/#{@metadata[:toc]}")]
         end
 
         def fetch_import(importer_href)
@@ -43,28 +44,13 @@ module Katello
           api.importer_api.delete(importer_href)
         end
 
-        def metadata
-          @metadata ||= self.class.metadata(@path)
-        end
-
         class << self
-          def metadata(path)
-            JSON.parse(File.read("#{path}/#{Export::METADATA_FILE}")).with_indifferent_access
-          end
-
-          def check_permissions!(path, assert_metadata: true)
+          def check_permissions!(path)
             fail _("Invalid path specified.") if path.blank? || !File.directory?(path)
             fail _("The import path must be in a subdirectory under '%s'." % BASEDIR) unless path.starts_with?(BASEDIR)
-
-            metadata_file = "#{path}/#{::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE}"
-            if assert_metadata
-              fail _("Could not find metadata.json at '%s'." % metadata_file) unless File.exist?(metadata_file)
-              fail _("Unable to read the metadata.json at '%s'." % metadata_file) unless File.readable?(metadata_file)
-            end
-
             fail _("Pulp user or group unable to read content in '%s'." % path) unless pulp_user_accessible?(path)
+
             Dir.glob("#{path}/*").each do |file|
-              next if file == metadata_file
               fail _("Pulp user or group unable to read '%s'." % file) unless pulp_user_accessible?(file)
             end
           end

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -52,12 +52,16 @@ module Katello
             JSON.parse(File.read("#{path}/#{Export::METADATA_FILE}")).with_indifferent_access
           end
 
-          def check_permissions!(path)
+          def check_permissions!(path, assert_metadata: true)
             fail _("Invalid path specified.") if path.blank? || !File.directory?(path)
             fail _("The import path must be in a subdirectory under '%s'." % BASEDIR) unless path.starts_with?(BASEDIR)
+
             metadata_file = "#{path}/#{::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE}"
-            fail _("Could not find metadata.json at '%s'." % metadata_file) unless File.exist?(metadata_file)
-            fail _("Unable to read the metadata.json at '%s'." % metadata_file) unless File.readable?(metadata_file)
+            if assert_metadata
+              fail _("Could not find metadata.json at '%s'." % metadata_file) unless File.exist?(metadata_file)
+              fail _("Unable to read the metadata.json at '%s'." % metadata_file) unless File.readable?(metadata_file)
+            end
+
             fail _("Pulp user or group unable to read content in '%s'." % path) unless pulp_user_accessible?(path)
             Dir.glob("#{path}/*").each do |file|
               next if file == metadata_file

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -5,7 +5,7 @@ module Katello
         include ImportExportCommon
         BASEDIR = '/var/lib/pulp'.freeze
 
-        def initialize(smart_proxy:, content_view_version:, path:, metadata:)
+        def initialize(smart_proxy:, content_view_version: nil, path: nil, metadata: nil)
           @smart_proxy = smart_proxy
           @content_view_version = content_view_version
           @path = path

--- a/app/views/katello/api/v2/content_view_version_export_histories/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_version_export_histories/show.json.rabl
@@ -1,6 +1,6 @@
 object @resource
 
-attributes :destination_server, :path, :id
+attributes :destination_server, :path, :id, :metadata
 
 node :content_view_version do |h|
   h.content_view_version.name

--- a/db/migrate/20201012192035_add_metadata_to_katello_content_view_version_export_history.rb
+++ b/db/migrate/20201012192035_add_metadata_to_katello_content_view_version_export_history.rb
@@ -1,0 +1,5 @@
+class AddMetadataToKatelloContentViewVersionExportHistory < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_content_view_version_export_histories, :metadata, :text
+  end
+end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -13,6 +13,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.13:republish_deb_metadata'},
     {:name => 'katello:upgrades:3.15:set_sub_facet_dmi_uuid'},
     {:name => 'katello:upgrades:3.15:reindex_rpm_modular'},
-    {:name => 'katello:upgrades:3.16:update_applicable_el8_hosts'}
+    {:name => 'katello:upgrades:3.16:update_applicable_el8_hosts'},
+    {:name => 'katello:upgrades:3.18:add_cvv_export_history_metadata'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.18/add_cvv_export_history_metadata.rb
+++ b/lib/katello/tasks/upgrades/3.18/add_cvv_export_history_metadata.rb
@@ -1,0 +1,18 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.18' do
+      task :add_cvv_export_history_metadata => ['environment', 'check_ping'] do
+        smart_proxy = SmartProxy.pulp_primary!
+
+        Katello::ContentViewVersionExportHistory.includes(:content_view_version).find_each do |export_history|
+          export = ::Katello::Pulp3::ContentViewVersion::Export.new(
+            content_view_version: export_history.content_view_version,
+            smart_proxy: smart_proxy
+          )
+
+          export_history.update(metadata: export.generate_metadata)
+        end
+      end
+    end
+  end
+end

--- a/lib/katello/tasks/upgrades/3.18/add_cvv_export_history_metadata.rb
+++ b/lib/katello/tasks/upgrades/3.18/add_cvv_export_history_metadata.rb
@@ -4,7 +4,7 @@ namespace :katello do
       task :add_cvv_export_history_metadata => ['environment', 'check_ping'] do
         smart_proxy = SmartProxy.pulp_primary!
 
-        Katello::ContentViewVersionExportHistory.includes(:content_view_version).find_each do |export_history|
+        Katello::ContentViewVersionExportHistory.includes(:content_view_version).where(metadata: nil).find_each do |export_history|
           export = ::Katello::Pulp3::ContentViewVersion::Export.new(
             content_view_version: export_history.content_view_version,
             smart_proxy: smart_proxy

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -78,19 +78,18 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     it 'gives precendence to metadata param over file' do
-      metadata = "{\"content_view_version\":{\"major\":\"1\",\"minor\":\"2\"}}"
-      metadata_json = JSON.parse(metadata).with_indifferent_access
+      metadata = {content_view_version: {major: 1, minor: 2}}
       ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(@import_export_dir, assert_metadata: false).returns
 
-      plan_action(action, content_view, path: @import_export_dir, metadata: "{\"content_view_version\":{\"major\":\"1\",\"minor\":\"2\"}}")
+      plan_action(action, content_view, path: @import_export_dir, metadata: metadata)
 
       assert_action_planned_with(action,
                                   ::Actions::Katello::ContentView::Publish,
                                   content_view, '',
                                   path: @import_export_dir,
                                   import_only: true,
-                                  major: metadata_json[:content_view_version][:major],
-                                  minor: metadata_json[:content_view_version][:minor])
+                                  major: metadata[:content_view_version][:major],
+                                  minor: metadata[:content_view_version][:minor])
     end
 
     it 'Import should plan the full tree appropriately' do

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -38,6 +38,7 @@ module ::Actions::Katello::ContentViewVersion
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
       ::Katello::Repository.any_instance.stubs(:pulp_scratchpad_checksum_type).returns(nil)
+      @import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
     end
   end
 
@@ -47,48 +48,61 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     it 'Import should fail on importing content for an existing versions' do
-      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(@import_export_dir, assert_metadata: true).returns
       metadata = { content_view_version: { major: content_view_version.major, minor: content_view_version.minor} }
 
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(@import_export_dir).returns(metadata)
       exception = assert_raises(RuntimeError) do
-        plan_action(action, content_view, path: import_export_dir)
+        plan_action(action, content_view, path: @import_export_dir)
       end
       assert_match(/'#{content_view_version.name}' already exists/, exception.message)
     end
 
     it 'Import should plan properly' do
-      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(@import_export_dir, assert_metadata: true).returns
 
       exporter = fetch_exporter(smart_proxy: SmartProxy.pulp_primary,
                                  content_view_version: content_view_version,
                                  destination_server: "foo")
       metadata = exporter.generate_metadata
       metadata[:content_view_version][:major] += 10
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
-      plan_action(action, content_view, path: import_export_dir)
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(@import_export_dir).returns(metadata)
+      plan_action(action, content_view, path: @import_export_dir)
       assert_action_planned_with(action,
                                   ::Actions::Katello::ContentView::Publish,
                                   content_view, '',
-                                  path: import_export_dir,
+                                  path: @import_export_dir,
                                   import_only: true,
                                   major: metadata[:content_view_version][:major],
                                   minor: metadata[:content_view_version][:minor])
     end
 
+    it 'gives precendence to metadata param over file' do
+      metadata = "{\"content_view_version\":{\"major\":\"1\",\"minor\":\"2\"}}"
+      metadata_json = JSON.parse(metadata).with_indifferent_access
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(@import_export_dir, assert_metadata: false).returns
+
+      plan_action(action, content_view, path: @import_export_dir, metadata: "{\"content_view_version\":{\"major\":\"1\",\"minor\":\"2\"}}")
+
+      assert_action_planned_with(action,
+                                  ::Actions::Katello::ContentView::Publish,
+                                  content_view, '',
+                                  path: @import_export_dir,
+                                  import_only: true,
+                                  major: metadata_json[:content_view_version][:major],
+                                  minor: metadata_json[:content_view_version][:minor])
+    end
+
     it 'Import should plan the full tree appropriately' do
-      import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(import_export_dir).returns
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:check_permissions!).with(@import_export_dir, assert_metadata: true).returns
       exporter = fetch_exporter(smart_proxy: SmartProxy.pulp_primary,
                                  content_view_version: content_view_version,
                                  destination_server: "foo")
       metadata = exporter.generate_metadata
       metadata[:content_view_version][:major] += 10
-      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(import_export_dir).returns(metadata)
+      ::Katello::Pulp3::ContentViewVersion::Import.expects(:metadata).with(@import_export_dir).returns(metadata)
       generated_cvv = nil
-      tree = plan_action_tree(action_class, content_view, path: import_export_dir)
+      tree = plan_action_tree(action_class, content_view, path: @import_export_dir)
 
       assert_empty tree.errors
       assert_tree_planned_steps(tree, Actions::Katello::ContentView::AddToEnvironment)
@@ -98,7 +112,7 @@ module ::Actions::Katello::ContentViewVersion
 
       assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::CreateImporter) do |input|
         assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-        assert_equal import_export_dir, input[:path]
+        assert_equal @import_export_dir, input[:path]
         generated_cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
         assert_equal content_view_version.content_view.id, generated_cvv.content_view.id
         assert_equal metadata[:content_view_version][:major], generated_cvv.major
@@ -107,7 +121,7 @@ module ::Actions::Katello::ContentViewVersion
 
       assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::Import) do |input|
         assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-        assert_equal import_export_dir, input[:path]
+        assert_equal @import_export_dir, input[:path]
         assert_equal generated_cvv.id, input[:content_view_version_id]
         refute_nil input[:importer_data]
       end

--- a/test/actions/pulp3/content_view_version/export_test.rb
+++ b/test/actions/pulp3/content_view_version/export_test.rb
@@ -59,11 +59,12 @@ module ::Actions::Pulp3::ContentView
     def test_export
       Actions::Pulp3::Orchestration::ContentViewVersion::Export.any_instance.expects(:action_subject).with(@content_view_version)
       File.expects(:directory?).returns(true).at_least_once
-      File.expects(:write).returns.with do |path|
-        assert path.end_with?(::Katello::Pulp3::ContentViewVersion::Export::METADATA_FILE)
-      end
 
       output = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @content_view_version, destination_server: "foo", chunk_size: 0.1).output
+
+      export_history = Katello::ContentViewVersionExportHistory.find_by(content_view_version_id: @content_view_version.id, destination_server: 'foo')
+
+      assert export_history.metadata
       refute_empty output[:export_path]
       assert output[:exported_file_checksum].length > 1
       assert_includes output[:export_path], 'foo'

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -218,9 +218,27 @@ module Katello
     end
 
     def test_import
-      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: {'foo' => 'bar'}).returns({})
+      metadata = {
+        organization: "org name",
+        repository_mapping: {
+          'repo name' => {
+            repository: 'root repo name',
+            product: 'product name',
+            redhat: true
+          }
+        },
+        content_view: "cv name",
+        content_view_version: {
+          major: "4",
+          minor: "5"
+        }
+      }
 
-      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: {foo: :bar}}
+      metadata_params = ActionController::Parameters.new(metadata).permit!
+
+      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: metadata_params).returns({})
+
+      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: metadata}
 
       assert_response :success
     end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -217,6 +217,14 @@ module Katello
       end
     end
 
+    def test_import
+      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: '{}').returns({})
+
+      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: '{}'}
+
+      assert_response :success
+    end
+
     def test_show_protected
       allowed_perms = [@view_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -227,6 +227,7 @@ module Katello
             redhat: true
           }
         },
+        toc: "toc file name",
         content_view: "cv name",
         content_view_version: {
           major: "4",

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -218,9 +218,9 @@ module Katello
     end
 
     def test_import
-      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: '{}').returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: {'foo' => 'bar'}).returns({})
 
-      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: '{}'}
+      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: {foo: :bar}}
 
       assert_response :success
     end

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -12,16 +12,19 @@ module Katello
       path = "/tmp"
       ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
                                                                           destination_server: destination,
+                                                                          metadata: {foo: :bar},
                                                                           path: path)
       assert_raises ActiveRecord::RecordInvalid do
         ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
                                                                   destination_server: destination,
+                                                                  metadata: {foo: :bar},
                                                                   path: path)
       end
 
       assert_nothing_raised do
         ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
                                                                 destination_server: destination + "foo",
+                                                                metadata: {foo: :bar},
                                                                 path: path)
       end
     end

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -29,38 +29,7 @@ module Katello
             assert_match(/import path must be in a subdirectory under/, exception.message)
           end
 
-          it "fails if not a metadata json found" do
-            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures')
-            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
-              exception = assert_raises(RuntimeError) do
-                ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir)
-              end
-              assert_match(/Could not find metadata/, exception.message)
-            end
-          end
-
-          it "can skip the metadata json check" do
-            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures')
-            File.expects(:readable?).with("#{import_export_dir}/metadata.json").never
-            ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accessible?).at_least_once.returns(true)
-            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
-              assert ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir, assert_metadata: false)
-            end
-          end
-
-          it "fails if not able to read metadata json" do
-            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-            File.expects(:readable?).with("#{import_export_dir}/metadata.json").returns(false)
-
-            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
-              exception = assert_raises(RuntimeError) do
-                ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir)
-              end
-              assert_match(/Unable to read the metadata/, exception.message)
-            end
-          end
-
-          it "fails if pulp user is not able to access metadata json" do
+          it "fails if pulp user is not able to access the export path" do
             import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
             ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accessible?).with(import_export_dir).returns(false)
 

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -42,8 +42,9 @@ module Katello
           it "can skip the metadata json check" do
             import_export_dir = File.join(Katello::Engine.root, 'test/fixtures')
             File.expects(:readable?).with("#{import_export_dir}/metadata.json").never
+            ::Katello::Pulp3::ContentViewVersion::Import.expects(:pulp_user_accessible?).at_least_once.returns(true)
             stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
-              ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir, assert_metadata: false)
+              assert ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir, assert_metadata: false)
             end
           end
 

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -39,6 +39,14 @@ module Katello
             end
           end
 
+          it "can skip the metadata json check" do
+            import_export_dir = File.join(Katello::Engine.root, 'test/fixtures')
+            File.expects(:readable?).with("#{import_export_dir}/metadata.json").never
+            stub_constant(::Katello::Pulp3::ContentViewVersion::Import, :BASEDIR, import_export_dir) do
+              ::Katello::Pulp3::ContentViewVersion::Import.check_permissions!(import_export_dir, assert_metadata: false)
+            end
+          end
+
           it "fails if not able to read metadata json" do
             import_export_dir = File.join(Katello::Engine.root, 'test/fixtures/import-export')
             File.expects(:readable?).with("#{import_export_dir}/metadata.json").returns(false)


### PR DESCRIPTION
- Adds `metadata` text field to the ContentViewExportHistory
- No longer writes metadata.json to disk
- Adds `metadata` field to /content_view_versions/export_histories API response
- Adds `metadata` parameter to /content_view_versions/import API which takes precedence over the metadata.json in the `path` parameter, if any
`check_permissions!` can optionally ignore checking metadata.json presence+readability based on API usage
- Clarified Import API `path` param description
- Upgrade rake task since export histories API is in 3.17
