### PR TITLE
Fixes #31189 - Add import-only flag to Content Views

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -21,6 +21,7 @@ module Katello
       param :component_ids, Array, :desc => N_("List of component content view version ids for composite views")
       param :auto_publish, :bool, :desc => N_("Enable/Disable auto publish of composite view")
       param :solve_dependencies, :bool, :desc => N_("Solve RPM dependencies by default on Content View publish, defaults to false")
+      param :import_only, :bool, :desc => N_("Designate this Content View for importing from upstream servers only. Defaults to false")
     end
 
     def filtered_associations
@@ -237,7 +238,7 @@ module Katello
     end
 
     def view_params
-      attrs = [:name, :description, :force_puppet_environment, :auto_publish, :solve_dependencies,
+      attrs = [:name, :description, :force_puppet_environment, :auto_publish, :solve_dependencies, :import_only,
                :default, :created_at, :updated_at, :next_version, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
       if (!@content_view || !@content_view.composite?)

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -21,7 +21,7 @@ module Katello
       param :component_ids, Array, :desc => N_("List of component content view version ids for composite views")
       param :auto_publish, :bool, :desc => N_("Enable/Disable auto publish of composite view")
       param :solve_dependencies, :bool, :desc => N_("Solve RPM dependencies by default on Content View publish, defaults to false")
-      param :import_only, :bool, :desc => N_("Designate this Content View for importing from upstream servers only. Defaults to false")
+      param :import_only, :bool, :desc => N_("Designate this Content View for importing from upstream servers only. Defaults to false") if pulp3_yum?
     end
 
     def filtered_associations
@@ -29,6 +29,10 @@ module Katello
         :component_ids => Katello::ContentViewVersion,
         :repository_ids => Katello::Repository
       }
+    end
+
+    def self.pulp3_yum?
+      SmartProxy.pulp_primary&.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE)
     end
 
     api :GET, "/organizations/:organization_id/content_views", N_("List content views")
@@ -68,6 +72,10 @@ module Katello
     param :composite, :bool, :desc => N_("Composite content view")
     param_group :content_view
     def create
+      if ::Foreman::Cast.to_bool(params[:content_view][:import_only])
+        fail HttpErrors::BadRequest, _("Import-only content views will be available in a future version.") unless self.class.pulp3_yum?
+      end
+
       @content_view = ContentView.create!(view_params) do |view|
         view.organization = @organization
         view.label ||= labelize_params(params[:content_view])

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -6,10 +6,10 @@ module Actions
         include ::Katello::ContentViewHelper
         attr_accessor :version
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
-        def plan(content_view, description = "", options = {})
+        def plan(content_view, description = "", options = {importing: false})
           action_subject(content_view)
-          import_only = options.fetch(:import_only, false)
-          content_view.check_ready_to_publish! unless import_only
+
+          content_view.check_ready_to_publish!(importing: options[:importing])
 
           if options[:repos_units].present?
             valid_labels_from_cv = content_view.repositories.map(&:label)
@@ -52,7 +52,8 @@ module Actions
 
             if separated_repo_map[:pulp3_yum].keys.flatten.present? &&
                 SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
-              if import_only
+
+              if options[:importing]
                 handle_import(version, options.slice(:path, :metadata))
               else
                 plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -6,6 +6,7 @@ module Actions
 
         def plan(content_view, path:, metadata:)
           content_view.check_ready_to_import!
+
           unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
             fail ::Katello::HttpErrors::BadRequest, _("This API endpoint is only valid for Pulp 3 repositories.")
           end
@@ -23,7 +24,7 @@ module Actions
           plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
                         path: path,
                         metadata: metadata,
-                        import_only: true,
+                        importing: true,
                         major: major,
                         minor: minor)
         end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -71,6 +71,9 @@ module Katello
     validates :import_only,
               inclusion: { in: [false], message: "Import-only Content Views can not be Composite"},
               if: :composite
+    validates :import_only,
+              inclusion: { in: [false], message: "Import-only Content Views can not solve dependencies"},
+              if: :solve_dependencies
 
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -74,6 +74,7 @@ module Katello
     validates :import_only,
               inclusion: { in: [false], message: "Import-only Content Views can not solve dependencies"},
               if: :solve_dependencies
+    validate :import_only_immutable
 
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
@@ -711,6 +712,12 @@ module Katello
     end
 
     private
+
+    def import_only_immutable
+      if import_only_changed? && self.persisted?
+        errors.add(:import_only, _("Import-only can not be changed after creation"))
+      end
+    end
 
     def generate_cp_environment_label(env)
       # The label for a default view, will simply be the env label; otherwise, it

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -157,6 +157,10 @@ module Katello
       if self.content_view.composite?
         errors.add(:base, _("cannot contain filters if composite view"))
       end
+
+      if self.content_view.import_only?
+        errors.add(:base, _("cannot add filter to import-only view"))
+      end
     end
 
     def validate_filter_repos(errors, content_view)

--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -17,6 +17,8 @@ module Katello
 
     before_validation :set_attributes
 
+    validate :import_only_content_view
+
     def puppet_module
       PuppetModule.find_by(:pulp_id => self.uuid)
     end
@@ -41,6 +43,12 @@ module Katello
     end
 
     private
+
+    def import_only_content_view
+      if self.content_view.import_only?
+        errors.add(:base, "Cannot add puppet modules to an import-only content view.")
+      end
+    end
 
     def set_attributes
       if self.uuid.present?

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -7,6 +7,10 @@ module Katello
                                 Repository::DEB_TYPE
                                ].freeze
 
+    ALLOWED_IMPORT_REPOSITORY_TYPES = [
+      Repository::YUM_TYPE
+    ].freeze
+
     belongs_to :content_view, :inverse_of => :content_view_repositories,
                               :class_name => "Katello::ContentView"
     belongs_to :repository, :inverse_of => :content_view_repositories,
@@ -27,7 +31,7 @@ module Katello
     end
 
     def ensure_repository_type
-      unless ALLOWED_REPOSITORY_TYPES.include?(repository.content_type)
+      unless allowed_repository_types.include?(repository.content_type)
         errors.add(:base, _("Cannot add %s repositories to a content view.") % repository.content_type)
       end
     end
@@ -39,6 +43,14 @@ module Katello
 
       unless self.repository.content_view.default?
         errors.add(:base, _("Repositories from published Content Views are not allowed."))
+      end
+    end
+
+    def allowed_repository_types
+      if self.content_view.import_only?
+        ALLOWED_IMPORT_REPOSITORY_TYPES
+      else
+        ALLOWED_REPOSITORY_TYPES
       end
     end
   end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -70,7 +70,8 @@ module Katello
       {
         :name => self.id.to_s,
         :id => self.id,
-        :creatable => @allow_creation_by_user
+        :creatable => @allow_creation_by_user,
+        :pulp3_support => SmartProxy.pulp_primary.pulp3_repository_type_support?(self)
       }
     end
 

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -9,6 +9,7 @@ attributes :version_count
 attributes :latest_version
 attributes :auto_publish
 attributes :solve_dependencies
+attributes :import_only
 
 node :next_version do |content_view|
   content_view.next_version.to_f.to_s

--- a/db/migrate/20201021150008_add_import_only_to_katello_content_view.rb
+++ b/db/migrate/20201021150008_add_import_only_to_katello_content_view.rb
@@ -1,0 +1,5 @@
+class AddImportOnlyToKatelloContentView < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_content_views, :import_only, :boolean, :default => false, :null => false
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.controller.js
@@ -13,8 +13,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-views').controller('ContentViewsController',
-    ['$scope', 'Nutupane', 'ContentView', 'CurrentOrganization',
-    function ($scope, Nutupane, ContentView, CurrentOrganization) {
+    ['$scope', 'Nutupane', 'ContentView', 'CurrentOrganization', 'RepositoryTypesService',
+    function ($scope, Nutupane, ContentView, CurrentOrganization, RepositoryTypesService) {
 
         var nutupane = new Nutupane(ContentView, {
             'nondefault': true,
@@ -26,5 +26,9 @@ angular.module('Bastion.content-views').controller('ContentViewsController',
         $scope.controllerName = 'katello_content_views';
 
         $scope.table = nutupane.table;
+
+        $scope.importOnlyEnabled = function() {
+            return RepositoryTypesService.pulp3Supported('yum');
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -87,7 +87,9 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
 
         $scope.$watch('contentView.import_only', function () {
             if ($scope.contentView.import_only) {
+                /* eslint-disable camelcase */
                 $scope.contentView.solve_dependencies = false;
+                /* eslint-enable camelcase */
             }
         });
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -84,5 +84,11 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
         };
 
         $scope.fetchContentView();
+
+        $scope.$watch('contentView.import_only', function () {
+            if ($scope.contentView.import_only) {
+                $scope.contentView.solve_dependencies = false;
+            }
+        });
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -92,5 +92,9 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
                 /* eslint-enable camelcase */
             }
         });
+
+        $scope.importOnlyEnabled = function() {
+            return RepositoryTypesService.pulp3Supported('yum');
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -73,7 +73,7 @@
               Repositories
             </a>
           </li>
-          <li>
+          <li ng-hide="contentView.import_only">
             <a ui-sref="content-view.yum.filters" translate>
               Filters
             </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -13,7 +13,7 @@
   </div>
 
   <nav data-block="item-actions">
-    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView)"
+    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView) || contentView.import_only"
             ui-sref="content-view.publish">
       <span translate>Publish New Version</span>
     </button>
@@ -82,21 +82,21 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.deb')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('deb')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('deb')">
         <a ui-sref="content-view.repositories.deb.list" translate>
           Apt Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.file')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('file')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('file')">
         <a ui-sref="content-view.repositories.file.list" translate>
           File Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.puppet-modules')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('puppet')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('puppet')">
         <a ui-sref="content-view.puppet-modules.list" translate>
           Puppet Modules
         </a>
@@ -104,7 +104,7 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.docker') || stateIncludes('content-view.docker.filters')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('docker')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('docker')">
         <a uib-dropdown-toggle>
           <span translate>Container Images</span>
           <i class="fa fa-chevron-down"></i>
@@ -124,7 +124,7 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.ostree')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('ostree')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('ostree')">
         <a ui-sref="content-view.repositories.ostree.list" translate>
           OSTree Content
         </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -24,9 +24,11 @@
       <dd ng-show="contentView.composite" translate>Yes</dd>
       <dd ng-hide="contentView.composite" translate>No</dd>
 
-      <dt translate>Import-only</dt>
-      <dd ng-show="contentView.import_only" translate>Yes</dd>
-      <dd ng-hide="contentView.import_only" translate>No</dd>
+      <div ng-show="importOnlyEnabled()">
+        <dt translate>Import-only</dt>
+        <dd ng-show="contentView.import_only" translate>Yes</dd>
+        <dd ng-hide="contentView.import_only" translate>No</dd>
+      </div>
 
       <dt translate>Force Puppet Environment</dt>
       <dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -24,6 +24,10 @@
       <dd ng-show="contentView.composite" translate>Yes</dd>
       <dd ng-hide="contentView.composite" translate>No</dd>
 
+      <dt translate>Import-only</dt>
+      <dd ng-show="contentView.import_only" translate>Yes</dd>
+      <dd ng-hide="contentView.import_only" translate>No</dd>
+
       <dt translate>Force Puppet Environment</dt>
       <dd>
         <div bst-edit-checkbox="contentView.force_puppet_environment"
@@ -61,20 +65,6 @@
           <p class="help-text" translate>
             This will solve RPM and Module Stream dependencies on every publish of this Content View. Dependency solving significantly increases publish time (publishes can take over three times as long) and filters will be ignored when adding packages to solve
             dependencies. Also, certain scenarios involving errata may still cause dependency errors.
-          </p>
-        </dd>
-      </div>
-
-      <div>
-        <dt translate>Import-only</dt>
-        <dd>
-          <div bst-edit-checkbox="contentView.import_only"
-               formatter="booleanToYesNo"
-               on-save="save(contentView)"
-               readonly="denied('edit_content_views', contentView) || contentView.composite">
-          </div>
-          <p class="help-text" translate>
-            Designate whether this Content View is for importing exported content from an upstream server. Import-only Content Views can not be published directly.
           </p>
         </dd>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -50,7 +50,7 @@
         </dd>
       </div>
 
-      <div>
+      <div ng-if="!contentView.import_only">
         <dt translate>Solve Dependencies</dt>
         <dd>
           <div bst-edit-checkbox="contentView.solve_dependencies"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -74,7 +74,7 @@
                readonly="denied('edit_content_views', contentView) || contentView.composite">
           </div>
           <p class="help-text" translate>
-            Designate whether this Content View is for importing exported content from an upstream server. Import-only Content Views can not be published directly.</p>
+            Designate whether this Content View is for importing exported content from an upstream server. Import-only Content Views can not be published directly.
           </p>
         </dd>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -64,6 +64,20 @@
           </p>
         </dd>
       </div>
+
+      <div>
+        <dt translate>Import-only</dt>
+        <dd>
+          <div bst-edit-checkbox="contentView.import_only"
+               formatter="booleanToYesNo"
+               on-save="save(contentView)"
+               readonly="denied('edit_content_views', contentView) || contentView.composite">
+          </div>
+          <p class="help-text" translate>
+            Designate whether this Content View is for importing exported content from an upstream server. Import-only Content Views can not be published directly.</p>
+          </p>
+        </dd>
+      </div>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -54,7 +54,9 @@ angular.module('Bastion.content-views').controller('NewContentViewController',
         $scope.$watch('contentView.import_only', function () {
             if ($scope.contentView.import_only) {
                 $scope.contentView.composite = false;
+                /* eslint-disable camelcase */
                 $scope.contentView.solve_dependencies = false;
+                /* eslint-enable camelcase */
             }
         });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -51,10 +51,17 @@ angular.module('Bastion.content-views').controller('NewContentViewController',
             }
         });
 
+        $scope.$watch('contentView.import_only', function () {
+            if ($scope.contentView.import_only) {
+                $scope.contentView.composite = false;
+            }
+        }
+
         $scope.$watch('contentView.composite', function () {
             if ($scope.contentView.composite) {
                 /* eslint-disable camelcase */
                 $scope.contentView.solve_dependencies = false;
+                $scope.contentView.import_only = false;
             } else {
                 $scope.contentView.auto_publish = false;
                 /* eslint-enable camelcase */

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -54,8 +54,9 @@ angular.module('Bastion.content-views').controller('NewContentViewController',
         $scope.$watch('contentView.import_only', function () {
             if ($scope.contentView.import_only) {
                 $scope.contentView.composite = false;
+                $scope.contentView.solve_dependencies = false;
             }
-        }
+        });
 
         $scope.$watch('contentView.composite', function () {
             if ($scope.contentView.composite) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -11,8 +11,8 @@
  * @description
  */
 angular.module('Bastion.content-views').controller('NewContentViewController',
-    ['$scope', 'ContentView', 'FormUtils', 'CurrentOrganization', 'contentViewSolveDependencies',
-    function ($scope, ContentView, FormUtils, CurrentOrganization, contentViewSolveDependencies) {
+    ['$scope', 'ContentView', 'FormUtils', 'CurrentOrganization', 'contentViewSolveDependencies', 'RepositoryTypesService',
+    function ($scope, ContentView, FormUtils, CurrentOrganization, contentViewSolveDependencies, RepositoryTypesService) {
 
         function success(response) {
             var successState = 'content-view.repositories.yum.available';
@@ -44,8 +44,12 @@ angular.module('Bastion.content-views').controller('NewContentViewController',
             contentView.$save(success, error);
         };
 
+        $scope.importOnlyEnabled = function() {
+            return RepositoryTypesService.pulp3Supported('yum');
+        };
+
         $scope.$watch('contentView.name', function () {
-            if ($scope.contentViewForm.name) {
+            if ($scope.contentViewForm && $scope.contentViewForm.name) {
                 $scope.contentViewForm.name.$setValidity('server', true);
                 FormUtils.labelize($scope.contentView);
             }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
@@ -84,7 +84,7 @@
         <p class="help-block" translate>Designate whether this Content View is for importing from an upstream server. Import-only Content Views can not be published directly.</p>
       </div>
 
-      <div bst-form-group ng-hide="contentView.composite">
+      <div bst-form-group ng-hide="contentView.composite || contentView.import_only">
         <div class="checkbox">
           <label for="solve_dependencies">
             <input id="solve_dependencies"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
@@ -56,7 +56,7 @@
         </textarea>
       </div>
 
-      <div bst-form-group>
+      <div bst-form-group ng-hide="contentView.import_only">
         <div class="checkbox">
           <label for="composite">
             <input id="composite"
@@ -68,6 +68,20 @@
           </label>
         </div>
         <p class="help-block" translate>A composite view contains other content views.</p>
+      </div>
+
+      <div bst-form-group ng-hide="contentView.composite">
+        <div class="checkbox">
+          <label for="import_only">
+            <input id="import_only"
+                   name="import_only"
+                   ng-model="contentView.import_only"
+                   type="checkbox"
+                   tabindex="4"/>
+            <span translate>Import-only</span>
+          </label>
+        </div>
+        <p class="help-block" translate>Designate whether this Content View is for importing from an upstream server. Import-only Content Views can not be published directly.</p>
       </div>
 
       <div bst-form-group ng-hide="contentView.composite">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
@@ -70,7 +70,7 @@
         <p class="help-block" translate>A composite view contains other content views.</p>
       </div>
 
-      <div bst-form-group ng-hide="contentView.composite">
+      <div bst-form-group ng-hide="!importOnlyEnabled() || contentView.composite">
         <div class="checkbox">
           <label for="import_only">
             <input id="import_only"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
@@ -29,6 +29,7 @@
         <tr bst-table-head>
           <th bst-table-column><span translate>Name</span></th>
           <th bst-table-column><span translate>Composite View?</span></th>
+          <th bst-table-column><span translate>Import-only?</span></th>
           <th bst-table-column><span translate>Last Published</span></th>
           <th bst-table-column><span translate>Environments</span></th>
           <th bst-table-column><span translate>Repositories</span></th>
@@ -45,6 +46,10 @@
           <td bst-table-cell>
             <span ng-show="contentView.composite" translate>Yes</span>
             <span ng-hide="contentView.composite" translate>No</span>
+          </td>
+          <td bst-table-cell>
+            <span ng-show="contentView.import_only" translate>Yes</span>
+            <span ng-hide="contentView.import_only" translate>No</span>
           </td>
           <td bst-table-cell>
             <span ng-show="contentView.last_published"><long-date-time date="contentView.last_published" /></span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
@@ -29,7 +29,7 @@
         <tr bst-table-head>
           <th bst-table-column><span translate>Name</span></th>
           <th bst-table-column><span translate>Composite View?</span></th>
-          <th bst-table-column><span translate>Import-only?</span></th>
+          <th bst-table-column ng-show="importOnlyEnabled()"><span translate>Import-only?</span></th>
           <th bst-table-column><span translate>Last Published</span></th>
           <th bst-table-column><span translate>Environments</span></th>
           <th bst-table-column><span translate>Repositories</span></th>
@@ -47,7 +47,7 @@
             <span ng-show="contentView.composite" translate>Yes</span>
             <span ng-hide="contentView.composite" translate>No</span>
           </td>
-          <td bst-table-cell>
+          <td bst-table-cell ng-show="importOnlyEnabled()">
             <span ng-show="contentView.import_only" translate>Yes</span>
             <span ng-hide="contentView.import_only" translate>No</span>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
@@ -11,7 +11,6 @@
      *   current state of the application.
      */
     function RepositoryTypesService(repositoryTypes) {
-
         this.repositoryTypes = function () {
             return repositoryTypes;
         };
@@ -27,6 +26,14 @@
                 return type.id === desiredType;
             });
             return angular.isDefined(found);
+        };
+
+        this.pulp3Supported = function(desiredType) {
+            var found = _.find(repositoryTypes, function(type) {
+                return type.id === desiredType;
+            });
+
+            return found.pulp3_support;
         };
     }
 

--- a/engines/bastion_katello/test/content-views/content-views.controller.test.js
+++ b/engines/bastion_katello/test/content-views/content-views.controller.test.js
@@ -1,6 +1,7 @@
 describe('Controller: ContentViewsController', function() {
     var $scope,
         ContentView,
+        RepositoryTypesService,
         Nutupane;
 
     beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'));
@@ -14,6 +15,9 @@ describe('Controller: ContentViewsController', function() {
             this.enableSelectAllResults = function() {}
         };
         ContentView = {};
+        RepositoryTypesService = {
+          pulp3Supported: function(){},
+        };
     });
 
     beforeEach(inject(function($injector) {
@@ -24,7 +28,8 @@ describe('Controller: ContentViewsController', function() {
             $scope: $scope,
             Nutupane: Nutupane,
             ContentView: ContentView,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            RepositoryTypesService: RepositoryTypesService
         });
     }));
 

--- a/engines/bastion_katello/test/content-views/new/content-view-new.controller.test.js
+++ b/engines/bastion_katello/test/content-views/new/content-view-new.controller.test.js
@@ -3,6 +3,7 @@ describe('Controller: NewContentViewController', function() {
         $controller,
         dependencies,
         FormUtils,
+        RepositoryTypesService,
         ContentView;
 
     beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'));
@@ -11,6 +12,9 @@ describe('Controller: NewContentViewController', function() {
         $controller = $injector.get('$controller');
 
         ContentView = $injector.get('MockResource').$new();
+        RepositoryTypesService = {
+          pulp3Supported: function(){},
+        };
 
         $scope = $injector.get('$rootScope').$new();
         FormUtils = {
@@ -24,7 +28,8 @@ describe('Controller: NewContentViewController', function() {
             ContentView: ContentView,
             FormUtils: FormUtils,
             CurrentOrganization: 'CurrentOrganization',
-            contentViewSolveDependencies: 'false'
+            contentViewSolveDependencies: 'false',
+            RepositoryTypesService: RepositoryTypesService
         };
 
         $controller('NewContentViewController', dependencies);

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -28,6 +28,15 @@ module ::Actions::Katello::ContentView
       plan_action(action, content_view)
     end
 
+    it 'fails when planning if the cv is import only' do
+      content_view = katello_content_views(:import_only_view)
+      action.stubs(:task).returns(success_task)
+
+      assert_raises(RuntimeError) do
+        plan_action(action, content_view)
+      end
+    end
+
     context 'run phase' do
       it 'creates auto-publish events for non-composite views' do
         composite_view = katello_content_views(:composite_view)

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -54,6 +54,7 @@ module ::Actions::Katello::ContentViewVersion
   class ImportTest < TestBase
     before do
       setup_proxy
+      content_view.import_only = true
     end
 
     it 'Import should fail on importing content for an existing versions' do
@@ -75,7 +76,7 @@ module ::Actions::Katello::ContentViewVersion
                                   content_view, '',
                                   path: @import_export_dir,
                                   metadata: metadata,
-                                  import_only: true,
+                                  importing: true,
                                   major: metadata[:content_view_version][:major],
                                   minor: metadata[:content_view_version][:minor])
     end

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -81,12 +81,32 @@ module Katello
 
     test_attributes :pid => '80d36498-2e71-4aa9-b696-f0a45e86267f'
     def test_create
+      FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+
       post :create, params: { :name => "My View", :label => "My_View", :description => "Cool",
                               :organization_id => @organization.id, :solve_dependencies => true }
 
       assert_response :success
       assert_template :layout => 'katello/api/v2/layouts/resource'
       assert_template 'katello/api/v2/common/create'
+    end
+
+    def test_create_import_only_pulp3
+      FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+
+      post :create, params: { :name => "My View", :label => "My_View", :description => "Cool",
+                              :organization_id => @organization.id, :import_only => true }
+
+      assert_response :success
+    end
+
+    def test_create_import_only_pulp2
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
+
+      post :create, params: { :name => "My View", :label => "My_View", :description => "Cool",
+                              :organization_id => @organization.id, :import_only => true }
+
+      assert_response :bad_request
     end
 
     def test_publish_with_version_params

--- a/test/factories/content_view_factory.rb
+++ b/test/factories/content_view_factory.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :composite do
       composite { true }
     end
+
+    trait :import_only do
+      import_only { true }
+    end
   end
 end

--- a/test/fixtures/models/katello_content_views.yml
+++ b/test/fixtures/models/katello_content_views.yml
@@ -106,6 +106,17 @@ composite_view:
   updated_at: <%= Time.now %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
+import_only_view:
+  name:           Import-only content view
+  description:    This CV may not be published except through CVV import
+  label:          import_only_view
+  default:        false
+  import_only:    true
+  next_version:   2
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+
 library_view_solve_deps:
   name:               Solve Dependencies CV
   description:        A content view

--- a/test/models/content_view_filter_test.rb
+++ b/test/models/content_view_filter_test.rb
@@ -30,6 +30,14 @@ module Katello
       refute ContentViewFilter.exists?(filter.id)
     end
 
+    def test_import_only_view
+      cv = katello_content_views(:import_only_view)
+
+      cv.filters << FactoryBot.build(:katello_content_view_filter)
+
+      refute cv.valid?
+    end
+
     def test_bad_name
       filter = FactoryBot.build(:katello_content_view_filter, :name => "")
       assert filter.invalid?

--- a/test/models/content_view_puppet_module_test.rb
+++ b/test/models/content_view_puppet_module_test.rb
@@ -104,5 +104,15 @@ module Katello
       modules = modules.where(:name => puppet_module_apt.name)
       assert content_view_puppet_module.latest_in_modules_by_author?(modules)
     end
+
+    def test_import_only_content_view
+      cv = katello_content_views(:import_only_view)
+      puppet_module = katello_puppet_modules(:acmecorp_motd)
+      content_view_puppet_module = ContentViewPuppetModule.new(
+        :uuid => puppet_module.pulp_id,
+        :content_view => cv
+      )
+      refute content_view_puppet_module.valid?
+    end
   end
 end

--- a/test/models/content_view_repository_test.rb
+++ b/test/models/content_view_repository_test.rb
@@ -1,0 +1,24 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewRepositoryTest < ActiveSupport::TestCase
+    def setup
+    end
+
+    def test_import_only_yum_repos
+      cv = katello_content_views(:import_only_view)
+
+      cv.repositories << katello_repositories(:fedora_17_x86_64)
+
+      assert cv.valid?
+    end
+
+    def test_import_only_non_yum_repos
+      cv = katello_content_views(:import_only_view)
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        cv.repositories << katello_repositories(:busybox)
+      end
+    end
+  end
+end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -661,5 +661,10 @@ module Katello
       cv = FactoryBot.build(:katello_content_view, :import_only, :composite)
       refute cv.valid?
     end
+
+    def test_import_only_dep_solve
+      cv = FactoryBot.build(:katello_content_view, :import_only, solve_dependencies: true)
+      refute cv.valid?
+    end
   end
 end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -666,5 +666,11 @@ module Katello
       cv = FactoryBot.build(:katello_content_view, :import_only, solve_dependencies: true)
       refute cv.valid?
     end
+
+    def test_import_only_immutable
+      cv = FactoryBot.create(:katello_content_view, :import_only)
+      cv.import_only = false
+      refute cv.valid?
+    end
   end
 end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -656,5 +656,10 @@ module Katello
       assert_equal 'Katello::ContentView', recent_audit.auditable_type
       assert_equal 'destroy', recent_audit.action
     end
+
+    def test_import_only_composite
+      cv = FactoryBot.build(:katello_content_view, :import_only, :composite)
+      refute cv.valid?
+    end
   end
 end


### PR DESCRIPTION
This PR introduces the idea of an import-only content view. an import-only CV is used in a downstream Katello solely for the purpose of being published when importing a CV that's been exported from a different (upstream) Katello server.

**The following restrictions are put into place when set to import-only:**

- it may not be published directly
- may not be composite
- may not do dep-solving
- may only have yum repos associated
- may not have filters associated

**Now we:**
- show import_only in the API
- show import-only in the CV table for easy identification
- can set import-only when creating a new CV, and not after creation
- hide the import-only UI aspects + api docs if yum content is not managed by pulp3

**Please especially give feedback on:**
- new messaging, api descriptions
- should there be any more restrictions?
- can you break it by somehow getting into a weird or conflicting state?