### PR TITLE
Fixes #31167 - fix authorization for repository sets controller

### DIFF
--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -292,7 +292,8 @@ module Katello
                                                         :repo_puppet_modules,
                                                         :repo_compare_errata,
                                                         :repo_compare_packages,
-                                                        :repo_compare_puppet_modules]
+                                                        :repo_compare_puppet_modules],
+                           'katello/api/v2/repository_sets' => [:index, :show, :available_repositories, :auto_complete_search]
                          },
                          :resource_type => 'Katello::Product',
                          :finder_scope => :readable
@@ -308,7 +309,8 @@ module Katello
                            'katello/api/v2/repositories' => [:create, :update, :remove_content, :import_uploads, :upload_content, :republish, :verify_checksum],
                            'katello/api/v2/products_bulk_actions' => [:update_sync_plans, :update_http_proxy, :verify_checksum_products],
                            'katello/api/v2/content_uploads' => [:create, :update, :destroy],
-                           'katello/api/v2/organizations' => [:repo_discover, :cancel_repo_discover]
+                           'katello/api/v2/organizations' => [:repo_discover, :cancel_repo_discover],
+                           'katello/api/v2/repository_sets' => [:enable, :disable]
                          },
                          :resource_type => 'Katello::Product',
                          :finder_scope => :editable
@@ -341,11 +343,10 @@ module Katello
                          :finder_scope => :exportable
     end
 
-    def subscription_permissions # rubocop:disable Metrics/MethodLength
+    def subscription_permissions
       @plugin.permission :view_subscriptions,
                          {
-                           'katello/api/v2/subscriptions' => [:index, :show, :available, :manifest_history, :auto_complete_search],
-                           'katello/api/v2/repository_sets' => [:index, :show, :available_repositories, :auto_complete_search]
+                           'katello/api/v2/subscriptions' => [:index, :show, :available, :manifest_history, :auto_complete_search]
                          },
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :attach_subscriptions,
@@ -360,8 +361,7 @@ module Katello
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :import_manifest,
                          {
-                           'katello/api/v2/subscriptions' => [:upload, :refresh_manifest],
-                           'katello/api/v2/repository_sets' => [:enable, :disable]
+                           'katello/api/v2/subscriptions' => [:upload, :refresh_manifest]
                          },
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :delete_manifest,
@@ -376,11 +376,10 @@ module Katello
                          :resource_type => 'Katello::Subscription'
     end
 
-    def sync_plan_permissions # rubocop:disable Metrics/MethodLength
+    def sync_plan_permissions
       @plugin.permission :view_sync_plans,
                          {
-                           'katello/api/v2/sync_plans' => [:index, :show, :add_products, :remove_products, :available_products, :auto_complete_search],
-                           'katello/api/v2/products' => [:index]
+                           'katello/api/v2/sync_plans' => [:index, :show, :add_products, :remove_products, :available_products, :auto_complete_search]
                          },
                          :resource_type => 'Katello::SyncPlan',
                          :finder_scope => :readable

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -58,7 +58,7 @@ module Katello
     end
 
     def test_index_protected
-      allowed_perms = [@read_permission, @sync_plan_permission]
+      allowed_perms = [@read_permission]
       denied_perms = [@create_permission, @delete_permission, @update_permission]
 
       assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -10,10 +10,10 @@ module Katello
     end
 
     def permissions
-      @view_permission = :view_subscriptions
+      @view_permission = :view_products
+      @edit_permission = :edit_products
       @attach_permission = :attach_subscriptions
       @unattach_permission = :unattach_subscriptions
-      @import_permission = :import_manifest
       @delete_permission = :delete_manifest
     end
 
@@ -183,7 +183,7 @@ module Katello
 
     def test_available_repositories_protected
       allowed_perms = [@view_permission]
-      denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @import_permission]
+      denied_perms = [@attach_permission, @unattach_permission, @delete_permission]
 
       assert_protected_action(:available_repositories, allowed_perms, denied_perms) do
         get :available_repositories, params: { :product_id => @product.id, :id => @content_id }
@@ -196,7 +196,7 @@ module Katello
 
       results = JSON.parse(response.body)
 
-      error_message = "Couldn't find product with id '#{fake_product_id}'"
+      error_message = "Could not find product resource with id #{fake_product_id}"
 
       assert_response :not_found
       assert_includes results["errors"], error_message
@@ -225,7 +225,7 @@ module Katello
     end
 
     def test_enable_protected
-      allowed_perms = [@import_permission]
+      allowed_perms = [@edit_permission]
       denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @view_permission]
 
       assert_protected_action(:enable, allowed_perms, denied_perms) do
@@ -256,7 +256,7 @@ module Katello
     end
 
     def test_disable_protected
-      allowed_perms = [@import_permission]
+      allowed_perms = [@edit_permission]
       denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @view_permission]
 
       assert_protected_action(:disable, allowed_perms, denied_perms) do


### PR DESCRIPTION
This PR attempts to shore up the authorization deficiencies in Katello in the repository sets controller. Substantial modifications were also incorporated from https://github.com/jjeffers/katello/pull/1 authored by @jturel 

The additional PR cleaned up many resource methods and simplified obtaining readable products by subscription.