### PR TITLE
Fixes #31050 - Global Registration fails when host not found

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -5,7 +5,11 @@ module Katello
 
       def prepare_host
         if params['uuid']
-          @host = Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid']).host
+          @host = Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid'])&.host
+          if @host.nil?
+            msg = N_("Host was not found by the subscription UUID: '%s', this can happen if the host is registered already, but not to this Foreman") % params['uuid']
+            fail ActiveRecord::RecordNotFound, msg
+          end
           @host.assign_attributes(host_params('host'))
           @host.save!
         else


### PR DESCRIPTION
Fix for case, when the host is already registered by
subscription-manager, but does not exists in Foreman.

How to reproduce:
* On the host run `curl --user admin:changeme -X GET "https://centos7-katello-devel-stable.example.com/register?activation_key=YOUR_KEY" | bash`
* Delete host in Foreman
* Run again`curl --user admin:changeme -X GET "https://centos7-katello-devel-stable.example.com/register?activation_key=YOUR_KEY" | bash`
