### PR TITLE
Refs #30987 - add cards to the experimental host details page

### DIFF
--- a/webpack/fills_index.js
+++ b/webpack/fills_index.js
@@ -1,10 +1,59 @@
 import React from 'react';
 import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
 import { registerReducer } from 'foremanReact/common/MountingService';
-
+import CardItem from 'foremanReact/components/common/CardTemplate/CardItem';
 import SystemStatuses from './components/extensions/about';
 import extendReducer from './components/extensions/reducers';
 
 registerReducer('katelloExtends', extendReducer);
+addGlobalFill(
+  'aboutFooterSlot',
+  '[katello]AboutSystemStatuses',
+  <SystemStatuses key="katello-system-statuses" />,
+  100
+);
 
-addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
+addGlobalFill(
+  'details-cards',
+  'dada',
+  <CardItem
+    content={[
+      {
+        id: 1,
+        name: 'item 1',
+        key: 'key 1',
+        value: 'value 1',
+      },
+      {
+        id: 2,
+        name: 'item 2',
+        key: 'key 2',
+        value: 'value 2',
+      },
+    ]}
+    header="Katello Card 1"
+  />,
+  300
+);
+addGlobalFill(
+  'details-cards',
+  'dada2',
+  <CardItem
+    content={[
+      {
+        id: 1,
+        name: 'item 1',
+        key: 'key 1',
+        value: 'value 1',
+      },
+      {
+        id: 2,
+        name: 'item 2',
+        key: 'key 2',
+        value: 'value 2',
+      },
+    ]}
+    header="Katello Card 2"
+  />,
+  1000
+);


### PR DESCRIPTION
This PR shows how to add pf4 cards into a foreman core page (experimental host details for now)
![katello-cards](https://user-images.githubusercontent.com/11807069/97222423-73a0dc80-17df-11eb-8955-51c26791b3bb.png)
Works with https://github.com/theforeman/foreman/pull/8086
