### PR TITLE
Fixes #31308 - when a CV has a conflict, disable publish functions 

### DIFF
--- a/app/views/katello/api/v2/content_views/show.json.rabl
+++ b/app/views/katello/api/v2/content_views/show.json.rabl
@@ -4,6 +4,12 @@ extends "katello/api/v2/content_views/base"
 
 attributes :content_host_count
 
+node :errors do
+  unless @resource.valid?
+    attribute :messages => @resource.errors.full_messages
+  end
+end
+
 child :duplicate_repositories_to_publish => :duplicate_repositories_to_publish do
   attributes :id, :name
   node :components do |repo|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -13,7 +13,7 @@
   </div>
 
   <nav data-block="item-actions">
-    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView) || contentView.import_only"
+    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView) || contentView.import_only" 
             ui-sref="content-view.publish">
       <span translate>Publish New Version</span>
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
@@ -7,6 +7,10 @@
   It can be promoted to other environments from the Versions tab of this Content View.
 </p>
 
+<div bst-alert="warning" ng-show="contentView.errors['messages'].length > 0">
+  <span translate>{{contentView.errors['messages'][0]}}</span>
+  </div>
+
 <header class="details-header">
   <h3 translate>Version Details</h3>
 </header>


### PR DESCRIPTION
This PR changes the CV details publish interaction by displaying validation errors that would occur when a CCV has component CV conflicts. For example, if you have duplicate puppet modules in different, published CV versions that are members of a CCV.

Previously, the publish would fail and display an error regarding a version number conflict. This caused confusion for the user because the fundamental error (the puppet module conflict) is not indicated.

Example:
![Screenshot from 2020-11-17 08-42-00](https://user-images.githubusercontent.com/266755/99398773-cfc4c100-28b2-11eb-9c42-1cb52b4fb790.png)
