### PR TITLE
Fixes #31271 - Sort package names in ContentViewPackageFilter rpm clause

### DIFF
--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -43,7 +43,7 @@ module Katello
     end
 
     def self.generate_rpm_clauses(package_filenames = [])
-      { 'filename' => { "$in" => package_filenames } } unless package_filenames.empty?
+      { 'filename' => { "$in" => package_filenames.sort } } unless package_filenames.empty?
     end
 
     def applicable_rpms

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,10 +44,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -55,7 +55,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -66,7 +66,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,10 +89,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -100,7 +100,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,10 +134,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -145,7 +145,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -156,7 +156,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,10 +179,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -190,7 +190,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -201,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -224,10 +224,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -235,7 +235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -246,7 +246,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,10 +269,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -291,7 +291,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -314,10 +314,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -325,7 +325,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -336,7 +336,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -359,10 +359,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -381,7 +381,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -403,10 +403,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -414,7 +414,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -425,7 +425,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:43 GMT
+      - Thu, 05 Nov 2020 20:12:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -447,10 +447,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:17 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -458,7 +458,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -469,7 +469,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -493,10 +493,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -515,7 +515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -539,10 +539,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +550,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -561,7 +561,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -583,10 +583,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +594,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -605,7 +605,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -627,10 +627,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -649,7 +649,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -672,10 +672,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +683,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -694,7 +694,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -717,10 +717,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -728,7 +728,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -739,7 +739,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -761,10 +761,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -772,7 +772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -783,7 +783,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -805,10 +805,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -816,7 +816,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -827,7 +827,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -849,10 +849,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -860,7 +860,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -871,7 +871,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -893,10 +893,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -904,7 +904,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -915,7 +915,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -937,10 +937,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -948,7 +948,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -959,7 +959,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:44 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -981,10 +981,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -992,7 +992,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1003,7 +1003,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -1026,10 +1026,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1048,7 +1048,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -1071,10 +1071,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1093,7 +1093,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -1118,10 +1118,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1129,7 +1129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1140,7 +1140,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -1165,10 +1165,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:18 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1187,7 +1187,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1213,10 +1213,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1235,7 +1235,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1261,10 +1261,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1272,7 +1272,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1283,7 +1283,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1309,10 +1309,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1320,7 +1320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1331,7 +1331,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1357,10 +1357,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1368,7 +1368,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1379,7 +1379,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1401,10 +1401,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1412,7 +1412,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1423,7 +1423,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:45 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1445,10 +1445,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1456,7 +1456,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1493,10 +1493,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1515,7 +1515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1541,10 +1541,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1552,7 +1552,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1563,7 +1563,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1589,10 +1589,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1600,7 +1600,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1611,7 +1611,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1637,10 +1637,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1648,7 +1648,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1659,7 +1659,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1685,10 +1685,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1696,7 +1696,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1707,7 +1707,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1733,10 +1733,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1744,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1755,7 +1755,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1781,10 +1781,10 @@ http_interactions:
         LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
         emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1792,7 +1792,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1803,7 +1803,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:46 GMT
+      - Thu, 05 Nov 2020 20:12:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -1829,10 +1829,10 @@ http_interactions:
         LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
         emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:19 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1840,11 +1840,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6ImltbWVkaWF0ZSIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvbGli
-        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
-        X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwic3NsX2NsaWVudF9jZXJ0Ijpu
-        dWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGws
+        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJ0eXBlX3NraXBfbGlz
+        dCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
+        aF9wYXNzd29yZCI6bnVsbCwicHJveHlfaG9zdCI6Imh0dHA6Ly91cmxfMSIs
         InByb3h5X3BvcnQiOjgwLCJwcm94eV91c2VybmFtZSI6bnVsbCwicHJveHlf
         cGFzc3dvcmQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
         cG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
@@ -1866,7 +1866,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1879,7 +1879,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:47 GMT
+      - Thu, 05 Nov 2020 20:12:20 GMT
       Server:
       - Apache
       Content-Length:
@@ -1896,14 +1896,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmN2YwMjIzOWY3NDFlODgzZDQ0In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjYTQwNmM3MWEwNDRmY2U4NTMzIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:20 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1911,7 +1911,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1922,15 +1922,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:47 GMT
+      - Thu, 05 Nov 2020 20:12:20 GMT
       Server:
       - Apache
       Etag:
-      - '"dc7dce7962aaa07435b125ae10619a7d-gzip"'
+      - '"671577127fb9f874696fa6f07c42d1f5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '638'
+      - '637'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1939,61 +1939,61 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0ODo0N1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMS0wNVQyMDoxMjoyMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmN2YwMjIzOWY3NDFlODgzZDQ4In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjYTQwNmM3MWEwNDRmY2U4NTM3In0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDg6NDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MjBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4M2Q0NyJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1Y2E0MDZjNzFhMDQ0ZmNlODUzNiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjIwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4
-        M2Q0NiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Y2E0MDZjNzFhMDQ0ZmNl
+        ODUzNSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjIwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY3
-        ZjAyMjM5Zjc0MWU4ODNkNDUifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWNh
+        NDA2YzcxYTA0NGZjZTg1MzQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
         Oi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b28i
         LCAicHJveHlfcG9ydCI6IDgwLCAiZG93bmxvYWRfcG9saWN5IjogImltbWVk
         aWF0ZSIsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJwcm94eV9ob3N0Ijog
         Imh0dHA6Ly91cmxfMSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWV9LCAiaWQi
         OiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAw
-        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjdmMDIyMzlmNzQxZTg4M2Q0NCJ9
+        LCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Y2E0MDZjNzFhMDQ0ZmNlODUzMyJ9
         LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFf
         MTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRv
         cmFfMTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:20 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2001,7 +2001,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2012,7 +2012,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:47 GMT
+      - Thu, 05 Nov 2020 20:12:20 GMT
       Server:
       - Apache
       Content-Length:
@@ -2023,14 +2023,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRmMGMxYzFjLWJmMmMtNGNiYy1hZTMyLWVjY2I1YjgzZjM0YS8iLCAi
-        dGFza19pZCI6ICI0ZjBjMWMxYy1iZjJjLTRjYmMtYWUzMi1lY2NiNWI4M2Yz
-        NGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc0YjJmN2FkLTFkMWUtNGU1Ny1iZTJiLTMxNTMxZmQzOGE2Zi8iLCAi
+        dGFza19pZCI6ICI3NGIyZjdhZC0xZDFlLTRlNTctYmUyYi0zMTUzMWZkMzhh
+        NmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:20 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f0c1c1c-bf2c-4cbc-ae32-eccb5b83f34a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/74b2f7ad-1d1e-4e57-be2b-31531fd38a6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2038,7 +2038,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2049,15 +2049,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:47 GMT
+      - Thu, 05 Nov 2020 20:12:20 GMT
       Server:
       - Apache
       Etag:
-      - '"8c74689e73d73bcc68b1c9fc52c79c98-gzip"'
+      - '"399f857e88672d02f0770d88f363d0b6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '362'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2065,20 +2065,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZjBjMWMxYy1iZjJjLTRjYmMtYWUzMi1lY2NiNWI4M2Yz
-        NGEvIiwgInRhc2tfaWQiOiAiNGYwYzFjMWMtYmYyYy00Y2JjLWFlMzItZWNj
-        YjViODNmMzRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83NGIyZjdhZC0xZDFlLTRlNTctYmUyYi0zMTUzMWZkMzhh
+        NmYvIiwgInRhc2tfaWQiOiAiNzRiMmY3YWQtMWQxZS00ZTU3LWJlMmItMzE1
+        MzFmZDM4YTZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ4OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjQ3WiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjIwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjdmMTI5NzNmOGNkZTJhNTczZCJ9LCAiaWQiOiAi
-        NWY3ZGZmN2YxMjk3M2Y4Y2RlMmE1NzNkIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTQ4OTdlNzM4N2I0MTY1
+        NWJkIn0sICJpZCI6ICI1ZmE0NWNhNDg5N2U3Mzg3YjQxNjU1YmQifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:20 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,10 +44,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -55,7 +55,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -66,7 +66,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,10 +89,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -100,7 +100,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -111,7 +111,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,10 +134,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -145,7 +145,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -156,7 +156,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,10 +179,10 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -190,7 +190,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -201,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -224,10 +224,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -235,7 +235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -246,7 +246,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,10 +269,10 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -291,7 +291,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -314,10 +314,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -325,7 +325,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -336,7 +336,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -359,10 +359,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -381,7 +381,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -403,10 +403,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -414,7 +414,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -425,7 +425,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:49 GMT
+      - Thu, 05 Nov 2020 20:12:21 GMT
       Server:
       - Apache
       Content-Length:
@@ -447,10 +447,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:21 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -458,7 +458,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -469,7 +469,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -493,10 +493,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -515,7 +515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -539,10 +539,10 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +550,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -561,7 +561,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -583,10 +583,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +594,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -605,7 +605,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -627,10 +627,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -649,7 +649,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -672,10 +672,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +683,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -694,7 +694,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -717,10 +717,10 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -728,7 +728,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -739,7 +739,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -761,10 +761,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -772,7 +772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -783,7 +783,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -805,10 +805,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -816,7 +816,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -827,7 +827,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -849,10 +849,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -860,7 +860,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -871,7 +871,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -893,10 +893,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -904,7 +904,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -915,7 +915,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -937,10 +937,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -948,7 +948,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -959,7 +959,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:50 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -981,10 +981,10 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -992,7 +992,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1003,7 +1003,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -1026,10 +1026,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1048,7 +1048,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -1071,10 +1071,10 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1093,7 +1093,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -1118,10 +1118,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1129,7 +1129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1140,7 +1140,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -1165,10 +1165,10 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:22 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1176,7 +1176,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1187,7 +1187,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1213,10 +1213,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1235,7 +1235,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1261,10 +1261,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1272,7 +1272,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1283,7 +1283,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1309,10 +1309,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1320,7 +1320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1331,7 +1331,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1357,10 +1357,10 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1368,7 +1368,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1379,7 +1379,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1401,10 +1401,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1412,7 +1412,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1423,7 +1423,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:51 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1445,10 +1445,10 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1456,7 +1456,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1493,10 +1493,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1504,7 +1504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1515,7 +1515,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1541,10 +1541,10 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1552,7 +1552,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1563,7 +1563,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1589,10 +1589,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1600,7 +1600,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1611,7 +1611,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1637,10 +1637,10 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1648,7 +1648,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1659,7 +1659,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1685,10 +1685,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1696,7 +1696,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1707,7 +1707,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1733,10 +1733,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1744,7 +1744,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1755,7 +1755,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1781,10 +1781,10 @@ http_interactions:
         LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
         emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Deb_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1792,7 +1792,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1803,7 +1803,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:52 GMT
+      - Thu, 05 Nov 2020 20:12:23 GMT
       Server:
       - Apache
       Content-Length:
@@ -1829,10 +1829,10 @@ http_interactions:
         LCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5p
         emF0aW9uLUNhYmluZXQtcHVscDNfRGViXzEifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:23 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1840,11 +1840,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6ImltbWVkaWF0ZSIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvbGli
-        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
-        X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiaHR0cDovL3VybF8xIiwic3NsX2NsaWVudF9jZXJ0Ijpu
-        dWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGws
+        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJ0eXBlX3NraXBfbGlz
+        dCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
+        aF9wYXNzd29yZCI6bnVsbCwicHJveHlfaG9zdCI6Imh0dHA6Ly91cmxfMSIs
         InByb3h5X3BvcnQiOjgwLCJwcm94eV91c2VybmFtZSI6bnVsbCwicHJveHlf
         cGFzc3dvcmQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJl
         cG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
@@ -1866,7 +1866,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1879,7 +1879,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:53 GMT
+      - Thu, 05 Nov 2020 20:12:24 GMT
       Server:
       - Apache
       Content-Length:
@@ -1896,14 +1896,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmODUwMjIzOWY3MzY0MTMxYjBlIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjYTgwNmM3MWEwNDUwM2E3YjNiIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:24 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1913,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1926,7 +1926,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:53 GMT
+      - Thu, 05 Nov 2020 20:12:24 GMT
       Server:
       - Apache
       Content-Length:
@@ -1937,14 +1937,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk3OTM3Zjc2LTRhYzItNGMxYi1iOTIwLWYwM2JiZmNmOTNiZC8iLCAi
-        dGFza19pZCI6ICI5NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzdhMjlmOGY5LTc1ZjAtNDJkYy04Y2NjLTI4ZTU2YjkyODM5NS8iLCAi
+        dGFza19pZCI6ICI3YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:24 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1952,7 +1952,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1963,15 +1963,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:24 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1979,16 +1979,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2000,42 +2000,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:24 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2043,7 +2044,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2054,15 +2055,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:24 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2070,16 +2071,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2091,42 +2092,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:24 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2134,7 +2136,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2145,15 +2147,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:24 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2161,16 +2163,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2182,42 +2184,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:24 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2225,7 +2228,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2236,15 +2239,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2252,16 +2255,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2273,42 +2276,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2316,7 +2320,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2327,15 +2331,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2343,16 +2347,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2364,42 +2368,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2407,7 +2412,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2418,15 +2423,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2434,16 +2439,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2455,42 +2460,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/97937f76-4ac2-4c1b-b920-f03bbfcf93bd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/7a29f8f9-75f0-42dc-8ccc-28e56b928395/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2498,7 +2504,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2509,15 +2515,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"b40b538d7fef9fc36a94c0650396de34-gzip"'
+      - '"39b316a5308745f0a11297e80f3df1dd-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '718'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2525,16 +2531,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NzkzN2Y3Ni00YWMyLTRjMWItYjkyMC1mMDNiYmZjZjkz
-        YmQvIiwgInRhc2tfaWQiOiAiOTc5MzdmNzYtNGFjMi00YzFiLWI5MjAtZjAz
-        YmJmY2Y5M2JkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTI5ZjhmOS03NWYwLTQyZGMtOGNjYy0yOGU1NmI5Mjgz
+        OTUvIiwgInRhc2tfaWQiOiAiN2EyOWY4ZjktNzVmMC00MmRjLThjY2MtMjhl
+        NTZiOTI4Mzk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzAwMjNhYTEtOTcxZC00NWUyLThmZTItYzdlMGExOTJl
-        MGY4LyIsICJ0YXNrX2lkIjogIjcwMDIzYWExLTk3MWQtNDVlMi04ZmUyLWM3
-        ZTBhMTkyZTBmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTRlMDJlOGUtYTMzOS00YTc0LTkzMGUtMGYzYzUxZDJi
+        MzY5LyIsICJ0YXNrX2lkIjogImE0ZTAyZThlLWEzMzktNGE3NC05MzBlLTBm
+        M2M1MWQyYjM2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2546,42 +2552,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        ODo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY4NjAyMjM5ZjA1N2Y4YTQzZGQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjg1MTI5NzNmOGNkZTJhNTg3MiJ9LCAi
-        aWQiOiAiNWY3ZGZmODUxMjk3M2Y4Y2RlMmE1ODcyIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Y2E4MDZjNzFhMDc1MTQ3
+        ZjA3MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTg4OTdlNzM4
+        N2I0MTY1NmYzIn0sICJpZCI6ICI1ZmE0NWNhODg5N2U3Mzg3YjQxNjU2ZjMi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/70023aa1-971d-45e2-8fe2-c7e0a192e0f8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a4e02e8e-a339-4a74-930e-0f3c51d2b369/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2589,7 +2596,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2600,15 +2607,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"8b4bf2767f520ef7aa25604661e2142a-gzip"'
+      - '"c30c19199af8b7b3dcb3b16a00491a68-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1360'
+      - '1370'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2616,199 +2623,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83MDAyM2FhMS05NzFkLTQ1ZTItOGZlMi1jN2Uw
-        YTE5MmUwZjgvIiwgInRhc2tfaWQiOiAiNzAwMjNhYTEtOTcxZC00NWUyLThm
-        ZTItYzdlMGExOTJlMGY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9hNGUwMmU4ZS1hMzM5LTRhNzQtOTMwZS0wZjNj
+        NTFkMmIzNjkvIiwgInRhc2tfaWQiOiAiYTRlMDJlOGUtYTMzOS00YTc0LTkz
+        MGUtMGYzYzUxZDJiMzY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0ODo1NFoiLCAi
+        bWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1NThhMmZiNy1iNjI3LTQyZGQtOGYyZC0yYzM0ZWJj
-        NjRlOWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJmZDFjOTJiYy05NTgxLTQwZDEtYmM0NC1hNGVmNjJi
+        NWIzZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZGZhZTMwOWQtYzI3Yi00Y2EwLWFhMzctNmVmYjM4MDg0OTBjIiwg
+        aWQiOiAiYTUzOWI2NzMtOTc1NC00ODZkLWI4OWQtMWY4MzM5NjU1YWY5Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWNhOWZjMy04NmI4LTQ5MzMtOWVi
-        Mi1jOWRkYzIzZTZhZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTc0MjU1MC0xYTRmLTQxOTktYmRl
+        Ni1hYzAxZDQ3YWUxMTEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MjcxOTFhOGYtN2MwNy00YTU2LWJhYjAtYWQ2MDdkNDEwZTc3IiwgIm51bV9w
+        ZTFkMDkwMDktMjRkNC00MjAyLWEzZTEtYTExMmM4MTVhZGVkIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImVjNTAwMzczLWEwMGItNDRkMC1iMGFmLTYz
-        Yjg5MzMxYTU3YyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjI3NTgzNzYxLTJmNmItNDJmNi05ODUwLTNm
+        NjgwODVlNWI4MyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAwYjg1
-        Yzk4LTE3MDctNGRlOS05Mzc5LWNhNzU5ZGZhZWY1YSIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY2YWYx
+        YjA0LTc5ZDUtNDA1ZC1hNWI4LWI2NmIwMGVhMGY3NSIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhYzhhZmE4YS1jYTNhLTQ0ZGUtYmE1Yi03OTBi
-        Y2NmNTk3ODQiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJhMmE0NThhMS02ZGI4LTRhYTctYjE0Ni1jNDU3
+        MDFjYzQ2YzEiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NjA1
-        M2Y3ZC01Yjc5LTQ1OTQtODdhZi00NzY1NzhiMmI0MTIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYmZh
+        YjRiMy1jZjlkLTQ4MGUtYTY3OC0zMDYyYjM2MmVlOTUiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YWMxYjUzMC01NjRi
-        LTRhYjctODhjMy1hYzY0ZGRmMDQwZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMzM3OWU0NS05M2I0
+        LTQ5MjktYmZhNi1hZDZiZjdmMjc3Y2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIxYTNiYWQzYi0wYjMwLTQ2ZWEtYTY2Ny1j
-        YzA0Y2I2YTRhYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNmI2NzRiNC01ZmViLTQyZjQtODdjZC1k
+        ZjRjNzBkOWVhODAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5MzkxNjI2My03NzAxLTQ4MzYtODViNS04OTUyYzlhZmJl
-        N2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJjMzQ4ODMzNC1jYjg5LTQxNGMtOGY3NC1mMWVlMDRmMGI1
+        ZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjI5MmNlMS1i
-        MTg4LTQxNGItYjE3Zi0zN2M2ODYwM2I3N2MiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NmUxMzExNC04
+        NjM5LTRhMmUtOWQ0OS1kMGZhMTg1MWM0ZDMiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MzE4YjU1Mi1iMmE5LTRjZmIt
-        ODlmMy1hYjEwMTRjZDc0NzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OGYxOTNiMS0zYjVmLTQzY2Yt
+        OTU2YS1hMGI1ZmI3MzQzZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjFhODg4NDVhLWNkMjQtNGRiNi1iYTUx
-        LWJhZDEwMzM2NTliYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0ODo1NFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
-        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
-        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
-        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
-        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
-        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
-        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
-        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
-        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjg2MDIyMzlmMDU3
-        ZjhhNDNkZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1NThhMmZiNy1iNjI3LTQyZGQtOGYyZC0yYzM0ZWJjNjRlOWUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZGZhZTMwOWQtYzI3Yi00Y2EwLWFhMzctNmVmYjM4MDg0OTBjIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
-        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwYWNhOWZjMy04NmI4LTQ5MzMtOWViMi1jOWRk
-        YzIzZTZhZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
-        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjcxOTFh
-        OGYtN2MwNy00YTU2LWJhYjAtYWQ2MDdkNDEwZTc3IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImVjNTAwMzczLWEwMGItNDRkMC1iMGFmLTYzYjg5MzMx
-        YTU3YyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
-        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAwYjg1Yzk4LTE3
-        MDctNGRlOS05Mzc5LWNhNzU5ZGZhZWY1YSIsICJudW1fcHJvY2Vzc2VkIjog
-        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
-        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJhYzhhZmE4YS1jYTNhLTQ0ZGUtYmE1Yi03OTBiY2NmNTk3
-        ODQiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
-        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NjA1M2Y3ZC01
-        Yjc5LTQ1OTQtODdhZi00NzY1NzhiMmI0MTIiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
-        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YWMxYjUzMC01NjRiLTRhYjct
-        ODhjMy1hYzY0ZGRmMDQwZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
-        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjJjM2IwYWRhLWUwYzItNGYzZi05ZmQ4
+        LTZmZTljNDQxNWU2NyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
+        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjI0WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjVa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
+        dGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQiLCAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
+        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
+        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
+        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
+        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNWZh
+        NDVjYTkwNmM3MWEwNzUxNDdmMDczIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImZkMWM5MmJjLTk1ODEtNDBkMS1iYzQ0
+        LWE0ZWY2MmI1YjNkYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxYTNiYWQzYi0wYjMwLTQ2ZWEtYTY2Ny1jYzA0Y2I2
-        YTRhYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5MzkxNjI2My03NzAxLTQ4MzYtODViNS04OTUyYzlhZmJlN2EiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
-        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
-        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjI5MmNlMS1iMTg4LTQx
-        NGItYjE3Zi0zN2M2ODYwM2I3N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
-        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3MzE4YjU1Mi1iMmE5LTRjZmItODlmMy1h
-        YjEwMTRjZDc0NzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
-        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFhODg4NDVhLWNkMjQtNGRiNi1iYTUxLWJhZDEw
-        MzM2NTliYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NjEyOTczZjhjZGUyYTViMjgi
-        fSwgImlkIjogIjVmN2RmZjg2MTI5NzNmOGNkZTJhNWIyOCJ9
+        LCAic3RlcF9pZCI6ICJhNTM5YjY3My05NzU0LTQ4NmQtYjg5ZC0xZjgzMzk2
+        NTVhZjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MTksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
+        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNzQyNTUwLTFhNGYt
+        NDE5OS1iZGU2LWFjMDFkNDdhZTExMSIsICJudW1fcHJvY2Vzc2VkIjogMTl9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJlMWQwOTAwOS0yNGQ0LTQyMDItYTNlMS1hMTEyYzgxNWFkZWQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogNiwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjc1ODM3NjEtMmY2Yi00MmY2
+        LTk4NTAtM2Y2ODA4NWU1YjgzIiwgIm51bV9wcm9jZXNzZWQiOiA2fSwgeyJu
+        dW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1v
+        ZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwi
+        OiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZjZhZjFiMDQtNzlkNS00MDVkLWE1YjgtYjY2YjAwZWEwZjc1IiwgIm51
+        bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjog
+        ImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogNCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyYTQ1OGExLTZkYjgtNGFhNy1i
+        MTQ2LWM0NTcwMWNjNDZjMSIsICJudW1fcHJvY2Vzc2VkIjogNH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRh
+        ZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjFiZmFiNGIzLWNmOWQtNDgwZS1hNjc4LTMwNjJiMzYyZWU5NSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIzMzc5
+        ZTQ1LTkzYjQtNDkyOS1iZmE2LWFkNmJmN2YyNzdjZiIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
+        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
+        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU2YjY3NGI0LTVmZWItNDJm
+        NC04N2NkLWRmNGM3MGQ5ZWE4MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
+        IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImMzNDg4MzM0LWNiODktNDE0Yy04Zjc0LWYx
+        ZWUwNGYwYjVkZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2
+        ZTEzMTE0LTg2MzktNGEyZS05ZDQ5LWQwZmExODUxYzRkMyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
+        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY4ZjE5M2IxLTNi
+        NWYtNDNjZi05NTZhLWEwYjVmYjczNDNkNCIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmMzYjBhZGEtZTBjMi00
+        ZjNmLTlmZDgtNmZlOWM0NDE1ZTY3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Y2E4ODk3
+        ZTczODdiNDE2NTlhNyJ9LCAiaWQiOiAiNWZhNDVjYTg4OTdlNzM4N2I0MTY1
+        OWE3In0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2816,7 +2824,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2827,15 +2835,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:54 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"06c4fac0ce70fe006433e996235788bd-gzip"'
+      - '"cecbfc2475f749b05348f37c2c9df742-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '828'
+      - '822'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2844,69 +2852,69 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDg6NTNa
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MjRa
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        Zjg1MDIyMzlmNzM2NDEzMWIxMiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        Y2E4MDZjNzFhMDQ1MDNhN2IzZiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjUzWiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjI0WiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5
-        ZjczNjQxMzFiMTEifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWNhODA2Yzcx
+        YTA0NTAzYTdiM2UifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAyMC0xMC0wN1QxNzo0ODo1M1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAyMC0xMS0wNVQyMDoxMjoyNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDIwLTExLTA1VDIwOjEyOjI1WiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5ZjczNjQxMzFi
-        MTAifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWNhODA2YzcxYTA0NTAzYTdi
+        M2QifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0ODo1NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjoyNFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         InBhY2thZ2VfZW52aXJvbm1lbnQiOiAxLCAiZGlzdHJpYnV0aW9uIjogMSwg
         Im1vZHVsZW1kIjogNiwgInJwbSI6IDE5LCAieXVtX3JlcG9fbWV0YWRhdGFf
         ZmlsZSI6IDF9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEw
-        LTA3VDE3OjQ4OjUzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEx
+        LTA1VDIwOjEyOjI0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
         dG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJf
         bnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
         dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3Rfc3luYyI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU0WiIsICJzY3JhdGNocGFk
+        c3Rfc3luYyI6ICIyMDIwLTExLTA1VDIwOjEyOjI0WiIsICJzY3JhdGNocGFk
         IjogeyJyZXBvbWRfcmV2aXNpb24iOiAxNTg4MTU4MDM4LCAicmVwb21kX2No
         ZWNrc3VtIjogImRjNDc0YjM2NTQ0YmVjYmExNzc5NWJiMjUxMDE0NTNlMjVi
         NDBmY2Q0ODExZmE1OTQ2ODYzMzRlZWFiZDVmMDkifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZjdkZmY4NTAyMjM5ZjczNjQxMzFiMGYifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZmE0NWNhODA2YzcxYTA0NTAzYTdiM2MifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVz
         dF9yZXBvcy96b28iLCAicHJveHlfcG9ydCI6IDgwLCAiZG93bmxvYWRfcG9s
         aWN5IjogImltbWVkaWF0ZSIsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJw
         cm94eV9ob3N0IjogImh0dHA6Ly91cmxfMSIsICJzc2xfdmFsaWRhdGlvbiI6
         IHRydWV9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9y
-        ZWRfdW5pdHMiOiA0MCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4NTAyMjM5
-        ZjczNjQxMzFiMGUifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiA0MCwg
+        ZWRfdW5pdHMiOiA0MCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWNhODA2Yzcx
+        YTA0NTAzYTdiM2IifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiA0MCwg
         ImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVw
         b3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2914,7 +2922,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2925,7 +2933,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:55 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Content-Length:
@@ -2936,14 +2944,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RkNWRmZDA0LTY2MWYtNDg2NC1iNTI5LTJiYjY1YzZmMGI0Mi8iLCAi
-        dGFza19pZCI6ICJkZDVkZmQwNC02NjFmLTQ4NjQtYjUyOS0yYmI2NWM2ZjBi
-        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzZmMDljMmMxLTA0YzItNDk3OS1hMTBiLTcxZTkwMGMzYzljMS8iLCAi
+        dGFza19pZCI6ICI2ZjA5YzJjMS0wNGMyLTQ5NzktYTEwYi03MWU5MDBjM2M5
+        YzEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/dd5dfd04-661f-4864-b529-2bb65c6f0b42/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/6f09c2c1-04c2-4979-a10b-71e900c3c9c1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2951,7 +2959,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2962,15 +2970,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:55 GMT
+      - Thu, 05 Nov 2020 20:12:25 GMT
       Server:
       - Apache
       Etag:
-      - '"6d037848d827049f98ac09c026c2db1e-gzip"'
+      - '"de8ac64be3979c04db2c1b6d54ca5b8f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '365'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2978,20 +2986,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZDVkZmQwNC02NjFmLTQ4NjQtYjUyOS0yYmI2NWM2ZjBi
-        NDIvIiwgInRhc2tfaWQiOiAiZGQ1ZGZkMDQtNjYxZi00ODY0LWI1MjktMmJi
-        NjVjNmYwYjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82ZjA5YzJjMS0wNGMyLTQ5NzktYTEwYi03MWU5MDBjM2M5
+        YzEvIiwgInRhc2tfaWQiOiAiNmYwOWMyYzEtMDRjMi00OTc5LWExMGItNzFl
+        OTAwYzNjOWMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ4OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU1WiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjI1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjI1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjg3MTI5NzNmOGNkZTJhNWM2YSJ9LCAiaWQiOiAi
-        NWY3ZGZmODcxMjk3M2Y4Y2RlMmE1YzZhIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTk4OTdlNzM4N2I0MTY1
+        YWU3In0sICJpZCI6ICI1ZmE0NWNhOTg5N2U3Mzg3YjQxNjVhZTcifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:57 GMT
+      - Thu, 05 Nov 2020 20:12:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:13 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:57 GMT
+      - Thu, 05 Nov 2020 20:12:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:13 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -96,11 +96,11 @@ http_interactions:
         IjoiUkhFTCA2IHg4Nl82NCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1w
         b3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoi
         b25fZGVtYW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRw
-        czovL2Nkbi5yZWRoYXQuY29tL2Zvby9iYXIiLCJ0eXBlX3NraXBfbGlzdCI6
-        WyJycG0iXSwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
-        aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5
-        X2hvc3QiOiIiLCJzc2xfY2xpZW50X2NlcnQiOiJyZXBvX2NlcnQiLCJzc2xf
-        Y2xpZW50X2tleSI6InJlcG9fa2V5Iiwic3NsX2NhX2NlcnQiOiJjYV9jZXJ0
+        czovL2Nkbi5yZWRoYXQuY29tL2Zvby9iYXIiLCJzc2xfY2xpZW50X2NlcnQi
+        OiJyZXBvX2NlcnQiLCJzc2xfY2xpZW50X2tleSI6InJlcG9fa2V5Iiwic3Ns
+        X2NhX2NlcnQiOiJjYV9jZXJ0Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInR5
+        cGVfc2tpcF9saXN0IjpbInJwbSJdLCJiYXNpY19hdXRoX3VzZXJuYW1lIjpu
+        dWxsLCJiYXNpY19hdXRoX3Bhc3N3b3JkIjpudWxsLCJwcm94eV9ob3N0Ijoi
         In0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmli
         dXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0
         b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiQUNN
@@ -121,7 +121,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -134,7 +134,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:57 GMT
+      - Thu, 05 Nov 2020 20:12:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,15 +150,15 @@ http_interactions:
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
         OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
         Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3
-        ZGZmODkwMjIzOWY3MzY0MTMxYjEzIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWZh
+        NDVjOWQwNmM3MWEwNDRmY2U4NTI0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:13 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -166,7 +166,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -177,15 +177,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:57 GMT
+      - Thu, 05 Nov 2020 20:12:13 GMT
       Server:
       - Apache
       Etag:
-      - '"f8396a01a48335f51f58cca5a109b928-gzip"'
+      - '"7fb4855f900bfc4b16a9e6d5f05eba1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '674'
+      - '671'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -194,37 +194,37 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
         eyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3Rf
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU3WiIsICJfaHJlZiI6ICIv
+        dXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjEzWiIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0L2Rpc3RyaWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NF9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmODkwMjIzOWY3MzY0MTMxYjE2In0sICJjb25maWci
+        IiRvaWQiOiAiNWZhNDVjOWQwNmM3MWEwNDRmY2U4NTI3In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1y
         aGVsXzZfeDg2XzY0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
         NF9jbG9uZSJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
-        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDg6NTdaIiwg
+        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTNaIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlk
         LXJoZWxfNl94ODZfNjQvZGlzdHJpYnV0b3JzL3B1bHAtdXVpZC1yaGVsXzZf
         eDg2XzY0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
         c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjg5MDIyMzlmNzM2NDEzMWIxNSJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1YzlkMDZjNzFhMDQ0ZmNlODUyNiJ9LCAiY29uZmlnIjog
         eyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0
         cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
         eS9yaGVsXzZfbGFiZWwifSwgImlkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0In0sIHsicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
-        ICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0ODo1N1oiLCAiX2hy
+        ICJsYXN0X3VwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxM1oiLCAiX2hy
         ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
         bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1
         dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9
         LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY4OTAyMjM5ZjczNjQxMzFiMTcifSwgImNvbmZpZyI6IHsiaHR0
+        ICI1ZmE0NWM5ZDA2YzcxYTA0NGZjZTg1MjgifSwgImNvbmZpZyI6IHsiaHR0
         cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24v
         bGlicmFyeS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6
         ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBu
@@ -232,29 +232,29 @@ http_interactions:
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
         OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
         IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ4OjU3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        ICIyMDIwLTExLTA1VDIwOjEyOjEzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
         djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2ltcG9y
         dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
         ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg5MDIyMzlm
-        NzM2NDEzMWIxNCJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
+        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlkMDZjNzFh
+        MDQ0ZmNlODUyNSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
         LnJlZGhhdC5jb20vZm9vL2JhciIsICJzc2xfY2FfY2VydCI6ICJjYV9jZXJ0
         IiwgInNzbF9jbGllbnRfY2VydCI6ICJyZXBvX2NlcnQiLCAicmVtb3ZlX21p
         c3NpbmciOiB0cnVlLCAicHJveHlfaG9zdCI6ICIiLCAic3NsX3ZhbGlkYXRp
         b24iOiB0cnVlLCAic3NsX2NsaWVudF9rZXkiOiAicmVwb19rZXkiLCAiZG93
         bmxvYWRfcG9saWN5IjogIm9uX2RlbWFuZCIsICJ0eXBlX3NraXBfbGlzdCI6
         IFsicnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
-        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg5MDIy
-        MzlmNzM2NDEzMWIxMyJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
+        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlkMDZj
+        NzFhMDQ0ZmNlODUyNCJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
         ICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0LyJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:13 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +262,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -273,7 +273,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:58 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -284,14 +284,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzExZTA1YWNjLTYxMTQtNGM0Ny1hMTI0LTkwMmFhOTBhYWM4Ny8iLCAi
-        dGFza19pZCI6ICIxMWUwNWFjYy02MTE0LTRjNDctYTEyNC05MDJhYTkwYWFj
-        ODcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzEyOTk0ZGMyLThlMzgtNDA1Mi1iNmIwLWQxMWVmNTQ1MTY5My8iLCAi
+        dGFza19pZCI6ICIxMjk5NGRjMi04ZTM4LTQwNTItYjZiMC1kMTFlZjU0NTE2
+        OTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/11e05acc-6114-4c47-a124-902aa90aac87/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/12994dc2-8e38-4052-b6b0-d11ef5451693/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -299,7 +299,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -310,15 +310,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:58 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Etag:
-      - '"f7c6cf51f25be76f530137c81f3e4da7-gzip"'
+      - '"6a5f9ae79d86a0e74cae686ff1c6de7f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '371'
+      - '377'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -326,20 +326,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMWUwNWFjYy02MTE0LTRjNDctYTEyNC05MDJhYTkwYWFj
-        ODcvIiwgInRhc2tfaWQiOiAiMTFlMDVhY2MtNjExNC00YzQ3LWExMjQtOTAy
-        YWE5MGFhYzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aS92Mi90YXNrcy8xMjk5NGRjMi04ZTM4LTQwNTItYjZiMC1kMTFlZjU0NTE2
+        OTMvIiwgInRhc2tfaWQiOiAiMTI5OTRkYzItOGUzOC00MDUyLWI2YjAtZDEx
+        ZWY1NDUxNjkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
         aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
-        bmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6NThaIiwgIl9ucyI6ICJ0
-        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6
-        NThaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
+        bmlzaF90aW1lIjogIjIwMjAtMTEtMDVUMjA6MTI6MTRaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTEtMDVUMjA6MTI6
+        MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
         ICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxv
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGExMjk3M2Y4Y2RlMmE1
-        ZDY2In0sICJpZCI6ICI1ZjdkZmY4YTEyOTczZjhjZGUyYTVkNjYifQ==
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5
+        ZTg5N2U3Mzg3YjQxNjUyYTcifSwgImlkIjogIjVmYTQ1YzllODk3ZTczODdi
+        NDE2NTJhNyJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -96,11 +96,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
-        b20iLCJ0eXBlX3NraXBfbGlzdCI6WyJkcnBtIl0sImJhc2ljX2F1dGhfdXNl
-        cm5hbWUiOiJyb290IiwiYmFzaWNfYXV0aF9wYXNzd29yZCI6InJlZGhhdCIs
-        InNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiIiwic3NsX2Ns
-        aWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2Nh
-        X2NlcnQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8i
+        b20iLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUs
+        InR5cGVfc2tpcF9saXN0IjpbImRycG0iXSwiYmFzaWNfYXV0aF91c2VybmFt
+        ZSI6InJvb3QiLCJiYXNpY19hdXRoX3Bhc3N3b3JkIjoicmVkaGF0IiwicHJv
+        eHlfaG9zdCI6IiJ9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8i
         fSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVt
         X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZl
         X3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFi
@@ -120,7 +120,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -133,7 +133,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,14 +150,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmODgwMjIzOWY3NDFlODgzZDQ5In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjYTAwNmM3MWEwNDRmY2U4NTJlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -176,11 +176,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Etag:
-      - '"13b2ed60c47e60f360432069a74c8915-gzip"'
+      - '"76cd936f58a53bf7781d6a9882b06bbe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -193,61 +193,61 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0ODo1NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMS0wNVQyMDoxMjoxNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmODgwMjIzOWY3NDFlODgzZDRkIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjYTAwNmM3MWEwNDRmY2U4NTMyIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDg6NTZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4M2Q0YyJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1Y2EwMDZjNzFhMDQ0ZmNlODUzMSJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE2WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4
-        M2Q0YiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Y2EwMDZjNzFhMDQ0ZmNl
+        ODUzMCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE2WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
-        ODAyMjM5Zjc0MWU4ODNkNGEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWNh
+        MDA2YzcxYTA0NGZjZTg1MmYifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJiYXNpY19hdXRoX3Bhc3N3b3JkIjogIioqKioq
         IiwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgInByb3h5X2hvc3QiOiAiIiwg
         InNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgImJhc2ljX2F1dGhfdXNlcm5hbWUi
         OiAicm9vdCIsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVtYW5kIiwgInR5
         cGVfc2tpcF9saXN0IjogWyJkcnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVy
         In1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lk
-        IjogIjVmN2RmZjg4MDIyMzlmNzQxZTg4M2Q0OSJ9LCAidG90YWxfcmVwb3Np
+        IjogIjVmYTQ1Y2EwMDZjNzFhMDQ0ZmNlODUyZSJ9LCAidG90YWxfcmVwb3Np
         dG9yeV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -255,7 +255,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -266,7 +266,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -277,14 +277,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdlYWViODU4LThmODYtNDlkYy05Njc0LTE5OWU3N2JmZjA5Ny8iLCAi
-        dGFza19pZCI6ICI3ZWFlYjg1OC04Zjg2LTQ5ZGMtOTY3NC0xOTllNzdiZmYw
-        OTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2RhYjE1YmQxLWU1ZDAtNDZhNy1hMmZlLTRhNjQwZmEwMDJiNS8iLCAi
+        dGFza19pZCI6ICJkYWIxNWJkMS1lNWQwLTQ2YTctYTJmZS00YTY0MGZhMDAy
+        YjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7eaeb858-8f86-49dc-9674-199e77bff097/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/dab15bd1-e5d0-46a7-a2fe-4a640fa002b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -292,7 +292,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -303,15 +303,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:56 GMT
+      - Thu, 05 Nov 2020 20:12:16 GMT
       Server:
       - Apache
       Etag:
-      - '"6a72652789e28d406005352d69af3e9c-gzip"'
+      - '"2e2306ef6c3f9a4552d225512bad9809-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '363'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -319,20 +319,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZWFlYjg1OC04Zjg2LTQ5ZGMtOTY3NC0xOTllNzdiZmYw
-        OTcvIiwgInRhc2tfaWQiOiAiN2VhZWI4NTgtOGY4Ni00OWRjLTk2NzQtMTk5
-        ZTc3YmZmMDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWIxNWJkMS1lNWQwLTQ2YTctYTJmZS00YTY0MGZhMDAy
+        YjUvIiwgInRhc2tfaWQiOiAiZGFiMTViZDEtZTVkMC00NmE3LWEyZmUtNGE2
+        NDBmYTAwMmI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ4OjU2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU2WiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjE2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjE2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjg4MTI5NzNmOGNkZTJhNWNlNSJ9LCAiaWQiOiAi
-        NWY3ZGZmODgxMjk3M2Y4Y2RlMmE1Y2U1In0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjYTA4OTdlNzM4N2I0MTY1
+        NDg2In0sICJpZCI6ICI1ZmE0NWNhMDg5N2U3Mzg3YjQxNjU0ODYifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:16 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,10 +43,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -54,7 +54,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -65,7 +65,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -96,11 +96,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
-        b20iLCJ0eXBlX3NraXBfbGlzdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFt
-        ZSI6bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlk
-        YXRpb24iOnRydWUsInByb3h5X2hvc3QiOiIiLCJzc2xfY2xpZW50X2NlcnQi
-        Om51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xfY2FfY2VydCI6bnVs
-        bH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmli
+        b20iLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUs
+        InR5cGVfc2tpcF9saXN0IjpudWxsLCJiYXNpY19hdXRoX3VzZXJuYW1lIjpu
+        dWxsLCJiYXNpY19hdXRoX3Bhc3N3b3JkIjpudWxsLCJwcm94eV9ob3N0Ijoi
+        In0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmli
         dXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0
         b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiQUNN
         RV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAi
@@ -119,7 +119,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -132,7 +132,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -149,14 +149,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjOWUwNmM3MWEwNDRmY2U4NTI5In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -164,7 +164,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -175,15 +175,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Etag:
-      - '"43109e57874bc8392eb66501c49cbc8c-gzip"'
+      - '"07b57f7fd95fb1143d0397fc5513061b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '606'
+      - '604'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -192,59 +192,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0ODo1OVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMS0wNVQyMDoxMjoxNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTJkIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDg6NTlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNlODUyYyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU5WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE0WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEz
-        MWIxYSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNl
+        ODUyYiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ4OjU5WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE0WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
-        YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5
+        ZTA2YzcxYTA0NGZjZTg1MmEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTI5In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -252,7 +252,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -263,7 +263,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -274,14 +274,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y4MDdiZmZiLWJjYjctNDA3ZC04ODE0LWNiNTIxZjk1ZDZmZC8iLCAi
-        dGFza19pZCI6ICJmODA3YmZmYi1iY2I3LTQwN2QtODgxNC1jYjUyMWY5NWQ2
-        ZmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2RiNjdlNmJjLTFhNTQtNDRlNC04MDI5LWMyMWVhOGE0MDNlOS8iLCAi
+        dGFza19pZCI6ICJkYjY3ZTZiYy0xYTU0LTQ0ZTQtODAyOS1jMjFlYThhNDAz
+        ZTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/f807bffb-bcb7-407d-8814-cb521f95d6fd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/db67e6bc-1a54-44e4-8029-c21ea8a403e9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -289,7 +289,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -300,15 +300,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:14 GMT
       Server:
       - Apache
       Etag:
-      - '"262fccff0bc4ad7aa12de47973053b8b-gzip"'
+      - '"8e82ada639a673d61ac1658671bfb209-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '384'
+      - '391'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -316,27 +316,27 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfZGVsZXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9mODA3YmZmYi1iY2I3LTQwN2QtODgx
-        NC1jYjUyMWY5NWQ2ZmQvIiwgInRhc2tfaWQiOiAiZjgwN2JmZmItYmNiNy00
-        MDdkLTg4MTQtY2I1MjFmOTVkNmZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9kYjY3ZTZiYy0xYTU0LTQ0ZTQtODAy
+        OS1jMjFlYThhNDAzZTkvIiwgInRhc2tfaWQiOiAiZGI2N2U2YmMtMWE1NC00
+        NGU0LTgwMjktYzIxZWE4YTQwM2U5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpyZW1vdmVfZGlzdHJpYnV0b3Ii
-        XSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDg6NTlaIiwgIl9u
-        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTAtMDdU
-        MTc6NDg6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        XSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTEtMDVUMjA6MTI6MTRaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAtMTEtMDVU
+        MjA6MTI6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
         IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1r
-        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIxMjk3M2Y4
-        Y2RlMmE1ZGYyIn0sICJpZCI6ICI1ZjdkZmY4YjEyOTczZjhjZGUyYTVkZjIi
-        fQ==
+        dmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1z
+        dGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNl
+        bnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM5ZTg5N2U3Mzg3YjQxNjUzMmEifSwgImlkIjogIjVmYTQ1YzllODk3
+        ZTczODdiNDE2NTMyYSJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:14 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -344,7 +344,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -355,15 +355,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:48:59 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"e10ad21fe97fbea40f8010b515a47c18-gzip"'
+      - '"855bd914b87b509bb676bdb7d044ba99-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '571'
+      - '568'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -372,49 +372,49 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0ODo1OVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMS0wNVQyMDoxMjoxNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTJkIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDg6NTlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNlODUyYyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
         IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
         bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
         cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3
-        VDE3OjQ4OjU5WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjE0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
         c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZmE0NWM5ZTA2YzcxYTA0NGZjZTg1MmEifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
         IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
         Y3kiOiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5
         dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTI5In0sICJ0
         b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:48:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -424,7 +424,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -437,7 +437,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -448,29 +448,29 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE1YmM4MGFlLTI0MTgtNDg4ZS04ODI4LWYzYzc1MGJlYWU5NC8iLCAi
-        dGFza19pZCI6ICIxNWJjODBhZS0yNDE4LTQ4OGUtODgyOC1mM2M3NTBiZWFl
-        OTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQ5YjI5MTQxLTY2ODctNDBhZS1hOGU2LTU0OGY1YzZiNDU5OC8iLCAi
+        dGFza19pZCI6ICI0OWIyOTE0MS02Njg3LTQwYWUtYThlNi01NDhmNWM2YjQ1
+        OTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
         eyJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoib25fZGVt
         YW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRwOi8vbXly
-        ZXBvLmNvbSIsInR5cGVfc2tpcF9saXN0IjpudWxsLCJiYXNpY19hdXRoX3Vz
-        ZXJuYW1lIjpudWxsLCJiYXNpY19hdXRoX3Bhc3N3b3JkIjpudWxsLCJzc2xf
-        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfaG9zdCI6IiIsInNzbF9jbGllbnRf
-        Y2VydCI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF9jYV9jZXJ0
-        IjpudWxsfX0=
+        ZXBvLmNvbSIsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3NsX2NsaWVudF9r
+        ZXkiOm51bGwsInNzbF9jYV9jZXJ0IjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6
+        dHJ1ZSwidHlwZV9za2lwX2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5h
+        bWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQiOm51bGwsInByb3h5X2hv
+        c3QiOiIifX0=
     headers:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -483,7 +483,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -494,14 +494,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I1OWIyNjI4LWIzOWQtNDYyOC1hZDQ4LTJhZTY0NTY2YTAxMS8iLCAi
-        dGFza19pZCI6ICJiNTliMjYyOC1iMzlkLTQ2MjgtYWQ0OC0yYWU2NDU2NmEw
-        MTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2NlODkyZWNiLTIzOTUtNDkxNi05M2Y0LTQyMTI5MjNlNmE3Yy8iLCAi
+        dGFza19pZCI6ICJjZTg5MmVjYi0yMzk1LTQ5MTYtOTNmNC00MjEyOTIzZTZh
+        N2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
     body:
       encoding: UTF-8
       base64_string: |
@@ -515,7 +515,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -528,7 +528,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -541,21 +541,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0OTowMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
+        MC0xMS0wNVQyMDoxMjoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
         cG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8i
         LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
         IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRv
         ciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAi
         X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZjdkZmY4YzAyMjM5ZjczNjUxZTYxYWMifSwgImNvbmZpZyI6IHsicHJvdGVj
+        ZmE0NWM5ZjA2YzcxYTA0NTAzYTdiM2EifSwgImNvbmZpZyI6IHsicHJvdGVj
         dGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
         Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
         dHBzIjogdHJ1ZX0sICJpZCI6ICJGZWRvcmFfMTcifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
     body:
       encoding: UTF-8
       base64_string: |
@@ -565,7 +565,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -578,7 +578,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -589,14 +589,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Q2MzAyZmI0LWZiNTktNGNjOC1iOWE0LWQ3YmIxNzJjNDU3MC8iLCAi
-        dGFza19pZCI6ICJkNjMwMmZiNC1mYjU5LTRjYzgtYjlhNC1kN2JiMTcyYzQ1
-        NzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc3YzY2MzkyLTZhNTYtNGY0NS1iOGU3LTBkZGQzODg2NzJhMS8iLCAi
+        dGFza19pZCI6ICI3N2M2NjM5Mi02YTU2LTRmNDUtYjhlNy0wZGRkMzg4Njcy
+        YTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
     body:
       encoding: UTF-8
       base64_string: |
@@ -607,7 +607,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -620,7 +620,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -631,14 +631,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNiODAwODBlLWIwYTUtNDdmNi1iOGVhLWFkZjE4NTViYWQ4Mi8iLCAi
-        dGFza19pZCI6ICIzYjgwMDgwZS1iMGE1LTQ3ZjYtYjhlYS1hZGYxODU1YmFk
-        ODIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzU0NDU5MWZlLWI2ZjctNDdlZC1hNGY1LWQ1OWVjMzYxOWY5YS8iLCAi
+        dGFza19pZCI6ICI1NDQ1OTFmZS1iNmY3LTQ3ZWQtYTRmNS1kNTllYzM2MTlm
+        OWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/15bc80ae-2418-488e-8828-f3c750beae94/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/49b29141-6687-40ae-a8e6-548f5c6b4598/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -646,7 +646,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -657,15 +657,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"2a40ebcd5f4891e2d13edea50970e903-gzip"'
+      - '"1f7f45e3116c8f22a7f9578c80cd389f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '564'
+      - '569'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -673,37 +673,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMTViYzgwYWUtMjQx
-        OC00ODhlLTg4MjgtZjNjNzUwYmVhZTk0LyIsICJ0YXNrX2lkIjogIjE1YmM4
-        MGFlLTI0MTgtNDg4ZS04ODI4LWYzYzc1MGJlYWU5NCIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDliMjkxNDEtNjY4
+        Ny00MGFlLWE4ZTYtNTQ4ZjVjNmI0NTk4LyIsICJ0YXNrX2lkIjogIjQ5YjI5
+        MTQxLTY2ODctNDBhZS1hOGU2LTU0OGY1YzZiNDU5OCIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6cmVwb3NpdG9yeV9p
         bXBvcnRlcjp5dW1faW1wb3J0ZXIiLCAicHVscDphY3Rpb246dXBkYXRlX2lt
-        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAw
+        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjE1
         WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIw
-        LTEwLTA3VDE3OjQ5OjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTExLTA1VDIwOjEyOjE1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
-        ZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
-        bnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIw
-        LTEwLTA3VDE3OjQ5OjAwWiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAi
-        cmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3lu
-        YyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVl
-        ZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRy
-        dWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3ki
-        OiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1f
-        aW1wb3J0ZXIifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZjdkZmY4YzEyOTczZjhjZGUyYTVlMjYifSwgImlkIjogIjVmN2RmZjhjMTI5
-        NzNmOGNkZTJhNWUyNiJ9
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8t
+        ZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91
+        cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTVaIiwgIl9ocmVmIjogIi92
+        Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0
+        ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6
+        IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNlODUyYSJ9LCAi
+        Y29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9teXJlcG8uY29tIiwgInNzbF92
+        YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgImRv
+        d25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQiLCAicHJveHlfaG9zdCI6ICIi
+        fSwgImlkIjogInl1bV9pbXBvcnRlciJ9LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1YzlmODk3ZTczODdiNDE2NTM2MCJ9LCAiaWQi
+        OiAiNWZhNDVjOWY4OTdlNzM4N2I0MTY1MzYwIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/b59b2628-b39d-4628-ad48-2ae64566a011/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/ce892ecb-2395-4916-93f4-4212923e6a7c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +711,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -722,15 +722,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:00 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"1ab3ce5cfb298193a9b1107a4a60ddd5-gzip"'
+      - '"d794c8591491c421e50e42441aa85f9e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '564'
+      - '570'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -738,37 +738,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjU5YjI2MjgtYjM5
-        ZC00NjI4LWFkNDgtMmFlNjQ1NjZhMDExLyIsICJ0YXNrX2lkIjogImI1OWIy
-        NjI4LWIzOWQtNDYyOC1hZDQ4LTJhZTY0NTY2YTAxMSIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvY2U4OTJlY2ItMjM5
+        NS00OTE2LTkzZjQtNDIxMjkyM2U2YTdjLyIsICJ0YXNrX2lkIjogImNlODky
+        ZWNiLTIzOTUtNDkxNi05M2Y0LTQyMTI5MjNlNmE3YyIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6cmVwb3NpdG9yeV9p
         bXBvcnRlcjp5dW1faW1wb3J0ZXIiLCAicHVscDphY3Rpb246dXBkYXRlX2lt
-        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAw
+        cG9ydGVyIl0sICJmaW5pc2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjE1
         WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIw
-        LTEwLTA3VDE3OjQ5OjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTExLTA1VDIwOjEyOjE1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
-        ZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
-        bnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIw
-        LTEwLTA3VDE3OjQ5OjAwWiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAi
-        cmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3lu
-        YyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY4YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVl
-        ZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRy
-        dWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3ki
-        OiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1f
-        aW1wb3J0ZXIifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZjdkZmY4YzEyOTczZjhjZGUyYTVlM2EifSwgImlkIjogIjVmN2RmZjhjMTI5
-        NzNmOGNkZTJhNWUzYSJ9
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8t
+        ZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91
+        cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTVaIiwgIl9ocmVmIjogIi92
+        Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0
+        ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6
+        IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNlODUyYSJ9LCAi
+        Y29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9teXJlcG8uY29tIiwgInNzbF92
+        YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgImRv
+        d25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQiLCAicHJveHlfaG9zdCI6ICIi
+        fSwgImlkIjogInl1bV9pbXBvcnRlciJ9LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1YzlmODk3ZTczODdiNDE2NTM3YSJ9LCAiaWQi
+        OiAiNWZhNDVjOWY4OTdlNzM4N2I0MTY1MzdhIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:00 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d6302fb4-fb59-4cc8-b9a4-d7bb172c4570/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/77c66392-6a56-4f45-b8e7-0ddd388672a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -776,7 +776,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -787,15 +787,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:01 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"2b73dc5fc03c5da4f54cd8a9f4471fd5-gzip"'
+      - '"0479cd76c516cab002fd0ba102e0a096-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '529'
+      - '533'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -803,36 +803,36 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9kNjMwMmZiNC1mYjU5LTRjYzgtYjlh
-        NC1kN2JiMTcyYzQ1NzAvIiwgInRhc2tfaWQiOiAiZDYzMDJmYjQtZmI1OS00
-        Y2M4LWI5YTQtZDdiYjE3MmM0NTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy83N2M2NjM5Mi02YTU2LTRmNDUtYjhl
+        Ny0wZGRkMzg4NjcyYTEvIiwgInRhc2tfaWQiOiAiNzdjNjYzOTItNmE1Ni00
+        ZjQ1LWI4ZTctMGRkZDM4ODY3MmExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OkZlZG9yYV8xN19jbG9uZSIsICJwdWxwOmFjdGlvbjp1cGRhdGVfZGlzdHJp
-        YnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDk6MDBa
+        YnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTEtMDVUMjA6MTI6MTVa
         IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjAt
-        MTAtMDdUMTc6NDk6MDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        MTEtMDVUMjA6MTI6MTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
         X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2Vu
-        dG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAt
-        MTAtMDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3JpZXMv
-        RmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUvIiwgImxh
-        c3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxs
-        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0
-        b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30s
-        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjog
-        IjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjogeyJkZXN0
-        aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwgImlkIjog
-        IkZlZG9yYV8xN19jbG9uZSJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjhjMTI5NzNmOGNkZTJhNWU1NiJ9LCAiaWQiOiAiNWY3
-        ZGZmOGMxMjk3M2Y4Y2RlMmE1ZTU2In0=
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1k
+        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3Vw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxNVoiLCAiX2hyZWYiOiAiL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8x
+        N19jbG9uZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
+        cHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9j
+        bG9uZV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTJjIn0sICJj
+        b25maWciOiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIkZlZG9y
+        YV8xNyJ9LCAiaWQiOiAiRmVkb3JhXzE3X2Nsb25lIn0sICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWY4OTdlNzM4N2I0MTY1M2E4
+        In0sICJpZCI6ICI1ZmE0NWM5Zjg5N2U3Mzg3YjQxNjUzYTgifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:01 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3b80080e-b0a5-47f6-b8ea-adf1855bad82/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/544591fe-b6f7-47ed-a4f5-d59ec3619f9a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -840,7 +840,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -851,15 +851,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:01 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"036da54d2ad5e7df675fd4714295782e-gzip"'
+      - '"538f8fe91db53437e2ec20b5ff031056-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '558'
+      - '563'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -867,37 +867,38 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8zYjgwMDgwZS1iMGE1LTQ3ZjYtYjhl
-        YS1hZGYxODU1YmFkODIvIiwgInRhc2tfaWQiOiAiM2I4MDA4MGUtYjBhNS00
-        N2Y2LWI4ZWEtYWRmMTg1NWJhZDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy81NDQ1OTFmZS1iNmY3LTQ3ZWQtYTRm
+        NS1kNTllYzM2MTlmOWEvIiwgInRhc2tfaWQiOiAiNTQ0NTkxZmUtYjZmNy00
+        N2VkLWE0ZjUtZDU5ZWMzNjE5ZjlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OmV4cG9ydF9kaXN0cmlidXRvciIsICJwdWxwOmFjdGlvbjp1cGRhdGVfZGlz
-        dHJpYnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTAtMDdUMTc6NDk6
-        MDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MjAtMTAtMDdUMTc6NDk6MDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        dHJpYnV0b3IiXSwgImZpbmlzaF90aW1lIjogIjIwMjAtMTEtMDVUMjA6MTI6
+        MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi92Mi9yZXBvc2l0b3Jp
-        ZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3Iv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJp
-        YnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjog
-        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
-        IjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYyJ9LCAiY29uZmlnIjogeyJo
-        dHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlv
-        bi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwg
-        ImlkIjogImV4cG9ydF9kaXN0cmlidXRvciJ9LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjhjMTI5NzNmOGNkZTJhNWU2MyJ9LCAi
-        aWQiOiAiNWY3ZGZmOGMxMjk3M2Y4Y2RlMmE1ZTYzIn0=
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0
+        X3VwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxNVoiLCAiX2hyZWYiOiAi
+        L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9y
+        dF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwg
+        Imxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        ImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwg
+        InNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTJkIn0s
+        ICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
+        dHBzIjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWY4OTdlNzM4
+        N2I0MTY1M2I3In0sICJpZCI6ICI1ZmE0NWM5Zjg5N2U3Mzg3YjQxNjUzYjci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:01 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -905,7 +906,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -916,11 +917,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:02 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"37f5aeb8230b8d01d27657acc52731d6-gzip"'
+      - '"fdae145acdc99d04f6f14369b136eb24-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -933,59 +934,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0OTowMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAyMC0xMS0wNVQyMDoxMjoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjFjIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTJkIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDk6MDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjhiMDIyMzlmNzM2NDEzMWIxYiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVmYTQ1YzllMDZjNzFhMDQ0ZmNlODUyYyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAwWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE1WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjhjMDIyMzlmNzM2NTFl
-        NjFhYyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlmMDZjNzFhMDQ1MDNh
+        N2IzYSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAwWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjE1WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY4
-        YjAyMjM5ZjczNjQxMzFiMTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5
+        ZTA2YzcxYTA0NGZjZTg1MmEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmOGIwMjIzOWY3MzY0MTMxYjE4In0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWZhNDVjOWUwNmM3MWEwNDRmY2U4NTI5In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -993,7 +994,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1004,7 +1005,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:02 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -1015,14 +1016,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzIyNzY2YmRlLTQ0YmItNDRhNi1iZTYyLTUyMTk5MDVlNWU0MS8iLCAi
-        dGFza19pZCI6ICIyMjc2NmJkZS00NGJiLTQ0YTYtYmU2Mi01MjE5OTA1ZTVl
-        NDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2VlYjU2MWFhLWNkNjItNGFkMS1hY2MxLTIzZTBjM2U4YTJkNS8iLCAi
+        dGFza19pZCI6ICJlZWI1NjFhYS1jZDYyLTRhZDEtYWNjMS0yM2UwYzNlOGEy
+        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/22766bde-44bb-44a6-be62-5219905e5e41/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/eeb561aa-cd62-4ad1-acc1-23e0c3e8a2d5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1030,7 +1031,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -1041,15 +1042,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:49:02 GMT
+      - Thu, 05 Nov 2020 20:12:15 GMT
       Server:
       - Apache
       Etag:
-      - '"8a4e5703fc150c066687ac8f8215e805-gzip"'
+      - '"620fddf0d7eb8c6cb69c69472d2272a5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '364'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1057,20 +1058,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMjc2NmJkZS00NGJiLTQ0YTYtYmU2Mi01MjE5OTA1ZTVl
-        NDEvIiwgInRhc2tfaWQiOiAiMjI3NjZiZGUtNDRiYi00NGE2LWJlNjItNTIx
-        OTkwNWU1ZTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lZWI1NjFhYS1jZDYyLTRhZDEtYWNjMS0yM2UwYzNlOGEy
+        ZDUvIiwgInRhc2tfaWQiOiAiZWViNTYxYWEtY2Q2Mi00YWQxLWFjYzEtMjNl
+        MGMzZThhMmQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ5OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ5OjAyWiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjE1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjE1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjhlMTI5NzNmOGNkZTJhNWVkYyJ9LCAiaWQiOiAi
-        NWY3ZGZmOGUxMjk3M2Y4Y2RlMmE1ZWRjIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWY4OTdlNzM4N2I0MTY1
+        NDA2In0sICJpZCI6ICI1ZmE0NWM5Zjg5N2U3Mzg3YjQxNjU0MDYifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:49:02 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:15 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:36 GMT
+      - Thu, 05 Nov 2020 20:11:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:36 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:56 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:36 GMT
+      - Thu, 05 Nov 2020 20:11:56 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:36 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:56 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -94,11 +94,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvbGli
-        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
-        X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xp
-        ZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJf
+        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJ0eXBlX3NraXBfbGlz
+        dCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
+        aF9wYXNzd29yZCI6bnVsbCwicHJveHlfaG9zdCI6IiJ9LCJub3RlcyI6eyJf
         cmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0
         cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0
         b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:37 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmMzkwMjIzOWY3NDFlODgzZDFmIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjOGQwNmM3MWEwNDRlYTUyZjFjIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:37 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:37 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FmMGJlY2YxLWNjNWItNDgwYS1iYWIzLWZkZmNiOTgzYjhjNC8iLCAi
-        dGFza19pZCI6ICJhZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI3ZDAxMzkxLTdhMmEtNDM3OC05YjAxLTdkMzFiYjdjYTBiYi8iLCAi
+        dGFza19pZCI6ICIyN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:37 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,16 +231,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -252,42 +252,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,7 +296,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -306,15 +307,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -322,16 +323,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -343,42 +344,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +388,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -397,15 +399,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -413,16 +415,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -434,42 +436,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -477,7 +480,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -488,15 +491,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -504,16 +507,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -525,42 +528,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +572,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -579,15 +583,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -595,16 +599,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -616,42 +620,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -659,7 +664,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -670,15 +675,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:57 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -686,16 +691,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -707,42 +712,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:57 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -750,7 +756,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -761,15 +767,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -777,16 +783,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -798,42 +804,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27d01391-7a2a-4378-9b01-7d31bb7ca0bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +848,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -852,15 +859,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"8218636bb14dff7fd271f1fa9839f86a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
+      - '712'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -868,16 +875,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yN2QwMTM5MS03YTJhLTQzNzgtOWIwMS03ZDMxYmI3Y2Ew
+        YmIvIiwgInRhc2tfaWQiOiAiMjdkMDEzOTEtN2EyYS00Mzc4LTliMDEtN2Qz
+        MWJiN2NhMGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNzA0YjVhNzYtYzk4ZS00YzU3LTkzYTctZjhjZmZhNWJi
+        N2ExLyIsICJ0YXNrX2lkIjogIjcwNGI1YTc2LWM5OGUtNGM1Ny05M2E3LWY4
+        Y2ZmYTViYjdhMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -889,42 +896,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzhkMDZjNzFhMDc1MTQ3
+        ZWZlNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjA2In0sICJpZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiMDYi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/af0becf1-cc5b-480a-bab3-fdfcb983b8c4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/704b5a76-c98e-4c57-93a7-f8cffa5bb7a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -932,7 +940,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -943,106 +951,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Etag:
-      - '"9c4677a4fab2efb6913a6e54a9d4afd3-gzip"'
+      - '"24d638b4592e13bdb226ea9edc1898fc-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '715'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZjBiZWNmMS1jYzViLTQ4MGEtYmFiMy1mZGZjYjk4M2I4
-        YzQvIiwgInRhc2tfaWQiOiAiYWYwYmVjZjEtY2M1Yi00ODBhLWJhYjMtZmRm
-        Y2I5ODNiOGM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0NzozOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM1ZjNiMTktNjE3ZC00Y2VhLWI5YzYtNDcwZWFhOWY2
-        MjJhLyIsICJ0YXNrX2lkIjogImQzNWYzYjE5LTYxN2QtNGNlYS1iOWM2LTQ3
-        MGVhYTlmNjIyYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        NzozOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmYzYzAyMjM5ZjA1N2Y4YTQzNGYiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjM5MTI5NzNmOGNkZTJhM2NkYyJ9LCAi
-        aWQiOiAiNWY3ZGZmMzkxMjk3M2Y4Y2RlMmEzY2RjIn0=
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d35f3b19-617d-4cea-b9c6-470eaa9f622a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"1aadfbcd6185458e03963e61ae5089dd-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1347'
+      - '1369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1050,199 +967,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMzVmM2IxOS02MTdkLTRjZWEtYjljNi00NzBl
-        YWE5ZjYyMmEvIiwgInRhc2tfaWQiOiAiZDM1ZjNiMTktNjE3ZC00Y2VhLWI5
-        YzYtNDcwZWFhOWY2MjJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83MDRiNWE3Ni1jOThlLTRjNTctOTNhNy1mOGNm
+        ZmE1YmI3YTEvIiwgInRhc2tfaWQiOiAiNzA0YjVhNzYtYzk4ZS00YzU3LTkz
+        YTctZjhjZmZhNWJiN2ExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0MFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0MFoiLCAi
+        bWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1OFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxNTQ1YmYwYS1mM2NhLTQ4YjYtYWY3Zi04YWJkN2Rk
-        YWZjNzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJjZGRlYTYwOS02MjE4LTQ2OGQtOGIyOS1jOWVhM2Ri
+        NWYwYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMDJlM2ZjOTgtYmYwZS00NDMyLWFmOTctMDVmMjE0NTM0ZGMxIiwg
+        aWQiOiAiMTY3N2Q0ZDAtN2IxNy00Mzc1LTkwOGMtNTg5MzQxODc5ZjYwIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDYyZDhhNS1iZTBhLTQ3YTYtYjFk
-        Yy02NzliMmJjOTU4YzkiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYWIxMmQyYi04ZDhmLTQ0MDktODFj
+        ZS02NTYwNTc4ZWI0MGUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MzBlN2M3ZjMtZGU1Ni00NDQ2LTg1ZGYtZjU1NGI5Njc3MmE1IiwgIm51bV9w
+        MmVkMWFlMmQtNmU1ZS00NjQyLWFmMjAtZDc3MzkwOWEyMWExIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjNmNmU5MDVhLTMwY2YtNGY3Ny05ZjkxLTdl
-        Y2I0YWJiNTJiYyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjY0ODA2ODIzLWYwOTgtNDk0NC05ODhhLWVj
+        ZGU4Y2Q4M2I5MiIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiZTM2
-        YTUxLTE3NmMtNDI2Mi05ZTJmLTZlZTA1YjA4ZTI3NyIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAxZjI3
+        NDNlLTE2MTYtNGRlOC04M2Q2LTZiM2U5OTJjMDUxMSIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0OWU2ZmE4OS0yOGFjLTRiNWQtODZiNS0yZGY5
-        NzAxZWNjMzkiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI0MGU4YzAxMi0zZDhmLTQ0MzYtOGQ1My04NDE0
+        MDQ4ODY4ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Mjhl
-        NWZmOS0xZDU0LTQwYTItYTQxOC01OTRjN2U5N2Q1OTgiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZjIz
+        MzQ1Zi03ZmE2LTQ2MzYtYTFkYy01MGZkNWY0Y2UwNGYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTAwOTJhMi05ZmI1
-        LTQzNzMtOTAxOS0xMWI5NjMxOWYzNmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMjJmZjY2YS0wZmU0
+        LTQ1NDMtODczNS1iY2Q3OWFiZGQ2MjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjYjI2ZWU0ZS1kZjE3LTQ4NDItOWQ5MS00
-        YTEwZWJhMzU4YWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI2YzcyNTIwNy0yOWY4LTRjMTEtYTIxNi1k
+        OTUxZDhiZmVlYzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIyMTNlYTUzNi1iZGIxLTRiMDUtYWFkYS1lOTY5N2JhNmEx
-        NmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI2NjRiMjRkYy0zNWM4LTQxMjEtODQ4ZC03ZTZiNmY0ODY3
+        YTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYWU5ZTNkNi02
-        NjFjLTRhMTktYTZmMS1jNzlkNmI2ZWM4MzMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiM2VlODA2My1m
+        ZDlkLTQ3ZjctODUwZi1kOWI0YmYwZDNjYTIiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNDhjODQyOC03YjMzLTQ5OGUt
-        YjFhMy00NzFhZDM0YzkzNDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NGQzZmM3Yi1kM2Y4LTRiOTMt
+        YWY5OS1kN2U5MWE5YWZhZWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjRiMTA5YzRlLTI2ZDQtNGU3MS1hMDk1
-        LTQzY2Q5Njc3YjE0NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo0MFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
-        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
-        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
-        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
-        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
-        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
-        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
-        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
-        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjNjMDIyMzlmMDU3
-        ZjhhNDM1MCIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxNTQ1YmYwYS1mM2NhLTQ4YjYtYWY3Zi04YWJkN2RkYWZjNzki
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MDJlM2ZjOTgtYmYwZS00NDMyLWFmOTctMDVmMjE0NTM0ZGMxIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
-        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxMDYyZDhhNS1iZTBhLTQ3YTYtYjFkYy02Nzli
-        MmJjOTU4YzkiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
-        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzBlN2M3
-        ZjMtZGU1Ni00NDQ2LTg1ZGYtZjU1NGI5Njc3MmE1IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNmNmU5MDVhLTMwY2YtNGY3Ny05ZjkxLTdlY2I0YWJi
-        NTJiYyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
-        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiZTM2YTUxLTE3
-        NmMtNDI2Mi05ZTJmLTZlZTA1YjA4ZTI3NyIsICJudW1fcHJvY2Vzc2VkIjog
-        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
-        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI0OWU2ZmE4OS0yOGFjLTRiNWQtODZiNS0yZGY5NzAxZWNj
-        MzkiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
-        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MjhlNWZmOS0x
-        ZDU0LTQwYTItYTQxOC01OTRjN2U5N2Q1OTgiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
-        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTAwOTJhMi05ZmI1LTQzNzMt
-        OTAxOS0xMWI5NjMxOWYzNmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
-        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NTRhNDI4LTA0ZTctNGRjYS04NTNi
+        LTExN2JhODFiMjVmNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
+        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTha
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
+        dGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQiLCAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
+        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
+        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
+        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
+        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNWZh
+        NDVjOGUwNmM3MWEwNzUxNDdlZmU1IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImNkZGVhNjA5LTYyMTgtNDY4ZC04YjI5
+        LWM5ZWEzZGI1ZjBjNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjYjI2ZWU0ZS1kZjE3LTQ4NDItOWQ5MS00YTEwZWJh
-        MzU4YWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyMTNlYTUzNi1iZGIxLTRiMDUtYWFkYS1lOTY5N2JhNmExNmEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
-        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
-        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYWU5ZTNkNi02NjFjLTRh
-        MTktYTZmMS1jNzlkNmI2ZWM4MzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
-        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjNDhjODQyOC03YjMzLTQ5OGUtYjFhMy00
-        NzFhZDM0YzkzNDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
-        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjRiMTA5YzRlLTI2ZDQtNGU3MS1hMDk1LTQzY2Q5
-        Njc3YjE0NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYzEyOTczZjhjZGUyYTQwYzAi
-        fSwgImlkIjogIjVmN2RmZjNjMTI5NzNmOGNkZTJhNDBjMCJ9
+        LCAic3RlcF9pZCI6ICIxNjc3ZDRkMC03YjE3LTQzNzUtOTA4Yy01ODkzNDE4
+        NzlmNjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MTksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
+        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRhYjEyZDJiLThkOGYt
+        NDQwOS04MWNlLTY1NjA1NzhlYjQwZSIsICJudW1fcHJvY2Vzc2VkIjogMTl9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIyZWQxYWUyZC02ZTVlLTQ2NDItYWYyMC1kNzczOTA5YTIxYTEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogNiwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjQ4MDY4MjMtZjA5OC00OTQ0
+        LTk4OGEtZWNkZThjZDgzYjkyIiwgIm51bV9wcm9jZXNzZWQiOiA2fSwgeyJu
+        dW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1v
+        ZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwi
+        OiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMDFmMjc0M2UtMTYxNi00ZGU4LTgzZDYtNmIzZTk5MmMwNTExIiwgIm51
+        bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjog
+        ImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogNCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQwZThjMDEyLTNkOGYtNDQzNi04
+        ZDUzLTg0MTQwNDg4NjhmYiIsICJudW1fcHJvY2Vzc2VkIjogNH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRh
+        ZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNmMjMzNDVmLTdmYTYtNDYzNi1hMWRjLTUwZmQ1ZjRjZTA0ZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyMmZm
+        NjZhLTBmZTQtNDU0My04NzM1LWJjZDc5YWJkZDYyNyIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
+        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
+        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZjNzI1MjA3LTI5ZjgtNGMx
+        MS1hMjE2LWQ5NTFkOGJmZWVjMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
+        IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjY2NGIyNGRjLTM1YzgtNDEyMS04NDhkLTdl
+        NmI2ZjQ4NjdhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIz
+        ZWU4MDYzLWZkOWQtNDdmNy04NTBmLWQ5YjRiZjBkM2NhMiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
+        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0ZDNmYzdiLWQz
+        ZjgtNGI5My1hZjk5LWQ3ZTkxYTlhZmFlYyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU1NGE0MjgtMDRlNy00
+        ZGNhLTg1M2ItMTE3YmE4MWIyNWY1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3
+        ZTczODdiNDE2M2RiMiJ9LCAiaWQiOiAiNWZhNDVjOGQ4OTdlNzM4N2I0MTYz
+        ZGIyIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1268,7 +1186,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1281,7 +1199,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -1298,14 +1216,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI0In0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWZhNDVjOGUwNmM3MWEwNDRmY2U4NTA2In0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1317,7 +1235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1330,281 +1248,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:40 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2168'
+      - '2173'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
-        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
-        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
-        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
-        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
-        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
-        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjNiMTI5NzNmOGNkZTJhM2VhMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
-        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
-        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
-        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
-        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
-        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
-        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
-        NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
-        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
-        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmEz
-        ZTY4In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
-        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
-        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
-        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
-        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
-        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
-        IjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U4OCJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
-        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
-        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
-        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
-        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
-        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNi
-        MTI5NzNmOGNkZTJhM2UxMiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
-        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
-        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U1
-        NiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
-        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
-        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
-        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
-        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
-        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90
-        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
-        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
-        M2IxMjk3M2Y4Y2RlMmEzZTQzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
-        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
-        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
-        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
-        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
-        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
-        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U1ZiJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
-        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
-        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
-        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
-        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZTdmIn19LCB7Im1ldGFkYXRhIjog
-        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
-        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
-        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
-        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
-        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
-        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
-        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQi
-        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
-        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTcz
-        ZjhjZGUyYTNlMzYifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
-        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
-        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
-        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
-        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
-        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
-        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlOWEifX0sIHsibWV0YWRh
-        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
-        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
-        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
-        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
-        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
-        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNi
-        MTI5NzNmOGNkZTJhM2U3MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
-        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
-        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2U5
-        MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
-        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
-        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
-        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
+        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
+        MTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        aXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAwZGU0Mzk1LTA3NmYtNDAw
+        Yy1iNmVhLWY5YWI4MGU2NjY2OSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwMGRlNDM5NS0w
+        NzZmLTQwMGMtYjZlYS1mOWFiODBlNjY2NjkiLCAiX2lkIjogeyIkb2lkIjog
+        IjVmYTQ1YzhkODk3ZTczODdiNDE2M2JjZSJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
+        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
+        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
+        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
+        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjA4YTk0ZjAyLWM2ZjEtNDg4Ni04MTI4LWJlMmU5
+        Y2U0N2U0ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwOGE5NGYwMi1jNmYxLTQ4ODYtODEy
+        OC1iZTJlOWNlNDdlNGQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3
+        ZTczODdiNDE2M2I2OSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        ImR1Y2stMC42LTEuc3JjLnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tz
+        dW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0
+        M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJzdW1tYXJ5IjogIkEgZHVt
+        bXkgcGFja2FnZSBvZiBkdWNrIiwgImZpbGVuYW1lIjogImR1Y2stMC42LTEu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42Iiwg
+        ImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI1NGEzZDllNi01ZTdiLTRiZmYt
+        OTkzYS0zMGY5MjE1ODIyMWUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJ1
+        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNTRhM2Q5ZTYtNWU3
+        Yi00YmZmLTk5M2EtMzBmOTIxNTgyMjFlIiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiNDkifX0sIHsibWV0YWRhdGEiOiB7InNv
+        dXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
+        ImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdj
+        YTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIs
+        ICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwgImZp
+        bGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjY4NjM5ZGU5LTgyNDctNDZmMS1hYTJkLWVmNmI4ZTEyNWQ0
+        NCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICI2ODYzOWRlOS04MjQ3LTQ2ZjEtYWEyZC1lZjZi
+        OGUxMjVkNDQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdi
+        NDE2M2I5MiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImFybWFk
+        aWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNo
+        ZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2
+        NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJt
+        YWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90
+        eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjcxY2Jl
+        YzQ2LTgxYTUtNDVkNy05OTg0LTcyMGYzNTMxN2VlYyIsICJhcmNoIjogIm5v
+        YXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVU
+        MjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6
+        ICI3MWNiZWM0Ni04MWE1LTQ1ZDctOTk4NC03MjBmMzUzMTdlZWMiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2JlOSJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIs
+        ICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4
+        MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMy
+        NDcxMiIsICJzdW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBw
+        YXJrLiIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAi
+        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjog
+        dHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiNzFmNmVmY2MtNWJjYS00NTRlLTg1MmUtYTA1NzRkNjY2
+        NjI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogIjcxZjZlZmNjLTViY2EtNDU0ZS04NTJlLWEw
+        NTc0ZDY2NjYyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYjdiIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZWxl
+        cGhhbnQtMC4yLTEuc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNo
+        ZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEyZTgzOGVhY2Q2
+        NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsICJmaWxlbmFtZSI6ICJlbGVw
+        aGFudC0wLjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI3NzdjYWRl
+        Ny0yZjcyLTRhNzYtYjE0YS01MTdiYmZiZDJmMGYiLCAiYXJjaCI6ICJub2Fy
+        Y2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjExOjU3WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
+        Nzc3Y2FkZTctMmY3Mi00YTc2LWIxNGEtNTE3YmJmYmQyZjBmIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNjMDAifX0sIHsibWV0
+        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBt
+        IiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdl
+        M2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYy
+        MWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2Fs
+        cnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjAuOCIsICJfaWQiOiAiNzk3ZTg5YjMtMDZiYS00NzBlLTllZWItYWMz
+        OTk1OGJlOTlhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSIsICJ1bml0X2lkIjogIjc5N2U4OWIzLTA2YmEtNDcwZS05
+        ZWViLWFjMzk5NThiZTk5YSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4
+        OTdlNzM4N2I0MTYzYmUwIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0i
+        OiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIs
+        ICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1
+        ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJt
+        b25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjg0
+        ODgwNzJhLWQ3NzgtNGE3ZS05ZjgwLTM0YzgwODE1MDE0ZSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICI4NDg4MDcyYS1kNzc4LTRhN2UtOWY4MC0zNGM4MDgxNTAxNGUiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2JiOCJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVhOTFkNzNk
+        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
+        Yzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB0
+        cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjlhMGU1OGNjLTlhMmMtNDNhMy05NjI2LTgyYTM5
+        ZWQyZTBiNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICI5YTBlNThjYy05YTJjLTQzYTMtOTYy
+        Ni04MmEzOWVkMmUwYjciLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3
+        ZTczODdiNDE2M2I3MiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJj
+        aGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3
+        NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1hcnkiOiAi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxy
+        dXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBl
+        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImEwYTJlM2Vi
+        LTZiMzgtNGY2Zi04ZWZlLWJjYWY4YWE1M2I0NiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJh
+        MGEyZTNlYi02YjM4LTRmNmYtOGVmZS1iY2FmOGFhNTNiNDYiLCAiX2lkIjog
+        eyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2I4OCJ9fSwgeyJtZXRh
+        ZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxsby0wLjEtMS5zcmMucnBt
+        IiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFmNDc4MTMy
+        Zjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJkMjliN2M2ZTliYmE4OThh
+        NjFkZGMyN2I1ODkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFy
+        bWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTAuMS0xLm5vYXJj
+        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMSIsICJpc19t
         b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
-        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
-        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        ZjNiMTI5NzNmOGNkZTJhM2UxYiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
-        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
-        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
-        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImExODVjNjRiLTBiMTctNDI3Mi1hY2E4
+        LTliNDdhODE0NDMwYiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMTg1YzY0Yi0wYjE3LTQy
+        NzItYWNhOC05YjQ3YTgxNDQzMGIiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzhkODk3ZTczODdiNDE2M2JhNSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVs
+        ZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5
+        N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAi
+        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmls
+        ZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImE4Njg1MzQ5LWY4MDUtNDEwYi05MDAxLTU1MDhkMjNmMTc3
+        YSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICJhODY4NTM0OS1mODA1LTQxMGItOTAwMS01NTA4
+        ZDIzZjE3N2EiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdi
+        NDE2M2I1NyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdh
+        cm9vLTAuMy0xLnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVj
+        a3N1bSI6ICI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJm
+        MDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9w
+        IGxpa2UgYSBrYW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAi
+        a2FuZ2Fyb28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJhZjU5
+        YzRmZi04YWJmLTQyMGEtODM4NC04MGNlMTdiMmQ4NDUiLCAiYXJjaCI6ICJu
+        b2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAi
+        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjExOjU3WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
+        OiAiYWY1OWM0ZmYtOGFiZi00MjBhLTgzODQtODBjZTE3YjJkODQ1IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiNjAifX0sIHsi
+        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMzYWY1
+        OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYx
+        MGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNf
+        bW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImNlZTA3NjkyLTBlNjctNGE3Ny1iNGQ4
+        LWYxYmE2Y2Q3YTI0MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJjZWUwNzY5Mi0wZTY3LTRh
+        NzctYjRkOC1mMWJhNmNkN2EyNDAiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzhkODk3ZTczODdiNDE2M2JjNSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYw
+        MTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1h
         cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
-        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
-        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
-        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
-        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2UyZCJ9fSwg
-        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
-        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
-        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
-        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
-        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
-        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlMDUifX0sIHsibWV0YWRhdGEiOiB7
-        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
-        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
-        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
-        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
-        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVf
-        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
-        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEy
-        OTczZjhjZGUyYTNkZmIifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
-        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
-        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
-        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
-        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
-        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
-        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
-        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZGYyIn19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
-        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
-        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
-        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
-        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        ICJ3YWxydXMtNS4yMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjUuMjEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImQ5
+        MjhjZDJjLTRjYmUtNGI0Ni1iZDVjLWZmOTUwNmE0NDFmMSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJkOTI4Y2QyYy00Y2JlLTRiNDYtYmQ1Yy1mZjk1MDZhNDQxZjEiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2JmNyJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAuOC5z
+        cmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJk
+        MGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGVi
+        ZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZGMzN2MyMDctOGQ1Ny00NTU5
+        LWI3ZTYtOGJiOTFhZGRlNTlkIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImRjMzdjMjA3LThk
+        NTctNDU1OS1iN2U2LThiYjkxYWRkZTU5ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOGQ4OTdlNzM4N2I0MTYzYmQ3In19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTIuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0NjMy
+        Njg1OWI4ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5
+        ZiIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMi4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgImlzX21vZHVsYXIiOiBm
         YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
-        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
-        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4
-        Y2RlMmEzZTRkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
-        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
-        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
-        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
-        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
-        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
-        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNlMjQifX1d
+        MSIsICJfaWQiOiAiZTM0M2U1YjQtM2RmYi00YTIwLWE0YTEtMTg3ODMxNGI2
+        ZGQyIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUzNDNlNWI0LTNkZmItNGEyMC1hNGExLTE4
+        NzgzMTRiNmRkMiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4
+        N2I0MTYzYmFlIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlv
+        bi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3Vt
+        IjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgx
+        NTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJlZTMyODBkNy1kY2VhLTRl
+        MjAtYWVkMy02Nzk5Nzk2MjBlYzkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWUzMjgwZDct
+        ZGNlYS00ZTIwLWFlZDMtNjc5OTc5NjIwZWM5IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNiOWMifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:40 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1616,7 +1534,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1629,7 +1547,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -1642,10 +1560,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1655,7 +1573,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1668,7 +1586,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
@@ -1681,131 +1599,131 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzkwLzY2ZjZiNDNiMWI0ZGYwOWY4
+        YTY4Nzk3YTA3YTg0ZmQzZjU1ZTQ3NGY3ZDM5OTNlZjJhOGRjNzQxOGQxMDAx
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZh
+        Y3RzIjogWyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiZTgyMGUwOGMwNWFhNzM2Y2U1MzAwNjZjNjg4Mjg4YmY1NzQ2MDk4MjY3
+        YzI4MjQyNzllMzZjOWE3MmU2YjljZSIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNjU4MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9vIl19LCAic3VtbWFyeSI6
+        ICJLYW5nYXJvbyAwLjIgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
+        dmVyc2lvbiI6IDIwMTgwNzA0MTExNzE5LCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19t
+        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIyYjFmMWIy
+        NS02ZmNhLTQxYzQtOWU4Ni0yYjkwZTQxZGQ5MDYiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBrYW5nYXJv
+        byAwLjIgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEx
+        OjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjJiMWYxYjI1LTZmY2EtNDFjNC05ZTg2LTJiOTBl
+        NDFkZDkwNiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4N2I0
+        MTYzYzU1In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83OC82ODcyN2Jj
+        YzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNkNTU1NmJjZGNl
+        YTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIw
+        IiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjMtMS5ub2FyY2giXSwg
+        ImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2NzdjNGJhYWNmMDA1ZWM5
+        ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNmZGUiLCAiX2xhc3RfdXBk
+        YXRlZCI6IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVs
+        ZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5nYXJvbyJdfSwg
+        InN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVsZSIsICJkb3dubG9hZGVk
+        IjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQwNywgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMi
+        OiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQi
+        OiAiM2QyMGIxODQtZjEyNC00ZTNlLWFjZjktMTIyODk5ZmE4M2U0IiwgImFy
+        Y2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0
+        aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MS0wNVQyMDoxMTo1N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJ1bml0X3R5cGVfaWQi
+        OiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzZDIwYjE4NC1mMTI0LTRlM2Ut
+        YWNmOS0xMjI4OTlmYTgzZTQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzhk
+        ODk3ZTczODdiNDE2M2M0YyJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2Vf
+        cGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvbW9kdWxlbWQv
+        ZWEvYTg3MjAzYWE3MWFjZDA5ZWQ0Yzg3MGUwODc1NDlkYTJhNWQyY2FjN2Ni
+        OWVlZDdlN2IwNjNiZjlmNDk3YTkiLCAibmFtZSI6ICJ3YWxydXMiLCAic3Ry
+        ZWFtIjogIjAuNzEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMtMDowLjcxLTEu
+        bm9hcmNoIl0sICJjaGVja3N1bSI6ICI4M2Y2YWZmMzI2MTQ4NTdlOTkwOTg3
+        NmE0ZmI3YTk1ZDU5MTk1ZmQ5OGI5YTI3YTA2NGE5NDJlY2JjNGY0NjgyIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVsdCI6IFsid2Fs
+        cnVzIl0sICJmbGlwcGVyIjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5IjogIldh
+        bHJ1cyAwLjcxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZlcnNp
+        b24iOiAyMDE4MDcwNzE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiY29udGV4dCI6ICJjMGZmZWU0MiIsICJfbnMiOiAidW5pdHNfbW9kdWxl
+        bWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiNTg4NTc1MGUtMWM4
+        Ny00Y2YwLTliMzgtOGI4ZGI0YWU5ZjgyIiwgImFyY2giOiAieDg2XzY0Iiwg
+        ImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVzIDAuNzEg
+        cGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJ1
+        bml0X2lkIjogIjU4ODU3NTBlLTFjODctNGNmMC05YjM4LThiOGRiNGFlOWY4
+        MiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4N2I0MTYzYzgz
+        In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGli
+        L3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC80MS85YzI2Y2EwMzIyZjA0
+        NThhYjc0ZjU4NzZlMjlhMzY2ZjgwYzJiNDkwMjBmNjYzYWJiOWZmNGJiZGNi
+        ZDZjYyIsICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSIsICJh
+        cnRpZmFjdHMiOiBbIndhbHJ1cy0wOjUuMjEtMS5ub2FyY2giXSwgImNoZWNr
+        c3VtIjogImZjMGNiOTUwZTUzYzVlYTk5YjAzYmNhYzQyNzI1YzYwMjk1ZjE0
+        OGFhYWRlMWE3Y2U2YzdkODAyOGEwNzNiNTkiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5
+        IjogIldhbHJ1cyA1LjIxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        InZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMiOiAidW5pdHNf
+        bW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiODhlZjA1
+        OWMtYWEzYy00YjdkLTgwNjEtM2Y0ZTcyZjI4ZWI0IiwgImFyY2giOiAieDg2
+        XzY0IiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVz
+        IDUuMjEgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEx
+        OjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjg4ZWYwNTljLWFhM2MtNGI3ZC04MDYxLTNmNGU3
+        MmYyOGViNCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4N2I0
+        MTYzYzc4In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC8xYi8yZjAwMzk2
+        NGJiNjQyMWRlNzQyNzdkYjE5YzljYThkMzMzYWJhOTYzOTM5MTBjNzgwZTU3
+        MDBkYzhhODNhMyIsICJuYW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAiLCAi
+        YXJ0aWZhY3RzIjogWyJkdWNrLTA6MC42LTEubm9hcmNoIl0sICJjaGVja3N1
+        bSI6ICI2YmQ5ZDkwOWM5MjcwNTcxYjgxMWU1MDI3MDllYTdiNTYxNTBkNDRh
+        MmI0YjM0Y2ZkMjVlNTJhODFjNWJmY2U3IiwgIl9sYXN0X3VwZGF0ZWQiOiAx
+        NjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJw
+        cm9maWxlcyI6IHsiZGVmYXVsdCI6IFsiZHVjayJdfSwgInN1bW1hcnkiOiAi
+        RHVjayAwLjYgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVyc2lv
+        biI6IDIwMTgwNzA0MjQ0MjA1LCAicHVscF91c2VyX21ldGFkYXRhIjoge30s
+        ICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1bGVt
+        ZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICI4ZGM4ZTI5Zi1lNTMx
+        LTQ0NWYtYTcwYy01NjQ2OTBmYTk4NGQiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        ZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBkdWNrIDAuNiBwYWNr
+        YWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
+        aWQiOiAiOGRjOGUyOWYtZTUzMS00NDVmLWE3MGMtNTY0NjkwZmE5ODRkIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNjNmMifX0s
+        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRlNGUzNWM2
+        N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIwYzM4MmNl
         IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        OiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjogImRkNjIx
+        YzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODczZDg1NmI3
+        OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEs
         ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNyBt
         b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
         OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
-        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
-        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y0ZCJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
-        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
-        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
-        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
-        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
-        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
-        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
-        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
-        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
-        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
-        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
-        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
-        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y1YiJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
-        ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
-        OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
-        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
-        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
-        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNm
-        MmQifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
-        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
-        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
-        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
-        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
-        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
-        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
-        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
-        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
-        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y0NCJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
-        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
-        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
-        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
-        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
-        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTNm
-        MzcifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
-        Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
-        ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
-        ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
-        Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
-        NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
-        LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
-        ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
-        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
-        NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
-        YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
-        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
-        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
-        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJhM2Y2NCJ9fV0=
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogImIxZmJhOGZjLTk2YmMtNDNiMi1hOWZl
+        LTNhNmRkMjBhYTg0NyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJiMWZi
+        YThmYy05NmJjLTQzYjItYTlmZS0zYTZkZDIwYWE4NDciLCAiX2lkIjogeyIk
+        b2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2M2MyJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1815,7 +1733,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1828,7 +1746,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -1841,10 +1759,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1854,7 +1772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1867,226 +1785,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1950'
+      - '1948'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
-        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
-        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
-        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
-        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
-        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
-        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
-        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
-        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
-        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
-        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
-        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
-        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
-        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
-        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
-        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NTksICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
-        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzla
-        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
-        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmYzYjEyOTczZjhjZGUyYTQwNDUifX0sIHsibWV0YWRh
-        dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
-        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
-        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9t
-        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
-        dGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2
-        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
-        ImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg1OSwgInJl
-        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
-        Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
-        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
-        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
-        MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
-        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
-        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5NzNmOGNkZTJh
-        NDAwZCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
-        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
-        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
-        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
-        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
-        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
-        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
-        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
-        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
-        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
-        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
-        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
-        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODU5
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
-        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
-        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2IxMjk3M2Y4
-        Y2RlMmE0MDJiIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
-        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
-        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
-        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
-        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMjA5Mjg1OSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
-        dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
-        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
-        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
-        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjNiMTI5NzNmOGNkZTJhM2ZiOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
-        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
-        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
-        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
-        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
-        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
-        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
-        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
-        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg1OSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
-        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
-        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNiMTI5
-        NzNmOGNkZTJhM2ZmMiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
-        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
-        dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
-        ZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0s
-        IHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemls
-        bGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxh
-        IiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6
-        aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3Mi
-        fSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkv
-        ZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwg
-        ImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
-        NSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
-        L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjog
-        Im90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91
-        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
-        dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIsICJmcm9tIjog
-        InNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50
-        IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBkYXRl
-        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMyIsICJy
-        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
-        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
-        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
-        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
-        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDIt
-        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
-        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
-        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
-        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
-        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZl
-        bCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2Vj
-        NGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        MiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5
-        OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
-        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29s
-        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIs
-        ICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
-        b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
-        dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
-        bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
-        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NTksICJy
-        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
-        aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
-        b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
-        YWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5
-        b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUg
-        aXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxz
-        IG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkg
-        dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
-        ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
-        YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
-        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
-        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
-        VDE3OjQ3OjM5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMTAtMDdUMTc6NDc6MzlaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
-        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYjEyOTcz
-        ZjhjZGUyYTNmZDgifX1d
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTE3LCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICIyOGY1ZmIxNC00MTVlLTRmYmItYmI5NS1mZmExMDcyYjAy
+        MTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjExOjU3WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lk
+        IjogIjI4ZjVmYjE0LTQxNWUtNGZiYi1iYjk1LWZmYTEwNzJiMDIxNiIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4OTdlNzM4N2I0MTYzY2U2In19LCB7
+        Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTowMTowMSIs
+        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDExMSIs
+        ICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEiLCAiX25z
+        IjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3Jh
+        cHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51bGwsICJm
+        aWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIs
+        ICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcxMTcsICJyZXN0YXJ0
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMi
+        OiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjc0YjgxMGMzLWZiNjMtNDA4My1hZTNhLTI1NzMx
+        ZjJhZGY4ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiNzRiODEwYzMtZmI2My00MDgzLWFlM2EtMjU3MzFmMmFkZjhk
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDg5N2U3Mzg3YjQxNjNkMzki
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5
+        OTE0MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
+        dHkiOiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9y
+        ZyIsICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNzExNywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
+        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
+        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTAyYmU4ZmQtZDc2
+        ZC00ODEyLWEzMmUtZGU5MWIyNWJiNWEzIn0sICJ1cGRhdGVkIjogIjIwMjAt
+        MTEtMDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNy
+        ZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lk
+        IjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJhMDJiZThmZC1kNzZkLTQ4MTIt
+        YTMyZS1kZTkxYjI1YmI1YTMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzhk
+        ODk3ZTczODdiNDE2M2QxZiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjog
+        IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBm
+        YWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktB
+        VEVMTE8tUkhFQS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0
+        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJv
+        b19FcnJhdHVtIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24i
+        OiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVu
+        aGFuY2VtZW50IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
+        ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVj
+        ayIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJl
+        bGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29s
+        bGVjdGlvbi0wIiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIs
+        ICJ2ZXJzaW9uIjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAi
+        In0sIHsicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGws
+        ICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwg
+        Im1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjog
+        IjIwMTgwNzMwMjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAi
+        a2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0
+        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAw
+        OjAxIFVUQyIsICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1
+        bSBkZXNjcmlwdGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzExNywg
+        InJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYjdjNGIzNmUtZjRiMy00MjViLTg4
+        NDMtY2RlYmE1MmE2ZDhhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0
+        dW0iLCAidW5pdF9pZCI6ICJiN2M0YjM2ZS1mNGIzLTQyNWItODg0My1jZGVi
+        YTUyYTZkOGEiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdi
+        NDE2M2Q1NiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEt
+        MDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
+        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
+        QS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
+        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEi
+        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
+        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
+        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
+        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxl
+        Y3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwg
+        InVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVy
+        cmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzExNywgInJlc3RhcnRf
+        c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
+        ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
+        OiAiMSIsICJfaWQiOiAiYmRhNDBiNzktZmI3Yi00NTM1LTg0YTktOGJlNmIx
+        ZmVmMTk3In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5p
+        dF9pZCI6ICJiZGE0MGI3OS1mYjdiLTQ1MzUtODRhOS04YmU2YjFmZWYxOTci
+        LCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3ZTczODdiNDE2M2QwMCJ9
+        fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
+        MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
+        OiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRz
+        X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAi
+        c3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlv
+        biI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcx
+        MTcsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImM1M2NhMWE2LTQ1NGYtNGVi
+        ZC1hMDdiLTVmMTlhNjEwZmNjOSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjExOjU3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYzUzY2ExYTYtNDU0Zi00ZWJkLWEwN2It
+        NWYxOWE2MTBmY2M5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDg5N2U3
+        Mzg3YjQxNjNjYzcifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2096,7 +2014,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2109,7 +2027,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2122,10 +2040,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2135,7 +2053,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2148,13 +2066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '519'
+      - '521'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2164,19 +2082,19 @@ http_interactions:
         b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
         X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
         YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
-        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEsICJv
         cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
         OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
         cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
         ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
-        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
-        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
-        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2Ix
-        Mjk3M2Y4Y2RlMmE0MDYxIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        YmlyZCIsICJfaWQiOiAiZjk3MTM3MWUtN2IyMi00NTY2LThhMjAtODBjNmQ2
+        MzEzYTM5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMTo1N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogImY5NzEzNzFlLTdiMjItNDU2Ni04
+        YTIwLTgwYzZkNjMxM2EzOSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGQ4
+        OTdlNzM4N2I0MTYzZDY4In19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
         cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
         ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
         ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
@@ -2184,24 +2102,24 @@ http_interactions:
         LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
         XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
         InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
-        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
-        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0
+        NjA2NTgxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
         YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
         ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
         YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
-        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
-        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZmE4NTFkNGMtZTgwZS00MDZl
+        LTg3OTktNmE0OTM3YWM0YjgxIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
         Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0NzozOVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM5WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
-        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmM2IxMjk3M2Y4Y2RlMmE0MDZkIn19XQ==
+        MjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImZhODUxZDRj
+        LWU4MGUtNDA2ZS04Nzk5LTZhNDkzN2FjNGI4MSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOGQ4OTdlNzM4N2I0MTYzZDc0In19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2211,7 +2129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2224,7 +2142,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2237,10 +2155,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2250,7 +2168,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2263,13 +2181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '405'
+      - '402'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2283,22 +2201,22 @@ http_interactions:
         Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
         b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
         ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODU4LCAiX2NvbnRlbnRfdHlwZV9p
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTE3LCAiX2NvbnRlbnRfdHlwZV9p
         ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
         cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
         eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
-        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6MzhaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
-        N1QxNzo0NzozOFoiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
-        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNhMTI5
-        NzNmOGNkZTJhM2RjNSJ9fV0=
+        YTI1NiIsICJfaWQiOiAiNDJlYmU5MGEtMDMwMS00ZjlhLWI2NzktNGFlODVk
+        ZTljZDI2In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTdaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMTo1N1oiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICI0MmViZTkwYS0wMzAxLTRmOWEtYjY3
+        OS00YWU4NWRlOWNkMjYiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzhkODk3
+        ZTczODdiNDE2M2IyZiJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2308,7 +2226,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2321,7 +2239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2334,10 +2252,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2349,7 +2267,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2362,7 +2280,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2375,10 +2293,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2388,7 +2306,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2401,13 +2319,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '533'
+      - '534'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2427,45 +2345,45 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg1OSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwNDYw
+        NzExNywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6MzlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0NzozOVoiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmM2IxMjk3M2Y4Y2RlMmEzZWY3In19XQ==
+        MjAtMTEtMDVUMjA6MTE6NTdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOGQ4OTdlNzM4N2I0MTYzYzNjIn19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCJ3YWxydXMt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJsaW9uLTAuMy0w
-        Ljgubm9hcmNoLnJwbSIsIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJj
-        aGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsImdpcmFmZmUtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwicGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJhcm1h
-        ZGlsbG8tMC4yLTEubm9hcmNoLnJwbSIsInRyb3V0LTAuMTItMS5ub2FyY2gu
-        cnBtIiwiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwiYXJtYWRpbGxv
-        LTAuMS0xLm5vYXJjaC5ycG0iXX19fSwiZmllbGRzIjp7InVuaXQiOlsibmFt
+        OnsiJGluIjpbImFybWFkaWxsby0wLjEtMS5ub2FyY2gucnBtIiwiYXJtYWRp
+        bGxvLTAuMi0xLm5vYXJjaC5ycG0iLCJhcm1hZGlsbG8tMi4xLTEubm9hcmNo
+        LnJwbSIsImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwiZWxlcGhhbnQt
+        MC4yLTEubm9hcmNoLnJwbSIsImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJw
+        bSIsImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwibGlvbi0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwicGVu
+        Z3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJzcXVpcnJlbC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIsIndhbHJ1cy0w
+        LjMtMC44Lm5vYXJjaC5ycG0iXX19fSwiZmllbGRzIjp7InVuaXQiOlsibmFt
         ZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwiY2hlY2tz
         dW10eXBlIiwiY2hlY2tzdW0iXX19LCJvdmVycmlkZV9jb25maWciOnt9fQ==
     headers:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2478,7 +2396,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2489,14 +2407,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzliODk4NGM1LWZlNmItNDNkNS1hYTI3LTVjMDUzNTc3NmNjYi8iLCAi
-        dGFza19pZCI6ICI5Yjg5ODRjNS1mZTZiLTQzZDUtYWEyNy01YzA1MzU3NzZj
-        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI3MTcxZDIwLTEyMGEtNGYyYi1hMzcxLThmNzk4NDBlNDczMC8iLCAi
+        dGFza19pZCI6ICIyNzE3MWQyMC0xMjBhLTRmMmItYTM3MS04Zjc5ODQwZTQ3
+        MzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2507,7 +2425,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2520,7 +2438,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2531,14 +2449,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzU2NWEyZmVlLTg1N2EtNGVjZS1hMWQ5LTE3NzU1MTYxNDlkNi8iLCAi
-        dGFza19pZCI6ICI1NjVhMmZlZS04NTdhLTRlY2UtYTFkOS0xNzc1NTE2MTQ5
-        ZDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E1ZjEwMDU1LTRlNTUtNGM5Zi04YTBlLWZlZDBmYzE3MmYxZS8iLCAi
+        dGFza19pZCI6ICJhNWYxMDA1NS00ZTU1LTRjOWYtOGEwZS1mZWQwZmMxNzJm
+        MWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2548,7 +2466,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2561,7 +2479,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2572,14 +2490,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M0YWE1NDU2LWYxNmEtNGZjOC04MWQwLWJjMDIzODZiNjE4NS8iLCAi
-        dGFza19pZCI6ICJjNGFhNTQ1Ni1mMTZhLTRmYzgtODFkMC1iYzAyMzg2YjYx
-        ODUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2EwM2UzYzcyLWM5ZDItNDVmMy05NjY4LTRkMzNjNTlkMTBkNi8iLCAi
+        dGFza19pZCI6ICJhMDNlM2M3Mi1jOWQyLTQ1ZjMtOTY2OC00ZDMzYzU5ZDEw
+        ZDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2589,7 +2507,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2602,7 +2520,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2613,14 +2531,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzlhYTg5NjE0LWY4NWEtNDllZS1hMDc2LTcwYmI0ZTU4YWIwMC8iLCAi
-        dGFza19pZCI6ICI5YWE4OTYxNC1mODVhLTQ5ZWUtYTA3Ni03MGJiNGU1OGFi
-        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzAxM2U0N2U2LWY4OTEtNGFmZC05NmZhLTJhNTYxZWE4NDYzMS8iLCAi
+        dGFza19pZCI6ICIwMTNlNDdlNi1mODkxLTRhZmQtOTZmYS0yYTU2MWVhODQ2
+        MzEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2630,7 +2548,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2643,7 +2561,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2654,14 +2572,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NmYTU4ZjFjLWZiM2QtNDhhYy1hMTBlLTAzMjViNmVmMjQ4MC8iLCAi
-        dGFza19pZCI6ICJjZmE1OGYxYy1mYjNkLTQ4YWMtYTEwZS0wMzI1YjZlZjI0
-        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FlZjgxMmM1LTM3ZGUtNDMwNy1hMGFiLTZkMzc4MDk4NzVjMi8iLCAi
+        dGFza19pZCI6ICJhZWY4MTJjNS0zN2RlLTQzMDctYTBhYi02ZDM3ODA5ODc1
+        YzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2672,7 +2590,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2685,7 +2603,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:58 GMT
       Server:
       - Apache
       Content-Length:
@@ -2696,14 +2614,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQzNjhiZDljLTRkM2MtNGRlMC1iNGZiLTQ5NmM2OGI3OWUyNi8iLCAi
-        dGFza19pZCI6ICI0MzY4YmQ5Yy00ZDNjLTRkZTAtYjRmYi00OTZjNjhiNzll
-        MjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E1MWMxMmFkLWM1NGMtNDMyNi05MzUyLTRlNTEyNGUzN2NlZS8iLCAi
+        dGFza19pZCI6ICJhNTFjMTJhZC1jNTRjLTQzMjYtOTM1Mi00ZTUxMjRlMzdj
+        ZWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:41 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:58 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2714,7 +2632,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2727,7 +2645,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:41 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -2738,14 +2656,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI5YmI1OTdkLWE2NzktNDA5NC05NTc1LWZmYmExMzhlMzA2Zi8iLCAi
-        dGFza19pZCI6ICIyOWJiNTk3ZC1hNjc5LTQwOTQtOTU3NS1mZmJhMTM4ZTMw
-        NmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Y2MmM2ZTNkLTljMWYtNDFiYi1iNzIxLTkxZmYwZTc1OGM5MS8iLCAi
+        dGFza19pZCI6ICJmNjJjNmUzZC05YzFmLTQxYmItYjcyMS05MWZmMGU3NThj
+        OTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2755,7 +2673,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2768,7 +2686,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -2779,14 +2697,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FiN2Y0MDE2LTc1ODQtNDI4OC1iYTExLTE4YjJhMmM3ODU1Mi8iLCAi
-        dGFza19pZCI6ICJhYjdmNDAxNi03NTg0LTQyODgtYmExMS0xOGIyYTJjNzg1
-        NTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJkNmRlYmRlLWNiNDAtNGEwNS1hMjgyLTZiNDA0YzMyODJjMS8iLCAi
+        dGFza19pZCI6ICIyZDZkZWJkZS1jYjQwLTRhMDUtYTI4Mi02YjQwNGMzMjgy
+        YzEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2796,7 +2714,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2809,7 +2727,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -2820,14 +2738,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc0Y2Q0ZTU1LWJkMTktNDRkMS1iOTRjLWU5YmYyZTFiYjczMi8iLCAi
-        dGFza19pZCI6ICI3NGNkNGU1NS1iZDE5LTQ0ZDEtYjk0Yy1lOWJmMmUxYmI3
-        MzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzg4MTUyYjAxLWUwNDMtNGQyNS1iYjIyLTNmOWMxNzI4NDgzZC8iLCAi
+        dGFza19pZCI6ICI4ODE1MmIwMS1lMDQzLTRkMjUtYmIyMi0zZjljMTcyODQ4
+        M2QifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2837,7 +2755,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2850,7 +2768,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Content-Length:
@@ -2861,14 +2779,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRmNDIzNTVjLWI1MzctNDZmOS05ZjI2LTJiNzYxMGUxMmFhMy8iLCAi
-        dGFza19pZCI6ICI0ZjQyMzU1Yy1iNTM3LTQ2ZjktOWYyNi0yYjc2MTBlMTJh
-        YTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2YyZjRkYTlhLWNhMGQtNDkxNC1hMmMxLTMyM2NjMWQ5NTUzZS8iLCAi
+        dGFza19pZCI6ICJmMmY0ZGE5YS1jYTBkLTQ5MTQtYTJjMS0zMjNjYzFkOTU1
+        M2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9b8984c5-fe6b-43d5-aa27-5c0535776ccb/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/27171d20-120a-4f2b-a371-8f79840e4730/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2876,7 +2794,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2887,15 +2805,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"bf50bbc4e43f2ce60ea9be9f846d0d18-gzip"'
+      - '"877a0a35d9b78dfa4a3c4b80a475612d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1174'
+      - '1173'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2903,206 +2821,206 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85Yjg5ODRj
-        NS1mZTZiLTQzZDUtYWEyNy01YzA1MzU3NzZjY2IvIiwgInRhc2tfaWQiOiAi
-        OWI4OTg0YzUtZmU2Yi00M2Q1LWFhMjctNWMwNTM1Nzc2Y2NiIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNzE3MWQy
+        MC0xMjBhLTRmMmItYTM3MS04Zjc5ODQwZTQ3MzAvIiwgInRhc2tfaWQiOiAi
+        MjcxNzFkMjAtMTIwYS00ZjJiLWEzNzEtOGY3OTg0MGU0NzMwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQx
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU4
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0
-        NjMyNjg1OWI4ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZm
-        Mzk5ZiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
-        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0i
-        OiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1
-        ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
-        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
-        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
-        OiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
-        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNo
-        YTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51
-        bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1
-        bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1
-        ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2Fy
-        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
-        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3
-        Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRi
-        MSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
-        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tz
-        dW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNm
-        NjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJw
-        bSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1l
-        IjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2
-        ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5
-        NCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
-        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
-        c3VtIjogImFmNDc4MTMyZjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJk
-        MjliN2M2ZTliYmE4OThhNjFkZGMyN2I1ODkiLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
-        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
-        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJjOTgx
-        OWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2MWRm
-        ZCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
-        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNr
-        c3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2NGU4
-        MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
-        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
-        cG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJ0cm91dCIsICJjaGVja3N1bSI6ICJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
-        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjEyIiwgInJlbGVhc2Ui
-        OiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
-        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVs
-        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0i
-        OiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNl
-        MzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
-        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
-        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
-        OiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVmMTNkNzg0
-        ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdk
-        MiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3Np
-        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0Mjk4In0sICJpZCI6ICI1
-        ZjdkZmYzZDEyOTczZjhjZGUyYTQyOTgifQ==
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/565a2fee-857a-4ece-a1d9-1775516149d6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"dfe895d5c43ed72eab1ff5c17b8251f4-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '960'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81NjVhMmZl
-        ZS04NTdhLTRlY2UtYTFkOS0xNzc1NTE2MTQ5ZDYvIiwgInRhc2tfaWQiOiAi
-        NTY1YTJmZWUtODU3YS00ZWNlLWExZDktMTc3NTUxNjE0OWQ2IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
-        ZXJzaW9uIjogMjAxODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJu
-        YW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9k
-        dWxlbWQifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIs
-        ICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIs
-        ICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9p
-        ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
-        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAi
-        bm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlw
-        ZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgz
-        M2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5
-        YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
-        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
-        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNr
-        IiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNl
-        ZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
-        aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
-        ZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tl
-        eSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVhNGM4
-        OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2Qw
-        OTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9r
-        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
-        NzA0MTExNzE5LCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJrYW5nYXJv
-        byIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
-        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndh
-        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
-        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIs
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJh
+        YmY2OTFlZTViNDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhk
+        MDU4OWU2ZjNkOGQxZmYzOTlmIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsi
+        c2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAibGlv
+        biIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2
+        Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
+        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQw
+        YmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJk
+        YmI3ZDY1ZmIzNjhkYWUiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
+        MyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
+        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNp
+        Z25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBo
+        YW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2Ni
+        M2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIs
         ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
         ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUz
-        M2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0
-        OGI3N2UwMTg5OGU3YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1
-        LjIxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
-        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVu
-        aXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAy
-        MDE4MDczMDIyMzQwNywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2Fu
-        Z2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQi
-        fSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
-        aW9uIjogMjAxODA3MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1l
-        IjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJt
-        b2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
-        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZl
-        NmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3
-        NGJjNyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVh
+        aXRfa2V5IjogeyJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThm
+        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
+        OGUyYzg0ZGU4NTAxZGIxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVw
+        aGFudCIsICJjaGVja3N1bSI6ICIzMzM1MWZkNmMyYTM4ZTVkNDlhZWE3ODhh
+        MmU4MzhlYWNkNjU0Y2Y2MWQ0NzZiYTViNjVkZTQzOWRkZDEyNWI5IiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFzZSI6ICIxIiwg
+        ImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwg
+        InR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5p
+        dF9rZXkiOiB7Im5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNi
+        MmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIx
+        MGZkNmU0ODYzNWJlNjk0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJhcm1h
+        ZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUz
+        Y2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
+        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThk
+        NmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFk
+        ZWM3ZmI2MjFhNDYxZGZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJhcm1h
+        ZGlsbG8iLCAiY2hlY2tzdW0iOiAiOGQzMTk5MDVlZWRiNWE1MjQ3ZTNhMzUy
+        NTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2ZjUxYWIzYjY1YSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
+        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogInRyb3V0IiwgImNoZWNrc3VtIjogImFlYTkx
+        ZDczZDhkZjIxNTAyZmVjYmMxYmJmNjRlN2NmZGQ2MTc1MWExYmEyNzMwOTM5
+        ZDU3ZmM4NDI2MDJlMTQiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
+        MTIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZ2lyYWZm
+        ZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3
+        YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0IiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
+        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3
+        NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNj
+        ZGUxYzBhZTg3OGExN2QyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV0sICJ1
+        bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZTg5N2U3Mzg3YjQxNjNm
+        NzYifSwgImlkIjogIjVmYTQ1YzhlODk3ZTczODdiNDE2M2Y3NiJ9
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a5f10055-4e55-4c9f-8a0e-fed0fc172f1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:11:59 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"aadbe6ba166060e0840d0746e6095f7b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '958'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNWYxMDA1
+        NS00ZTU1LTRjOWYtOGEwZS1mZWQwZmMxNzJmMWUvIiwgInRhc2tfaWQiOiAi
+        YTVmMTAwNTUtNGU1NS00YzlmLThhMGUtZmVkMGZjMTcyZjFlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU4
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250ZXh0Ijog
+        ImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwgImFyY2gi
+        OiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAi
+        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
+        IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIwMywgImFy
+        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIw
+        LjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9rZXkiOiB7
+        ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjMz
+        MTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwgInN0cmVh
+        bSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAi
+        Y2hlY2tzdW0iOiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
+        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
+        IjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
+        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4
+        MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMy
+        NDcxMiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43IiwgInJlbGVh
         c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9z
-        aWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjNkMTI5NzNmOGNkZTJhNDJhOSJ9LCAiaWQiOiAi
-        NWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MmE5In0=
+        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
+        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNr
+        c3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2EzYzQwNzI4MGMxNDFlOTIwMmYw
+        MjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQiLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
+        cG0ifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
+        ZXJzaW9uIjogMjAxODA3MDQxMTE3MTksICJhcmNoIjogIm5vYXJjaCIsICJu
+        YW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjog
+        Im1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXki
+        OiB7Im5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBj
+        YmUzZWNiMmNiZWUxYzYyNmEzOWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1
+        NjUyMzE0MmMiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAi
+        cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNo
+        ZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4
+        OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAi
+        bm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQi
+        OiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYi
+        LCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJub2FyY2gi
+        LCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
+        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFyY2giOiAi
+        eDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIn0s
+        ICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXkiOiBudWxs
+        LCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5
+        NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3
+        Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGU4OTdlNzM4N2I0MTYz
+        ZjhiIn0sICJpZCI6ICI1ZmE0NWM4ZTg5N2U3Mzg3YjQxNjNmOGIifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c4aa5456-f16a-4fc8-81d0-bc02386b6185/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a03e3c72-c9d2-45f3-9668-4d33c59d10d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3110,7 +3028,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3121,15 +3039,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"2951977b4ab3b12f6d71e437f78fcaa8-gzip"'
+      - '"b19653f075a98bf7836765954c6d5a61-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '427'
+      - '432'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3137,93 +3055,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jNGFhNTQ1
-        Ni1mMTZhLTRmYzgtODFkMC1iYzAyMzg2YjYxODUvIiwgInRhc2tfaWQiOiAi
-        YzRhYTU0NTYtZjE2YS00ZmM4LTgxZDAtYmMwMjM4NmI2MTg1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMDNlM2M3
+        Mi1jOWQyLTQ1ZjMtOTY2OC00ZDMzYzU5ZDEwZDYvIiwgInRhc2tfaWQiOiAi
+        YTAzZTNjNzItYzlkMi00NWYzLTk2NjgtNGQzM2M1OWQxMGQ2IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNkMTI5
-        NzNmOGNkZTJhNDJiYiJ9LCAiaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0
-        MmJiIn0=
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9aa89614-f85a-49ee-a076-70bb4e58ab00/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"75806a3e736dc5cf89f5cd0f5846f1a1-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '510'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YWE4OTYx
-        NC1mODVhLTQ5ZWUtYTA3Ni03MGJiNGU1OGFiMDAvIiwgInRhc2tfaWQiOiAi
-        OWFhODk2MTQtZjg1YS00OWVlLWEwNzYtNzBiYjRlNThhYjAwIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
-        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
-        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
-        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
-        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
-        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
-        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
-        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
         ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MmQ0In0sICJpZCI6ICI1ZjdkZmYz
-        ZDEyOTczZjhjZGUyYTQyZDQifQ==
+        OiAiNWZhNDVjOGU4OTdlNzM4N2I0MTYzZmI4In0sICJpZCI6ICI1ZmE0NWM4
+        ZTg5N2U3Mzg3YjQxNjNmYjgifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/cfa58f1c-fb3d-48ac-a10e-0325b6ef2480/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/013e47e6-f891-4afd-96fa-2a561ea84631/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3231,7 +3084,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3242,15 +3095,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:42 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"1304ab44f3b6a411f594fad2176ae5a3-gzip"'
+      - '"4ade0f2fb3fdf58ed8684f5d36e96f22-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '482'
+      - '512'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3258,35 +3111,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZmE1OGYx
-        Yy1mYjNkLTQ4YWMtYTEwZS0wMzI1YjZlZjI0ODAvIiwgInRhc2tfaWQiOiAi
-        Y2ZhNThmMWMtZmIzZC00OGFjLWExMGUtMDMyNWI2ZWYyNDgwIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMTNlNDdl
+        Ni1mODkxLTRhZmQtOTZmYS0yYTU2MWVhODQ2MzEvIiwgInRhc2tfaWQiOiAi
+        MDEzZTQ3ZTYtZjg5MS00YWZkLTk2ZmEtMmE1NjFlYTg0NjMxIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
-        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
-        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
-        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjNkMTI5NzNmOGNkZTJhNDJmNSJ9LCAiaWQiOiAiNWY3ZGZmM2QxMjk3
-        M2Y4Y2RlMmE0MmY1In0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
+        TExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
+        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9
+        LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjog
+        IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJyYXR1
+        bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
+        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1bml0c19m
+        YWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZTg5N2U3Mzg3YjQxNjNmZGIifSwg
+        ImlkIjogIjVmYTQ1YzhlODk3ZTczODdiNDE2M2ZkYiJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:42 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4368bd9c-4d3c-4de0-b4fb-496c68b79e26/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/aef812c5-37de-4307-a0ab-6d37809875c2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3294,7 +3149,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3305,15 +3160,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:43 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"263f9e943b0ea17c2efdb6dfba0197c5-gzip"'
+      - '"07195355b3b6a687e601b8478fa2a586-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '472'
+      - '487'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3321,32 +3176,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80MzY4YmQ5
-        Yy00ZDNjLTRkZTAtYjRmYi00OTZjNjhiNzllMjYvIiwgInRhc2tfaWQiOiAi
-        NDM2OGJkOWMtNGQzYy00ZGUwLWI0ZmItNDk2YzY4Yjc5ZTI2IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hZWY4MTJj
+        NS0zN2RlLTQzMDctYTBhYi02ZDM3ODA5ODc1YzIvIiwgInRhc2tfaWQiOiAi
+        YWVmODEyYzUtMzdkZS00MzA3LWEwYWItNmQzNzgwOTg3NWMyIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
-        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
-        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
-        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4
-        Y2RlMmE0MzI3In0sICJpZCI6ICI1ZjdkZmYzZDEyOTczZjhjZGUyYTQzMjci
-        fQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIs
+        ICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJpcmQifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVf
+        aWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNWZhNDVjOGU4OTdlNzM4N2I0MTYzZmVlIn0sICJpZCI6
+        ICI1ZmE0NWM4ZTg5N2U3Mzg3YjQxNjNmZWUifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/29bb597d-a679-4094-9575-ffba138e306f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a51c12ad-c54c-4326-9352-4e5124e37cee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3354,7 +3212,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3365,15 +3223,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:43 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"7d5b5220a2c0c6ead1bb8a96ab543b17-gzip"'
+      - '"2fff15ee774306b1c680aaca1a666214-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '473'
+      - '477'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3381,32 +3239,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yOWJiNTk3
-        ZC1hNjc5LTQwOTQtOTU3NS1mZmJhMTM4ZTMwNmYvIiwgInRhc2tfaWQiOiAi
-        MjliYjU5N2QtYTY3OS00MDk0LTk1NzUtZmZiYTEzOGUzMDZmIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNTFjMTJh
+        ZC1jNTRjLTQzMjYtOTM1Mi00ZTUxMjRlMzdjZWUvIiwgInRhc2tfaWQiOiAi
+        YTUxYzEyYWQtYzU0Yy00MzI2LTkzNTItNGU1MTI0ZTM3Y2VlIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
-        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
-        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmM2QxMjk3M2Y4Y2RlMmE0MzQ3In0sICJpZCI6ICI1
-        ZjdkZmYzZDEyOTczZjhjZGUyYTQzNDcifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNr
+        YWdlX2Vudmlyb25tZW50In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2Vudmly
+        b25tZW50In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM4ZTg5N2U3Mzg3YjQxNjQwM2QifSwgImlkIjogIjVmYTQ1YzhlODk3
+        ZTczODdiNDE2NDAzZCJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:43 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/ab7f4016-7584-4288-ba11-18b2a2c78552/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/f62c6e3d-9c1f-41bb-b721-91ff0e758c91/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3414,7 +3272,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3425,15 +3283,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:44 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"f596d1e453752f663907294207cf4cff-gzip"'
+      - '"0b619d065de54475026531d227da02d2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '510'
+      - '479'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3441,31 +3299,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hYjdmNDAx
-        Ni03NTg0LTQyODgtYmExMS0xOGIyYTJjNzg1NTIvIiwgInRhc2tfaWQiOiAi
-        YWI3ZjQwMTYtNzU4NC00Mjg4LWJhMTEtMThiMmEyYzc4NTUyIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mNjJjNmUz
+        ZC05YzFmLTQxYmItYjcyMS05MWZmMGU3NThjOTEvIiwgInRhc2tfaWQiOiAi
+        ZjYyYzZlM2QtOWMxZi00MWJiLWI3MjEtOTFmZjBlNzU4YzkxIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
-        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
-        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
-        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
-        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2Rl
-        MmE0MzYxIn0sICJpZCI6ICI1ZjdkZmYzZTEyOTczZjhjZGUyYTQzNjEifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dLCAidW5pdHNfZmFpbGVk
+        X3NpZ25hdHVyZV9maWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlw
+        ZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4Zjg5N2U3Mzg3YjQxNjQw
+        NWEifSwgImlkIjogIjVmYTQ1YzhmODk3ZTczODdiNDE2NDA1YSJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/74cd4e55-bd19-44d1-b94c-e9bf2e1bb732/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/2d6debde-cb40-4a05-a282-6b404c3282c1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3473,7 +3332,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3484,15 +3343,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:44 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"01a22bc79e3927a38e18a2353bf08de8-gzip"'
+      - '"82d9c93d2421209622d94e46370009b8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '501'
+      - '512'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3500,39 +3359,100 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83NGNkNGU1
-        NS1iZDE5LTQ0ZDEtYjk0Yy1lOWJmMmUxYmI3MzIvIiwgInRhc2tfaWQiOiAi
-        NzRjZDRlNTUtYmQxOS00NGQxLWI5NGMtZTliZjJlMWJiNzMyIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yZDZkZWJk
+        ZS1jYjQwLTRhMDUtYTI4Mi02YjQwNGMzMjgyYzEvIiwgInRhc2tfaWQiOiAi
+        MmQ2ZGViZGUtY2I0MC00YTA1LWEyODItNmI0MDRjMzI4MmMxIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJpYW50Ijog
+        IlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6ICJ4ODZf
+        NjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQtMTYteDg2
+        XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9pZCI6ICJk
+        aXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
+        ciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0
+        NWM4Zjg5N2U3Mzg3YjQxNjQwNzIifSwgImlkIjogIjVmYTQ1YzhmODk3ZTcz
+        ODdiNDE2NDA3MiJ9
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/88152b01-e043-4d25-bb22-3f9c1728483d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:11:59 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"c88c0d7c5ba1fc9cd59bffd0ccdaefe6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '507'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84ODE1MmIw
+        MS1lMDQzLTRkMjUtYmIyMi0zZjljMTcyODQ4M2QvIiwgInRhc2tfaWQiOiAi
+        ODgxNTJiMDEtZTA0My00ZDI1LWJiMjItM2Y5YzE3Mjg0ODNkIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQiOiAibW9k
+        dWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIz
+        X3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
+        ZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
+        IjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
-        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        bmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
-        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
-        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
-        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2RlMmE0
-        MzhhIn0sICJpZCI6ICI1ZjdkZmYzZTEyOTczZjhjZGUyYTQzOGEifQ==
+        In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4
+        Zjg5N2U3Mzg3YjQxNjQwODcifSwgImlkIjogIjVmYTQ1YzhmODk3ZTczODdi
+        NDE2NDA4NyJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:44 GMT
+  recorded_at: Thu, 05 Nov 2020 20:11:59 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f42355c-b537-46f9-9f26-2b7610e12aa3/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/f2f4da9a-ca0d-4914-a2c1-323cc1d9553e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3540,7 +3460,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3551,15 +3471,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:45 GMT
+      - Thu, 05 Nov 2020 20:11:59 GMT
       Server:
       - Apache
       Etag:
-      - '"d41874b4e3d00fd8ff959eca5e30df91-gzip"'
+      - '"e67d67a68e64100bdae754b28faa003c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '427'
+      - '432'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3567,28 +3487,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZjQyMzU1
-        Yy1iNTM3LTQ2ZjktOWYyNi0yYjc2MTBlMTJhYTMvIiwgInRhc2tfaWQiOiAi
-        NGY0MjM1NWMtYjUzNy00NmY5LTlmMjYtMmI3NjEwZTEyYWEzIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mMmY0ZGE5
+        YS1jYTBkLTQ5MTQtYTJjMS0zMjNjYzFkOTU1M2UvIiwgInRhc2tfaWQiOiAi
+        ZjJmNGRhOWEtY2EwZC00OTE0LWEyYzEtMzIzY2MxZDk1NTNlIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQyWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQy
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjExOjU5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjNlMTI5
-        NzNmOGNkZTJhNDM5ZCJ9LCAiaWQiOiAiNWY3ZGZmM2UxMjk3M2Y4Y2RlMmE0
-        MzlkIn0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOGY4OTdlNzM4N2I0MTY0MGE5In0sICJpZCI6ICI1ZmE0NWM4
+        Zjg5N2U3Mzg3YjQxNjQwYTkifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3596,7 +3516,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3607,15 +3527,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:45 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Etag:
-      - '"760f39eb8bcc094373dfa35b9b738b51-gzip"'
+      - '"1e3f478e4a684fcdda4dd250e478ce86-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '811'
+      - '807'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3624,68 +3544,68 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6Mzda
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NTda
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        ZjM5MDIyMzlmNzQxZTg4M2QyMyJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzhkMDZjNzFhMDQ0ZWE1MmYyMCJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjM3WiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzOTAyMjM5
-        Zjc0MWU4ODNkMjIifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDA2Yzcx
+        YTA0NGVhNTJmMWYifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAyMC0xMC0wN1QxNzo0NzozN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAyMC0xMS0wNVQyMDoxMTo1N1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDIwLTExLTA1VDIwOjExOjU4WiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNk
-        MjEifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZDA2YzcxYTA0NGVhNTJm
+        MWUifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo0MFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMTo1N1oiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         InBhY2thZ2VfZW52aXJvbm1lbnQiOiAxLCAiZGlzdHJpYnV0aW9uIjogMSwg
         Im1vZHVsZW1kIjogNiwgInJwbSI6IDE5LCAieXVtX3JlcG9fbWV0YWRhdGFf
         ZmlsZSI6IDF9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEw
-        LTA3VDE3OjQ3OjM3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDIwLTEx
+        LTA1VDIwOjExOjU3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
         dG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJf
         bnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
         dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3Rfc3luYyI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJzY3JhdGNocGFk
+        c3Rfc3luYyI6ICIyMDIwLTExLTA1VDIwOjExOjU3WiIsICJzY3JhdGNocGFk
         IjogeyJyZXBvbWRfcmV2aXNpb24iOiAxNTg4MTU4MDM4LCAicmVwb21kX2No
         ZWNrc3VtIjogImRjNDc0YjM2NTQ0YmVjYmExNzc5NWJiMjUxMDE0NTNlMjVi
         NDBmY2Q0ODExZmE1OTQ2ODYzMzRlZWFiZDVmMDkifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNkMjAifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZmE0NWM4ZDA2YzcxYTA0NGVhNTJmMWQifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJmaWxlOi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVz
         dF9yZXBvcy96b28iLCAic3NsX3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3Zl
         X21pc3NpbmciOiB0cnVlLCAiZG93bmxvYWRfcG9saWN5IjogIm9uX2RlbWFu
         ZCIsICJwcm94eV9ob3N0IjogIiJ9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1d
         LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAzOSwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmYzOTAyMjM5Zjc0MWU4ODNkMWYifSwgInRvdGFsX3JlcG9zaXRv
+        ICI1ZmE0NWM4ZDA2YzcxYTA0NGVhNTJmMWMifSwgInRvdGFsX3JlcG9zaXRv
         cnlfdW5pdHMiOiA0MCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3693,7 +3613,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3704,15 +3624,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:45 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Etag:
-      - '"59a5dbcec414cf44e829b3a41ceb7944-gzip"'
+      - '"df099ee93f5c897f129eac2784f2cdef-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '636'
+      - '635'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3721,60 +3641,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTE6NThaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjdkZmYzYzAyMjM5Zjc0MWU4ODNkMjgifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZmE0NWM4ZTA2YzcxYTA0NGZjZTg1MGEifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTE6NThaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI3In0sICJjb25maWci
+        IiRvaWQiOiAiNWZhNDVjOGUwNmM3MWEwNDRmY2U4NTA5In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDBaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTE6NThaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmYzYzAyMjM5Zjc0MWU4ODNkMjYifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM4ZTA2YzcxYTA0NGZjZTg1MDgifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NDJaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTE6NTlaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJlcnJhdHVt
         IjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQiOiA2LCAicGFj
         a2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24iOiAxLCAicnBt
         IjogMTksICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIjogMX0sICJfbnMiOiAi
         cmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICIzX3ZpZXcxIiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQwWiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjExOjU4WiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvaW1wb3J0
         ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwg
         ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3Zl
         cnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiBudWxsLCAic2NyYXRj
-        aHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmM2MwMjIzOWY3
-        NDFlODgzZDI1In0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRl
+        aHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOGUwNmM3MWEw
+        NDRmY2U4NTA3In0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRl
         ciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMzgsICJfaWQiOiB7IiRv
-        aWQiOiAiNWY3ZGZmM2MwMjIzOWY3NDFlODgzZDI0In0sICJ0b3RhbF9yZXBv
+        aWQiOiAiNWZhNDVjOGUwNmM3MWEwNDRmY2U4NTA2In0sICJ0b3RhbF9yZXBv
         c2l0b3J5X3VuaXRzIjogMzksICJpZCI6ICIzX3ZpZXcxIiwgIl9ocmVmIjog
         Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8ifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:45 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3782,7 +3702,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3793,7 +3713,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:45 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -3804,14 +3724,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FmYzUzZjlmLTFkOTQtNDM5OS05NTM1LWY4MWQ4ODdiZWJlZC8iLCAi
-        dGFza19pZCI6ICJhZmM1M2Y5Zi0xZDk0LTQzOTktOTUzNS1mODFkODg3YmVi
-        ZWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzg1ODUwODIzLTM1MjEtNDk1Ny05YTRhLTMzNzIzYzA1YzE5YS8iLCAi
+        dGFza19pZCI6ICI4NTg1MDgyMy0zNTIxLTQ5NTctOWE0YS0zMzcyM2MwNWMx
+        OWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/afc53f9f-1d94-4399-9535-f81d887bebed/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/85850823-3521-4957-9a4a-33723c05c19a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3819,7 +3739,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3830,15 +3750,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:46 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Etag:
-      - '"b217f959be6293b43f12e2a1e008c4ee-gzip"'
+      - '"1cceb63ea4ef70d165667e2df58104a9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '364'
+      - '370'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3846,25 +3766,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZmM1M2Y5Zi0xZDk0LTQzOTktOTUzNS1mODFkODg3YmVi
-        ZWQvIiwgInRhc2tfaWQiOiAiYWZjNTNmOWYtMWQ5NC00Mzk5LTk1MzUtZjgx
-        ZDg4N2JlYmVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84NTg1MDgyMy0zNTIxLTQ5NTctOWE0YS0zMzcyM2MwNWMx
+        OWEvIiwgInRhc2tfaWQiOiAiODU4NTA4MjMtMzUyMS00OTU3LTlhNGEtMzM3
+        MjNjMDVjMTlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjQ2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ2WiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjAwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjQyMTI5NzNmOGNkZTJhNDU3MCJ9LCAiaWQiOiAi
-        NWY3ZGZmNDIxMjk3M2Y4Y2RlMmE0NTcwIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTA4OTdlNzM4N2I0MTY0
+        MjI3In0sICJpZCI6ICI1ZmE0NWM5MDg5N2U3Mzg3YjQxNjQyMjcifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3872,7 +3792,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3883,7 +3803,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:46 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Content-Length:
@@ -3894,14 +3814,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc2MWFhNjMyLTA1YjUtNGVlMi04MmQyLTM2MGU3NzE5ODdkYy8iLCAi
-        dGFza19pZCI6ICI3NjFhYTYzMi0wNWI1LTRlZTItODJkMi0zNjBlNzcxOTg3
-        ZGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzYwZDI3NWM3LTUyYzctNDQ5Ni1hNjc2LWI5ZjIyOWVmMzk4Zi8iLCAi
+        dGFza19pZCI6ICI2MGQyNzVjNy01MmM3LTQ0OTYtYTY3Ni1iOWYyMjllZjM5
+        OGYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/761aa632-05b5-4ee2-82d2-360e771987dc/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/60d275c7-52c7-4496-a676-b9f229ef398f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3909,7 +3829,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3920,15 +3840,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:46 GMT
+      - Thu, 05 Nov 2020 20:12:00 GMT
       Server:
       - Apache
       Etag:
-      - '"357a0b8ab01871b054d06caf3a95fb23-gzip"'
+      - '"5fc92724b0d5ca88843a31e07906006a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '362'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3936,20 +3856,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NjFhYTYzMi0wNWI1LTRlZTItODJkMi0zNjBlNzcxOTg3
-        ZGMvIiwgInRhc2tfaWQiOiAiNzYxYWE2MzItMDViNS00ZWUyLTgyZDItMzYw
-        ZTc3MTk4N2RjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy82MGQyNzVjNy01MmM3LTQ0OTYtYTY3Ni1iOWYyMjllZjM5
+        OGYvIiwgInRhc2tfaWQiOiAiNjBkMjc1YzctNTJjNy00NDk2LWE2NzYtYjlm
+        MjI5ZWYzOThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0NloiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
-        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0MjEyOTczZjhjZGUyYTQ1YzUifSwgImlkIjogIjVm
-        N2RmZjQyMTI5NzNmOGNkZTJhNDVjNSJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0
+        YWJsZS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkwODk3ZTczODdiNDE2NDI3
+        NSJ9LCAiaWQiOiAiNWZhNDVjOTA4OTdlNzM4N2I0MTY0Mjc1In0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:46 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:47 GMT
+      - Thu, 05 Nov 2020 20:12:01 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:01 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:47 GMT
+      - Thu, 05 Nov 2020 20:12:01 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:01 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -94,11 +94,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvbGli
-        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
-        X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xp
-        ZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJf
+        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJ0eXBlX3NraXBfbGlz
+        dCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
+        aF9wYXNzd29yZCI6bnVsbCwicHJveHlfaG9zdCI6IiJ9LCJub3RlcyI6eyJf
         cmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0
         cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0
         b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:47 GMT
+      - Thu, 05 Nov 2020 20:12:01 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDMwMjIzOWY3MzY1MWU2MThlIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjOTEwNmM3MWEwNDRlYTUyZjJhIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:01 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:47 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNlNzlhNmE2LWMzNjktNGVmYy04OWMwLWUwODRjZjcxYzVkYi8iLCAi
-        dGFza19pZCI6ICIzZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2EzY2IyMjU1LWE4MzYtNDlkNS1hYjBlLWJhMzBlZjk0MGE4Zi8iLCAi
+        dGFza19pZCI6ICJhM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:47 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,16 +231,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -252,42 +252,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,7 +296,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -306,15 +307,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -322,16 +323,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -343,42 +344,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +388,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -397,15 +399,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -413,16 +415,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -434,42 +436,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -477,7 +480,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -488,15 +491,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -504,16 +507,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -525,42 +528,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +572,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -579,15 +583,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -595,16 +599,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -616,42 +620,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -659,7 +664,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -670,15 +675,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -686,16 +691,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -707,42 +712,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e79a6a6-c369-4efc-89c0-e084cf71c5db/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -750,7 +756,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -761,15 +767,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:02 GMT
       Server:
       - Apache
       Etag:
-      - '"36b330d2139d485218b32eec7566c1a0-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '716'
+      - '713'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -777,16 +783,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTc5YTZhNi1jMzY5LTRlZmMtODljMC1lMDg0Y2Y3MWM1
-        ZGIvIiwgInRhc2tfaWQiOiAiM2U3OWE2YTYtYzM2OS00ZWZjLTg5YzAtZTA4
-        NGNmNzFjNWRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2Y0MjM2ZTEtZjk2ZC00YmFmLWIzMzMtZjhiNDJiM2M0
-        NzAwLyIsICJ0YXNrX2lkIjogIjNmNDIzNmUxLWY5NmQtNGJhZi1iMzMzLWY4
-        YjQyYjNjNDcwMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -798,42 +804,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0NDAyMjM5ZjA1N2Y4YTQzN2UiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDY0MyJ9LCAi
-        aWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NjQzIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3f4236e1-f96d-4baf-b333-f8b42b3c4700/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a3cb2255-a836-49d5-ab0e-ba30ef940a8f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +848,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -852,15 +859,107 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Etag:
-      - '"e6439452f261e64e89aef34cb9012364-gzip"'
+      - '"0c3b150cf96681b188d7ba3b11bedafe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1364'
+      - '713'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hM2NiMjI1NS1hODM2LTQ5ZDUtYWIwZS1iYTMwZWY5NDBh
+        OGYvIiwgInRhc2tfaWQiOiAiYTNjYjIyNTUtYTgzNi00OWQ1LWFiMGUtYmEz
+        MGVmOTQwYThmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
+        MC0xMS0wNVQyMDoxMjowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNjEwYjQ3YTctOWExYi00NDAzLTk1YjctODA3Y2JkZjY1
+        YWQwLyIsICJ0YXNrX2lkIjogIjYxMGI0N2E3LTlhMWItNDQwMy05NWI3LTgw
+        N2NiZGY2NWFkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1YzkyMDZjNzFhMDc1MTQ3
+        ZjAxMyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MmU0In0sICJpZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQyZTQi
+        fQ==
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/610b47a7-9a1b-4403-95b7-807cbdf65ad0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:12:03 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"889803245352801b114f093f1c4540de-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1356'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -868,199 +967,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zZjQyMzZlMS1mOTZkLTRiYWYtYjMzMy1mOGI0
-        MmIzYzQ3MDAvIiwgInRhc2tfaWQiOiAiM2Y0MjM2ZTEtZjk2ZC00YmFmLWIz
-        MzMtZjhiNDJiM2M0NzAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy82MTBiNDdhNy05YTFiLTQ0MDMtOTViNy04MDdj
+        YmRmNjVhZDAvIiwgInRhc2tfaWQiOiAiNjEwYjQ3YTctOWExYi00NDAzLTk1
+        YjctODA3Y2JkZjY1YWQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAi
+        bWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowM1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1Y2EwYWFiMC0yN2MwLTQ1MDUtYTIxZS01ZWVjYWM3
-        N2ZhZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJjNzk0NTMzZS1kMGNlLTQ3NmUtOWY2Yi04NzM5NTUw
+        ODZlMmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNDY4ZDA4NzctYjFkNi00ZThlLTljNjItOTI4MzNiOGQzYjY5Iiwg
+        aWQiOiAiMTRjMjgyMWItNDA2Yy00OTAwLTgyNDAtNzM3MWJkNDkyODZiIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTFiNjVlZi03NmJjLTQ0YTMtODkw
-        Ni1hNzRkNDE2OWE4NWUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmE3M2Y3ZC1lMDNmLTRiNjAtYmNh
+        Mi1lOGEwNGFlZTdiZGEiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MmRjYjVlMmQtYTY2OS00YjhiLWJkYTUtZmQ5NDQ2ODMyZDc0IiwgIm51bV9w
+        M2RkNDJkNzgtZDI5Yi00OTU1LWE0NWQtMWI4N2FkZTI4NzdiIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImRhYTM5ZDFiLWEwNjktNDYwNC04NmQyLTQy
-        ZTU0NjM1ZGYwMCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImFlOTVlZGZjLWY2N2ItNDJiMC05MGExLTQw
+        NWEzMzI5NDE0YiIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5Yzk5
-        MmE5LTFmYzEtNDRmOC04OTFmLTUwYjFlMmFiMTg0YSIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3NmY5
+        OTBiLTI5YzctNGY5NC1hODliLTQ0YjhkNDg3ZTAwNyIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwODVhZjQ4ZS02NDBlLTQ5ODItYjA5ZS02OWU3
-        NTVmZGFjMjYiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIxNjI0ZWQ1MC0yYjExLTRhZjktYTc3Ny02NDQ4
+        NmVjMzBlZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTc2
-        MDYzMC0wMDExLTQ1MzktODJhYi0yZDA5NGYwYWM2NTkiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzE0
+        NDhjOS1jN2NlLTRjNTAtOTM0My02Mzk4Y2Q4MmM4NjAiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMmQ0N2JiNC1jMmMz
-        LTRkM2UtOTM2YS00MTkxMjdkZWVhMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNTk4NTNmMi00ZTQy
+        LTRmMzMtODFmNC1hMDJlNmJhNTRmMjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MjllOTBiYy1hMDMzLTQ3MzctODYwMC03
-        YThjYWRhZTdjY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzNmFlZjZhYS1kMDUzLTQ4NDMtOTQ3Zi03
+        ZGVjODVjZDNlMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJmOTg5N2YzOS0wY2I5LTQ1OGYtYTc3Yy1mNmI5NDk2Yzlk
-        YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJmNzE4NzVlYy0xNjlmLTQ1NmYtODMzZC1jMjg4ZjY1MWI1
+        MzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWI4NmEyMS05
-        MjY4LTQwMzEtOTM2Yy1kMWJhNmM0ODRhM2YiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZDYwN2UxNi04
+        NTFlLTQ1MGEtYTJmYi02MzNjMzI5ZTYzNzYiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTUwMDhkMS0zZGI4LTRkZjkt
-        OTBjOS0yZGNlMjEzNTJiMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MTM3NTFkYS1mZTA3LTQ5Mzgt
+        YWVjMS05YjRkOTNhY2VlM2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZGU4ZWNkLWQ1ZTYtNDcxYy1iODhl
-        LTMwYWJjYmVlZGQ5MiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo0OFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
-        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
-        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
-        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
-        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
-        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
-        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
-        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
-        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjQ0MDIyMzlmMDU3
-        ZjhhNDM3ZiIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1Y2EwYWFiMC0yN2MwLTQ1MDUtYTIxZS01ZWVjYWM3N2ZhZGYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NDY4ZDA4NzctYjFkNi00ZThlLTljNjItOTI4MzNiOGQzYjY5IiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
-        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiMTFiNjVlZi03NmJjLTQ0YTMtODkwNi1hNzRk
-        NDE2OWE4NWUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
-        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmRjYjVl
-        MmQtYTY2OS00YjhiLWJkYTUtZmQ5NDQ2ODMyZDc0IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImRhYTM5ZDFiLWEwNjktNDYwNC04NmQyLTQyZTU0NjM1
-        ZGYwMCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
-        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5Yzk5MmE5LTFm
-        YzEtNDRmOC04OTFmLTUwYjFlMmFiMTg0YSIsICJudW1fcHJvY2Vzc2VkIjog
-        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
-        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIwODVhZjQ4ZS02NDBlLTQ5ODItYjA5ZS02OWU3NTVmZGFj
-        MjYiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
-        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTc2MDYzMC0w
-        MDExLTQ1MzktODJhYi0yZDA5NGYwYWM2NTkiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
-        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMmQ0N2JiNC1jMmMzLTRkM2Ut
-        OTM2YS00MTkxMjdkZWVhMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
-        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjY5NzM4ZWYwLWU2MWItNDJkMS1iNjM5
+        LTJlNDAwMTRhZDViYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
+        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJfbnMiOiAicmVwb19wdWJsaXNo
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
+        dGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQiLCAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
+        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
+        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
+        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
+        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNWZh
+        NDVjOTIwNmM3MWEwNzUxNDdmMDE0IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImM3OTQ1MzNlLWQwY2UtNDc2ZS05ZjZi
+        LTg3Mzk1NTA4NmUyYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MjllOTBiYy1hMDMzLTQ3MzctODYwMC03YThjYWRh
-        ZTdjY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmOTg5N2YzOS0wY2I5LTQ1OGYtYTc3Yy1mNmI5NDk2YzlkYjAiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
-        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
-        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWI4NmEyMS05MjY4LTQw
-        MzEtOTM2Yy1kMWJhNmM0ODRhM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
-        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZTUwMDhkMS0zZGI4LTRkZjktOTBjOS0y
-        ZGNlMjEzNTJiMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
-        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImM3ZGU4ZWNkLWQ1ZTYtNDcxYy1iODhlLTMwYWJj
-        YmVlZGQ5MiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ4ZWEi
-        fSwgImlkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDhlYSJ9
+        LCAic3RlcF9pZCI6ICIxNGMyODIxYi00MDZjLTQ5MDAtODI0MC03MzcxYmQ0
+        OTI4NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MTksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
+        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc2YTczZjdkLWUwM2Yt
+        NGI2MC1iY2EyLWU4YTA0YWVlN2JkYSIsICJudW1fcHJvY2Vzc2VkIjogMTl9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzZGQ0MmQ3OC1kMjliLTQ5NTUtYTQ1ZC0xYjg3YWRlMjg3N2Ii
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogNiwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU5NWVkZmMtZjY3Yi00MmIw
+        LTkwYTEtNDA1YTMzMjk0MTRiIiwgIm51bV9wcm9jZXNzZWQiOiA2fSwgeyJu
+        dW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1v
+        ZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwi
+        OiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMzc2Zjk5MGItMjljNy00Zjk0LWE4OWItNDRiOGQ0ODdlMDA3IiwgIm51
+        bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjog
+        ImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogNCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE2MjRlZDUwLTJiMTEtNGFmOS1h
+        Nzc3LTY0NDg2ZWMzMGVkNiIsICJudW1fcHJvY2Vzc2VkIjogNH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRh
+        ZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjFjMTQ0OGM5LWM3Y2UtNGM1MC05MzQzLTYzOThjZDgyYzg2MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1OTg1
+        M2YyLTRlNDItNGYzMy04MWY0LWEwMmU2YmE1NGYyNyIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
+        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
+        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2YWVmNmFhLWQwNTMtNDg0
+        My05NDdmLTdkZWM4NWNkM2UwOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
+        IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImY3MTg3NWVjLTE2OWYtNDU2Zi04MzNkLWMy
+        ODhmNjUxYjUzNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBk
+        NjA3ZTE2LTg1MWUtNDUwYS1hMmZiLTYzM2MzMjllNjM3NiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
+        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUxMzc1MWRhLWZl
+        MDctNDkzOC1hZWMxLTliNGQ5M2FjZWUzYSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjk3MzhlZjAtZTYxYi00
+        MmQxLWI2MzktMmU0MDAxNGFkNWJjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3
+        ZTczODdiNDE2NDU5MyJ9LCAiaWQiOiAiNWZhNDVjOTI4OTdlNzM4N2I0MTY0
+        NTkzIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1086,7 +1186,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1099,7 +1199,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -1116,14 +1216,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDQwMjIzOWY3MzY1MWU2MTkzIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWZhNDVjOTMwNmM3MWEwNDUwM2E3YjI0In0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1135,7 +1235,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1148,281 +1248,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:48 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2166'
+      - '2169'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
-        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
-        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
-        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
-        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
-        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
-        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjQzMTI5NzNmOGNkZTJhNDczOCJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
-        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
-        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
-        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
-        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
-        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
-        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
-        NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
-        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
-        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0
-        NmZkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
-        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
-        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
-        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
-        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDda
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
-        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
-        IjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDcxZCJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
-        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
-        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
-        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
-        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
-        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQz
-        MTI5NzNmOGNkZTJhNDZhNiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
-        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
-        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZl
-        YSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
-        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
-        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
-        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
-        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
-        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90
-        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
-        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
-        NDMxMjk3M2Y4Y2RlMmE0NmQ4In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
-        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
-        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
-        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
-        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
-        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
-        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZmNCJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
-        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
-        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
-        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
-        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0NzE0In19LCB7Im1ldGFkYXRhIjog
-        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
-        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
-        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
-        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
-        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
-        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
-        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJ1bml0X3R5cGVfaWQi
-        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
-        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0MzEyOTcz
-        ZjhjZGUyYTQ2Y2MifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
-        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
-        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
-        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
-        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
-        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjQ3WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
-        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ3MmYifX0sIHsibWV0YWRh
-        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
-        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
-        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
-        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
-        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
-        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQz
-        MTI5NzNmOGNkZTJhNDcwOSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
-        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
-        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDcy
-        NiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
-        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
-        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
-        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
+        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
+        MTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        aXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAwZGU0Mzk1LTA3NmYtNDAw
+        Yy1iNmVhLWY5YWI4MGU2NjY2OSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwMGRlNDM5NS0w
+        NzZmLTQwMGMtYjZlYS1mOWFiODBlNjY2NjkiLCAiX2lkIjogeyIkb2lkIjog
+        IjVmYTQ1YzkyODk3ZTczODdiNDE2NDNhYyJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
+        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
+        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
+        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
+        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjA4YTk0ZjAyLWM2ZjEtNDg4Ni04MTI4LWJlMmU5
+        Y2U0N2U0ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwOGE5NGYwMi1jNmYxLTQ4ODYtODEy
+        OC1iZTJlOWNlNDdlNGQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3
+        ZTczODdiNDE2NDM0YSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        ImR1Y2stMC42LTEuc3JjLnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tz
+        dW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0
+        M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJzdW1tYXJ5IjogIkEgZHVt
+        bXkgcGFja2FnZSBvZiBkdWNrIiwgImZpbGVuYW1lIjogImR1Y2stMC42LTEu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42Iiwg
+        ImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI1NGEzZDllNi01ZTdiLTRiZmYt
+        OTkzYS0zMGY5MjE1ODIyMWUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJ1
+        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNTRhM2Q5ZTYtNWU3
+        Yi00YmZmLTk5M2EtMzBmOTIxNTgyMjFlIiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQzMmEifX0sIHsibWV0YWRhdGEiOiB7InNv
+        dXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
+        ImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdj
+        YTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIs
+        ICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwgImZp
+        bGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjY4NjM5ZGU5LTgyNDctNDZmMS1hYTJkLWVmNmI4ZTEyNWQ0
+        NCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICI2ODYzOWRlOS04MjQ3LTQ2ZjEtYWEyZC1lZjZi
+        OGUxMjVkNDQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdi
+        NDE2NDM3MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImFybWFk
+        aWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNo
+        ZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2
+        NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJt
+        YWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90
+        eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjcxY2Jl
+        YzQ2LTgxYTUtNDVkNy05OTg0LTcyMGYzNTMxN2VlYyIsICJhcmNoIjogIm5v
+        YXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVU
+        MjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6
+        ICI3MWNiZWM0Ni04MWE1LTQ1ZDctOTk4NC03MjBmMzUzMTdlZWMiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDNjYyJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIs
+        ICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4
+        MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMy
+        NDcxMiIsICJzdW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBw
+        YXJrLiIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAi
+        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjog
+        dHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiNzFmNmVmY2MtNWJjYS00NTRlLTg1MmUtYTA1NzRkNjY2
+        NjI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogIjcxZjZlZmNjLTViY2EtNDU0ZS04NTJlLWEw
+        NTc0ZDY2NjYyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MzVkIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZWxl
+        cGhhbnQtMC4yLTEuc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNo
+        ZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEyZTgzOGVhY2Q2
+        NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsICJmaWxlbmFtZSI6ICJlbGVw
+        aGFudC0wLjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI3NzdjYWRl
+        Ny0yZjcyLTRhNzYtYjE0YS01MTdiYmZiZDJmMGYiLCAiYXJjaCI6ICJub2Fy
+        Y2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjEyOjAyWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
+        Nzc3Y2FkZTctMmY3Mi00YTc2LWIxNGEtNTE3YmJmYmQyZjBmIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQzZGUifX0sIHsibWV0
+        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBt
+        IiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdl
+        M2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYy
+        MWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2Fs
+        cnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjAuOCIsICJfaWQiOiAiNzk3ZTg5YjMtMDZiYS00NzBlLTllZWItYWMz
+        OTk1OGJlOTlhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSIsICJ1bml0X2lkIjogIjc5N2U4OWIzLTA2YmEtNDcwZS05
+        ZWViLWFjMzk5NThiZTk5YSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4
+        OTdlNzM4N2I0MTY0M2MzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0i
+        OiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIs
+        ICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1
+        ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJt
+        b25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjg0
+        ODgwNzJhLWQ3NzgtNGE3ZS05ZjgwLTM0YzgwODE1MDE0ZSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICI4NDg4MDcyYS1kNzc4LTRhN2UtOWY4MC0zNGM4MDgxNTAxNGUiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDM5YSJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVhOTFkNzNk
+        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
+        Yzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB0
+        cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjlhMGU1OGNjLTlhMmMtNDNhMy05NjI2LTgyYTM5
+        ZWQyZTBiNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICI5YTBlNThjYy05YTJjLTQzYTMtOTYy
+        Ni04MmEzOWVkMmUwYjciLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3
+        ZTczODdiNDE2NDM1MyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJj
+        aGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3
+        NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1hcnkiOiAi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxy
+        dXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBl
+        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImEwYTJlM2Vi
+        LTZiMzgtNGY2Zi04ZWZlLWJjYWY4YWE1M2I0NiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJh
+        MGEyZTNlYi02YjM4LTRmNmYtOGVmZS1iY2FmOGFhNTNiNDYiLCAiX2lkIjog
+        eyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDM2OCJ9fSwgeyJtZXRh
+        ZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxsby0wLjEtMS5zcmMucnBt
+        IiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFmNDc4MTMy
+        Zjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJkMjliN2M2ZTliYmE4OThh
+        NjFkZGMyN2I1ODkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFy
+        bWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTAuMS0xLm5vYXJj
+        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMSIsICJpc19t
         b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
-        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
-        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        ZjQzMTI5NzNmOGNkZTJhNDZhZiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
-        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
-        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
-        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImExODVjNjRiLTBiMTctNDI3Mi1hY2E4
+        LTliNDdhODE0NDMwYiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMTg1YzY0Yi0wYjE3LTQy
+        NzItYWNhOC05YjQ3YTgxNDQzMGIiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzkyODk3ZTczODdiNDE2NDM4NSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVs
+        ZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5
+        N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAi
+        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmls
+        ZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImE4Njg1MzQ5LWY4MDUtNDEwYi05MDAxLTU1MDhkMjNmMTc3
+        YSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICJhODY4NTM0OS1mODA1LTQxMGItOTAwMS01NTA4
+        ZDIzZjE3N2EiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdi
+        NDE2NDMzMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdh
+        cm9vLTAuMy0xLnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVj
+        a3N1bSI6ICI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJm
+        MDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9w
+        IGxpa2UgYSBrYW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAi
+        a2FuZ2Fyb28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJhZjU5
+        YzRmZi04YWJmLTQyMGEtODM4NC04MGNlMTdiMmQ4NDUiLCAiYXJjaCI6ICJu
+        b2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAi
+        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjAyWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
+        OiAiYWY1OWM0ZmYtOGFiZi00MjBhLTgzODQtODBjZTE3YjJkODQ1IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQzM2YifX0sIHsi
+        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMzYWY1
+        OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYx
+        MGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNf
+        bW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImNlZTA3NjkyLTBlNjctNGE3Ny1iNGQ4
+        LWYxYmE2Y2Q3YTI0MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJjZWUwNzY5Mi0wZTY3LTRh
+        NzctYjRkOC1mMWJhNmNkN2EyNDAiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzkyODk3ZTczODdiNDE2NDNhMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYw
+        MTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1h
         cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
-        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
-        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
-        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NDdaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
-        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5NzNmOGNkZTJhNDZjMSJ9fSwg
-        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
-        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
-        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
-        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
-        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
-        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ2OWQifX0sIHsibWV0YWRhdGEiOiB7
-        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
-        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
-        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
-        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
-        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIsICJ1bml0X3R5cGVf
-        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
-        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0MzEy
-        OTczZjhjZGUyYTQ2OTEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
-        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
-        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
-        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
-        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
-        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
-        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
-        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDMxMjk3M2Y4Y2RlMmE0Njg2In19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
-        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
-        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
-        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
-        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        ICJ3YWxydXMtNS4yMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjUuMjEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImQ5
+        MjhjZDJjLTRjYmUtNGI0Ni1iZDVjLWZmOTUwNmE0NDFmMSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJkOTI4Y2QyYy00Y2JlLTRiNDYtYmQ1Yy1mZjk1MDZhNDQxZjEiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDNkNSJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAuOC5z
+        cmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJk
+        MGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGVi
+        ZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZGMzN2MyMDctOGQ1Ny00NTU5
+        LWI3ZTYtOGJiOTFhZGRlNTlkIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImRjMzdjMjA3LThk
+        NTctNDU1OS1iN2U2LThiYjkxYWRkZTU5ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOTI4OTdlNzM4N2I0MTY0M2I1In19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTIuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0NjMy
+        Njg1OWI4ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5
+        ZiIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMi4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgImlzX21vZHVsYXIiOiBm
         YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
-        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NDdaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
-        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDMxMjk3M2Y4
-        Y2RlMmE0NmUxIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
-        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
-        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
-        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
-        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
-        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0N1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ3WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
-        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY0MzEyOTczZjhjZGUyYTQ2YjgifX1d
+        MSIsICJfaWQiOiAiZTM0M2U1YjQtM2RmYi00YTIwLWE0YTEtMTg3ODMxNGI2
+        ZGQyIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUzNDNlNWI0LTNkZmItNGEyMC1hNGExLTE4
+        NzgzMTRiNmRkMiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4
+        N2I0MTY0MzkxIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlv
+        bi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3Vt
+        IjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgx
+        NTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJlZTMyODBkNy1kY2VhLTRl
+        MjAtYWVkMy02Nzk5Nzk2MjBlYzkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWUzMjgwZDct
+        ZGNlYS00ZTIwLWFlZDMtNjc5OTc5NjIwZWM5IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQzN2EifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:48 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1434,7 +1534,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1447,7 +1547,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -1460,10 +1560,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1473,7 +1573,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1486,144 +1586,144 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1317'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzkwLzY2ZjZiNDNiMWI0ZGYwOWY4
+        YTY4Nzk3YTA3YTg0ZmQzZjU1ZTQ3NGY3ZDM5OTNlZjJhOGRjNzQxOGQxMDAx
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZh
+        Y3RzIjogWyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiZTgyMGUwOGMwNWFhNzM2Y2U1MzAwNjZjNjg4Mjg4YmY1NzQ2MDk4MjY3
+        YzI4MjQyNzllMzZjOWE3MmU2YjljZSIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNjU4MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9vIl19LCAic3VtbWFyeSI6
+        ICJLYW5nYXJvbyAwLjIgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
+        dmVyc2lvbiI6IDIwMTgwNzA0MTExNzE5LCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19t
+        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIyYjFmMWIy
+        NS02ZmNhLTQxYzQtOWU4Ni0yYjkwZTQxZGQ5MDYiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBrYW5nYXJv
+        byAwLjIgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEy
+        OjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjJiMWYxYjI1LTZmY2EtNDFjNC05ZTg2LTJiOTBl
+        NDFkZDkwNiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4N2I0
+        MTY0NDNiIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83OC82ODcyN2Jj
+        YzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNkNTU1NmJjZGNl
+        YTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIw
+        IiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjMtMS5ub2FyY2giXSwg
+        ImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2NzdjNGJhYWNmMDA1ZWM5
+        ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNmZGUiLCAiX2xhc3RfdXBk
+        YXRlZCI6IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVs
+        ZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5nYXJvbyJdfSwg
+        InN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVsZSIsICJkb3dubG9hZGVk
+        IjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQwNywgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMi
+        OiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQi
+        OiAiM2QyMGIxODQtZjEyNC00ZTNlLWFjZjktMTIyODk5ZmE4M2U0IiwgImFy
+        Y2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0
+        aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MS0wNVQyMDoxMjowMloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJ1bml0X3R5cGVfaWQi
+        OiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzZDIwYjE4NC1mMTI0LTRlM2Ut
+        YWNmOS0xMjI4OTlmYTgzZTQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzky
+        ODk3ZTczODdiNDE2NDQyZCJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2Vf
+        cGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvbW9kdWxlbWQv
+        ZWEvYTg3MjAzYWE3MWFjZDA5ZWQ0Yzg3MGUwODc1NDlkYTJhNWQyY2FjN2Ni
+        OWVlZDdlN2IwNjNiZjlmNDk3YTkiLCAibmFtZSI6ICJ3YWxydXMiLCAic3Ry
+        ZWFtIjogIjAuNzEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMtMDowLjcxLTEu
+        bm9hcmNoIl0sICJjaGVja3N1bSI6ICI4M2Y2YWZmMzI2MTQ4NTdlOTkwOTg3
+        NmE0ZmI3YTk1ZDU5MTk1ZmQ5OGI5YTI3YTA2NGE5NDJlY2JjNGY0NjgyIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVsdCI6IFsid2Fs
+        cnVzIl0sICJmbGlwcGVyIjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5IjogIldh
+        bHJ1cyAwLjcxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZlcnNp
+        b24iOiAyMDE4MDcwNzE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiY29udGV4dCI6ICJjMGZmZWU0MiIsICJfbnMiOiAidW5pdHNfbW9kdWxl
+        bWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiNTg4NTc1MGUtMWM4
+        Ny00Y2YwLTliMzgtOGI4ZGI0YWU5ZjgyIiwgImFyY2giOiAieDg2XzY0Iiwg
+        ImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVzIDAuNzEg
+        cGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJ1
+        bml0X2lkIjogIjU4ODU3NTBlLTFjODctNGNmMC05YjM4LThiOGRiNGFlOWY4
+        MiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4N2I0MTY0NDY0
+        In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGli
+        L3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC80MS85YzI2Y2EwMzIyZjA0
+        NThhYjc0ZjU4NzZlMjlhMzY2ZjgwYzJiNDkwMjBmNjYzYWJiOWZmNGJiZGNi
+        ZDZjYyIsICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSIsICJh
+        cnRpZmFjdHMiOiBbIndhbHJ1cy0wOjUuMjEtMS5ub2FyY2giXSwgImNoZWNr
+        c3VtIjogImZjMGNiOTUwZTUzYzVlYTk5YjAzYmNhYzQyNzI1YzYwMjk1ZjE0
+        OGFhYWRlMWE3Y2U2YzdkODAyOGEwNzNiNTkiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5
+        IjogIldhbHJ1cyA1LjIxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        InZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMiOiAidW5pdHNf
+        bW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiODhlZjA1
+        OWMtYWEzYy00YjdkLTgwNjEtM2Y0ZTcyZjI4ZWI0IiwgImFyY2giOiAieDg2
+        XzY0IiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVz
+        IDUuMjEgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEy
+        OjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjg4ZWYwNTljLWFhM2MtNGI3ZC04MDYxLTNmNGU3
+        MmYyOGViNCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4N2I0
+        MTY0NDViIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC8xYi8yZjAwMzk2
+        NGJiNjQyMWRlNzQyNzdkYjE5YzljYThkMzMzYWJhOTYzOTM5MTBjNzgwZTU3
+        MDBkYzhhODNhMyIsICJuYW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAiLCAi
+        YXJ0aWZhY3RzIjogWyJkdWNrLTA6MC42LTEubm9hcmNoIl0sICJjaGVja3N1
+        bSI6ICI2YmQ5ZDkwOWM5MjcwNTcxYjgxMWU1MDI3MDllYTdiNTYxNTBkNDRh
+        MmI0YjM0Y2ZkMjVlNTJhODFjNWJmY2U3IiwgIl9sYXN0X3VwZGF0ZWQiOiAx
+        NjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJw
+        cm9maWxlcyI6IHsiZGVmYXVsdCI6IFsiZHVjayJdfSwgInN1bW1hcnkiOiAi
+        RHVjayAwLjYgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVyc2lv
+        biI6IDIwMTgwNzA0MjQ0MjA1LCAicHVscF91c2VyX21ldGFkYXRhIjoge30s
+        ICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1bGVt
+        ZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICI4ZGM4ZTI5Zi1lNTMx
+        LTQ0NWYtYTcwYy01NjQ2OTBmYTk4NGQiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        ZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBkdWNrIDAuNiBwYWNr
+        YWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjowMloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
+        aWQiOiAiOGRjOGUyOWYtZTUzMS00NDVmLWE3MGMtNTY0NjkwZmE5ODRkIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQ0NGQifX0s
+        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRlNGUzNWM2
+        N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIwYzM4MmNl
         IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        OiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjogImRkNjIx
+        YzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODczZDg1NmI3
+        OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEs
         ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNyBt
         b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
         OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
-        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
-        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdhNSJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
-        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
-        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
-        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
-        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
-        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
-        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
-        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
-        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
-        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
-        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
-        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
-        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdiMCJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
-        ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
-        OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
-        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
-        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
-        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ3
-        ODUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
-        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
-        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
-        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
-        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
-        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
-        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
-        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
-        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
-        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDc5OSJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
-        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
-        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
-        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
-        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
-        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ3
-        OGUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
-        Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
-        ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
-        ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
-        Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
-        NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
-        LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
-        ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
-        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
-        NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
-        YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
-        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
-        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
-        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJhNDdiZSJ9fV0=
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogImIxZmJhOGZjLTk2YmMtNDNiMi1hOWZl
+        LTNhNmRkMjBhYTg0NyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJiMWZi
+        YThmYy05NmJjLTQzYjItYTlmZS0zYTZkZDIwYWE4NDciLCAiX2lkIjogeyIk
+        b2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDQ0NCJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1633,7 +1733,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1646,7 +1746,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -1659,10 +1759,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1672,7 +1772,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1685,226 +1785,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1948'
+      - '1947'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
-        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
-        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
-        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
-        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
-        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
-        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
-        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
-        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
-        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
-        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
-        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
-        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
-        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
-        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
-        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NjgsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
-        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDha
-        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
-        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0NDEyOTczZjhjZGUyYTQ4OTAifX0sIHsibWV0YWRh
-        dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
-        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
-        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9t
-        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
-        dGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2
-        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
-        ImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg2OCwgInJl
-        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
-        Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
-        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
-        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
-        NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
-        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
-        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5NzNmOGNkZTJh
-        NDg1NSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
-        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
-        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
-        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
-        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
-        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
-        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
-        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
-        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
-        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
-        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
-        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
-        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODY4
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
-        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
-        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDQxMjk3M2Y4
-        Y2RlMmE0ODcxIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
-        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
-        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
-        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
-        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMjA5Mjg2OCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
-        dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
-        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
-        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
-        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjQ0MTI5NzNmOGNkZTJhNDgwMiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
-        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
-        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
-        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
-        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
-        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
-        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
-        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
-        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg2OCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
-        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
-        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ0MTI5
-        NzNmOGNkZTJhNDgzYiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
-        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
-        dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
-        ZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0s
-        IHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemls
-        bGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxh
-        IiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6
-        aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3Mi
-        fSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkv
-        ZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwg
-        ImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
-        NSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
-        L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjog
-        Im90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91
-        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
-        dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIsICJmcm9tIjog
-        InNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50
-        IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBkYXRl
-        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMyIsICJy
-        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
-        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
-        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
-        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
-        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDIt
-        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
-        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
-        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
-        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
-        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZl
-        bCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2Vj
-        NGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        MiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5
-        OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
-        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29s
-        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIs
-        ICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
-        b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
-        dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
-        bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
-        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NjgsICJy
-        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
-        aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
-        b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
-        YWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5
-        b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUg
-        aXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxz
-        IG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkg
-        dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
-        ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
-        YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
-        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
-        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
-        VDE3OjQ3OjQ4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
-        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDEyOTcz
-        ZjhjZGUyYTQ4MWMifX1d
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTIyLCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICIyOGY1ZmIxNC00MTVlLTRmYmItYmI5NS1mZmExMDcyYjAy
+        MTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjEyOjAyWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lk
+        IjogIjI4ZjVmYjE0LTQxNWUtNGZiYi1iYjk1LWZmYTEwNzJiMDIxNiIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4OTdlNzM4N2I0MTY0NGM3In19LCB7
+        Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTowMTowMSIs
+        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDExMSIs
+        ICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEiLCAiX25z
+        IjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3Jh
+        cHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51bGwsICJm
+        aWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIs
+        ICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcxMjIsICJyZXN0YXJ0
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMi
+        OiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjc0YjgxMGMzLWZiNjMtNDA4My1hZTNhLTI1NzMx
+        ZjJhZGY4ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiNzRiODEwYzMtZmI2My00MDgzLWFlM2EtMjU3MzFmMmFkZjhk
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mjg5N2U3Mzg3YjQxNjQ1MWEi
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5
+        OTE0MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
+        dHkiOiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9y
+        ZyIsICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNzEyMiwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
+        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
+        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTAyYmU4ZmQtZDc2
+        ZC00ODEyLWEzMmUtZGU5MWIyNWJiNWEzIn0sICJ1cGRhdGVkIjogIjIwMjAt
+        MTEtMDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNy
+        ZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lk
+        IjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJhMDJiZThmZC1kNzZkLTQ4MTIt
+        YTMyZS1kZTkxYjI1YmI1YTMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzky
+        ODk3ZTczODdiNDE2NDUwMCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjog
+        IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBm
+        YWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktB
+        VEVMTE8tUkhFQS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0
+        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJv
+        b19FcnJhdHVtIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24i
+        OiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVu
+        aGFuY2VtZW50IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
+        ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVj
+        ayIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJl
+        bGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29s
+        bGVjdGlvbi0wIiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIs
+        ICJ2ZXJzaW9uIjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAi
+        In0sIHsicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGws
+        ICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwg
+        Im1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjog
+        IjIwMTgwNzMwMjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAi
+        a2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0
+        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAw
+        OjAxIFVUQyIsICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1
+        bSBkZXNjcmlwdGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyMiwg
+        InJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYjdjNGIzNmUtZjRiMy00MjViLTg4
+        NDMtY2RlYmE1MmE2ZDhhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lkIjogImVycmF0
+        dW0iLCAidW5pdF9pZCI6ICJiN2M0YjM2ZS1mNGIzLTQyNWItODg0My1jZGVi
+        YTUyYTZkOGEiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdi
+        NDE2NDUzOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEt
+        MDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
+        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
+        QS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
+        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEi
+        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
+        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
+        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
+        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxl
+        Y3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwg
+        InVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVy
+        cmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyMiwgInJlc3RhcnRf
+        c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
+        ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
+        OiAiMSIsICJfaWQiOiAiYmRhNDBiNzktZmI3Yi00NTM1LTg0YTktOGJlNmIx
+        ZmVmMTk3In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5p
+        dF9pZCI6ICJiZGE0MGI3OS1mYjdiLTQ1MzUtODRhOS04YmU2YjFmZWYxOTci
+        LCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3ZTczODdiNDE2NDRlMiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
+        MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
+        OiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRz
+        X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAi
+        c3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlv
+        biI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcx
+        MjIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImM1M2NhMWE2LTQ1NGYtNGVi
+        ZC1hMDdiLTVmMTlhNjEwZmNjOSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjAyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYzUzY2ExYTYtNDU0Zi00ZWJkLWEwN2It
+        NWYxOWE2MTBmY2M5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mjg5N2U3
+        Mzg3YjQxNjQ0YWQifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1914,7 +2014,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1927,7 +2027,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -1940,10 +2040,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1953,7 +2053,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1966,13 +2066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '519'
+      - '521'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1982,19 +2082,19 @@ http_interactions:
         b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
         X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
         YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
-        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEsICJv
         cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
         OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
         cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
         ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
-        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
-        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
-        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDQx
-        Mjk3M2Y4Y2RlMmE0OGEwIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        YmlyZCIsICJfaWQiOiAiZjk3MTM3MWUtN2IyMi00NTY2LThhMjAtODBjNmQ2
+        MzEzYTM5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjowMloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogImY5NzEzNzFlLTdiMjItNDU2Ni04
+        YTIwLTgwYzZkNjMxM2EzOSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTI4
+        OTdlNzM4N2I0MTY0NTQ5In19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
         cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
         ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
         ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
@@ -2002,24 +2102,24 @@ http_interactions:
         LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
         XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
         InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
-        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
-        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0
+        NjA2NTgxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
         YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
         ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
         YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
-        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
-        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZmE4NTFkNGMtZTgwZS00MDZl
+        LTg3OTktNmE0OTM3YWM0YjgxIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
         Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ4WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
-        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNDQxMjk3M2Y4Y2RlMmE0OGFjIn19XQ==
+        MjAyMC0xMS0wNVQyMDoxMjowMloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjAyWiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImZhODUxZDRj
+        LWU4MGUtNDA2ZS04Nzk5LTZhNDkzN2FjNGI4MSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOTI4OTdlNzM4N2I0MTY0NTU1In19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2029,7 +2129,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2042,7 +2142,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2055,10 +2155,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2068,7 +2168,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2081,13 +2181,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '402'
+      - '405'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2101,22 +2201,22 @@ http_interactions:
         Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
         b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
         ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODY3LCAiX2NvbnRlbnRfdHlwZV9p
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTIyLCAiX2NvbnRlbnRfdHlwZV9p
         ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
         cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
         eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
-        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDdaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
-        N1QxNzo0Nzo0N1oiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
-        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQzMTI5
-        NzNmOGNkZTJhNDY2YyJ9fV0=
+        YTI1NiIsICJfaWQiOiAiNDJlYmU5MGEtMDMwMS00ZjlhLWI2NzktNGFlODVk
+        ZTljZDI2In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDJaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjowMloiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICI0MmViZTkwYS0wMzAxLTRmOWEtYjY3
+        OS00YWU4NWRlOWNkMjYiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzkyODk3
+        ZTczODdiNDE2NDMwZCJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2126,7 +2226,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2139,7 +2239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2152,10 +2252,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2167,7 +2267,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2180,7 +2280,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2193,10 +2293,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2206,7 +2306,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2219,7 +2319,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Vary:
@@ -2245,42 +2345,42 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg2NywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwNDYw
+        NzEyMiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo0OFoiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDQxMjk3M2Y4Y2RlMmE0Nzc0In19XQ==
+        MjAtMTEtMDVUMjA6MTI6MDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowMloiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOTI4OTdlNzM4N2I0MTY0NDIxIn19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iXX19fSwiZmll
-        bGRzIjp7InVuaXQiOlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVh
-        c2UiLCJhcmNoIiwiY2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19LCJvdmVy
-        cmlkZV9jb25maWciOnt9fQ==
+        OnsiJGluIjpbInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIl19fX0sImZp
+        ZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJlcG9jaCIsInZlcnNpb24iLCJyZWxl
+        YXNlIiwiYXJjaCIsImNoZWNrc3VtdHlwZSIsImNoZWNrc3VtIl19fSwib3Zl
+        cnJpZGVfY29uZmlnIjp7fX0=
     headers:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
-      - '241'
+      - '242'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2289,7 +2389,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2300,14 +2400,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NjODY3OGY3LWZiY2QtNDU5Yy05MDVlLWU3YTQ2ZTVjY2MwNy8iLCAi
-        dGFza19pZCI6ICJjYzg2NzhmNy1mYmNkLTQ1OWMtOTA1ZS1lN2E0NmU1Y2Nj
-        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzAzM2RiNjdkLTUyZmItNDgxYS1iNDgwLTkyN2MwOGUwMWUwYy8iLCAi
+        dGFza19pZCI6ICIwMzNkYjY3ZC01MmZiLTQ4MWEtYjQ4MC05MjdjMDhlMDFl
+        MGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2318,7 +2418,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2331,7 +2431,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2342,14 +2442,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkxOTQ2NjFkLTc3OWQtNDgwZi1hYTYzLTYwNGU2MGU0NjkwZC8iLCAi
-        dGFza19pZCI6ICI5MTk0NjYxZC03NzlkLTQ4MGYtYWE2My02MDRlNjBlNDY5
-        MGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQ1ODFlZDM2LWM3YTgtNGYxNC04ZjdhLTg0MjhiOTNhMGZjOS8iLCAi
+        dGFza19pZCI6ICI0NTgxZWQzNi1jN2E4LTRmMTQtOGY3YS04NDI4YjkzYTBm
+        YzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2359,7 +2459,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2372,7 +2472,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2383,14 +2483,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgyMGM3NDQzLTU2ODAtNDgwOS04NzA1LTRiMWMyNGZjN2YwNi8iLCAi
-        dGFza19pZCI6ICI4MjBjNzQ0My01NjgwLTQ4MDktODcwNS00YjFjMjRmYzdm
-        MDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzBhNTUwYjQ0LWIxYWMtNDJhMy05ZjNmLWM2NDA5NmVhNWY2Ny8iLCAi
+        dGFza19pZCI6ICIwYTU1MGI0NC1iMWFjLTQyYTMtOWYzZi1jNjQwOTZlYTVm
+        NjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2400,7 +2500,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2413,7 +2513,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2424,14 +2524,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdiZDQxNjYwLTE5OTMtNDA3NC05NzllLTY2OGZiYjJlNDIwNC8iLCAi
-        dGFza19pZCI6ICI3YmQ0MTY2MC0xOTkzLTQwNzQtOTc5ZS02NjhmYmIyZTQy
-        MDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FjNDk5ZTA5LWU4NTAtNGVhNy05MjU4LTdjNjk2MmJjYmM2Ni8iLCAi
+        dGFza19pZCI6ICJhYzQ5OWUwOS1lODUwLTRlYTctOTI1OC03YzY5NjJiY2Jj
+        NjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2441,7 +2541,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2454,7 +2554,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2465,14 +2565,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I1ODZjN2RiLWNlMTktNDg4Yy1hYTg2LTM5M2Y2MDQxOTQxNC8iLCAi
-        dGFza19pZCI6ICJiNTg2YzdkYi1jZTE5LTQ4OGMtYWE4Ni0zOTNmNjA0MTk0
-        MTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRlMzFjOGIzLWRhMjQtNDI0ZS04MDdhLTUzMTNmOWJhYzZjNC8iLCAi
+        dGFza19pZCI6ICI0ZTMxYzhiMy1kYTI0LTQyNGUtODA3YS01MzEzZjliYWM2
+        YzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2483,7 +2583,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2496,7 +2596,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2507,14 +2607,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MyOWE3ZmZjLTQzMWYtNDU2MC04MDA5LWEyNGQ0ZjYwOWJmZC8iLCAi
-        dGFza19pZCI6ICJjMjlhN2ZmYy00MzFmLTQ1NjAtODAwOS1hMjRkNGY2MDli
-        ZmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzgwZGUzYzNmLWZmMzMtNDE3My04ODExLTNkNDI2N2ZlNTJlMy8iLCAi
+        dGFza19pZCI6ICI4MGRlM2MzZi1mZjMzLTQxNzMtODgxMS0zZDQyNjdmZTUy
+        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2525,7 +2625,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2538,7 +2638,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2549,14 +2649,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRmM2NjYTQ1LWIwNGEtNDdmMC05NzAwLTRmY2NiMmRmMTdiNS8iLCAi
-        dGFza19pZCI6ICI0ZjNjY2E0NS1iMDRhLTQ3ZjAtOTcwMC00ZmNjYjJkZjE3
-        YjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Y0Zjg3Yzk2LTVhYWMtNDNlMS05Y2M2LWUyMjQzZWRlNjE2Ny8iLCAi
+        dGFza19pZCI6ICJmNGY4N2M5Ni01YWFjLTQzZTEtOWNjNi1lMjI0M2VkZTYx
+        NjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2566,7 +2666,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2579,7 +2679,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2590,14 +2690,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUxNjk0M2E3LTE1YWItNDc0Yi1hYTk4LTExZWI4NDMzZWJjYi8iLCAi
-        dGFza19pZCI6ICI1MTY5NDNhNy0xNWFiLTQ3NGItYWE5OC0xMWViODQzM2Vi
-        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E3OTcyM2VjLWRiY2ItNDE5ZC05YzhlLTQ4YjllMmY3NzBmMC8iLCAi
+        dGFza19pZCI6ICJhNzk3MjNlYy1kYmNiLTQxOWQtOWM4ZS00OGI5ZTJmNzcw
+        ZjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2607,7 +2707,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2620,7 +2720,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2631,14 +2731,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzVjMmI0YjJhLTlmMjQtNDFkOC05NmQ1LTk5NTVhYWIwZTdlMy8iLCAi
-        dGFza19pZCI6ICI1YzJiNGIyYS05ZjI0LTQxZDgtOTZkNS05OTU1YWFiMGU3
-        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzE0YzYyZDY5LWZjMmEtNDMyNi05OWEzLTFlMThhNjViYTViMS8iLCAi
+        dGFza19pZCI6ICIxNGM2MmQ2OS1mYzJhLTQzMjYtOTlhMy0xZTE4YTY1YmE1
+        YjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2648,7 +2748,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2661,7 +2761,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Content-Length:
@@ -2672,14 +2772,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNlMGExMmQ1LTcyZmMtNGNlYi1hZjMxLWIxMGRkY2Q1M2Y5Yy8iLCAi
-        dGFza19pZCI6ICIzZTBhMTJkNS03MmZjLTRjZWItYWYzMS1iMTBkZGNkNTNm
-        OWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2ZjZGFhOTA4LWVhZmUtNDU4OC1iZjFlLTZjNzVmMjFjMzhhMi8iLCAi
+        dGFza19pZCI6ICJmY2RhYTkwOC1lYWZlLTQ1ODgtYmYxZS02Yzc1ZjIxYzM4
+        YTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/cc8678f7-fbcd-459c-905e-e7a46e5ccc07/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/033db67d-52fb-481a-b480-927c08e01e0c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2687,7 +2787,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2698,15 +2798,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Etag:
-      - '"5ca04ef41342600a9c752460816056c8-gzip"'
+      - '"294ebd92e9ab252dd89f8fe272667ab6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '555'
+      - '561'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2714,33 +2814,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jYzg2Nzhm
-        Ny1mYmNkLTQ1OWMtOTA1ZS1lN2E0NmU1Y2NjMDcvIiwgInRhc2tfaWQiOiAi
-        Y2M4Njc4ZjctZmJjZC00NTljLTkwNWUtZTdhNDZlNWNjYzA3IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMzNkYjY3
+        ZC01MmZiLTQ4MWEtYjQ4MC05MjdjMDhlMDFlMGMvIiwgInRhc2tfaWQiOiAi
+        MDMzZGI2N2QtNTJmYi00ODFhLWI0ODAtOTI3YzA4ZTAxZTBjIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAz
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzMzM1MWZkNmMyYTM4ZTVk
-        NDlhZWE3ODhhMmU4MzhlYWNkNjU0Y2Y2MWQ0NzZiYTViNjVkZTQzOWRkZDEy
-        NWI5IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
-        ZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3Np
-        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWEwIn0sICJpZCI6ICI1
-        ZjdkZmY0NTEyOTczZjhjZGUyYTRhYTAifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
+        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
+        MTBmZDZlNDg2MzViZTY5NCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
+        MC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTM4OTdlNzM4N2I0MTY0
+        NzUwIn0sICJpZCI6ICI1ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ3NTAifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:49 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:03 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9194661d-779d-480f-aa63-604e60e4690d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4581ed36-c7a8-4f14-8f7a-8428b93a0fc9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2748,7 +2848,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2759,15 +2859,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:49 GMT
+      - Thu, 05 Nov 2020 20:12:03 GMT
       Server:
       - Apache
       Etag:
-      - '"2f1aa97abf31e5aa53b8bd0bf7934509-gzip"'
+      - '"bdaf557f61c7a255deff53cf703a4fca-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '956'
+      - '960'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2775,79 +2875,79 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85MTk0NjYx
-        ZC03NzlkLTQ4MGYtYWE2My02MDRlNjBlNDY5MGQvIiwgInRhc2tfaWQiOiAi
-        OTE5NDY2MWQtNzc5ZC00ODBmLWFhNjMtNjA0ZTYwZTQ2OTBkIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80NTgxZWQz
+        Ni1jN2E4LTRmMTQtOGY3YS04NDI4YjkzYTBmYzkvIiwgInRhc2tfaWQiOiAi
+        NDU4MWVkMzYtYzdhOC00ZjE0LThmN2EtODQyOGI5M2EwZmM5IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAz
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
-        ZXJzaW9uIjogMjAxODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJu
-        YW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9k
-        dWxlbWQifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIs
-        ICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIs
-        ICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9p
-        ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
-        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAi
-        bm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlw
-        ZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgz
-        M2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5
-        YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
-        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
-        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNr
-        IiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNl
-        ZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
-        aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
-        ZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tl
-        eSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVhNGM4
-        OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2Qw
-        OTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9r
-        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
-        NzA0MTExNzE5LCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJrYW5nYXJv
-        byIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
-        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndh
-        bHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2
-        MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIs
-        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
-        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
-        aXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUz
-        M2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0
-        OGI3N2UwMTg5OGU3YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1
-        LjIxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVj
-        a3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVu
-        aXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAy
-        MDE4MDczMDIyMzQwNywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2Fu
-        Z2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQi
-        fSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
-        aW9uIjogMjAxODA3MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1l
-        IjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJt
-        b2R1bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
-        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZl
-        NmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3
-        NGJjNyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVh
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250ZXh0Ijog
+        ImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwgImFyY2gi
+        OiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAi
+        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
+        IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIwMywgImFy
+        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIw
+        LjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9rZXkiOiB7
+        ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjMz
+        MTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwgInN0cmVh
+        bSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAi
+        Y2hlY2tzdW0iOiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYy
+        ZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
+        IjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
+        eyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4
+        MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMy
+        NDcxMiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43IiwgInJlbGVh
         c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9z
-        aWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjQ1MTI5NzNmOGNkZTJhNGFiNiJ9LCAiaWQiOiAi
-        NWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWI2In0=
+        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
+        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNr
+        c3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2EzYzQwNzI4MGMxNDFlOTIwMmYw
+        MjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQiLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJy
+        cG0ifSwgeyJ1bml0X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2
+        ZXJzaW9uIjogMjAxODA3MDQxMTE3MTksICJhcmNoIjogIm5vYXJjaCIsICJu
+        YW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjog
+        Im1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXki
+        OiB7Im5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBj
+        YmUzZWNiMmNiZWUxYzYyNmEzOWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1
+        NjUyMzE0MmMiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAi
+        cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNo
+        ZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4
+        OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAi
+        bm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQi
+        OiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYi
+        LCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJub2FyY2gi
+        LCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRl
+        YWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFyY2giOiAi
+        eDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIn0s
+        ICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXkiOiBudWxs
+        LCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5
+        NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3
+        Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        ZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTM4OTdlNzM4N2I0MTY0
+        NzYyIn0sICJpZCI6ICI1ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ3NjIifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/820c7443-5680-4809-8705-4b1c24fc7f06/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/0a550b44-b1ac-42a3-9f3f-c64096ea5f67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2855,7 +2955,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2866,15 +2966,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:04 GMT
       Server:
       - Apache
       Etag:
-      - '"cec6e053bbf27ab2ce6aa5dc0c5fd678-gzip"'
+      - '"5d082a1deb8838bcd92ea5af1b9a9153-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '427'
+      - '432'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2882,93 +2982,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MjBjNzQ0
-        My01NjgwLTQ4MDktODcwNS00YjFjMjRmYzdmMDYvIiwgInRhc2tfaWQiOiAi
-        ODIwYzc0NDMtNTY4MC00ODA5LTg3MDUtNGIxYzI0ZmM3ZjA2IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYTU1MGI0
+        NC1iMWFjLTQyYTMtOWYzZi1jNjQwOTZlYTVmNjcvIiwgInRhc2tfaWQiOiAi
+        MGE1NTBiNDQtYjFhYy00MmEzLTlmM2YtYzY0MDk2ZWE1ZjY3IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAz
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ1MTI5
-        NzNmOGNkZTJhNGFkNyJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
-        YWQ3In0=
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7bd41660-1993-4074-979e-668fbb2e4204/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d0d2172f83bd8679c94b1e8a16f20aa4-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '510'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YmQ0MTY2
-        MC0xOTkzLTQwNzQtOTc5ZS02NjhmYmIyZTQyMDQvIiwgInRhc2tfaWQiOiAi
-        N2JkNDE2NjAtMTk5My00MDc0LTk3OWUtNjY4ZmJiMmU0MjA0IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
-        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
-        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
-        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
-        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
-        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
-        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
-        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
         ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YWU3In0sICJpZCI6ICI1ZjdkZmY0
-        NTEyOTczZjhjZGUyYTRhZTcifQ==
+        OiAiNWZhNDVjOTM4OTdlNzM4N2I0MTY0Nzg5In0sICJpZCI6ICI1ZmE0NWM5
+        Mzg5N2U3Mzg3YjQxNjQ3ODkifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/b586c7db-ce19-488c-aa86-393f60419414/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/ac499e09-e850-4ea7-9258-7c6962bcbc66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2976,7 +3011,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2987,15 +3022,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:04 GMT
       Server:
       - Apache
       Etag:
-      - '"8478664a8321789033e16a6c78de6294-gzip"'
+      - '"0d52e907c6b43ad04fde1918ae10f747-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '484'
+      - '513'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3003,35 +3038,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iNTg2Yzdk
-        Yi1jZTE5LTQ4OGMtYWE4Ni0zOTNmNjA0MTk0MTQvIiwgInRhc2tfaWQiOiAi
-        YjU4NmM3ZGItY2UxOS00ODhjLWFhODYtMzkzZjYwNDE5NDE0IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hYzQ5OWUw
+        OS1lODUwLTRlYTctOTI1OC03YzY5NjJiY2JjNjYvIiwgInRhc2tfaWQiOiAi
+        YWM0OTllMDktZTg1MC00ZWE3LTkyNTgtN2M2OTYyYmNiYzY2IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjQ5
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjAz
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
-        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
-        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
-        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjQ1MTI5NzNmOGNkZTJhNGIxZiJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3
-        M2Y4Y2RlMmE0YjFmIn0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
+        TExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
+        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9
+        LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjog
+        IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJyYXR1
+        bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
+        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1bml0c19m
+        YWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ3OTYifSwg
+        ImlkIjogIjVmYTQ1YzkzODk3ZTczODdiNDE2NDc5NiJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c29a7ffc-431f-4560-8009-a24d4f609bfd/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4e31c8b3-da24-424e-807a-5313f9bac6c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3039,7 +3076,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3050,15 +3087,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:04 GMT
       Server:
       - Apache
       Etag:
-      - '"ef92b9281b5effa69aea08e423e5846c-gzip"'
+      - '"b2f7acac27a1ed214252553dbf12d5cf-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '473'
+      - '488'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3066,32 +3103,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jMjlhN2Zm
-        Yy00MzFmLTQ1NjAtODAwOS1hMjRkNGY2MDliZmQvIiwgInRhc2tfaWQiOiAi
-        YzI5YTdmZmMtNDMxZi00NTYwLTgwMDktYTI0ZDRmNjA5YmZkIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZTMxYzhi
+        My1kYTI0LTQyNGUtODA3YS01MzEzZjliYWM2YzQvIiwgInRhc2tfaWQiOiAi
+        NGUzMWM4YjMtZGEyNC00MjRlLTgwN2EtNTMxM2Y5YmFjNmM0IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
-        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
-        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
-        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4
-        Y2RlMmE0YjQ0In0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiNDQi
-        fQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIs
+        ICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJpcmQifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVf
+        aWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNWZhNDVjOTM4OTdlNzM4N2I0MTY0N2MzIn0sICJpZCI6
+        ICI1ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ3YzMifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/4f3cca45-b04a-47f0-9700-4fccb2df17b5/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/80de3c3f-ff33-4173-8811-3d4267fe52e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3099,7 +3139,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3110,15 +3150,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:04 GMT
       Server:
       - Apache
       Etag:
-      - '"82c0bc196554e798768c0248c08c46de-gzip"'
+      - '"2ca8bbb700eac724c88c0f671bcaa2bb-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '473'
+      - '478'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3126,32 +3166,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZjNjY2E0
-        NS1iMDRhLTQ3ZjAtOTcwMC00ZmNjYjJkZjE3YjUvIiwgInRhc2tfaWQiOiAi
-        NGYzY2NhNDUtYjA0YS00N2YwLTk3MDAtNGZjY2IyZGYxN2I1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MGRlM2Mz
+        Zi1mZjMzLTQxNzMtODgxMS0zZDQyNjdmZTUyZTMvIiwgInRhc2tfaWQiOiAi
+        ODBkZTNjM2YtZmYzMy00MTczLTg4MTEtM2Q0MjY3ZmU1MmUzIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
-        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
-        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0YjY2In0sICJpZCI6ICI1
-        ZjdkZmY0NTEyOTczZjhjZGUyYTRiNjYifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNr
+        YWdlX2Vudmlyb25tZW50In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2Vudmly
+        b25tZW50In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ3ZjUifSwgImlkIjogIjVmYTQ1YzkzODk3
+        ZTczODdiNDE2NDdmNSJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/516943a7-15ab-474b-aa98-11eb8433ebcb/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/f4f87c96-5aac-43e1-9cc6-e2243ede6167/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3159,7 +3199,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3170,15 +3210,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:04 GMT
       Server:
       - Apache
       Etag:
-      - '"7a1321605459ecc7b334c9d8d78d28f2-gzip"'
+      - '"0d52e5d4e872795560b0a0a45d2efd0e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '509'
+      - '478'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3186,31 +3226,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81MTY5NDNh
-        Ny0xNWFiLTQ3NGItYWE5OC0xMWViODQzM2ViY2IvIiwgInRhc2tfaWQiOiAi
-        NTE2OTQzYTctMTVhYi00NzRiLWFhOTgtMTFlYjg0MzNlYmNiIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mNGY4N2M5
+        Ni01YWFjLTQzZTEtOWNjNi1lMjI0M2VkZTYxNjcvIiwgInRhc2tfaWQiOiAi
+        ZjRmODdjOTYtNWFhYy00M2UxLTljYzYtZTIyNDNlZGU2MTY3IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
-        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
-        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
-        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
-        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2Rl
-        MmE0Yjc0In0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiNzQifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dLCAidW5pdHNfZmFpbGVk
+        X3NpZ25hdHVyZV9maWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlw
+        ZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5Mzg5N2U3Mzg3YjQxNjQ4
+        MGEifSwgImlkIjogIjVmYTQ1YzkzODk3ZTczODdiNDE2NDgwYSJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/5c2b4b2a-9f24-41d8-96d5-9955aab0e7e3/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/a79723ec-dbcb-419d-9c8e-48b9e2f770f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3218,7 +3259,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3229,15 +3270,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:05 GMT
       Server:
       - Apache
       Etag:
-      - '"6f94b547708cbfb3e5810b60597117a9-gzip"'
+      - '"97035bb0305f8305ca6ff995a2d66106-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '501'
+      - '514'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3245,39 +3286,100 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YzJiNGIy
-        YS05ZjI0LTQxZDgtOTZkNS05OTU1YWFiMGU3ZTMvIiwgInRhc2tfaWQiOiAi
-        NWMyYjRiMmEtOWYyNC00MWQ4LTk2ZDUtOTk1NWFhYjBlN2UzIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNzk3MjNl
+        Yy1kYmNiLTQxOWQtOWM4ZS00OGI5ZTJmNzcwZjAvIiwgInRhc2tfaWQiOiAi
+        YTc5NzIzZWMtZGJjYi00MTlkLTljOGUtNDhiOWUyZjc3MGYwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJpYW50Ijog
+        IlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6ICJ4ODZf
+        NjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQtMTYteDg2
+        XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9pZCI6ICJk
+        aXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
+        ciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0
+        NWM5Mzg5N2U3Mzg3YjQxNjQ4MjIifSwgImlkIjogIjVmYTQ1YzkzODk3ZTcz
+        ODdiNDE2NDgyMiJ9
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:12:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/14c62d69-fc2a-4326-99a3-1e18a65ba5b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:12:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f14a8686ce073cd3269db753206617ad-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '505'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xNGM2MmQ2
+        OS1mYzJhLTQzMjYtOTlhMy0xZTE4YTY1YmE1YjEvIiwgInRhc2tfaWQiOiAi
+        MTRjNjJkNjktZmMyYS00MzI2LTk5YTMtMWUxOGE2NWJhNWIxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQiOiAibW9k
+        dWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIz
+        X3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
+        ZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
+        IjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
-        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        bmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
-        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
-        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
-        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
-        YmFiIn0sICJpZCI6ICI1ZjdkZmY0NTEyOTczZjhjZGUyYTRiYWIifQ==
+        In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5
+        Mzg5N2U3Mzg3YjQxNjQ4MzAifSwgImlkIjogIjVmYTQ1YzkzODk3ZTczODdi
+        NDE2NDgzMCJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:05 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3e0a12d5-72fc-4ceb-af31-b10ddcd53f9c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/fcdaa908-eafe-4588-bf1e-6c75f21c38a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3285,7 +3387,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3296,15 +3398,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:50 GMT
+      - Thu, 05 Nov 2020 20:12:06 GMT
       Server:
       - Apache
       Etag:
-      - '"c56c2d584e34b0105a272b6c8958bf89-gzip"'
+      - '"47b1bec96bbde0c8b31a12ecdc804a82-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '424'
+      - '432'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3312,28 +3414,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZTBhMTJk
-        NS03MmZjLTRjZWItYWYzMS1iMTBkZGNkNTNmOWMvIiwgInRhc2tfaWQiOiAi
-        M2UwYTEyZDUtNzJmYy00Y2ViLWFmMzEtYjEwZGRjZDUzZjljIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mY2RhYTkw
+        OC1lYWZlLTQ1ODgtYmYxZS02Yzc1ZjIxYzM4YTIvIiwgInRhc2tfaWQiOiAi
+        ZmNkYWE5MDgtZWFmZS00NTg4LWJmMWUtNmM3NWYyMWMzOGEyIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUwWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUw
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA0
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ1MTI5
-        NzNmOGNkZTJhNGJjMyJ9LCAiaWQiOiAiNWY3ZGZmNDUxMjk3M2Y4Y2RlMmE0
-        YmMzIn0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOTM4OTdlNzM4N2I0MTY0ODQ5In0sICJpZCI6ICI1ZmE0NWM5
+        Mzg5N2U3Mzg3YjQxNjQ4NDkifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:50 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:06 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3341,7 +3443,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3352,15 +3454,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:51 GMT
+      - Thu, 05 Nov 2020 20:12:06 GMT
       Server:
       - Apache
       Etag:
-      - '"6d160c2611b939595d9b75dde93d5e1d-gzip"'
+      - '"fb6b5425fa536d6e622fd42e07f32561-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '637'
+      - '636'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3369,60 +3471,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTI6MDNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTcifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZmE0NWM5MzA2YzcxYTA0NTAzYTdiMjgifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTI6MDNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmNDQwMjIzOWY3MzY1MWU2MTk2In0sICJjb25maWci
+        IiRvaWQiOiAiNWZhNDVjOTMwNmM3MWEwNDUwM2E3YjI3In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDNaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTUifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5MzA2YzcxYTA0NTAzYTdiMjYifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTBaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDRaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJlcnJhdHVt
         IjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQiOiA2LCAicGFj
         a2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24iOiAxLCAicnBt
         IjogNywgInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwgIl9ucyI6ICJy
         ZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAi
-        bGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NDhaIiwgIl9ocmVm
+        bGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDNaIiwgIl9ocmVm
         IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9pbXBvcnRl
         cnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMiLCAi
         aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVy
         cmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3JhdGNo
-        cGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0NDAyMjM5Zjcz
-        NjUxZTYxOTQifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9ydGVy
+        cGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5MzA2YzcxYTA0
+        NTAzYTdiMjUifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9ydGVy
         In1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAyNiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZjdkZmY0NDAyMjM5ZjczNjUxZTYxOTMifSwgInRvdGFsX3JlcG9z
+        ZCI6ICI1ZmE0NWM5MzA2YzcxYTA0NTAzYTdiMjQifSwgInRvdGFsX3JlcG9z
         aXRvcnlfdW5pdHMiOiAyNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:06 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3430,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3441,7 +3543,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:51 GMT
+      - Thu, 05 Nov 2020 20:12:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -3452,14 +3554,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JkZDVkMGE4LWUwODYtNGE5NC04MjVjLWY4ZjM1NDUwNzI4Ni8iLCAi
-        dGFza19pZCI6ICJiZGQ1ZDBhOC1lMDg2LTRhOTQtODI1Yy1mOGYzNTQ1MDcy
-        ODYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MyYWY4NjhiLWViODMtNGM5OC1iNTIzLWIyMzNhZWNlMDE5MS8iLCAi
+        dGFza19pZCI6ICJjMmFmODY4Yi1lYjgzLTRjOTgtYjUyMy1iMjMzYWVjZTAx
+        OTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:07 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/bdd5d0a8-e086-4a94-825c-f8f354507286/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/c2af868b-eb83-4c98-b523-b233aece0191/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3467,7 +3569,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3478,15 +3580,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:51 GMT
+      - Thu, 05 Nov 2020 20:12:07 GMT
       Server:
       - Apache
       Etag:
-      - '"b85a72a9ef1660479e6ff6997fca97e5-gzip"'
+      - '"6b4c46f2555e1abd35d37b20ec1317b0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '365'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3494,25 +3596,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZGQ1ZDBhOC1lMDg2LTRhOTQtODI1Yy1mOGYzNTQ1MDcy
-        ODYvIiwgInRhc2tfaWQiOiAiYmRkNWQwYTgtZTA4Ni00YTk0LTgyNWMtZjhm
-        MzU0NTA3Mjg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMmFmODY4Yi1lYjgzLTRjOTgtYjUyMy1iMjMzYWVjZTAx
+        OTEvIiwgInRhc2tfaWQiOiAiYzJhZjg2OGItZWI4My00Yzk4LWI1MjMtYjIz
+        M2FlY2UwMTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjUxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUxWiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjA3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjA3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjQ3MTI5NzNmOGNkZTJhNGQyOCJ9LCAiaWQiOiAi
-        NWY3ZGZmNDcxMjk3M2Y4Y2RlMmE0ZDI4In0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTc4OTdlNzM4N2I0MTY0
+        OWU5In0sICJpZCI6ICI1ZmE0NWM5Nzg5N2U3Mzg3YjQxNjQ5ZTkifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:07 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3520,7 +3622,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3531,7 +3633,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:51 GMT
+      - Thu, 05 Nov 2020 20:12:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -3542,14 +3644,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzllMTkzZTM2LTU3MjctNDZkMy05NmQyLWE1YjFmMjFlMmYxOS8iLCAi
-        dGFza19pZCI6ICI5ZTE5M2UzNi01NzI3LTQ2ZDMtOTZkMi1hNWIxZjIxZTJm
-        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzcxYzcyZGUyLWNjZmMtNDg0Zi1hNTA3LTA5NzYxMWZjM2E3My8iLCAi
+        dGFza19pZCI6ICI3MWM3MmRlMi1jY2ZjLTQ4NGYtYTUwNy0wOTc2MTFmYzNh
+        NzMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:07 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/9e193e36-5727-46d3-96d2-a5b1f21e2f19/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/71c72de2-ccfc-484f-a507-097611fc3a73/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3557,7 +3659,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3568,15 +3670,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:51 GMT
+      - Thu, 05 Nov 2020 20:12:07 GMT
       Server:
       - Apache
       Etag:
-      - '"80e777224f0f64b6bf521c8e888d2463-gzip"'
+      - '"f81747e23183e3b2dedb499ef8004e3a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '361'
+      - '367'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3584,20 +3686,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZTE5M2UzNi01NzI3LTQ2ZDMtOTZkMi1hNWIxZjIxZTJm
-        MTkvIiwgInRhc2tfaWQiOiAiOWUxOTNlMzYtNTcyNy00NmQzLTk2ZDItYTVi
-        MWYyMWUyZjE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy83MWM3MmRlMi1jY2ZjLTQ4NGYtYTUwNy0wOTc2MTFmYzNh
+        NzMvIiwgInRhc2tfaWQiOiAiNzFjNzJkZTItY2NmYy00ODRmLWE1MDctMDk3
+        NjExZmMzYTczIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1MVoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
-        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0NzEyOTczZjhjZGUyYTRkNzEifSwgImlkIjogIjVm
-        N2RmZjQ3MTI5NzNmOGNkZTJhNGQ3MSJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0
+        YWJsZS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk3ODk3ZTczODdiNDE2NGEz
+        NyJ9LCAiaWQiOiAiNWZhNDVjOTc4OTdlNzM4N2I0MTY0YTM3In0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:51 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:52 GMT
+      - Thu, 05 Nov 2020 20:12:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         LCAic3ViX2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNv
         dXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiM192aWV3MSJ9fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:08 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -52,7 +52,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -63,7 +63,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:52 GMT
+      - Thu, 05 Nov 2020 20:12:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -83,10 +83,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:08 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -94,11 +94,11 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvbGli
-        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lw
-        X2xpc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJw
-        cm94eV9ob3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xp
-        ZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJf
+        L3B1bHAvc3luY19pbXBvcnRzL3Rlc3RfcmVwb3Mvem9vIiwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJ0eXBlX3NraXBfbGlz
+        dCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0
+        aF9wYXNzd29yZCI6bnVsbCwicHJveHlfaG9zdCI6IiJ9LCJub3RlcyI6eyJf
         cmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0
         cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0
         b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
@@ -118,7 +118,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -131,7 +131,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:52 GMT
+      - Thu, 05 Nov 2020 20:12:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -148,14 +148,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDgwMjIzOWY3MzY0MTMxYWZiIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWZhNDVjOTgwNmM3MWEwNDRlYTUyZjM1In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:52 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:08 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -165,7 +165,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -178,7 +178,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:53 GMT
+      - Thu, 05 Nov 2020 20:12:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -189,14 +189,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MxOWI5NGNhLTYwN2ItNGQ4Ny1iMWQxLWVlMTQ0ZGZkZGZhNy8iLCAi
-        dGFza19pZCI6ICJjMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzEzYTdjMWVkLWYzNjgtNDk3Yi1iMWQ2LTgxZDRmZTljYzE4Yi8iLCAi
+        dGFza19pZCI6ICIxM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:08 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -204,7 +204,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -215,15 +215,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:53 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -231,16 +231,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -252,42 +252,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -295,7 +296,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -306,15 +307,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:53 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -322,16 +323,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -343,42 +344,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +388,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -397,15 +399,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:53 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -413,16 +415,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -434,42 +436,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -477,7 +480,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -488,15 +491,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:53 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -504,16 +507,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -525,42 +528,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:53 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +572,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -579,15 +583,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -595,16 +599,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -616,42 +620,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -659,7 +664,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -670,15 +675,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -686,16 +691,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -707,42 +712,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c19b94ca-607b-4d87-b1d1-ee144dfddfa7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/13a7c1ed-f368-497b-b1d6-81d4fe9cc18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -750,7 +756,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -761,15 +767,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"30f6b1e989f4c937f4ca23cc29e3e8f2-gzip"'
+      - '"e6f202008d0bbb17491fcdcdc046798e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '710'
+      - '718'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -777,16 +783,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTliOTRjYS02MDdiLTRkODctYjFkMS1lZTE0NGRmZGRm
-        YTcvIiwgInRhc2tfaWQiOiAiYzE5Yjk0Y2EtNjA3Yi00ZDg3LWIxZDEtZWUx
-        NDRkZmRkZmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xM2E3YzFlZC1mMzY4LTQ5N2ItYjFkNi04MWQ0ZmU5Y2Mx
+        OGIvIiwgInRhc2tfaWQiOiAiMTNhN2MxZWQtZjM2OC00OTdiLWIxZDYtODFk
+        NGZlOWNjMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDg2NTY1NzYtMTczZi00OTkyLTk2YjUtY2IxMGU1MzZj
-        N2ZmLyIsICJ0YXNrX2lkIjogImQ4NjU2NTc2LTE3M2YtNDk5Mi05NmI1LWNi
-        MTBlNTM2YzdmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODIwNjA1N2EtZTY1Ni00N2Q4LTgyZTctYmRiMDlmZjhi
+        YzFjLyIsICJ0YXNrX2lkIjogIjgyMDYwNTdhLWU2NTYtNDdkOC04MmU3LWJk
+        YjA5ZmY4YmMxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -798,42 +804,43 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
-        a2F0ZWxsby1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0
-        Nzo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1ZjdkZmY0OTAyMjM5ZjA1N2Y4YTQzYWQiLCAiZGV0YWls
-        cyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGRlNSJ9LCAi
-        aWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZGU1In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDIwLTExLTA1VDIwOjEyOjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX0sICJhZGRlZF9jb3VudCI6IDQwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVmYTQ1Yzk4MDZjNzFhMDc1MTQ3
+        ZjA0MiIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YWE3In0sICJpZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhYTci
+        fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/d8656576-173f-4992-96b5-cb10e536c7ff/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/8206057a-e656-47d8-82e7-bdb09ff8bc1c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,7 +848,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -852,15 +859,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Etag:
-      - '"7cf1933a74b9720d64e35d7debcea678-gzip"'
+      - '"3bcda451a805bdc814308d69cda37642-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1364'
+      - '1369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -868,199 +875,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kODY1NjU3Ni0xNzNmLTQ5OTItOTZiNS1jYjEw
-        ZTUzNmM3ZmYvIiwgInRhc2tfaWQiOiAiZDg2NTY1NzYtMTczZi00OTkyLTk2
-        YjUtY2IxMGU1MzZjN2ZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy84MjA2MDU3YS1lNjU2LTQ3ZDgtODJlNy1iZGIw
+        OWZmOGJjMWMvIiwgInRhc2tfaWQiOiAiODIwNjA1N2EtZTY1Ni00N2Q4LTgy
+        ZTctYmRiMDlmZjhiYzFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAi
+        bWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjowOVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyMmVmZmY3OS1iOTljLTQ2ODYtOTcxMi05OGUzYWM4
-        MTM5ZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI5ZDk5Y2RhMi0xYTdiLTQyNWMtOTgyZi04N2JmYjkx
+        M2M5OTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjhjMmUwOTQtMmVlZi00MmMxLWEyYzYtOTQ0ZTEzOWFhMjdjIiwg
+        aWQiOiAiNWIwMjZhNmYtZjNlZi00NjAzLTgzNjctMjI1MDkzMjI3YTc2Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNDg5ZWNmZC03YjM5LTRlZGUtOWJj
-        My1mZjc0MzNkNjc3NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MzU2Yjc1MS1iMDJlLTQzNTMtOTlj
+        OS1mNzU4OTk3ZTJkNjUiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MTY3YTA4MGYtZjJkNS00ZTEyLWI3NWMtYTU1NGExNDM1ZWIzIiwgIm51bV9w
+        MjJiZGY1YWItZjczNi00ZTU1LTg3NTItOTE1OTEzNTYwMjQ0IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImUxMTg2MTY0LTI1MTAtNGJmYi04ODA0LWIz
-        NmZkZDIxYTY5ZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjUyY2M3MTcyLWRlN2EtNDFlZC1iZDVjLTg0
+        YjkxZjllYWNjMSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0MWVm
-        NjJjLTM3OWEtNDE1OS04ODBhLWZhZWFmZjgxOTM5ZiIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNThk
+        ZWIzLWI0OTUtNDg5NS1iMDQ2LTY4NGYxZTEzNTI0ZCIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0ZGM4MzdmZi0xOWExLTQwZTgtYjc1Ny1mYjA2
-        MzI5ZDQ5MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIyYjU3YzVlNC1iM2I2LTQ0YzUtODlhNS0zZmE3
+        ZmUwNzM4YjciLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTNm
-        NWIwNC0wMGM0LTQzNWYtOTA3Ni0xNzFiZmMxZjliM2IiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYjVm
+        MGJmMi0zNjk0LTQ1ZWYtYmVlYS05OThhMTgwNTg4OTciLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYzg2Yzc0MC0xNGUy
-        LTQ5NjEtODM1My1mM2VhNWI5YjBiYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODAyZTFiYi1jN2Yy
+        LTRjMjktYTZhZS1iOTdmYjVjYzZkNzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MmM2MmIyZC04NjM3LTQ2NGEtODE3NS0y
-        MGM1ODg2OWExYTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJkY2YzODNiMS0xYTcwLTRiYjUtOTkzNy05
+        ZGY4NWVlMjIxN2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIwZGU1ZWI1Mi00MTcxLTQ0ZmUtYmNjMy1jNTNjZTEyNmQ5
-        ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI4N2Q5NGI4Ni1hZmMzLTRiNTgtYmU2MS1lOTI0OTBmYjkz
+        NmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMjM1NzdlZi1i
-        ZTc4LTRmMjItOGMyYS1hMjk5NmM2Mjk1MjYiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjQ4MDkxZC01
+        MzVlLTQ2OTQtODU2Mi1kODBlY2RmNGYwNDEiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYzE5NzI5Ny0wNGIzLTQ0NzYt
-        YTFiMi0wZmU3YTdjMmZmYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNzVlY2I3ZC00MWQ1LTRlMzUt
+        YjFiOC1iZTk5NmQ3MzY5MTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMzOGM4Njc1LWEyZmEtNDAyNi1hYmI2
-        LWRhMTMwZjdiYTEyNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
-        by1kZXZlbC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo1M1oiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU0WiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0
-        b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5J
-        U0hFRCIsICJtb2R1bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0
-        YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21w
-        cyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAi
-        cmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJG
-        SU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAi
-        RklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
-        b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIjVmN2RmZjRhMDIyMzlmMDU3
-        ZjhhNDNhZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyMmVmZmY3OS1iOTljLTQ2ODYtOTcxMi05OGUzYWM4MTM5ZWQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZjhjMmUwOTQtMmVlZi00MmMxLWEyYzYtOTQ0ZTEzOWFhMjdjIiwgIm51bV9w
-        cm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwg
-        Iml0ZW1zX3RvdGFsIjogMTksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiNDg5ZWNmZC03YjM5LTRlZGUtOWJjMy1mZjc0
-        MzNkNjc3NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDE5fSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMi
-        LCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTY3YTA4
-        MGYtZjJkNS00ZTEyLWI3NWMtYTU1NGExNDM1ZWIzIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImUxMTg2MTY0LTI1MTAtNGJmYi04ODA0LWIzNmZkZDIx
-        YTY5ZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBf
-        dHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0MWVmNjJjLTM3
-        OWEtNDE1OS04ODBhLWZhZWFmZjgxOTM5ZiIsICJudW1fcHJvY2Vzc2VkIjog
-        OX0sIHsibnVtX3N1Y2Nlc3MiOiA0LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVt
-        c190b3RhbCI6IDQsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI0ZGM4MzdmZi0xOWExLTQwZTgtYjc1Ny1mYjA2MzI5ZDQ5
-        MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDR9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBf
-        dHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTNmNWIwNC0w
-        MGM0LTQzNWYtOTA3Ni0xNzFiZmMxZjliM2IiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3Np
-        bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYzg2Yzc0MC0xNGUyLTQ5NjEt
-        ODM1My1mM2VhNWI5YjBiYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
-        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhlZjk1ZjIwLTNiNTktNGM3Mi04NTlh
+        LThlMTE3NGYzMjNkYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
+        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjA5WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDla
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
+        dGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQiLCAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
+        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
+        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
+        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
+        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNWZh
+        NDVjOTkwNmM3MWEwNzUxNDdmMDQzIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjlkOTljZGEyLTFhN2ItNDI1Yy05ODJm
+        LTg3YmZiOTEzYzk5MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MmM2MmIyZC04NjM3LTQ2NGEtODE3NS0yMGM1ODg2
-        OWExYTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwZGU1ZWI1Mi00MTcxLTQ0ZmUtYmNjMy1jNTNjZTEyNmQ5ZDQiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
-        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
-        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMjM1NzdlZi1iZTc4LTRm
-        MjItOGMyYS1hMjk5NmM2Mjk1MjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
-        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzE5NzI5Ny0wNGIzLTQ0NzYtYTFiMi0w
-        ZmU3YTdjMmZmYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmls
-        ZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjMzOGM4Njc1LWEyZmEtNDAyNi1hYmI2LWRhMTMw
-        ZjdiYTEyNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTUwOGIi
-        fSwgImlkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNTA4YiJ9
+        LCAic3RlcF9pZCI6ICI1YjAyNmE2Zi1mM2VmLTQ2MDMtODM2Ny0yMjUwOTMy
+        MjdhNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MTksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
+        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgzNTZiNzUxLWIwMmUt
+        NDM1My05OWM5LWY3NTg5OTdlMmQ2NSIsICJudW1fcHJvY2Vzc2VkIjogMTl9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIyMmJkZjVhYi1mNzM2LTRlNTUtODc1Mi05MTU5MTM1NjAyNDQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogNiwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTJjYzcxNzItZGU3YS00MWVk
+        LWJkNWMtODRiOTFmOWVhY2MxIiwgIm51bV9wcm9jZXNzZWQiOiA2fSwgeyJu
+        dW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1v
+        ZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwi
+        OiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYzA1OGRlYjMtYjQ5NS00ODk1LWIwNDYtNjg0ZjFlMTM1MjRkIiwgIm51
+        bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjog
+        ImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogNCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJiNTdjNWU0LWIzYjYtNDRjNS04
+        OWE1LTNmYTdmZTA3MzhiNyIsICJudW1fcHJvY2Vzc2VkIjogNH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRh
+        ZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjJiNWYwYmYyLTM2OTQtNDVlZi1iZWVhLTk5OGExODA1ODg5NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM4MDJl
+        MWJiLWM3ZjItNGMyOS1hNmFlLWI5N2ZiNWNjNmQ3MyIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
+        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
+        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRjZjM4M2IxLTFhNzAtNGJi
+        NS05OTM3LTlkZjg1ZWUyMjE3YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
+        IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjg3ZDk0Yjg2LWFmYzMtNGI1OC1iZTYxLWU5
+        MjQ5MGZiOTM2ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNm
+        NDgwOTFkLTUzNWUtNDY5NC04NTYyLWQ4MGVjZGY0ZjA0MSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
+        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3NWVjYjdkLTQx
+        ZDUtNGUzNS1iMWI4LWJlOTk2ZDczNjkxNiIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGVmOTVmMjAtM2I1OS00
+        YzcyLTg1OWEtOGUxMTc0ZjMyM2RiIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3
+        ZTczODdiNDE2NGQ0ZCJ9LCAiaWQiOiAiNWZhNDVjOTg4OTdlNzM4N2I0MTY0
+        ZDRkIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1086,7 +1094,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1099,7 +1107,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -1116,14 +1124,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNGEwMjIzOWY3NDFlODgzZDM1In0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWZhNDVjOTkwNmM3MWEwNDRlYTUyZjNhIn0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1135,7 +1143,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1148,281 +1156,281 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2169'
+      - '2175'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjItMS5z
-        cmMucnBtIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiMzMz
-        NTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4ZWFjZDY1NGNmNjFkNDc2YmE1
-        YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBm
-        b3IgZWxlcGhhbnQuIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMi0xLm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJp
-        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
-        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIxNjc3M2JmLTM4MGEtNDZkNi05
-        ODI2LWE2M2ZkZDE0OGM4ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
-        ZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIyMTY3NzNiZi0zODBh
-        LTQ2ZDYtOTgyNi1hNjNmZGQxNDhjOGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjQ5MTI5NzNmOGNkZTJhNGVkOSJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogImthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCAibmFtZSI6ICJr
-        YW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVl
-        ZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4Iiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGthbmdhcm9vIiwgImZp
-        bGVuYW1lIjogImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
-        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
-        aWQiOiAiMzE0NjdhOTctMDRhNS00OTdjLWE5NGYtYWQ3ZjRkNjhiYTM0Iiwg
-        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6
-        NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogInJwbSIs
-        ICJ1bml0X2lkIjogIjMxNDY3YTk3LTA0YTUtNDk3Yy1hOTRmLWFkN2Y0ZDY4
-        YmEzNCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0
-        ZTllIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTAu
-        My0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
-        ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJi
-        YTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNiYmFlYmVkLTQxOGYt
-        NDkzZC1hNmUzLWJhMjg4MDAxYjgyNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzYmJhZWJl
-        ZC00MThmLTQ5M2QtYTZlMy1iYTI4ODAwMWI4MjciLCAiX2lkIjogeyIkb2lk
-        IjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGViZSJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEz
-        ZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4
-        YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
-        ZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjQzODE1MTYwLTQzZDYtNDQ3NS1iYzZlLTQy
-        MWNmYmMwMzYzNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI0MzgxNTE2MC00M2Q2LTQ0NzUt
-        YmM2ZS00MjFjZmJjMDM2MzUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5
-        MTI5NzNmOGNkZTJhNGU0OCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTliOGQ4
-        YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjUxYTVlZjkwLWY2ODEtNDkxMC04MzJiLTM5M2Y3YTEzMzQwZSIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICI1MWE1ZWY5MC1mNjgxLTQ5MTAtODMyYi0zOTNmN2ExMzM0
-        MGUiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU4
-        YyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxpb24tMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
-        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
-        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
-        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
-        YXNlIjogIjAuOCIsICJfaWQiOiAiNmZkMDQ3MzgtMjA1ZS00NWFkLWJiZjEt
-        YWMyMTNjMDU0NDI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90
-        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjZmZDA0NzM4LTIwNWUtNDVh
-        ZC1iYmYxLWFjMjEzYzA1NDQyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZm
-        NDkxMjk3M2Y4Y2RlMmE0ZTc2In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
-        cG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtl
-        eSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNm
-        YTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1h
-        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6
-        ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
-        IjdhYWEzNjg1LTdlZjAtNGIyNC05OTJjLWQxMmE1NDQzMGJiYSIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUz
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAt
-        MTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI3YWFhMzY4NS03ZWYwLTRiMjQtOTkyYy1kMTJhNTQ0MzBiYmEi
-        LCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU5NSJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
-        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
-        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiODYxYjMzMzMtYTZiYy00
-        NjAyLWFlYjktMWYzYTRkMmM3M2U3IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjg2MWIzMzMz
-        LWE2YmMtNDYwMi1hZWI5LTFmM2E0ZDJjNzNlNyIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZWIwIn19LCB7Im1ldGFkYXRhIjog
-        eyJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEy
-        ZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5Zjlm
-        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIs
-        ICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
-        YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MC44IiwgIl9pZCI6ICI4YzA0M2YxYi0zNDQ2LTRlZDctYWQzMi1iMDVmODZi
-        NDMwOGEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
-        YXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQi
-        OiAicnBtIiwgInVuaXRfaWQiOiAiOGMwNDNmMWItMzQ0Ni00ZWQ3LWFkMzIt
-        YjA1Zjg2YjQzMDhhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTcz
-        ZjhjZGUyYTRlNmMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3
-        YWxydXMtNS4yMS0xLnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hl
-        Y2tzdW0iOiAiNzQ1MzNmYmQ0ZjlhZGE5ZTAyYTYzNjFjYmJmMDE0YjhmZjg4
-        ZGZmOGQ2OTc4NWVjNDhiNzdlMDE4OThlN2MzMSIsICJzdW1tYXJ5IjogIkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVz
-        LTUuMjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICI1LjIxIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4YzNiODYwNC01
-        Y2ZjLTRhMmMtOTcwZi05YTRhN2UyYjE5MjYiLCAiYXJjaCI6ICJub2FyY2gi
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGMz
-        Yjg2MDQtNWNmYy00YTJjLTk3MGYtOWE0YTdlMmIxOTI2IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlZDAifX0sIHsibWV0YWRh
-        dGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5
-        ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2
-        MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5n
-        dWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjhkOTljYzk0LWU2NWItNGJlNC1hYTI0LTM3
-        YzlkMTg4MTcxMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ZDk5Y2M5NC1lNjViLTRiZTQt
-        YWEyNC0zN2M5ZDE4ODE3MTMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5
-        MTI5NzNmOGNkZTJhNGVhNyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
-        IjogImFybWFkaWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRp
-        bGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4
-        ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3Vt
-        bWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5h
-        bWUiOiAiYXJtYWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogImE3MzE2YTVjLTM3YTItNDc4NC1hODQ3LWZmMGU2Yzg1N2FkMiIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
-        dW5pdF9pZCI6ICJhNzMxNmE1Yy0zN2EyLTQ3ODQtYTg0Ny1mZjBlNmM4NTdh
-        ZDIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGVj
-        NyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTIt
-        MS5zcmMucnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVh
-        OTFkNzNkOGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5
-        MzlkNTdmYzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiB0cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19t
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2Zj
+        YjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMy
+        MTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        aXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAwZGU0Mzk1LTA3NmYtNDAw
+        Yy1iNmVhLWY5YWI4MGU2NjY2OSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwMGRlNDM5NS0w
+        NzZmLTQwMGMtYjZlYS1mOWFiODBlNjY2NjkiLCAiX2lkIjogeyIkb2lkIjog
+        IjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGI2OSJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
+        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
+        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
+        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
+        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjA4YTk0ZjAyLWM2ZjEtNDg4Ni04MTI4LWJlMmU5
+        Y2U0N2U0ZCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwOGE5NGYwMi1jNmYxLTQ4ODYtODEy
+        OC1iZTJlOWNlNDdlNGQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3
+        ZTczODdiNDE2NGIwYSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        ImR1Y2stMC42LTEuc3JjLnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tz
+        dW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0
+        M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJzdW1tYXJ5IjogIkEgZHVt
+        bXkgcGFja2FnZSBvZiBkdWNrIiwgImZpbGVuYW1lIjogImR1Y2stMC42LTEu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42Iiwg
+        ImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI1NGEzZDllNi01ZTdiLTRiZmYt
+        OTkzYS0zMGY5MjE1ODIyMWUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJ1
+        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNTRhM2Q5ZTYtNWU3
+        Yi00YmZmLTk5M2EtMzBmOTIxNTgyMjFlIiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhZWEifX0sIHsibWV0YWRhdGEiOiB7InNv
+        dXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
+        ImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdj
+        YTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIs
+        ICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwgImZp
+        bGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjY4NjM5ZGU5LTgyNDctNDZmMS1hYTJkLWVmNmI4ZTEyNWQ0
+        NCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICI2ODYzOWRlOS04MjQ3LTQ2ZjEtYWEyZC1lZjZi
+        OGUxMjVkNDQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdi
+        NDE2NGIyZSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImFybWFk
+        aWxsby0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNo
+        ZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2UzYTM1MjU4ODlhMjhkNWQ2
+        NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGFybWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJt
+        YWRpbGxvLTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90
+        eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjcxY2Jl
+        YzQ2LTgxYTUtNDVkNy05OTg0LTcyMGYzNTMxN2VlYyIsICJhcmNoIjogIm5v
+        YXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVU
+        MjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6
+        ICI3MWNiZWM0Ni04MWE1LTQ1ZDctOTk4NC03MjBmMzUzMTdlZWMiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGI4OSJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIs
+        ICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4
+        MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMy
+        NDcxMiIsICJzdW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBw
+        YXJrLiIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAi
+        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjog
+        dHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
+        MSIsICJfaWQiOiAiNzFmNmVmY2MtNWJjYS00NTRlLTg1MmUtYTA1NzRkNjY2
+        NjI4IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogIjcxZjZlZmNjLTViY2EtNDU0ZS04NTJlLWEw
+        NTc0ZDY2NjYyOCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YjFjIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZWxl
+        cGhhbnQtMC4yLTEuc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNo
+        ZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0OWFlYTc4OGEyZTgzOGVhY2Q2
+        NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1YjkiLCAic3VtbWFyeSI6ICJG
+        YWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIsICJmaWxlbmFtZSI6ICJlbGVw
+        aGFudC0wLjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI3NzdjYWRl
+        Ny0yZjcyLTRhNzYtYjE0YS01MTdiYmZiZDJmMGYiLCAiYXJjaCI6ICJub2Fy
+        Y2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjEyOjA4WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
+        Nzc3Y2FkZTctMmY3Mi00YTc2LWIxNGEtNTE3YmJmYmQyZjBmIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRiOWIifX0sIHsibWV0
+        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBt
+        IiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdl
+        M2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYy
+        MWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2Fs
+        cnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjAuOCIsICJfaWQiOiAiNzk3ZTg5YjMtMDZiYS00NzBlLTllZWItYWMz
+        OTk1OGJlOTlhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSIsICJ1bml0X2lkIjogIjc5N2U4OWIzLTA2YmEtNDcwZS05
+        ZWViLWFjMzk5NThiZTk5YSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4
+        OTdlNzM4N2I0MTY0YjgwIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0i
+        OiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIs
+        ICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1
+        ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJt
+        b25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjg0
+        ODgwNzJhLWQ3NzgtNGE3ZS05ZjgwLTM0YzgwODE1MDE0ZSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICI4NDg4MDcyYS1kNzc4LTRhN2UtOWY4MC0zNGM4MDgxNTAxNGUiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGI1NyJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInRyb3V0LTAuMTItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAidHJvdXQiLCAiY2hlY2tzdW0iOiAiYWVhOTFkNzNk
+        OGRmMjE1MDJmZWNiYzFiYmY2NGU3Y2ZkZDYxNzUxYTFiYTI3MzA5MzlkNTdm
+        Yzg0MjYwMmUxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB0
+        cm91dCIsICJmaWxlbmFtZSI6ICJ0cm91dC0wLjEyLTEubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xMiIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjlhMGU1OGNjLTlhMmMtNDNhMy05NjI2LTgyYTM5
+        ZWQyZTBiNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIw
+        LTExLTA1VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICI5YTBlNThjYy05YTJjLTQzYTMtOTYy
+        Ni04MmEzOWVkMmUwYjciLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3
+        ZTczODdiNDE2NGIxMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        IndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJj
+        aGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3
+        NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1hcnkiOiAi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxy
+        dXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBl
+        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImEwYTJlM2Vi
+        LTZiMzgtNGY2Zi04ZWZlLWJjYWY4YWE1M2I0NiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJh
+        MGEyZTNlYi02YjM4LTRmNmYtOGVmZS1iY2FmOGFhNTNiNDYiLCAiX2lkIjog
+        eyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGIyNSJ9fSwgeyJtZXRh
+        ZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxsby0wLjEtMS5zcmMucnBt
+        IiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFmNDc4MTMy
+        Zjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJkMjliN2M2ZTliYmE4OThh
+        NjFkZGMyN2I1ODkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFy
+        bWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTAuMS0xLm5vYXJj
+        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMSIsICJpc19t
         b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogImI1M2IwMDNjLTZkOWUtNGRiMy05OTI2
-        LTY3NzJhYzE4ZTg2YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJiNTNiMDAzYy02ZDllLTRk
-        YjMtOTkyNi02NzcyYWMxOGU4NmIiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        ZjQ5MTI5NzNmOGNkZTJhNGU1MSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
-        cnBtIjogIndhbHJ1cy0wLjcxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
-        cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZh
-        MzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgInN1bW1h
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImExODVjNjRiLTBiMTctNDI3Mi1hY2E4
+        LTliNDdhODE0NDMwYiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMTg1YzY0Yi0wYjE3LTQy
+        NzItYWNhOC05YjQ3YTgxNDQzMGIiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        Yzk4ODk3ZTczODdiNDE2NGI0NSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVs
+        ZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5
+        N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAi
+        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmls
+        ZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImE4Njg1MzQ5LWY4MDUtNDEwYi05MDAxLTU1MDhkMjNmMTc3
+        YSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICJhODY4NTM0OS1mODA1LTQxMGItOTAwMS01NTA4
+        ZDIzZjE3N2EiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdi
+        NDE2NGFmMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdh
+        cm9vLTAuMy0xLnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVj
+        a3N1bSI6ICI4NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJm
+        MDI0ZTdkYjM4Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9w
+        IGxpa2UgYSBrYW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAi
+        a2FuZ2Fyb28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJhZjU5
+        YzRmZi04YWJmLTQyMGEtODM4NC04MGNlMTdiMmQ4NDUiLCAiYXJjaCI6ICJu
+        b2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAi
+        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjA4WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
+        OiAiYWY1OWM0ZmYtOGFiZi00MjBhLTgzODQtODBjZTE3YjJkODQ1IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRhZmMifX0sIHsi
+        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5zcmMu
+        cnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMzYWY1
+        OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYx
+        MGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNf
+        bW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogImNlZTA3NjkyLTBlNjctNGE3Ny1iNGQ4
+        LWYxYmE2Y2Q3YTI0MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJjZWUwNzY5Mi0wZTY3LTRh
+        NzctYjRkOC1mMWJhNmNkN2EyNDAiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        Yzk4ODk3ZTczODdiNDE2NGI2MCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYw
+        MTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1h
         cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
-        ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImI1
-        NmMwZDJkLTgzNjMtNGNjNS05MTg5LTA4Nzg5MjNiZTUyMiIsICJhcmNoIjog
-        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
-        ZCI6ICJiNTZjMGQyZC04MzYzLTRjYzUtOTE4OS0wODc4OTIzYmU1MjIiLCAi
-        X2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGU2MyJ9fSwg
-        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
-        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
-        M2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBrYW5n
-        YXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4z
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiYmIyOWY1MC01ODk5LTQ0
-        ODMtOGQxZi1iODdiMmRkOWE2NTgiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmJiMjlmNTAt
-        NTg5OS00NDgzLThkMWYtYjg3YjJkZDlhNjU4IiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlM2IifX0sIHsibWV0YWRhdGEiOiB7
-        InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
-        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
-        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
-        MWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50
-        IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0LTQzZjktOWM1NC0zNTI0
-        OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        Y3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVf
-        aWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYzU5MGM0YjYtZDczNC00M2Y5LTlj
-        NTQtMzUyNDlkNmI4NzcwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEy
-        OTczZjhjZGUyYTRlMzEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6
-        ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNr
-        c3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgw
-        NDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1
-        bW15IHBhY2thZ2Ugb2YgZHVjayIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0x
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIs
-        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
-        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZTAyYzBiMDMtYzlhZi00MDVi
-        LWE2NzMtMWNiYmMxYTMwYTc2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUwMmMwYjAzLWM5
-        YWYtNDA1Yi1hNjczLTFjYmJjMWEzMGE3NiIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZTI4In19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0iLCAibmFtZSI6
-        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJmODgyZTQyZDRm
-        NTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4
-        OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
-        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21vZHVsYXIiOiBm
+        ICJ3YWxydXMtNS4yMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjUuMjEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImQ5
+        MjhjZDJjLTRjYmUtNGI0Ni1iZDVjLWZmOTUwNmE0NDFmMSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJkOTI4Y2QyYy00Y2JlLTRiNDYtYmQ1Yy1mZjk1MDZhNDQxZjEiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGI5MiJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAuOC5z
+        cmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJk
+        MGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGVi
+        ZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZGMzN2MyMDctOGQ1Ny00NTU5
+        LWI3ZTYtOGJiOTFhZGRlNTlkIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAi
+        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImRjMzdjMjA3LThk
+        NTctNDU1OS1iN2U2LThiYjkxYWRkZTU5ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOTg4OTdlNzM4N2I0MTY0YjczIn19LCB7Im1ldGFkYXRhIjogeyJz
+        b3VyY2VycG0iOiAiYXJtYWRpbGxvLTIuMS0xLnNyYy5ycG0iLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0NjMy
+        Njg1OWI4ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5
+        ZiIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRpbGxvLiIs
+        ICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMi4xLTEubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgImlzX21vZHVsYXIiOiBm
         YWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAi
-        MSIsICJfaWQiOiAiZTEzZGM4ZjctMzRjZC00NDYyLThmMWUtYTY5NWRjNDQ4
-        MThjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogImUxM2RjOGY3LTM0Y2QtNDQ2Mi04ZjFlLWE2
-        OTVkYzQ0ODE4YyIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4
-        Y2RlMmE0ZTgzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
-        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
-        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
-        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
-        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmMWQwZGYxYS0wMzRhLTRh
-        ZTgtYTU4Yi1hZTZlYmQxMmZjZDEiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZjFkMGRmMWEt
-        MDM0YS00YWU4LWE1OGItYWU2ZWJkMTJmY2QxIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRlNWEifX1d
+        MSIsICJfaWQiOiAiZTM0M2U1YjQtM2RmYi00YTIwLWE0YTEtMTg3ODMxNGI2
+        ZGQyIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImUzNDNlNWI0LTNkZmItNGEyMC1hNGExLTE4
+        NzgzMTRiNmRkMiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4
+        N2I0MTY0YjRlIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlv
+        bi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3Vt
+        IjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgx
+        NTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJlZTMyODBkNy1kY2VhLTRl
+        MjAtYWVkMy02Nzk5Nzk2MjBlYzkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWUzMjgwZDct
+        ZGNlYS00ZTIwLWFlZDMtNjc5OTc5NjIwZWM5IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRiMzcifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1434,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1447,7 +1455,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -1460,10 +1468,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1473,7 +1481,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1486,144 +1494,144 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1315'
+      - '1316'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzkwLzY2ZjZiNDNiMWI0ZGYwOWY4
+        YTY4Nzk3YTA3YTg0ZmQzZjU1ZTQ3NGY3ZDM5OTNlZjJhOGRjNzQxOGQxMDAx
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZh
+        Y3RzIjogWyJrYW5nYXJvby0wOjAuMi0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiZTgyMGUwOGMwNWFhNzM2Y2U1MzAwNjZjNjg4Mjg4YmY1NzQ2MDk4MjY3
+        YzI4MjQyNzllMzZjOWE3MmU2YjljZSIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNjU4MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9vIl19LCAic3VtbWFyeSI6
+        ICJLYW5nYXJvbyAwLjIgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
+        dmVyc2lvbiI6IDIwMTgwNzA0MTExNzE5LCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19t
+        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIyYjFmMWIy
+        NS02ZmNhLTQxYzQtOWU4Ni0yYjkwZTQxZGQ5MDYiLCAiYXJjaCI6ICJub2Fy
+        Y2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBrYW5nYXJv
+        byAwLjIgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEy
+        OjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjJiMWYxYjI1LTZmY2EtNDFjNC05ZTg2LTJiOTBl
+        NDFkZDkwNiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4N2I0
+        MTY0YmYxIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83OC82ODcyN2Jj
+        YzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNkNTU1NmJjZGNl
+        YTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIw
+        IiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjMtMS5ub2FyY2giXSwg
+        ImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2NzdjNGJhYWNmMDA1ZWM5
+        ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNmZGUiLCAiX2xhc3RfdXBk
+        YXRlZCI6IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVs
+        ZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5nYXJvbyJdfSwg
+        InN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVsZSIsICJkb3dubG9hZGVk
+        IjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQwNywgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMi
+        OiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQi
+        OiAiM2QyMGIxODQtZjEyNC00ZTNlLWFjZjktMTIyODk5ZmE4M2U0IiwgImFy
+        Y2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0
+        aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAyMC0x
+        MS0wNVQyMDoxMjowOFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
+        YXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJ1bml0X3R5cGVfaWQi
+        OiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzZDIwYjE4NC1mMTI0LTRlM2Ut
+        YWNmOS0xMjI4OTlmYTgzZTQiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4
+        ODk3ZTczODdiNDE2NGJlNyJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2Vf
+        cGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvbW9kdWxlbWQv
+        ZWEvYTg3MjAzYWE3MWFjZDA5ZWQ0Yzg3MGUwODc1NDlkYTJhNWQyY2FjN2Ni
+        OWVlZDdlN2IwNjNiZjlmNDk3YTkiLCAibmFtZSI6ICJ3YWxydXMiLCAic3Ry
+        ZWFtIjogIjAuNzEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMtMDowLjcxLTEu
+        bm9hcmNoIl0sICJjaGVja3N1bSI6ICI4M2Y2YWZmMzI2MTQ4NTdlOTkwOTg3
+        NmE0ZmI3YTk1ZDU5MTk1ZmQ5OGI5YTI3YTA2NGE5NDJlY2JjNGY0NjgyIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVsdCI6IFsid2Fs
+        cnVzIl0sICJmbGlwcGVyIjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5IjogIldh
+        bHJ1cyAwLjcxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZlcnNp
+        b24iOiAyMDE4MDcwNzE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiY29udGV4dCI6ICJjMGZmZWU0MiIsICJfbnMiOiAidW5pdHNfbW9kdWxl
+        bWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiNTg4NTc1MGUtMWM4
+        Ny00Y2YwLTliMzgtOGI4ZGI0YWU5ZjgyIiwgImFyY2giOiAieDg2XzY0Iiwg
+        ImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVzIDAuNzEg
+        cGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJ1
+        bml0X2lkIjogIjU4ODU3NTBlLTFjODctNGNmMC05YjM4LThiOGRiNGFlOWY4
+        MiIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4N2I0MTY0YzFl
+        In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGli
+        L3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC80MS85YzI2Y2EwMzIyZjA0
+        NThhYjc0ZjU4NzZlMjlhMzY2ZjgwYzJiNDkwMjBmNjYzYWJiOWZmNGJiZGNi
+        ZDZjYyIsICJuYW1lIjogIndhbHJ1cyIsICJzdHJlYW0iOiAiNS4yMSIsICJh
+        cnRpZmFjdHMiOiBbIndhbHJ1cy0wOjUuMjEtMS5ub2FyY2giXSwgImNoZWNr
+        c3VtIjogImZjMGNiOTUwZTUzYzVlYTk5YjAzYmNhYzQyNzI1YzYwMjk1ZjE0
+        OGFhYWRlMWE3Y2U2YzdkODAyOGEwNzNiNTkiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE2MDQ2MDY1ODEsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
+        InByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJ3YWxydXMiXX0sICJzdW1tYXJ5
+        IjogIldhbHJ1cyA1LjIxIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        InZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMiOiAidW5pdHNf
+        bW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiODhlZjA1
+        OWMtYWEzYy00YjdkLTgwNjEtM2Y0ZTcyZjI4ZWI0IiwgImFyY2giOiAieDg2
+        XzY0IiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUgd2FscnVz
+        IDUuMjEgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEy
+        OjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVt
+        ZCIsICJ1bml0X2lkIjogIjg4ZWYwNTljLWFhM2MtNGI3ZC04MDYxLTNmNGU3
+        MmYyOGViNCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4N2I0
+        MTY0YzE1In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC8xYi8yZjAwMzk2
+        NGJiNjQyMWRlNzQyNzdkYjE5YzljYThkMzMzYWJhOTYzOTM5MTBjNzgwZTU3
+        MDBkYzhhODNhMyIsICJuYW1lIjogImR1Y2siLCAic3RyZWFtIjogIjAiLCAi
+        YXJ0aWZhY3RzIjogWyJkdWNrLTA6MC42LTEubm9hcmNoIl0sICJjaGVja3N1
+        bSI6ICI2YmQ5ZDkwOWM5MjcwNTcxYjgxMWU1MDI3MDllYTdiNTYxNTBkNDRh
+        MmI0YjM0Y2ZkMjVlNTJhODFjNWJmY2U3IiwgIl9sYXN0X3VwZGF0ZWQiOiAx
+        NjA0NjA2NTgxLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJw
+        cm9maWxlcyI6IHsiZGVmYXVsdCI6IFsiZHVjayJdfSwgInN1bW1hcnkiOiAi
+        RHVjayAwLjYgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVyc2lv
+        biI6IDIwMTgwNzA0MjQ0MjA1LCAicHVscF91c2VyX21ldGFkYXRhIjoge30s
+        ICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1bGVt
+        ZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICI4ZGM4ZTI5Zi1lNTMx
+        LTQ0NWYtYTcwYy01NjQ2OTBmYTk4NGQiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        ZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBkdWNrIDAuNiBwYWNr
+        YWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
+        aWQiOiAiOGRjOGUyOWYtZTUzMS00NDVmLWE3MGMtNTY0NjkwZmE5ODRkIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRjMDcifX0s
+        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRlNGUzNWM2
+        N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIwYzM4MmNl
         IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIs
+        OiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjogImRkNjIx
+        YzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODczZDg1NmI3
+        OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEs
         ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNyBt
         b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
         OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjAwMjVjZTlhLThiZjQtNDA0MC04MjU3
-        LTZiMTdlOGI0YWI5NCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwMDI1
-        Y2U5YS04YmY0LTQwNDAtODI1Ny02YjE3ZThiNGFiOTQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY0NSJ9fSwgeyJtZXRhZGF0
-        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
-        dW5pdHMvbW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5
-        YTM2NmY4MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6
-        ICJ3YWxydXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3
-        YWxydXMtMDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1
-        MGU1M2M1ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3
-        ZDgwMjhhMDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEwMTEyLCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
-        ZGVmYXVsdCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4y
-        MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRl
-        eHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRl
-        cGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjI3Mjc2YWQ5LTFlYTgtNDFjOS1i
-        YzYyLWY0MmNiNWZkZTE1NyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlw
-        dGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICIyNzI3NmFkOS0xZWE4LTQxYzktYmM2Mi1mNDJjYjVmZGUxNTciLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY0ZSJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvNzgvNjg3MjdiY2MyYTlkOWE2MDNiZTFi
-        ZDQwN2Y0N2VkODdiOTZiMTJlZDZjZDU1NTZiY2RjZWE5MWRhOTgwZTAiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4zLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICIw
-        OTAwZGQwZmFhNjdmOTM4Njc3YzRiYWFjZjAwNWVjOWQyNDgyN2FmYTIxMWNi
-        NDE1N2VkODZkMzVjYzgzZmRlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MzAyMjM0MDcsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjczMmJiZDQxLWU3
-        MDAtNDFkOC05ZGEzLWE1ZDU0MDliNWU0NyIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiNzMyYmJkNDEtZTcwMC00MWQ4LTlkYTMtYTVkNTQwOWI1
-        ZTQ3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRm
-        MjUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRl
-        NGUzNWM2N2FiMDhkMjZjYjdhMDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIw
-        YzM4MmNlIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRp
-        ZmFjdHMiOiBbImR1Y2stMDowLjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
-        ImRkNjIxYzA1OGNkZTFlNjc1NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODcz
-        ZDg1NmI3OTBhN2Y3MDI4MjUwMjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5
-        MTAxMTIsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
-        bGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNr
-        IDAuNyBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
-        MjAxODA3MzAyMzMxMDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
-        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
-        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImIwOGFlODBmLTRlZjItNDQ3
-        NC05YzA4LTM0YWUxZDgyZjM2OCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
-        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2Ui
-        fSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6
-        ICJiMDhhZTgwZi00ZWYyLTQ0NzQtOWMwOC0zNGFlMWQ4MmYzNjgiLCAiX2lk
-        IjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGYzYSJ9fSwgeyJt
-        ZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2Nv
-        bnRlbnQvdW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3
-        OTdhMDdhODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAi
-        bmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImthbmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJl
-        ODIwZTA4YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgy
-        NDI3OWUzNmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAxOTEw
-        MTEyLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxl
-        cyI6IHsiZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkth
-        bmdhcm9vIDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImI4ZDE0Yjk2LTI0
-        MjgtNDZmOS1hMDY1LTBmMjUyYjgyNTEyOCIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAu
-        MiBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
-        IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwg
-        InVuaXRfaWQiOiAiYjhkMTRiOTYtMjQyOC00NmY5LWEwNjUtMGYyNTJiODI1
-        MTI4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTRm
-        MmUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
-        aWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFh
-        Y2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5
-        ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwg
-        ImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hl
-        Y2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5
-        NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMTkxMDExMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQi
-        LCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBl
-        ciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1
-        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcx
-        NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
-        YzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
-        Y2llcyI6IFtdLCAiX2lkIjogImY1ZTg4MDc5LWE1MjktNDViNC04YTkyLTEy
-        MDhiMTFjMmRmMyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
-        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJmNWU4
-        ODA3OS1hNTI5LTQ1YjQtOGE5Mi0xMjA4YjExYzJkZjMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJhNGY1YyJ9fV0=
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogImIxZmJhOGZjLTk2YmMtNDNiMi1hOWZl
+        LTNhNmRkMjBhYTg0NyIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJiMWZi
+        YThmYy05NmJjLTQzYjItYTlmZS0zYTZkZDIwYWE4NDciLCAiX2lkIjogeyIk
+        b2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGJmZSJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1633,7 +1641,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1646,7 +1654,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -1659,10 +1667,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1672,7 +1680,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1685,226 +1693,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1951'
+      - '1943'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
-        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
-        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
-        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
-        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
-        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
-        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
-        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
-        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
-        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
-        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
-        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
-        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
-        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
-        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
-        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
-        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMjgw
-        YmIyNzItNzIyNi00ZDk4LWI0MmUtYzQ5NTNkNWU1ODA3IiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0OTEyOTczZjhjZGUyYTUwMmMifX0sIHsibWV0YWRh
-        dGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9n
-        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
-        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9t
-        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
-        dGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2
-        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjog
-        ImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRp
-        bGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        IkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3MywgInJl
-        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
-        Z2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJl
-        bGVhc2UiOiAiMSIsICJfaWQiOiAiM2YyYzEzZmYtYTBhNi00OGRiLTgxNmQt
-        NmViNGYzMDIzYzM4In0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6
-        NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0i
-        LCAidW5pdF9pZCI6ICIzZjJjMTNmZi1hMGE2LTQ4ZGItODE2ZC02ZWI0ZjMw
-        MjNjMzgiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5NzNmOGNkZTJh
-        NGZmMyJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEg
-        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
-        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
-        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0y
-        MDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNl
-        dmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJy
-        YXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
-        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
-        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
-        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
-        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3Vt
-        IjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
-        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25l
-        IHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODcz
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0NDgzNWFmZC1lNjIwLTRmMTUt
-        YTg5Yi1iMjgzMTM2MDI1YTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIy
-        ODMxMzYwMjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkxMjk3M2Y4
-        Y2RlMmE1MDEyIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
-        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
-        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJf
-        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwg
-        ImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogMTYwMjA5Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
-        dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwg
-        InN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2Mx
-        YTQtYjM2MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjog
-        IjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI1NGFjYzFhNC1iMzYx
-        LTQ5ZDYtYTdkMC1kYmZkZWYyNTk0ZDEiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjQ5MTI5NzNmOGNkZTJhNGZhMCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
-        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
-        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1
-        YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUg
-        cGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
-        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
-        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
-        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
-        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0
-        dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjog
-        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiODVkOGViMTQtOTQ4Ny00
-        YmJlLTgyODUtZWJjZjIzNTgxZDRhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAidW5pdF9pZCI6ICI4NWQ4ZWIxNC05NDg3LTRiYmUtODI4
-        NS1lYmNmMjM1ODFkNGEiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5
-        NzNmOGNkZTJhNGZkOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIw
-        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhh
-        dC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJz
-        ZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0s
-        IHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemls
-        bGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxh
-        IiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6
-        aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3Mi
-        fSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkv
-        ZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwg
-        ImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
-        NSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5
-        L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjog
-        Im90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91
-        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
-        dW0iLCAiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCIsICJmcm9tIjog
-        InNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50
-        IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBkYXRl
-        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMyIsICJy
-        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
-        InBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
-        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
-        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
-        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDIt
-        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
-        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
-        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
-        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
-        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZl
-        bCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2Vj
-        NGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        MiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5
-        OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0s
-        ICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
-        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29s
-        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIs
-        ICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
-        b24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxp
-        dHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIg
-        bGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0
-        YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
-        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
-        aWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRp
-        b24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUg
-        YWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5
-        b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUg
-        aXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxz
-        IG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkg
-        dGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJl
-        ZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBk
-        YXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNz
-        dWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImE2MDcyMzEzLTIzNjAtNDkx
-        Zi04ZDEwLTQ3YzRmZWFhNzE2ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3
-        VDE3OjQ3OjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAt
-        NDdjNGZlYWE3MTZkIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0OTEyOTcz
-        ZjhjZGUyYTRmYmEifX1d
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTI4LCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICIyOGY1ZmIxNC00MTVlLTRmYmItYmI5NS1mZmExMDcyYjAy
+        MTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjEyOjA4WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lk
+        IjogIjI4ZjVmYjE0LTQxNWUtNGZiYi1iYjk1LWZmYTEwNzJiMDIxNiIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4OTdlNzM4N2I0MTY0YzgxIn19LCB7
+        Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTowMTowMSIs
+        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDExMSIs
+        ICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEiLCAiX25z
+        IjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3Jh
+        cHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51bGwsICJm
+        aWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIs
+        ICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcxMjgsICJyZXN0YXJ0
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMi
+        OiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjc0YjgxMGMzLWZiNjMtNDA4My1hZTNhLTI1NzMx
+        ZjJhZGY4ZCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiNzRiODEwYzMtZmI2My00MDgzLWFlM2EtMjU3MzFmMmFkZjhk
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5ODg5N2U3Mzg3YjQxNjRjZDQi
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5
+        OTE0MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
+        dHkiOiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9y
+        ZyIsICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5h
+        bWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTYw
+        NDYwNzEyOCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
+        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
+        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTAyYmU4ZmQtZDc2
+        ZC00ODEyLWEzMmUtZGU5MWIyNWJiNWEzIn0sICJ1cGRhdGVkIjogIjIwMjAt
+        MTEtMDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNy
+        ZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lk
+        IjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJhMDJiZThmZC1kNzZkLTQ4MTIt
+        YTMyZS1kZTkxYjI1YmI1YTMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4
+        ODk3ZTczODdiNDE2NGNiYSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjog
+        IjIwMTgtMDEtMjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBm
+        YWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktB
+        VEVMTE8tUkhFQS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0
+        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJv
+        b19FcnJhdHVtIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24i
+        OiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVu
+        aGFuY2VtZW50IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
+        ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVj
+        ayIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJl
+        bGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29s
+        bGVjdGlvbi0wIiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIs
+        ICJ2ZXJzaW9uIjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAi
+        In0sIHsicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
+        cm9qZWN0Lm9yZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGws
+        ICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwg
+        Im1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjog
+        IjIwMTgwNzMwMjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAi
+        a2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0
+        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAw
+        OjAxIFVUQyIsICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1
+        bSBkZXNjcmlwdGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyOCwg
+        InJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYjdjNGIzNmUtZjRiMy00MjViLTg4
+        NDMtY2RlYmE1MmE2ZDhhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6
+        MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0
+        dW0iLCAidW5pdF9pZCI6ICJiN2M0YjM2ZS1mNGIzLTQyNWItODg0My1jZGVi
+        YTUyYTZkOGEiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdi
+        NDE2NGNlZSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEt
+        MDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
+        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
+        QS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
+        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEi
+        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
+        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
+        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
+        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxl
+        Y3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwg
+        InVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVy
+        cmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyOCwgInJlc3RhcnRf
+        c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
+        ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
+        OiAiMSIsICJfaWQiOiAiYmRhNDBiNzktZmI3Yi00NTM1LTg0YTktOGJlNmIx
+        ZmVmMTk3In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5p
+        dF9pZCI6ICJiZGE0MGI3OS1mYjdiLTQ1MzUtODRhOS04YmU2YjFmZWYxOTci
+        LCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3ZTczODdiNDE2NGM5YiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
+        MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
+        OiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRz
+        X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAi
+        c3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlv
+        biI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcx
+        MjgsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImM1M2NhMWE2LTQ1NGYtNGVi
+        ZC1hMDdiLTVmMTlhNjEwZmNjOSJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1
+        VDIwOjEyOjA4WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiYzUzY2ExYTYtNDU0Zi00ZWJkLWEwN2It
+        NWYxOWE2MTBmY2M5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5ODg5N2U3
+        Mzg3YjQxNjRjNjIifX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1914,7 +1922,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1927,7 +1935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -1940,10 +1948,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1953,7 +1961,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -1966,13 +1974,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '519'
+      - '520'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1982,19 +1990,19 @@ http_interactions:
         b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
         X2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNp
         YmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3Bh
-        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDE5MTAxMTIsICJv
+        Y2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDY1ODEsICJv
         cHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUi
         OiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNl
         cl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10s
         ICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAi
-        YmlyZCIsICJfaWQiOiAiMTgyYWZhNTEtOGIxMy00YmIyLWE4ZWUtN2NmNzJm
-        MGE0ZjQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjE4MmFmYTUxLThiMTMtNGJiMi1h
-        OGVlLTdjZjcyZjBhNGY0OSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNDkx
-        Mjk3M2Y4Y2RlMmE1MDNjIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
+        YmlyZCIsICJfaWQiOiAiZjk3MTM3MWUtN2IyMi00NTY2LThhMjAtODBjNmQ2
+        MzEzYTM5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxf
+        cGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjowOFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
+        ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJ1bml0X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCIsICJ1bml0X2lkIjogImY5NzEzNzFlLTdiMjItNDU2Ni04
+        YTIwLTgwYzZkNjMxM2EzOSIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOTg4
+        OTdlNzM4N2I0MTY0ZDAzIn19LCB7Im1ldGFkYXRhIjogeyJtYW5kYXRvcnlf
         cGFja2FnZV9uYW1lcyI6IFsiYmVhciIsICJjYW1lbCIsICJjYXQiLCAiY2hl
         ZXRhaCIsICJjaGltcGFuemVlIiwgImNvdyIsICJkb2ciLCAiZG9scGhpbiIs
         ICJlbGVwaGFudCIsICJmb3giLCAiZ2lyYWZmZSIsICJnb3JpbGxhIiwgImhv
@@ -2002,24 +2010,24 @@ http_interactions:
         LCAidGlnZXIiLCAid2FscnVzIiwgIndoYWxlIiwgIndvbGYiLCAiemVicmEi
         XSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAibWFtbWFsIiwg
         InVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6
-        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAx
-        OTEwMTEyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
+        ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0
+        NjA2NTgxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNs
         YXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30s
         ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9u
         YW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3Vw
-        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiYWQzZmZlYWEtNzkwYS00NGNm
-        LWEzYjktMTk3OTcxMzcxMTJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
+        IiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZmE4NTFkNGMtZTgwZS00MDZl
+        LTg3OTktNmE0OTM3YWM0YjgxIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAi
         Y29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAi
-        MjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjUzWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImFkM2ZmZWFh
-        LTc5MGEtNDRjZi1hM2I5LTE5Nzk3MTM3MTEyZiIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNDkxMjk3M2Y4Y2RlMmE1MDRjIn19XQ==
+        MjAyMC0xMS0wNVQyMDoxMjowOFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjA4WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImZhODUxZDRj
+        LWU4MGUtNDA2ZS04Nzk5LTZhNDkzN2FjNGI4MSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOTg4OTdlNzM4N2I0MTY0ZDBmIn19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2029,7 +2037,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2042,7 +2050,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -2055,10 +2063,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2068,7 +2076,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2081,13 +2089,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '403'
+      - '402'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2101,22 +2109,22 @@ http_interactions:
         Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
         b2R1Y3RpZCIsICJjaGVja3N1bSI6ICJiYTgyZDRjN2E3YzBiMGE2YTU3NTA2
         ZTI3NzVhYTBkZTAzNjJjYTZhY2ZlNWE1ZmFkZWQ4ZTg3NTk5Yjk1MjMyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODczLCAiX2NvbnRlbnRfdHlwZV9p
+        Il9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTI4LCAiX2NvbnRlbnRfdHlwZV9p
         ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
         cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
         eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiZTkxYjJiMTEtN2E5Zi00MzhlLThiZjMtYjA4OWQ4
-        MDNlZTZjIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTNaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
-        N1QxNzo0Nzo1M1oiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICJlOTFiMmIxMS03YTlmLTQzOGUtOGJm
-        My1iMDg5ZDgwM2VlNmMiLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjQ5MTI5
-        NzNmOGNkZTJhNGUwZSJ9fV0=
+        YTI1NiIsICJfaWQiOiAiNDJlYmU5MGEtMDMwMS00ZjlhLWI2NzktNGFlODVk
+        ZTljZDI2In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDhaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjowOFoiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICI0MmViZTkwYS0wMzAxLTRmOWEtYjY3
+        OS00YWU4NWRlOWNkMjYiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1Yzk4ODk3
+        ZTczODdiNDE2NGFkMCJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2126,7 +2134,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2139,7 +2147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -2152,10 +2160,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2167,7 +2175,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2180,7 +2188,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -2193,10 +2201,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2206,7 +2214,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2219,7 +2227,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Vary:
@@ -2245,24 +2253,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg3MywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwNDYw
+        NzEyOCwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTNaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1M1oiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWY3ZGZmNDkxMjk3M2Y4Y2RlMmE0ZjE2In19XQ==
+        MjAtMTEtMDVUMjA6MTI6MDhaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjowOFoiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWZhNDVjOTg4OTdlNzM4N2I0MTY0YmRiIn19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:09 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2277,7 +2285,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2290,7 +2298,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -2301,14 +2309,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY3ZDc4NWFjLTI0MDUtNDZiZS1iZmNhLTFjY2ZiN2Y3OTUwMC8iLCAi
-        dGFza19pZCI6ICI2N2Q3ODVhYy0yNDA1LTQ2YmUtYmZjYS0xY2NmYjdmNzk1
-        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRmYjNiZjM0LWJhMjgtNGNhOS04MGNmLWNkZWFjMTRhM2ZjNy8iLCAi
+        dGFza19pZCI6ICI0ZmIzYmYzNC1iYTI4LTRjYTktODBjZi1jZGVhYzE0YTNm
+        YzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:54 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2320,7 +2328,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2333,7 +2341,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:54 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2344,14 +2352,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzhjOTUzYmQ3LTkwNmQtNGExYS1hY2VlLWM3YTc4MzdlMjAzNS8iLCAi
-        dGFza19pZCI6ICI4Yzk1M2JkNy05MDZkLTRhMWEtYWNlZS1jN2E3ODM3ZTIw
-        MzUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzM1NGIxNGFiLWVlYjAtNGE0Ni1iZmEzLWYyNWRhZjY3MmU1MC8iLCAi
+        dGFza19pZCI6ICIzNTRiMTRhYi1lZWIwLTRhNDYtYmZhMy1mMjVkYWY2NzJl
+        NTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2361,7 +2369,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2374,7 +2382,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2385,14 +2393,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E4ODlhN2EzLTk3YTktNGQ4My05NWFjLWE0NmYzMWU2NzU3ZS8iLCAi
-        dGFza19pZCI6ICJhODg5YTdhMy05N2E5LTRkODMtOTVhYy1hNDZmMzFlNjc1
-        N2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzk5Njg1MGVjLWQ1OTktNGJlNi05MWQ3LTNjMTNmYWRmYWY5YS8iLCAi
+        dGFza19pZCI6ICI5OTY4NTBlYy1kNTk5LTRiZTYtOTFkNy0zYzEzZmFkZmFm
+        OWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2402,7 +2410,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2415,7 +2423,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2426,14 +2434,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzExMDQwNDI1LTJmNmUtNDUyMC1hNjNkLTFhMjgzNWQ1ZTljMi8iLCAi
-        dGFza19pZCI6ICIxMTA0MDQyNS0yZjZlLTQ1MjAtYTYzZC0xYTI4MzVkNWU5
-        YzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRjMzcxMDY5LTM5MzgtNGYxNC1hY2JlLTJjY2I4N2I0Nzk5MC8iLCAi
+        dGFza19pZCI6ICI0YzM3MTA2OS0zOTM4LTRmMTQtYWNiZS0yY2NiODdiNDc5
+        OTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2443,7 +2451,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2456,7 +2464,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2467,14 +2475,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdjNGQ1MmFiLTMzOWItNGE0OS05NTcxLTA1MDA0YWNjMDZmMy8iLCAi
-        dGFza19pZCI6ICI3YzRkNTJhYi0zMzliLTRhNDktOTU3MS0wNTAwNGFjYzA2
-        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc1MzU3MTk2LTc2ZTItNGIxMS1hMTg2LWYwOTUwMTExOGYxNS8iLCAi
+        dGFza19pZCI6ICI3NTM1NzE5Ni03NmUyLTRiMTEtYTE4Ni1mMDk1MDExMThm
+        MTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2485,7 +2493,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2498,7 +2506,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2509,14 +2517,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZmMTVmMTZiLWZjMWMtNGMxNy1hNzNiLTdjNjJkYjk0NzJhMC8iLCAi
-        dGFza19pZCI6ICI2ZjE1ZjE2Yi1mYzFjLTRjMTctYTczYi03YzYyZGI5NDcy
-        YTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJhNjcxMTVhLWM1NTktNDQxNS05NmYxLTQ0NTY3YTE2OTE3Ni8iLCAi
+        dGFza19pZCI6ICIyYTY3MTE1YS1jNTU5LTQ0MTUtOTZmMS00NDU2N2ExNjkx
+        NzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2527,7 +2535,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2540,7 +2548,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2551,14 +2559,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JmMTQ1YWYwLWM2NmItNGY5OS1hYzUyLTE1ODBjOTYyOGI1Ny8iLCAi
-        dGFza19pZCI6ICJiZjE0NWFmMC1jNjZiLTRmOTktYWM1Mi0xNTgwYzk2Mjhi
-        NTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2U5NzMyOWU5LWNmNDgtNDczZC1hMmM4LWY0MjkxM2YyYWMyZS8iLCAi
+        dGFza19pZCI6ICJlOTczMjllOS1jZjQ4LTQ3M2QtYTJjOC1mNDI5MTNmMmFj
+        MmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2568,7 +2576,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2581,7 +2589,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2592,14 +2600,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ1MzY4OTYyLTZjNWEtNGQxNS05Njc5LTg3MDkxMDczYzA1OS8iLCAi
-        dGFza19pZCI6ICI0NTM2ODk2Mi02YzVhLTRkMTUtOTY3OS04NzA5MTA3M2Mw
-        NTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2ZlODNlZGRhLTUwNjUtNDAyYS1hYTFkLTFmM2Y2MmZmNzVmZS8iLCAi
+        dGFza19pZCI6ICJmZTgzZWRkYS01MDY1LTQwMmEtYWExZC0xZjNmNjJmZjc1
+        ZmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2609,7 +2617,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2622,7 +2630,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2633,14 +2641,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI5ZTIyMzc5LWEyNzMtNDQwZi1hMWNlLTEyZmM4NDlhZTExZS8iLCAi
-        dGFza19pZCI6ICIyOWUyMjM3OS1hMjczLTQ0MGYtYTFjZS0xMmZjODQ5YWUx
-        MWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzU5MDFlZmFjLWI0NDgtNGQ0ZS1iMjk1LTZhZTYxZDg0YjM1ZS8iLCAi
+        dGFza19pZCI6ICI1OTAxZWZhYy1iNDQ4LTRkNGUtYjI5NS02YWU2MWQ4NGIz
+        NWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2650,7 +2658,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -2663,7 +2671,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -2674,14 +2682,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBmN2U1ZGQwLWExZDAtNDI4Ni05ODdiLTc4MmZjZWQyNDIwNS8iLCAi
-        dGFza19pZCI6ICIwZjdlNWRkMC1hMWQwLTQyODYtOTg3Yi03ODJmY2VkMjQy
-        MDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2IyZGM5YmY5LWY3M2MtNDJmZS1iZjU4LTkyMjZmZWY3ZWU1Zi8iLCAi
+        dGFza19pZCI6ICJiMmRjOWJmOS1mNzNjLTQyZmUtYmY1OC05MjI2ZmVmN2Vl
+        NWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/67d785ac-2405-46be-bfca-1ccfb7f79500/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4fb3bf34-ba28-4ca9-80cf-cdeac14a3fc7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2689,7 +2697,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2700,15 +2708,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"a2505b7c42bbbeac32111f346564d14d-gzip"'
+      - '"b411a90bbba83feeeeeb83e76b22cd71-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '559'
+      - '561'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2716,33 +2724,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82N2Q3ODVh
-        Yy0yNDA1LTQ2YmUtYmZjYS0xY2NmYjdmNzk1MDAvIiwgInRhc2tfaWQiOiAi
-        NjdkNzg1YWMtMjQwNS00NmJlLWJmY2EtMWNjZmI3Zjc5NTAwIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZmIzYmYz
+        NC1iYTI4LTRjYTktODBjZi1jZGVhYzE0YTNmYzcvIiwgInRhc2tfaWQiOiAi
+        NGZiM2JmMzQtYmEyOC00Y2E5LTgwY2YtY2RlYWMxNGEzZmM3IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU0
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
-        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
-        MWYzIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjog
-        InNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV0sICJ1bml0c19mYWlsZWRf
-        c2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjdkZmY0YTEyOTczZjhjZGUyYTUyM2IifSwgImlkIjog
-        IjVmN2RmZjRhMTI5NzNmOGNkZTJhNTIzYiJ9
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNl
+        MWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIw
+        OTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJj
+        aGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwg
+        InVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2
+        NGVmYiJ9LCAiaWQiOiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0ZWZiIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/8c953bd7-906d-4a1a-acee-c7a7837e2035/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/354b14ab-eeb0-4a46-bfa3-f25daf672e50/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2750,7 +2758,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2761,15 +2769,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"cf2787cfd45b3798c3aaf7cc8976ac70-gzip"'
+      - '"117826609e8212c438cdce7dc3838dba-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '425'
+      - '431'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2777,149 +2785,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84Yzk1M2Jk
-        Ny05MDZkLTRhMWEtYWNlZS1jN2E3ODM3ZTIwMzUvIiwgInRhc2tfaWQiOiAi
-        OGM5NTNiZDctOTA2ZC00YTFhLWFjZWUtYzdhNzgzN2UyMDM1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zNTRiMTRh
+        Yi1lZWIwLTRhNDYtYmZhMy1mMjVkYWY2NzJlNTAvIiwgInRhc2tfaWQiOiAi
+        MzU0YjE0YWItZWViMC00YTQ2LWJmYTMtZjI1ZGFmNjcyZTUwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
-        NzNmOGNkZTJhNTI2NCJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MjY0In0=
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/a889a7a3-97a9-4d83-95ac-a46f31e6757e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"be9e541acca3005690e06b668db6b6c9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '425'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hODg5YTdh
-        My05N2E5LTRkODMtOTVhYy1hNDZmMzFlNjc1N2UvIiwgInRhc2tfaWQiOiAi
-        YTg4OWE3YTMtOTdhOS00ZDgzLTk1YWMtYTQ2ZjMxZTY3NTdlIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
-        NzNmOGNkZTJhNTI3YyJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MjdjIn0=
-    http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/11040425-2f6e-4520-a63d-1a2835d5e9c2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"70f2a3fc3b7dac2bb4f61e7559587bdd-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '509'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMTA0MDQy
-        NS0yZjZlLTQ1MjAtYTYzZC0xYTI4MzVkNWU5YzIvIiwgInRhc2tfaWQiOiAi
-        MTEwNDA0MjUtMmY2ZS00NTIwLWE2M2QtMWEyODM1ZDVlOWMyIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
-        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
-        ImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAi
-        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
-        MjAxMDowMTExIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
-        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9p
-        ZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEwOjk5MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1
-        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAi
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
         ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1Mjk2In0sICJpZCI6ICI1ZjdkZmY0
-        YjEyOTczZjhjZGUyYTUyOTYifQ==
+        OiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0ZjFkIn0sICJpZCI6ICI1ZmE0NWM5
+        YTg5N2U3Mzg3YjQxNjRmMWQifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/7c4d52ab-339b-4a49-9571-05004acc06f3/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/996850ec-d599-4be6-91d7-3c13fadfaf9a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2927,7 +2814,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -2938,15 +2825,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"7843f602e9ca0866c1ba7c47387ebcb5-gzip"'
+      - '"ec3ebe34d843b60d061088c9d5ecbf86-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '483'
+      - '432'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2954,35 +2841,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YzRkNTJh
-        Yi0zMzliLTRhNDktOTU3MS0wNTAwNGFjYzA2ZjMvIiwgInRhc2tfaWQiOiAi
-        N2M0ZDUyYWItMzM5Yi00YTQ5LTk1NzEtMDUwMDRhY2MwNmYzIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85OTY4NTBl
+        Yy1kNTk5LTRiZTYtOTFkNy0zYzEzZmFkZmFmOWEvIiwgInRhc2tfaWQiOiAi
+        OTk2ODUwZWMtZDU5OS00YmU2LTkxZDctM2MxM2ZhZGZhZjlhIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVu
-        aXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFs
-        In0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBh
-        Y2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAifV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjRiMTI5NzNmOGNkZTJhNTJhNSJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3
-        M2Y4Y2RlMmE1MmE1In0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0ZjNjIn0sICJpZCI6ICI1ZmE0NWM5
+        YTg5N2U3Mzg3YjQxNjRmM2MifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/6f15f16b-fc1c-4c17-a73b-7c62db9472a0/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/4c371069-3938-4f14-acbe-2ccb87b47990/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2990,7 +2870,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3001,15 +2881,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"a9ce735e7beb59707e76846a84175b01-gzip"'
+      - '"a611fcd14a88ed6cf9c3d26b0733c8b0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '473'
+      - '512'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3017,32 +2897,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82ZjE1ZjE2
-        Yi1mYzFjLTRjMTctYTczYi03YzYyZGI5NDcyYTAvIiwgInRhc2tfaWQiOiAi
-        NmYxNWYxNmItZmMxYy00YzE3LWE3M2ItN2M2MmRiOTQ3MmEwIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80YzM3MTA2
+        OS0zOTM4LTRmMTQtYWNiZS0yY2NiODdiNDc5OTAvIiwgInRhc2tfaWQiOiAi
+        NGMzNzEwNjktMzkzOC00ZjE0LWFjYmUtMmNjYjg3YjQ3OTkwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlk
-        IjogIm1pbmltYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVu
-        dCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5p
-        dF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogIm1pbmlt
-        YWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9lbnZpcm9ubWVudCJ9XX0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4
-        Y2RlMmE1MmMyIn0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyYzIi
-        fQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRF
+        TExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwg
+        eyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9
+        LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjog
+        IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJyYXR1
+        bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
+        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1bml0c19m
+        YWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5YTg5N2U3Mzg3YjQxNjRmNTgifSwg
+        ImlkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2NGY1OCJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/bf145af0-c66b-4f99-ac52-1580c9628b57/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/75357196-76e2-4b11-a186-f09501118f15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3050,7 +2935,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3061,15 +2946,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"04efd4a40d468f31d81bdcb4d0aca854-gzip"'
+      - '"4b7691c24d6925bb91d217a4d27388df-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '473'
+      - '489'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3077,32 +2962,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZjE0NWFm
-        MC1jNjZiLTRmOTktYWM1Mi0xNTgwYzk2MjhiNTcvIiwgInRhc2tfaWQiOiAi
-        YmYxNDVhZjAtYzY2Yi00Zjk5LWFjNTItMTU4MGM5NjI4YjU3IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83NTM1NzE5
+        Ni03NmUyLTRiMTEtYTE4Ni1mMDk1MDExMThmMTUvIiwgInRhc2tfaWQiOiAi
+        NzUzNTcxOTYtNzZlMi00YjExLWExODYtZjA5NTAxMTE4ZjE1IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
-        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3Jl
-        cG9fbWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmQ1In0sICJpZCI6ICI1
-        ZjdkZmY0YjEyOTczZjhjZGUyYTUyZDUifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIs
+        ICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJpcmQifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVf
+        aWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0Zjc4In0sICJpZCI6
+        ICI1ZmE0NWM5YTg5N2U3Mzg3YjQxNjRmNzgifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/45368962-6c5a-4d15-9679-87091073c059/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/2a67115a-c559-4415-96f1-44567a169176/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3110,7 +2998,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3121,15 +3009,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"530806b7932d032bad29e8fb6e2c76c4-gzip"'
+      - '"39fb3a7b9b36a0e6795973bea30f11c4-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '511'
+      - '478'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3137,31 +3025,32 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80NTM2ODk2
-        Mi02YzVhLTRkMTUtOTY3OS04NzA5MTA3M2MwNTkvIiwgInRhc2tfaWQiOiAi
-        NDUzNjg5NjItNmM1YS00ZDE1LTk2NzktODcwOTEwNzNjMDU5IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yYTY3MTE1
+        YS1jNTU5LTQ0MTUtOTZmMS00NDU2N2ExNjkxNzYvIiwgInRhc2tfaWQiOiAi
+        MmE2NzExNWEtYzU1OS00NDE1LTk2ZjEtNDQ1NjdhMTY5MTc2IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
-        ICJ2ZXJzaW9uIjogIjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtz
-        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
-        OiAiVGVzdCBGYW1pbHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1d
-        LCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2Rl
-        MmE1MmYwIn0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyZjAifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNr
+        YWdlX2Vudmlyb25tZW50In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAibWluaW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2Vudmly
+        b25tZW50In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZmE0NWM5YTg5N2U3Mzg3YjQxNjRmODkifSwgImlkIjogIjVmYTQ1YzlhODk3
+        ZTczODdiNDE2NGY4OSJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/29e22379-a273-440f-a1ce-12fc849ae11e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/e97329e9-cf48-473d-a2c8-f42913f2ac2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3169,7 +3058,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3180,15 +3069,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:55 GMT
+      - Thu, 05 Nov 2020 20:12:10 GMT
       Server:
       - Apache
       Etag:
-      - '"044256b17af86ae2ce119daa17e5effb-gzip"'
+      - '"ae3348820f37c1447ee3ed5bd040092d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '500'
+      - '479'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3196,39 +3085,160 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yOWUyMjM3
-        OS1hMjczLTQ0MGYtYTFjZS0xMmZjODQ5YWUxMWUvIiwgInRhc2tfaWQiOiAi
-        MjllMjIzNzktYTI3My00NDBmLWExY2UtMTJmYzg0OWFlMTFlIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lOTczMjll
+        OS1jZjQ4LTQ3M2QtYTJjOC1mNDI5MTNmMmFjMmUvIiwgInRhc2tfaWQiOiAi
+        ZTk3MzI5ZTktY2Y0OC00NzNkLWEyYzgtZjQyOTEzZjJhYzJlIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dLCAidW5pdHNfZmFpbGVk
+        X3NpZ25hdHVyZV9maWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAidHlw
+        ZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn1dfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5YTg5N2U3Mzg3YjQxNjRm
+        YjMifSwgImlkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2NGZiMyJ9
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/fe83edda-5065-402a-aa1d-1f3f62ff75fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:12:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1b4f3b879d82146c8655a544289ecd62-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '514'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mZTgzZWRk
+        YS01MDY1LTQwMmEtYWExZC0xZjNmNjJmZjc1ZmUvIiwgInRhc2tfaWQiOiAi
+        ZmU4M2VkZGEtNTA2NS00MDJhLWFhMWQtMWYzZjYyZmY3NWZlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJpYW50Ijog
+        IlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6ICJ4ODZf
+        NjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQtMTYteDg2
+        XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9pZCI6ICJk
+        aXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
+        ciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0
+        NWM5YTg5N2U3Mzg3YjQxNjRmZDAifSwgImlkIjogIjVmYTQ1YzlhODk3ZTcz
+        ODdiNDE2NGZkMCJ9
+    http_version: 
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/5901efac-b448-4d4e-b295-6ae61d84b35e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 05 Nov 2020 20:12:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2789f4c9bb2d6726624af82a2fbb9408-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '507'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81OTAxZWZh
+        Yy1iNDQ4LTRkNGUtYjI5NS02YWU2MWQ4NGIzNWUvIiwgInRhc2tfaWQiOiAi
+        NTkwMWVmYWMtYjQ0OC00ZDRlLWIyOTUtNmFlNjFkODRiMzVlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQiOiAibW9k
+        dWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIz
+        X3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
+        ZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
+        IjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVs
-        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5h
+        dHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        bmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRz
-        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1l
-        IjogImR1Y2sifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0s
-        ICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9v
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5
-        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9
-        LCAidHlwZV9pZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MzE4In0sICJpZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUzMTgifQ==
+        In1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5
+        YTg5N2U3Mzg3YjQxNjUwMDYifSwgImlkIjogIjVmYTQ1YzlhODk3ZTczODdi
+        NDE2NTAwNiJ9
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:55 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:10 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/0f7e5dd0-a1d0-4286-987b-782fced24205/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/b2dc9bf9-f73c-42fe-bf58-9226fef7ee5f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3236,7 +3246,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -3247,15 +3257,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Etag:
-      - '"58fc6ca55dde42509e7d901716ff98df-gzip"'
+      - '"9413b41e2ab78a2970ba9b71f1e66d41-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '426'
+      - '431'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3263,28 +3273,28 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wZjdlNWRk
-        MC1hMWQwLTQyODYtOTg3Yi03ODJmY2VkMjQyMDUvIiwgInRhc2tfaWQiOiAi
-        MGY3ZTVkZDAtYTFkMC00Mjg2LTk4N2ItNzgyZmNlZDI0MjA1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iMmRjOWJm
+        OS1mNzNjLTQyZmUtYmY1OC05MjI2ZmVmN2VlNWYvIiwgInRhc2tfaWQiOiAi
+        YjJkYzliZjktZjczYy00MmZlLWJmNTgtOTIyNmZlZjdlZTVmIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
+        c2hfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1k
-        ZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3Nm
-        dWwiOiBbXSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5
-        NzNmOGNkZTJhNTMzNyJ9LCAiaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MzM3In0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        dW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVy
+        ZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY1MDFjIn0sICJpZCI6ICI1ZmE0NWM5
+        YTg5N2U3Mzg3YjQxNjUwMWMifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3296,7 +3306,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3309,13 +3319,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '347'
+      - '348'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3328,18 +3338,18 @@ http_interactions:
         YWdlIG9mIGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0w
         Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
         IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjNTkwYzRiNi1kNzM0
-        LTQzZjktOWM1NC0zNTI0OWQ2Yjg3NzAiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoiLCAicmVwb19pZCI6
-        ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NFoi
-        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImM1OTBjNGI2
-        LWQ3MzQtNDNmOS05YzU0LTM1MjQ5ZDZiODc3MCIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWY3ZGZmNGExMjk3M2Y4Y2RlMmE1MjUyIn19XQ==
+        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJhODY4NTM0OS1mODA1
+        LTQxMGItOTAwMS01NTA4ZDIzZjE3N2EiLCAiYXJjaCI6ICJub2FyY2gifSwg
+        InVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoiLCAicmVwb19pZCI6
+        ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImE4Njg1MzQ5
+        LWY4MDUtNDEwYi05MDAxLTU1MDhkMjNmMTc3YSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0ZjE0In19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3351,7 +3361,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3364,7 +3374,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3377,10 +3387,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3390,7 +3400,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3403,7 +3413,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3416,10 +3426,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3429,7 +3439,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3442,226 +3452,226 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1946'
+      - '1944'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4OjA5
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjowMDU5
-        IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
-        IiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMiOiAi
-        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
-        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2dsaXN0
-        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFw
-        cm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwgImZp
-        bGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51
-        bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6
-        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1bGUi
-        OiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDcz
-        MDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2siLCAi
-        c3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjogW3si
-        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
-        ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2FuZ2Fy
-        b28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0s
-        ICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIsICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3JpcHRp
-        b24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAiX2xh
-        c3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
-        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjI4MGJiMjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyJ9LCAi
-        dXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJyZXBvX2lkIjog
-        IjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lkIjogIjI4MGJi
-        MjcyLTcyMjYtNGQ5OC1iNDJlLWM0OTUzZDVlNTgwNyIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmU5In19LCB7Im1ldGFkYXRh
-        IjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxvZ2lu
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91
-        c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0
-        dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMiLCAiZnJvbSI6
-        ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRs
-        ZSI6ICJBcm1hZGlsbG8iLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVy
-        c2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
-        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
-        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJh
-        cm1hZGlsbG8iLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImFybWFkaWxs
-        by0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIn1dLCAi
-        bmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVz
-        IjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJB
-        cm1hZGlsbG8iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJyZXN0
-        YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdo
-        dHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxl
-        YXNlIjogIjEiLCAiX2lkIjogIjNmMmMxM2ZmLWEwYTYtNDhkYi04MTZkLTZl
-        YjRmMzAyM2MzOCJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1
-        WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEw
-        LTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1
-        bml0X2lkIjogIjNmMmMxM2ZmLWEwYTYtNDhkYi04MTZkLTZlYjRmMzAyM2Mz
-        OCIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1MmY4
-        In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTow
-        MTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
-        cyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
-        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6
-        MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
-        dHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEi
-        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
-        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
-        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
-        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51
-        bGwsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTI4LCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICIyOGY1ZmIxNC00MTVlLTRmYmItYmI5NS1mZmExMDcyYjAy
+        MTYifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoiLCAicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQyMDox
+        MjoxMFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6
+        ICIyOGY1ZmIxNC00MTVlLTRmYmItYmI5NS1mZmExMDcyYjAyMTYiLCAiX2lk
+        IjogeyIkb2lkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2NGY5YiJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEgMDE6MDE6MDEiLCAi
+        cmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCAi
+        ZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIs
+        ICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6
+        ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
+        b2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0iOiBudWxsLCAiZmls
+        ZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2pl
+        Y3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
+        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAi
+        c2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjog
+        IiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25lIHBhY2thZ2UgZXJy
+        YXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTI4LCAicmVzdGFydF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjog
+        IiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6
+        ICIxIiwgIl9pZCI6ICI3NGI4MTBjMy1mYjYzLTQwODMtYWUzYS0yNTczMWYy
+        YWRmOGQifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoiLCAi
+        cmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjoxMFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9p
+        ZCI6ICI3NGI4MTBjMy1mYjYzLTQwODMtYWUzYS0yNTczMWYyYWRmOGQiLCAi
+        X2lkIjogeyIkb2lkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2NGZhMyJ9fSwg
+        eyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEi
+        LCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBb
+        XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjk5MTQz
+        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
+        ICIiLCAidGl0bGUiOiAiQXJtYWRpbGxvIiwgIl9ucyI6ICJ1bml0c19lcnJh
+        dHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFs
+        c2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdl
+        cyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwg
+        Im5hbWUiOiAiYXJtYWRpbGxvIiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6
+        ICJhcm1hZGlsbG8tMi4xLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMi4xIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
+        YXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9
+        XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3Jp
+        cHRpb24iOiAiQXJtYWRpbGxvIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3
+        MTI4LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6
+        ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6
+        ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJhMDJiZThmZC1kNzZkLTQ4
+        MTItYTMyZS1kZTkxYjI1YmI1YTMifSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjoxMFoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
+        OiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoiLCAidW5pdF90eXBlX2lkIjogImVy
+        cmF0dW0iLCAidW5pdF9pZCI6ICJhMDJiZThmZC1kNzZkLTQ4MTItYTMyZS1k
+        ZTkxYjI1YmI1YTMiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlhODk3ZTcz
+        ODdiNDE2NGZhYyJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgt
+        MDEtMjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwg
+        InJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8t
+        UkhFQS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0LmNvbSIs
+        ICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJvb19FcnJh
+        dHVtIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2Vt
+        ZW50IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRw
+        Oi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVjayIsICJz
+        dW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJlbGVhc2Ui
+        OiAiMSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlv
+        bi0wIiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJz
+        aW9uIjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNoIiwgIm5h
+        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn0sIHsi
+        cGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0
+        Lm9yZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGwsICJmaWxl
+        bmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
+        bnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNo
+        IjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwgIm1vZHVs
+        ZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIwMTgw
+        NzMwMjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fy
+        b28iLCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6
+        ICJzdGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVU
+        QyIsICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNj
+        cmlwdGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyOCwgInJlc3Rh
+        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
+        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiYjdjNGIzNmUtZjRiMy00MjViLTg4NDMtY2Rl
+        YmE1MmE2ZDhhIn0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTBa
+        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTBaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiYjdjNGIzNmUtZjRiMy00MjViLTg4NDMtY2RlYmE1MmE2ZDhh
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5YTg5N2U3Mzg3YjQxNjRmOWYi
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0
+        eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6
+        ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
+        b2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwg
+        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
         cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44
-        IiwgImFyY2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVk
-        b3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBu
-        dWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
-        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rp
-        b24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
-        ZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFj
-        a2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
-        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
-        aWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODli
-        LWIyODMxMzYwMjVhNiJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjU1WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIw
-        LTEwLTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIs
-        ICJ1bml0X2lkIjogIjQ0ODM1YWZkLWU2MjAtNGYxNS1hODliLWIyODMxMzYw
-        MjVhNiIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MmYyIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAw
-        MTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJl
-        bmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVu
-        dF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIw
-        MTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2
-        ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJfbnMiOiAi
-        dW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
-        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0Ijog
-        W10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYw
-        MjA5Mjg3MywgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291
-        bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1h
-        cnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNTRhY2MxYTQtYjM2
-        MS00OWQ2LWE3ZDAtZGJmZGVmMjU5NGQxIn0sICJ1cGRhdGVkIjogIjIwMjAt
-        MTAtMDdUMTc6NDc6NTVaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVh
-        dGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNTRhY2MxYTQtYjM2MS00OWQ2LWE3
-        ZDAtZGJmZGVmMjU5NGQxIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YjEy
-        OTczZjhjZGUyYTUyZmIifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIy
-        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
-        c2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRF
-        TExPLVJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0
-        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2Ug
-        ZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAi
-        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
-        aXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRw
-        Oi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQi
-        LCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6
-        ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0
-        YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFj
-        a2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4NzMsICJy
-        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
-        aWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjg1ZDhlYjE0LTk0ODctNGJiZS04Mjg1
-        LWViY2YyMzU4MWQ0YSJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjU1WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIw
-        LTEwLTA3VDE3OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIs
-        ICJ1bml0X2lkIjogIjg1ZDhlYjE0LTk0ODctNGJiZS04Mjg1LWViY2YyMzU4
-        MWQ0YSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4Y2RlMmE1
-        MmY1In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0xMS0xMCAw
-        MDowMDowMCIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJl
-        bmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJh
-        dGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQi
-        OiBudWxsLCAidGl0bGUiOiAiUkhTQS0yMDEwOjA4NTgifSwgeyJocmVmIjog
-        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
-        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
-        NjI3ODgyIiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUgYnppcDI6IGludGVn
-        ZXIgb3ZlcmZsb3cgZmxhdyBpbiBCWjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYi
-        OiAiaHR0cHM6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9D
-        VkUtMjAxMC0wNDA1Lmh0bWwiLCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZF
-        LTIwMTAtMDQwNSIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJl
-        ZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9j
-        bGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAi
-        aWQiOiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRh
-        dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6
-        ICJLQVRFTExPLVJIU0EtMjAxMDowODU4IiwgImZyb20iOiAic2VjdXJpdHlA
-        cmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0bGUi
-        OiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1cGRhdGUiLCAiX25zIjog
-        InVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdn
-        ZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6
-        IFt7InBhY2thZ2VzIjogW3sic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAu
-        c3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEy
-        NTYiLCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQy
-        M2E0NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnpp
-        cDItbGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIs
-        ICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBb
-        InNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZh
-        YjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6
-        ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
-        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
-        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5
-        NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
-        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
-        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6
-        IFsic2hhMjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVk
-        Mzc0NjU2ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3
-        LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEu
-        MC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6
-        IFsic2hhMjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQy
-        YWY0YmVhMDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8w
-        IiwgImFyY2giOiAieDg2XzY0In1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
-        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
-        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
-        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
-        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
-        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3MywgInJlc3RhcnRfc3Vn
-        Z2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJD
-        b3B5cmlnaHQgMjAxMCBSZWQgSGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZv
-        cmUgYXBwbHlpbmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlv
-        dXNseS1yZWxlYXNlZCBlcnJhdGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVt
-        IGhhdmUgYmVlbiBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFi
-        bGUgdmlhIHRoZSBSZWQgSGF0IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRv
-        XG51c2UgdGhlIFJlZCBIYXQgTmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0
-        ZSBhcmUgYXZhaWxhYmxlIGF0XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9m
-        YXEvZG9jcy9ET0MtMTEyNTkiLCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAy
-        IHBhY2thZ2VzIHRoYXQgZml4IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxl
-        YXNlIjogIiIsICJfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAtNDdj
-        NGZlYWE3MTZkIn0sICJ1cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVa
-        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
-        aXRfaWQiOiAiYTYwNzIzMTMtMjM2MC00OTFmLThkMTAtNDdjNGZlYWE3MTZk
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YjEyOTczZjhjZGUyYTUyZWQi
+        IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
+        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVk
+        IjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAi
+        X2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcxMjgsICJyZXN0YXJ0X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogImJkYTQwYjc5LWZiN2ItNDUzNS04NGE5LThiZTZiMWZlZjE5NyJ9
+        LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJyZXBvX2lk
+        IjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjEw
+        WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lkIjogImJk
+        YTQwYjc5LWZiN2ItNDUzNS04NGE5LThiZTZiMWZlZjE5NyIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWZhNDVjOWE4OTdlNzM4N2I0MTY0ZmE3In19LCB7Im1ldGFk
+        YXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxv
+        Z2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVy
+        cmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIsICJmcm9t
+        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
+        dGxlIjogIkVtcHR5IGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAi
+        dHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW10sICJzdGF0dXMiOiAi
+        c3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkVtcHR5
+        IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTYwNDYwNzEyOCwgInJlc3Rh
+        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
+        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiYzUzY2ExYTYtNDU0Zi00ZWJkLWEwN2ItNWYx
+        OWE2MTBmY2M5In0sICJ1cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTBa
+        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTBaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiYzUzY2ExYTYtNDU0Zi00ZWJkLWEwN2ItNWYxOWE2MTBmY2M5
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5YTg5N2U3Mzg3YjQxNjRmYjAi
         fX1d
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3671,7 +3681,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3684,7 +3694,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3697,10 +3707,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3710,7 +3720,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3723,13 +3733,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '517'
+      - '520'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3743,40 +3753,40 @@ http_interactions:
         LCAid2hhbGUiLCAid29sZiIsICJ6ZWJyYSJdLCAicmVwb19pZCI6ICIzX3Zp
         ZXcxIiwgIm5hbWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUs
         ICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3Vw
-        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjAyMDkyODc1LCAib3B0aW9uYWxfcGFj
+        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjA0NjA3MTMwLCAib3B0aW9uYWxfcGFj
         a2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFu
         c2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEi
         OiB7fSwgImRlZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRf
         dHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJf
-        aWQiOiAiY2VjZGE5YjEtMTk5Zi00M2ZhLThkYmYtMGQ2M2I1YWMyNGE3Iiwg
+        aWQiOiAiNjVhNTQ1NjYtYTM0YS00NGE0LTk5MjgtYmI5MGYzNGI3YzQ3Iiwg
         ImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9u
-        YW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NVoi
-        LCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMC0w
-        N1QxNzo0Nzo1NVoiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
-        LCAidW5pdF9pZCI6ICJjZWNkYTliMS0xOTlmLTQzZmEtOGRiZi0wZDYzYjVh
-        YzI0YTciLCAiX2lkIjogeyIkb2lkIjogIjVmN2RmZjRiMTI5NzNmOGNkZTJh
-        NTM2MSJ9fSwgeyJtZXRhZGF0YSI6IHsibWFuZGF0b3J5X3BhY2thZ2VfbmFt
+        YW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoi
+        LCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAyMC0xMS0w
+        NVQyMDoxMjoxMFoiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
+        LCAidW5pdF9pZCI6ICI2NWE1NDU2Ni1hMzRhLTQ0YTQtOTkyOC1iYjkwZjM0
+        YjdjNDciLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzlhODk3ZTczODdiNDE2
+        NTAyMSJ9fSwgeyJtZXRhZGF0YSI6IHsibWFuZGF0b3J5X3BhY2thZ2VfbmFt
         ZXMiOiBbImNvY2thdGVlbCIsICJkdWNrIiwgInBlbmd1aW4iLCAic3Rvcmsi
         XSwgInJlcG9faWQiOiAiM192aWV3MSIsICJuYW1lIjogImJpcmQiLCAidXNl
         cl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVu
-        aXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDIwOTI4
-        NzUsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVk
+        aXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MDQ2MDcx
+        MzAsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVk
         X25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
         bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVz
         IjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAi
-        aWQiOiAiYmlyZCIsICJfaWQiOiAiZWUwYjBmY2YtZmE3ZS00OGRiLTk3YWIt
-        OWU1MGY0MGU4NGNhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0
+        aWQiOiAiYmlyZCIsICJfaWQiOiAiZDJjODgwYmEtZmZkZi00ZWQ0LWJmOGUt
+        MzE5NWRiODkxOGI1IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0
         aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAyMC0x
-        MC0wN1QxNzo0Nzo1NVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0
-        ZWQiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1NVoiLCAidW5pdF90eXBlX2lkIjog
-        InBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJlZTBiMGZjZi1mYTdlLTQ4
-        ZGItOTdhYi05ZTUwZjQwZTg0Y2EiLCAiX2lkIjogeyIkb2lkIjogIjVmN2Rm
-        ZjRiMTI5NzNmOGNkZTJhNTM0NiJ9fV0=
+        MS0wNVQyMDoxMjoxMFoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0
+        ZWQiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMFoiLCAidW5pdF90eXBlX2lkIjog
+        InBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJkMmM4ODBiYS1mZmRmLTRl
+        ZDQtYmY4ZS0zMTk1ZGI4OTE4YjUiLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1
+        YzlhODk3ZTczODdiNDE2NGZmOSJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3786,7 +3796,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3799,7 +3809,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3812,10 +3822,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3825,7 +3835,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3838,7 +3848,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Vary:
@@ -3858,22 +3868,22 @@ http_interactions:
         Z3oiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJwcm9k
         dWN0aWQiLCAiY2hlY2tzdW0iOiAiYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUy
         Nzc1YWEwZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMiIsICJf
-        bGFzdF91cGRhdGVkIjogMTYwMjA5Mjg3NSwgIl9jb250ZW50X3R5cGVfaWQi
+        bGFzdF91cGRhdGVkIjogMTYwNDYwNzEzMCwgIl9jb250ZW50X3R5cGVfaWQi
         OiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJkb3dubG9hZGVkIjogdHJ1
         ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX25zIjogInVuaXRzX3l1
         bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
-        NTYiLCAiX2lkIjogImRjZWI1MmZhLTg1ZTMtNDJmMi1hMGFhLTI0ZWNlODFh
-        OGYwZSJ9LCAidXBkYXRlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU1WiIsICJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTEwLTA3VDE3
-        OjQ3OjU1WiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFf
-        ZmlsZSIsICJ1bml0X2lkIjogImRjZWI1MmZhLTg1ZTMtNDJmMi1hMGFhLTI0
-        ZWNlODFhOGYwZSIsICJfaWQiOiB7IiRvaWQiOiAiNWY3ZGZmNGIxMjk3M2Y4
-        Y2RlMmE1M2NlIn19XQ==
+        NTYiLCAiX2lkIjogImRmMTM2NjU0LTZlZTYtNGFkYi04NzBkLTBkM2Q2MmNi
+        ODNiNCJ9LCAidXBkYXRlZCI6ICIyMDIwLTExLTA1VDIwOjEyOjEwWiIsICJy
+        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDIwLTExLTA1VDIw
+        OjEyOjEwWiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFf
+        ZmlsZSIsICJ1bml0X2lkIjogImRmMTM2NjU0LTZlZTYtNGFkYi04NzBkLTBk
+        M2Q2MmNiODNiNCIsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWE4OTdlNzM4
+        N2I0MTY1MDhlIn19XQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3883,7 +3893,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3896,7 +3906,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3909,10 +3919,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3924,7 +3934,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3937,7 +3947,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:56 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -3950,10 +3960,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:56 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -3963,7 +3973,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -3976,13 +3986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:57 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '531'
+      - '532'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4002,24 +4012,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwMjA5
-        Mjg3MywgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTYwNDYw
+        NzEyOCwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImVkOWU1ZDE2LTdi
-        YzgtNDQzNi1hOTdjLWJhYTY1MzRlMGFlMSIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU2MGEwYzdjLWFl
+        NDItNDg4NS1iNDUwLWQ2NmY1Yzg0Mzg4ZCIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTVaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
-        cmVhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTVaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICJlZDllNWQxNi03YmM4
-        LTQ0MzYtYTk3Yy1iYWE2NTM0ZTBhZTEiLCAiX2lkIjogeyIkb2lkIjogIjVm
-        N2RmZjRiMTI5NzNmOGNkZTJhNTNmMCJ9fV0=
+        MjAtMTEtMDVUMjA6MTI6MTBaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
+        cmVhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MTBaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICJlNjBhMGM3Yy1hZTQy
+        LTQ4ODUtYjQ1MC1kNjZmNWM4NDM4OGQiLCAiX2lkIjogeyIkb2lkIjogIjVm
+        YTQ1YzlhODk3ZTczODdiNDE2NTBiMiJ9fV0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4033,7 +4043,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
@@ -4046,7 +4056,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:57 GMT
+      - Thu, 05 Nov 2020 20:12:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -4057,14 +4067,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNlYjE5MTZkLWUwNTUtNDc2MS1hMTY4LWE4NWY1MzkzNDdmOC8iLCAi
-        dGFza19pZCI6ICIzZWIxOTE2ZC1lMDU1LTQ3NjEtYTE2OC1hODVmNTM5MzQ3
-        ZjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzA4MDcwMTczLTNhMDMtNDNkOC05Zjg1LWMwODZmNjk5YmI1Ni8iLCAi
+        dGFza19pZCI6ICIwODA3MDE3My0zYTAzLTQzZDgtOWY4NS1jMDg2ZjY5OWJi
+        NTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:57 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:11 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/3eb1916d-e055-4761-a168-a85f539347f8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/08070173-3a03-43d8-9f85-c086f699bb56/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4072,7 +4082,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4083,15 +4093,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:58 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Etag:
-      - '"417ee02372b625c55426296cc19aac6a-gzip"'
+      - '"40a456cc41e1625d78062ded5144c0ef-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '476'
+      - '485'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4099,34 +4109,34 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi51bmFzc29jaWF0ZV9i
-        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvM2Vi
-        MTkxNmQtZTA1NS00NzYxLWExNjgtYTg1ZjUzOTM0N2Y4LyIsICJ0YXNrX2lk
-        IjogIjNlYjE5MTZkLWUwNTUtNDc2MS1hMTY4LWE4NWY1MzkzNDdmOCIsICJ0
+        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDgw
+        NzAxNzMtM2EwMy00M2Q4LTlmODUtYzA4NmY2OTliYjU2LyIsICJ0YXNrX2lk
+        IjogIjA4MDcwMTczLTNhMDMtNDNkOC05Zjg1LWMwODZmNjk5YmI1NiIsICJ0
         YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6M192aWV3MSIsICJwdWxwOmFjdGlv
-        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0xMC0wN1Qx
-        Nzo0Nzo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAyMC0xMC0wN1QxNzo0Nzo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMC0xMS0wNVQy
+        MDoxMjoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAyMC0xMS0wNVQyMDoxMjoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1r
-        YXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9rZXkiOiB7Imlk
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1r
+        YXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1
+        bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCJ9LCAi
+        dHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktB
+        VEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9
+        LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0
+        MyJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7Imlk
         IjogIktBVEVMTE8tUkhFQS0yMDEyOjAwNTkifSwgInR5cGVfaWQiOiAiZXJy
         YXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAx
-        MDo5OTE0MyJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXki
-        OiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQi
-        OiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJI
-        RUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0
-        X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1OCJ9LCAidHlw
-        ZV9pZCI6ICJlcnJhdHVtIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0ZDEyOTczZjhjZGUyYTU0ZDgifSwgImlkIjogIjVm
-        N2RmZjRkMTI5NzNmOGNkZTJhNTRkOCJ9
+        MDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzliODk3ZTczODdiNDE2NTE5
+        ZSJ9LCAiaWQiOiAiNWZhNDVjOWI4OTdlNzM4N2I0MTY1MTllIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4134,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4145,15 +4155,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:58 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Etag:
-      - '"87987a8045785ca2a1fd9d319a855aac-gzip"'
+      - '"785662f56c758b7337bf298df0bcaa35-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '632'
+      - '631'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4162,60 +4172,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTI6MDlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5Zjc0MWU4ODNkMzkifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZmE0NWM5OTA2YzcxYTA0NGVhNTJmM2UifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MjAtMTEtMDVUMjA6MTI6MDlaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWY3ZGZmNGEwMjIzOWY3NDFlODgzZDM4In0sICJjb25maWci
+        IiRvaWQiOiAiNWZhNDVjOTkwNmM3MWEwNDRlYTUyZjNkIn0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDlaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5Zjc0MWU4ODNkMzcifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5OTA2YzcxYTA0NGVhNTJmM2MifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTAt
-        MDdUMTc6NDc6NTVaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDIwLTEwLTA3VDE3OjQ3
-        OjU3WiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjAtMTEt
+        MDVUMjA6MTI6MTBaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDIwLTExLTA1VDIwOjEy
+        OjEyWiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
         IjogMiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiAxLCAi
         ZGlzdHJpYnV0aW9uIjogMSwgInJwbSI6IDEsICJ5dW1fcmVwb19tZXRhZGF0
         YV9maWxlIjogMSwgInBhY2thZ2VfZW52aXJvbm1lbnQiOiAxfSwgIl9ucyI6
         ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTAtMDdUMTc6NDc6NTRaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMjAtMTEtMDVUMjA6MTI6MDlaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9pbXBv
         cnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMi
         LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9v
         dmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3Jh
-        dGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZjdkZmY0YTAyMjM5
-        Zjc0MWU4ODNkMzYifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9y
+        dGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZmE0NWM5OTA2Yzcx
+        YTA0NGVhNTJmM2IifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9y
         dGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiA5LCAiX2lkIjogeyIk
-        b2lkIjogIjVmN2RmZjRhMDIyMzlmNzQxZTg4M2QzNSJ9LCAidG90YWxfcmVw
+        b2lkIjogIjVmYTQ1Yzk5MDZjNzFhMDQ0ZWE1MmYzYSJ9LCAidG90YWxfcmVw
         b3NpdG9yeV91bml0cyI6IDEwLCAiaWQiOiAiM192aWV3MSIsICJfaHJlZiI6
         ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4223,7 +4233,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4234,7 +4244,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:58 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -4245,14 +4255,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MzZTU0M2ZjLTU4N2EtNDcxYi04ZTU2LTJlMzNhNDRkMzM1OC8iLCAi
-        dGFza19pZCI6ICJjM2U1NDNmYy01ODdhLTQ3MWItOGU1Ni0yZTMzYTQ0ZDMz
-        NTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2UzYzc1MGY5LTNjZWQtNDY4MC1iNGFjLTQ0ZmRlYzQzYWQ0OS8iLCAi
+        dGFza19pZCI6ICJlM2M3NTBmOS0zY2VkLTQ2ODAtYjRhYy00NGZkZWM0M2Fk
+        NDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/c3e543fc-587a-471b-8e56-2e33a44d3358/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/e3c750f9-3ced-4680-b4ac-44fdec43ad49/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4260,7 +4270,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4271,15 +4281,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:58 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Etag:
-      - '"ec4e07c1a9527b5266cfc84b3751bd54-gzip"'
+      - '"d2f237a4c58e5e6eb276f02d9e54ea72-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '363'
+      - '369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4287,25 +4297,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jM2U1NDNmYy01ODdhLTQ3MWItOGU1Ni0yZTMzYTQ0ZDMz
-        NTgvIiwgInRhc2tfaWQiOiAiYzNlNTQzZmMtNTg3YS00NzFiLThlNTYtMmUz
-        M2E0NGQzMzU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lM2M3NTBmOS0zY2VkLTQ2ODAtYjRhYy00NGZkZWM0M2Fk
+        NDkvIiwgInRhc2tfaWQiOiAiZTNjNzUwZjktM2NlZC00NjgwLWI0YWMtNDRm
+        ZGVjNDNhZDQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDIwLTEwLTA3VDE3OjQ3OjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDIwLTEwLTA3VDE3OjQ3OjU4WiIsICJ0cmFjZWJh
+        MDIwLTExLTA1VDIwOjEyOjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDIwLTExLTA1VDIwOjEyOjEyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVmN2RmZjRlMTI5NzNmOGNkZTJhNTUyZiJ9LCAiaWQiOiAi
-        NWY3ZGZmNGUxMjk3M2Y4Y2RlMmE1NTJmIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtc3RhYmxlLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWZhNDVjOWM4OTdlNzM4N2I0MTY1
+        MWRmIn0sICJpZCI6ICI1ZmE0NWM5Yzg5N2U3Mzg3YjQxNjUxZGYifQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:58 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4313,7 +4323,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4324,7 +4334,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:59 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -4335,14 +4345,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzEyZjhkNTMzLTBlODgtNGYyZS1iOWUwLTIyZDIxMGMxZGNmYi8iLCAi
-        dGFza19pZCI6ICIxMmY4ZDUzMy0wZTg4LTRmMmUtYjllMC0yMmQyMTBjMWRj
-        ZmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQ5OWM3YTZhLWMzN2QtNGFjMi1hNGYwLTBjNDRhZmI5MTliOC8iLCAi
+        dGFza19pZCI6ICI0OTljN2E2YS1jMzdkLTRhYzItYTRmMC0wYzQ0YWZiOTE5
+        YjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.example.com/pulp/api/v2/tasks/12f8d533-0e88-4f2e-b9e0-22d210c1dcfb/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v2/tasks/499c7a6a-c37d-4ac2-a4f0-0c44afb919b8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4350,7 +4360,7 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.6.2p47
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -4361,15 +4371,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Oct 2020 17:47:59 GMT
+      - Thu, 05 Nov 2020 20:12:12 GMT
       Server:
       - Apache
       Etag:
-      - '"ef6e730c2a0e54a19dc9d27a566e3fe0-gzip"'
+      - '"9f2b822a3ede1c534db85d289006aa25-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '361'
+      - '368'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4377,20 +4387,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMmY4ZDUzMy0wZTg4LTRmMmUtYjllMC0yMmQyMTBjMWRj
-        ZmIvIiwgInRhc2tfaWQiOiAiMTJmOGQ1MzMtMGU4OC00ZjJlLWI5ZTAtMjJk
-        MjEwYzFkY2ZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy80OTljN2E2YS1jMzdkLTRhYzItYTRmMC0wYzQ0YWZiOTE5
+        YjgvIiwgInRhc2tfaWQiOiAiNDk5YzdhNmEtYzM3ZC00YWMyLWE0ZjAtMGM0
+        NGFmYjkxOWI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
-        MC0xMC0wN1QxNzo0Nzo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAyMC0xMC0wN1QxNzo0Nzo1OVoiLCAidHJhY2ViYWNr
+        MC0xMS0wNVQyMDoxMjoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMC0xMS0wNVQyMDoxMjoxMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        Y2VudG9zNy1rYXRlbGxvLWRldmVsLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
-        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZjdkZmY0ZjEyOTczZjhjZGUyYTU1ODIifSwgImlkIjogIjVm
-        N2RmZjRmMTI5NzNmOGNkZTJhNTU4MiJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLXN0
+        YWJsZS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVmYTQ1YzljODk3ZTczODdiNDE2NTIy
+        ZCJ9LCAiaWQiOiAiNWZhNDVjOWM4OTdlNzM4N2I0MTY1MjJkIn0=
     http_version: 
-  recorded_at: Wed, 07 Oct 2020 17:47:59 GMT
+  recorded_at: Thu, 05 Nov 2020 20:12:12 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes flaky tests we are seeing ex https://ci.theforeman.org/job/katello-master-source-release/1171/testReport/(root)/Katello__Service__Repository__YumVcrCopyTest/test_copy_no_filters/

I regenerated cassettes for the whole test file