### PR TITLE
Add a Slot to manage manifest modal

### DIFF
--- a/webpack/__mocks__/foremanReact/components/common/Fill/GlobalFill.js
+++ b/webpack/__mocks__/foremanReact/components/common/Fill/GlobalFill.js
@@ -1,3 +1,0 @@
-
-const addGlobalFill = () => jest.fn();
-export default addGlobalFill;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Grid, Col, Row, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
 import { Button, Spinner } from 'patternfly-react';
 import ForemanModal from 'foremanReact/components/ForemanModal';
+import Slot from 'foremanReact/components/common/Slot';
 import { translate as __ } from 'foremanReact/common/I18n';
 import TooltipButton from '../../../components/TooltipButton';
 import { LoadingState } from '../../../components/LoadingState';
@@ -250,17 +251,17 @@ class ManageManifestModal extends Component {
                                 />
                               }
                               {canDeleteManifest &&
-                              <React.Fragment>
-                                <TooltipButton
-                                  disabled={!isManifestImported || actionInProgress}
-                                  bsStyle="danger"
-                                  onClick={this.showDeleteManifestModal}
-                                  title={__('Delete')}
-                                  tooltipId="delete-manifest-button-tooltip"
-                                  tooltipText={this.disabledTooltipText()}
-                                  tooltipPlacement="top"
-                                />
-                              </React.Fragment>
+                                <React.Fragment>
+                                  <TooltipButton
+                                    disabled={!isManifestImported || actionInProgress}
+                                    bsStyle="danger"
+                                    onClick={this.showDeleteManifestModal}
+                                    title={__('Delete')}
+                                    tooltipId="delete-manifest-button-tooltip"
+                                    tooltipText={this.disabledTooltipText()}
+                                    tooltipPlacement="top"
+                                  />
+                                </React.Fragment>
                               }
                             </div>
                             <ForemanModal title={__('Confirm delete manifest')} id={DELETE_MANIFEST_MODAL_ID}>
@@ -280,6 +281,7 @@ class ManageManifestModal extends Component {
                     </FormGroup>
                   </React.Fragment>
                 }
+                <Slot id="katello-manage-manifest-form" multi />
               </Form>
             </Tab>
           }

--- a/webpack/test-utils/react-testing-lib-wrapper.js
+++ b/webpack/test-utils/react-testing-lib-wrapper.js
@@ -5,6 +5,7 @@ import React from 'react';
 import thunk from 'redux-thunk';
 import Immutable from 'seamless-immutable';
 import { APIMiddleware, reducers as apiReducer } from 'foremanReact/redux/API';
+import { reducers as fillReducers } from 'foremanReact/components/common/Fill';
 import { reducers as foremanModalReducer } from 'foremanReact/components/ForemanModal';
 import { STATUS } from 'foremanReact/constants';
 import { render, waitFor } from '@testing-library/react';
@@ -33,6 +34,7 @@ function renderWithRedux(
     katello: allKatelloReducers,
     ...apiReducer,
     ...foremanModalReducer,
+    ...fillReducers,
   });
 
   // Namespacing the initial state as well
@@ -45,6 +47,7 @@ function renderWithRedux(
         settings: initialSettingsState,
       },
     },
+    extendable: {},
     ...initialState,
   });
   const middlewares = applyMiddleware(thunk, APIMiddleware);


### PR DESCRIPTION
Adding a slot to be able to extend the manage manifest modal from core/plugins,
@shimshtein @amirfefer @johnpmitsch @jturel it would be awesome if we could get this in before the upcoming code-freeze :)

What has been done here:
- Moved the two main components upper in the component
  (didn't want to create a huge refactor in this PR and move them to another files)
- Used the `Slot` component from foreman with the id of `'katello-manage-manifest-form'`
- Used the `Fill` component in the `ComponentDidUpdate` section. the same `Fill` can be used from another plugin.

 