### PR TITLE
Fixes #31182 - Add Activation Keys to Global Registration UI form

### DIFF
--- a/app/controllers/katello/concerns/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/registration_controller_extensions.rb
@@ -1,0 +1,16 @@
+module Katello
+  module Concerns
+    module RegistrationControllerExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :format_activation_key, only: [:create]
+      end
+
+      def format_activation_key
+        return if params[:activation_key].blank?
+        params[:activation_key] = params[:activation_key].split(',').map(&:strip).reject(&:blank?).join(',')
+      end
+    end
+  end
+end

--- a/app/views/foreman/hosts/_registration.html.erb
+++ b/app/views/foreman/hosts/_registration.html.erb
@@ -1,0 +1,12 @@
+<div class='form-group'>
+  <label class='col-md-2 control-label'>
+    <%= _('Activation Key(s)') %>
+    <% help = _('Activation key(s) for Subscription Manager. Required for CentOS and Red Hat Enterprise Linux. Multiple keys add separated by comma, example: key1,key2,key3.') %>
+    <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+      <span class="pficon pficon-info "></span>
+    </a>
+  </label>
+  <div class='col-md-4'>
+    <%= text_field_tag 'activation_key', params[:activation_key], class: 'form-control' %>
+  </div>
+</div>

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -178,6 +178,7 @@ module Katello
       ::SmartProxiesController.include Katello::Concerns::SmartProxiesControllerExtensions
       ::Foreman::Plugin.fact_importer_registry.register(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactImporter)
       ::FactParser.register_fact_parser(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactParser)
+      ::RegistrationController.include Katello::Concerns::RegistrationControllerExtensions
 
       #Helper Extensions
       ::SmartProxiesController.class_eval do

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -3,7 +3,7 @@ require 'katello/repository_types.rb'
 require 'katello/host_status_manager.rb'
 # rubocop:disable Metrics/BlockLength
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 1.24'
+  requires_foreman '>= 2.3'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'),
            :icon => 'fa fa-book', :after => :monitor_menu do
@@ -282,6 +282,11 @@ Foreman::Plugin.register :katello do
 
   # Extend Global Registration endpoint
   extend_allowed_registration_vars :activation_key
+
+  # Extend Global Registration UI
+  extend_page 'registration/_form' do |cx|
+    cx.add_pagelet :global_registration, name: N_('Katello'), partial: 'foreman/hosts/registration', priority: 100, id: 'katello'
+  end
 
   extend_page "smart_proxies/show" do |cx|
     cx.add_pagelet :details_content,

--- a/test/controllers/foreman/registration_controller_test.rb
+++ b/test/controllers/foreman/registration_controller_test.rb
@@ -1,0 +1,51 @@
+require 'katello_test_helper'
+
+class RegistrationControllerTest < ActionController::TestCase
+  def setup
+    @tax_params = { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id }
+
+    setup_controller_defaults(false)
+    setup_foreman_routes
+    login_user(User.find(users(:admin).id))
+  end
+
+  def test_one_key
+    post :create, params: { activation_key: ' key1 ' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1')
+  end
+
+  def test_two_keys
+    post :create, params: { activation_key: ' key1 , key2 , ' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1%2Ckey2')
+  end
+
+  def test_formatting1
+    post :create, params: { activation_key: ' , ,,key1, , key2, , ,,,  , ,' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1%2Ckey2')
+  end
+
+  def test_key_with_space
+    post :create, params: { activation_key: ' key1 with space ' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1+with+space')
+  end
+
+  def test_keys_with_spaces
+    post :create, params: { activation_key: ' key1 with space , key2 with space ' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1+with+space%2Ckey2+with+space')
+  end
+
+  def test_formatting_keys
+    post :create, params: { activation_key: ' key1 with space , key2 with space ,, ,, , ' }.merge(@tax_params)
+    assert_includes(assigns(:command), 'activation_key=key1+with+space%2Ckey2+with+space')
+  end
+
+  def test_empty_key
+    post :create, params: { activation_key: '' }.merge(@tax_params)
+    refute_includes(assigns(:command), 'activation_key=')
+  end
+
+  def test_nil_key
+    post :create, params: @tax_params
+    refute_includes(assigns(:command), 'activation_key=')
+  end
+end


### PR DESCRIPTION
Add Activation key select to Registration Form (Hosts > All Hosts > Register Host)

![katello](https://user-images.githubusercontent.com/59385976/97296904-98359c80-1851-11eb-9d3e-28e904647b41.png)
