### PR TITLE
Fixes #31152 - add auth for sync controller

### DIFF
--- a/app/controllers/katello/api/v2/sync_controller.rb
+++ b/app/controllers/katello/api/v2/sync_controller.rb
@@ -15,23 +15,23 @@ module Katello
     # used in unit tests
     def find_object
       if params.key?(:product_id)
-        @obj = find_product
+        @obj = find_syncable_product
       elsif params.key?(:repository_id)
-        @obj = find_repository
+        @obj = find_syncable_repository
       else
         fail HttpErrors::NotFound, N_("Couldn't find subject of synchronization") if @obj.nil?
       end
       @obj
     end
 
-    def find_product
+    def find_syncable_product
       fail _("Organization required") if @organization.nil?
       @product = Product.syncable.find_by_cp_id(params[:product_id], @organization)
       fail HttpErrors::NotFound, _("Couldn't find product with id '%s'") % params[:product_id] if @product.nil?
       @product
     end
 
-    def find_repository
+    def find_syncable_repository
       @repository = Repository.syncable.find_by(:id => params[:repository_id])
       fail HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:repository_id] if @repository.nil?
       @repository


### PR DESCRIPTION
It seems like the `SyncController` is all set permissions-wise.  I figured I would change the `find_*` methods to match our new naming.  Let me know if I missed anything.