### PR TITLE
Refs #30994 - Add ability to set system purpose via bulk actions

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-system-purpose-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-system-purpose-modal.controller.js
@@ -1,0 +1,112 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-hosts.controller:ContentHostsBulkSystemPurposeModalController
+ *
+ * @requires $scope
+ * @requires $uibModalInstance
+ * @requires HostBulkAction
+ * @requires Organization
+ * @requires CurrentOrganization
+ * @requires Notification
+ * @requires hostIds
+ *
+ * @description
+ *   A controller for providing bulk action functionality for setting system purpose values
+ */
+angular.module('Bastion.content-hosts').controller('ContentHostsBulkSystemPurposeModalController',
+    ['$scope', '$uibModalInstance', 'HostBulkAction', 'Organization', 'CurrentOrganization', 'Notification', 'hostIds',
+    function ($scope, $uibModalInstance, HostBulkAction, Organization, CurrentOrganization, Notification, hostIds) {
+
+        $scope.organization = Organization.get({id: CurrentOrganization});
+
+        $scope.purposeAddonsList = function () {
+            var defaultOptions = ['No Change', 'None (Clear)'];
+            if ($scope.organization.system_purposes && $scope.organization.system_purposes.addons) {
+                return defaultOptions.concat($scope.organization.system_purposes.addons);
+            }
+            return [];
+        };
+
+        $scope.defaultUsages = ['No change', 'None (Clear)', 'Production', 'Development/Test', 'Disaster Recovery'];
+        $scope.defaultRoles = ['No change', 'None (Clear)', 'Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
+        $scope.defaultServiceLevels = ['No change', 'None (Clear)', 'Self-Support', 'Standard', 'Premium'];
+
+        $scope.hostCount = hostIds.included.ids.length;
+
+        $scope.selectedUsages = $scope.defaultUsages[0];
+        $scope.selectedRoles = $scope.defaultRoles[0];
+        $scope.selectedServiceLevels = $scope.defaultServiceLevels[0];
+
+        $scope.selected = {
+           addons: undefined
+        };
+
+        $scope.selectedItemToParam = function (item) {
+            var mapping = {
+                "None (Clear)": "",
+                "No change": null,
+                "": []
+            };
+            if (Array.isArray(item)) {
+                return $scope.selectedAddonsToParam(item);
+            }
+            if (mapping.hasOwnProperty(item)) {
+                return mapping[item];
+            }
+            return item;
+        };
+
+        $scope.selectedAddonsToParam = function (addons) {
+            var intentOptions = ['No Change', 'None (Clear)'];
+
+            var userIntent = intentOptions.filter(function(val) {
+                return addons.indexOf(val) !== -1;
+            });
+
+            if (userIntent.length === 0) {
+                return addons;
+            }
+
+            if (userIntent.includes('No Change')) {
+                return null;
+            }
+
+            if (userIntent.includes('None (Clear)') && addons.length === 1) {
+                return [];
+            } if (userIntent.includes('None (Clear)') && addons.length > 1) {
+                addons.shift();
+                return addons;
+            }
+        };
+
+        function actionParams() {
+            var params = hostIds;
+
+            params['purpose_usage'] = $scope.selectedItemToParam($scope.selectedUsages);
+            params['purpose_role'] = $scope.selectedItemToParam($scope.selectedRoles);
+            params['purpose_addons'] = $scope.selectedItemToParam($scope.selectedAddons);
+            params['service_level'] = $scope.selectedItemToParam($scope.selectedServiceLevels);
+
+            return params;
+        }
+
+        $scope.performAction = function () {
+            HostBulkAction.systemPurpose(actionParams(), function (task) {
+            $scope.ok();
+            $scope.transitionTo('content-hosts.bulk-task', {taskId: task.id});
+        }, function (response) {
+            angular.forEach(response.data.errors, function (error) {
+                Notification.setErrorMessage(error);
+            });
+        });
+        };
+
+        $scope.ok = function () {
+            $uibModalInstance.close();
+        };
+
+        $scope.cancel = function () {
+            $uibModalInstance.dismiss('cancel');
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-system-purpose-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-system-purpose-modal.html
@@ -1,0 +1,78 @@
+<div data-extend-template="components/views/bst-modal.html">
+  <h4 data-block="modal-header" translate>Content Host System Purpose</h4>
+
+  <div data-block="modal-body">
+    <h4 translate>Assign System Purpose:</h4>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <div bst-global-notification></div>
+      </div>
+    </div>
+
+    <form name="contentHostContentForm" class="form" ng-hide="content.workingMode">
+      <div>
+        <label translate>Service Level:</label>
+
+        <select type="select"
+                ng-options="item for item in defaultServiceLevels"
+                ng-model="selectedServiceLevels">
+        </select>
+      <br /><br />
+
+        <label translate>Usage Type:</label>
+
+        <select type="select"
+                ng-options="item for item in defaultUsages"
+                ng-model="selectedRoles">
+        </select>
+        <br /><br />
+
+        <label translate>Role:</label>
+
+        <select type="select"
+                ng-options="item for item in defaultRoles"
+                ng-model="selectedUsages">
+        </select>
+        <br /><br />
+
+        <label ng-hide="!purposeAddonsList().length" translate>Add ons:</label>
+        <div class="help-block" style="text-align:left;">
+          <p translate>ctrl-click or shift-click to select multiple Add ons</p>
+        </div>
+
+        <select multiple ng-multiple="true"
+                ng-hide="!purposeAddonsList().length"
+                ng-options="item for item in purposeAddonsList()"
+                ng-model="selectedAddons">
+        </select>
+        <br /><br />
+
+      </div>
+
+      <div bst-alert="info" ng-show="showConfirm">
+        <span translate>
+          Set System Purpose values on {{ hostCount }} selected content hosts?
+        </span>
+        <div>
+          <br />
+          <button type="button" class="btn btn-primary" ng-click="showConfirm = false; performAction()" translate>Assign</button>
+        </div>
+      </div>
+
+      <button class="btn btn-primary"
+              type="button"
+              ng-hide="showConfirm"
+              ng-click="showConfirm = true;">
+        <span translate>Assign</span>
+      </button>
+
+    </form>
+  </div>
+
+  <div data-block="modal-footer">
+    <button type="button" class="btn btn-default" ng-click="cancel()" translate>
+      Cancel
+    </button>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
@@ -91,6 +91,17 @@ angular.module('Bastion.content-hosts').service('ContentHostsModalHelper', ['$ui
             });
         };
 
+        this.openSystemPurposeModal = function() {
+            $uibModal.open({
+                templateUrl: 'content-hosts/bulk/views/content-hosts-bulk-system-purpose-modal.html',
+                controller: 'ContentHostsBulkSystemPurposeModalController',
+                size: 'lg',
+                resolve: {
+                    hostIds: this.resolveFunc()
+                }
+            });
+        };
+
         this.openModuleStreamsModal = function() {
             $uibModal.open({
                 templateUrl: 'content-hosts/bulk/views/content-host-bulk-module-streams-modal.html',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -160,6 +160,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
             ContentHostsModalHelper.openModuleStreamsModal();
         };
 
+        $scope.openSystemPurposeModal = function () {
+            nutupane.invalidate();
+            ContentHostsModalHelper.openSystemPurposeModal();
+        };
+
         $scope.openTracesModal = function () {
             nutupane.invalidate();
             ContentHostsModalHelper.openTracesModal();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -52,6 +52,10 @@
         </li>
 
         <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openSystemPurposeModal()" disable-link="table.numSelected === 0" translate>Manage System Purpose</a>
+        </li>
+
+        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
           <a ng-click="openTracesModal()" disable-link="table.numSelected === 0" translate>Manage Host Traces</a>
         </li>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
@@ -77,6 +77,10 @@ angular.module('Bastion.host-collections').controller('HostCollectionDetailsCont
             ContentHostsModalHelper.openSubscriptionsModal();
         };
 
+        $scope.openSystemPurposeModal = function () {
+            ContentHostsModalHelper.openSystemPurposeModal();
+        };
+
         $scope.openModuleStreamsModal = function () {
             ContentHostsModalHelper.openModuleStreamsModal();
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-info.html
@@ -100,6 +100,12 @@
           </a>
         </li>
 
+        <li>
+          <a translate ng-click="openSystemPurposeModal()">
+            System Purpose Management
+          </a>
+        </li>
+
         <li bst-feature-flag="lifecycle_environments">
           <a translate ng-click="openEnvironmentModal()">
             Change assigned Lifecycle Environment or Content View

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
@@ -27,7 +27,8 @@ angular.module('Bastion.hosts').factory('HostBulkAction',
             availableIncrementalUpdates: {method: 'POST', isArray: true, params: {action: 'available_incremental_updates'}},
             moduleStreams: {method: 'POST', params: {action: 'module_streams'}},
             traces: {method: 'POST', params: {action: 'traces'}},
-            resolveTraces: {method: 'PUT', isArray: true, params: {action: 'resolve_traces'}}
+            resolveTraces: {method: 'PUT', isArray: true, params: {action: 'resolve_traces'}},
+            systemPurpose: {method: 'PUT', params: {action: 'system_purpose'}}
         });
 
     }]

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-system-purpose-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-system-purpose-modal.controller.test.js
@@ -1,0 +1,105 @@
+
+describe('Controller: ContentHostsBulkSystemPurposeModalController', function() {
+    var $scope, $uibModalInstance, BulkAction, Organization, CurrentOrganization, hostIds;
+
+    beforeEach(module('Bastion.content-hosts', 'Bastion.test-mocks'));
+
+    beforeEach(inject(function($injector) {
+        BulkAction = {
+            systemPurpose: function() {}
+        };
+        $httpBackend = $injector.get('$httpBackend');
+
+        CurrentOrganization = '1';
+        hostIds = {included: {ids: [1, 2]}};
+
+        mockOrg = {
+            id: '1',
+            service_levels: ['Premium'],
+            system_purposes: {
+              roles: ['custom-role'],
+              usage: ['custom-usage'],
+              addons: ['custom-addon']
+            }
+          }
+  
+          Organization = $injector.get('Organization');
+          spyOn(Organization, 'get').and.callThrough();
+          $httpBackend.expectGET('katello/api/v2/organizations/1').respond(mockOrg);
+
+        $uibModalInstance = {
+            close: function () {},
+            dismiss: function () {}
+        };
+
+        hostIds = {included: {ids: [1, 2]}};
+    }));
+
+    beforeEach(inject(function($controller, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $controller('ContentHostsBulkSystemPurposeModalController', {
+            $scope: $scope,
+            $uibModalInstance: $uibModalInstance,
+            hostIds: hostIds,
+            HostBulkAction: BulkAction,
+            Organization: Organization,
+            CurrentOrganization: CurrentOrganization
+        });
+    }));
+
+    it("checks options to show correctly", function() {
+        var serviceLevels = $scope.defaultServiceLevels;
+        var usageRoles = $scope.defaultRoles;
+        var usages = $scope.defaultUsages;
+        $httpBackend.flush();
+        var addons = $scope.purposeAddonsList();
+
+        expect(serviceLevels.length).toEqual(5);
+        expect(serviceLevels.sort()).toEqual(['No change', 'None (Clear)', 'Self-Support', 'Standard', 'Premium'].sort());
+        expect(usageRoles.length).toEqual(5);
+        expect(usageRoles.sort()).toEqual(['No change', 'None (Clear)', 'Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'].sort());
+        expect(usages.length).toEqual(5);
+        expect(usages.sort()).toEqual(['No change', 'None (Clear)', 'Production', 'Development/Test', 'Disaster Recovery'].sort());
+        expect(addons.length).toEqual(3);
+        expect(addons.sort()).toEqual(['No Change', 'None (Clear)', 'custom-addon'].sort());
+    });
+
+    it("should perform the function and transition", function() {
+        var params = _.extend(hostIds, {purpose_usage: null, purpose_role: null, service_level: null, purpose_addons: null});
+        spyOn(BulkAction, 'systemPurpose');
+
+        $scope.performAction();
+        spyOn($scope, "transitionTo");
+        expect(BulkAction.systemPurpose).toHaveBeenCalledWith(params, jasmine.any(Function), jasmine.any(Function));
+    });
+
+    it("should return null when 'No Change' is selected", function() {
+        var param = $scope.selectedItemToParam(['No Change']);
+        expect(param).toEqual(null);
+    });
+
+    it("should return empty string/array when 'None (Clear)' is only selected", function() {
+        var stringParam = $scope.selectedItemToParam('None (Clear)');
+        var addonParam = $scope.selectedItemToParam(['None (Clear)']);
+        expect(stringParam).toEqual("");
+        expect(addonParam).toEqual([]);
+    });
+
+    it("should return addons when 'None (Clear)' is selected with other addons", function() {
+        var addonParam = $scope.selectedItemToParam(['None (Clear)', 'custom-addon']);
+        expect(addonParam).toEqual(['custom-addon'])
+    });
+
+    it("provides a function for closing the modal", function () {
+        spyOn($uibModalInstance, 'close');
+        $scope.ok();
+        expect($uibModalInstance.close).toHaveBeenCalled();
+    });
+
+    it("provides a function for cancelling the modal", function () {
+        spyOn($uibModalInstance, 'dismiss');
+        $scope.cancel();
+        expect($uibModalInstance.dismiss).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
This PR gives the ability to set system purpose values on content hosts via the bulk actions. 

* You can add/update/delete `Service Level` `Usage Type` `Role` and `Add ons`
* The `Add ons` selection will be hidden unless there are purpose addons present in Candlepin.
* By default the form opens up to not change anything if you were to press assign. Under that is an option to clear the values. 
* Since the `Add ons` selection is hidden, running assign on hosts will not touch the purpose addon value in the host subscription facet. 

The changes can then be seen by going into the individual content host details page. 