### PR TITLE
Fixes #31195 - Add rake task that kills running pulp 3 migration tasks

### DIFF
--- a/lib/katello/tasks/pulp3_migration_abort.rake
+++ b/lib/katello/tasks/pulp3_migration_abort.rake
@@ -1,0 +1,17 @@
+namespace :katello do
+  desc "Cancels all running Pulp 2 to 3 migration tasks."
+  task :pulp3_migration_abort => ["environment"] do
+    migration_tasks = ForemanTasks::Task::DynflowTask.where(:label => "Actions::Pulp3::ContentMigration").where.not(:state => ["stopped", "paused"])
+    cancelled_tasks_count = 0
+    migration_tasks.each do |task|
+      task.execution_plan.steps.each do |_number, step|
+        if step.cancellable? && step.is_a?(Dynflow::ExecutionPlan::Steps::RunStep)
+          ::ForemanTasks.dynflow.world.event(task.execution_plan.id, step.id, Dynflow::Action::Cancellable::Cancel)
+          cancelled_tasks_count += 1
+        end
+      end
+    end
+
+    puts _("\e[33mCancelled #{cancelled_tasks_count} tasks.\e[0m")
+  end
+end


### PR DESCRIPTION
This rake task will kill the migration dynflow action and the related Pulp 3 migration task.  Currently it will not cancel ImportMigration since that action isn't skippable.   Cancelling the migration Pulp 3 task is the most important part, so ImportMigration cancelling will come in another PR later.

Dependent on https://github.com/Katello/katello/pull/9019

To test:

1) Apply #9019 and this PR
2) Sync some content with a Pulp 2 enabled Katello server
3) Migrate that content with `rake katello:pulp3_migration`
4) Once the task is running, try cancelling it with `rake katello:pulp3_migration_abort`
5) Check that the task is actually cancelled.  It will not cancel if the last step (ImportMigration) is running.