### PR TITLE
Fixes #31306 - fetch pxe files after SP sync

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -19,9 +19,14 @@ module Actions
                                     Actions::Pulp3::CapsuleContent::Sync],
                                      repo, smart_proxy,
                                      skip_metadata_check: skip_metadata_check)
+                end
+              end
+
+              concurrence do
+                repo_batch.each do |repo|
                   if repo.is_a?(::Katello::Repository) &&
-                    repo.distribution_bootable? &&
-                    repo.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+                      repo.distribution_bootable? &&
+                      repo.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
                     plan_action(Katello::Repository::FetchPxeFiles,
                                 id: repo.id,
                                 capsule_id: smart_proxy.id)


### PR DESCRIPTION
Currently the FetchPxeFiles action is scheduled
concurrently with the Smart Proxy sync action.
This results in 404s upon initial sync.  This
schedules them sequentually to occur after the sync