### PR TITLE
Fixes #31223 - Pulp 3 task cancelling does not work

### DIFF
--- a/app/lib/actions/pulp3/abstract_async_task.rb
+++ b/app/lib/actions/pulp3/abstract_async_task.rb
@@ -74,6 +74,7 @@ module Actions
 
       def cancel
         pulp_tasks.each { |task| task.cancel }
+        task_groups.each { |task_group| task_group.cancel }
       end
 
       def rescue_external_task(error)

--- a/app/services/katello/pulp3/task.rb
+++ b/app/services/katello/pulp3/task.rb
@@ -79,7 +79,7 @@ module Katello
 
       def error
         if task_data[:state] == CANCELED
-          self.new(_("Task canceled"))
+          _("Task canceled")
         elsif task_data[:state] == FAILED
           if task_data[:error][:description].blank?
             _("Pulp task error")
@@ -90,8 +90,8 @@ module Katello
       end
 
       def cancel
-        data = PulpcoreClient::Task.new(state: 'canceled')
-        tasks_api.tasks_cancel(pulp_task['pulp_href'], data)
+        data = PulpcoreClient::TaskResponse.new(state: 'canceled')
+        tasks_api.tasks_cancel(task_data['pulp_href'], data)
         #the main task may have completed, so cancel spawned tasks too
         task_data['spawned_tasks']&.each { |spawned| tasks_api.tasks_cancel(spawned['pulp_href'], data) }
       end

--- a/app/services/katello/pulp3/task_group.rb
+++ b/app/services/katello/pulp3/task_group.rb
@@ -73,6 +73,12 @@ module Katello
       end
 
       def cancel
+        tasks_api = ::Katello::Pulp3::Api::Core.new(@smart_proxy).tasks_api
+        tasks_response = tasks_api.list(task_group: task_group_data['pulp_href'])
+        data = PulpcoreClient::TaskResponse.new(state: 'canceled')
+        tasks_response.results.collect do |result|
+          tasks_api.tasks_cancel(result.pulp_href, data)
+        end
       end
     end
   end


### PR DESCRIPTION
Pulp 3 tasks can't be cancelled.  To test, try cancelling a Pulp 3 action, like a content migration.