### PR TITLE
Fixes #30828 - conditionally skip content indexing

### DIFF
--- a/app/lib/actions/katello/check_matching_content.rb
+++ b/app/lib/actions/katello/check_matching_content.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Katello
+    module CheckMatchingContent
+      def check_matching_content(new_repository, source_repositories)
+        check_matching_content = ::Katello::RepositoryTypeManager.find(new_repository.content_type).metadata_publish_matching_check
+        if new_repository.environment && source_repositories.count == 1 && check_matching_content
+          match_check_output = plan_action(Katello::Repository::CheckMatchingContent,
+                                           :source_repo_id => source_repositories.first.id,
+                                           :target_repo_id => new_repository.id).output
+
+          return match_check_output[:matching_content]
+        end
+        false
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/check_matching_content.rb
+++ b/app/lib/actions/katello/repository/check_matching_content.rb
@@ -23,8 +23,10 @@ module Actions
             yum_metadata_files = yum_metadata_files_match?(source_repo, target_repo)
             checksum_match = (target_repo.saved_checksum_type == source_repo.saved_checksum_type)
 
+            published = target_repo.backend_service(SmartProxy.pulp_primary).published?
+
             output[:checksum_match] = checksum_match
-            output[:matching_content] = yum_metadata_files && srpms_match && rpms && errata && package_groups && distributions && target_repo.published? && checksum_match
+            output[:matching_content] = yum_metadata_files && srpms_match && rpms && errata && package_groups && distributions && published && checksum_match
           end
 
           if source_repo.content_type == ::Katello::Repository::DEB_TYPE

--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -8,6 +8,7 @@ module Actions
           param :id, Integer
           param :dependency, Hash
           param :contents_changed
+          param :matching_content
           param :source_repository_id
         end
 

--- a/app/lib/actions/middleware/execute_if_contents_changed.rb
+++ b/app/lib/actions/middleware/execute_if_contents_changed.rb
@@ -13,7 +13,10 @@ module Actions
 
       def execute?
         if action.input.keys.include?('contents_changed') && action.input['contents_changed'] == false
-          self.action.output[:post_sync_skipped] = true
+          self.action.output[:post_action_skipped] = true
+          false
+        elsif action.input.keys.include?('matching_content') && action.input['matching_content'] == true
+          self.action.output[:post_action_skipped] = true
           false
         else
           true

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 require "pulpcore_client"
 module Katello
   module Pulp3
@@ -45,6 +46,10 @@ module Katello
       rescue api.class.api_exception_class => e
         raise e unless e.code == 404
         nil
+      end
+
+      def published?
+        !repo.publication_href.nil?
       end
 
       def skip_types

--- a/test/actions/katello/check_matching_content_test.rb
+++ b/test/actions/katello/check_matching_content_test.rb
@@ -1,0 +1,71 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello
+  class KatelloTestAction < Actions::EntryAction
+    include Actions::Katello::CheckMatchingContent
+
+    def plan_self(*args)
+      check_matching_content(*args)
+    end
+  end
+
+  class CheckMatchingContentTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::RemoteAction
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+    include Actions::Katello::CheckMatchingContent
+
+    let(:smart_proxy) { SmartProxy.new }
+    let(:repo) { katello_repositories(:fedora_17_x86_64) }
+
+    def test_plans_check_matching_content
+      smart_proxy.stubs(:pulp3_support?).returns(true)
+      action = create_action KatelloTestAction
+
+      new_repo = FactoryBot.create(:katello_repository, :with_product)
+      new_repo.environment = repo.environment
+
+      plan_action(action, new_repo, [repo])
+
+      assert_action_planed_with(action, Actions::Katello::Repository::CheckMatchingContent, :source_repo_id => repo.id, :target_repo_id => new_repo.id)
+    end
+
+    def test_does_not_plan_check_matching_content_without_target_repo_environment
+      smart_proxy.stubs(:pulp3_support?).returns(true)
+      action = create_action KatelloTestAction
+
+      new_repo = FactoryBot.create(:katello_repository, :with_product)
+
+      plan_action(action, new_repo, [repo])
+
+      refute_action_planed(action, Actions::Katello::Repository::CheckMatchingContent)
+    end
+
+    def test_does_not_plan_check_matching_content_with_multiple_source_repositories
+      smart_proxy.stubs(:pulp3_support?).returns(true)
+      action = create_action KatelloTestAction
+
+      new_repo = FactoryBot.create(:katello_repository, :with_product)
+      new_repo.environment = repo.environment
+      another_source_repo = FactoryBot.create(:katello_repository, :with_product)
+
+      plan_action(action, new_repo, [repo, another_source_repo])
+
+      refute_action_planed(action, Actions::Katello::Repository::CheckMatchingContent)
+    end
+
+    def test_does_not_plan_check_matching_content_when_repo_content_type_fails_metadata_publish_matching_check
+      smart_proxy.stubs(:pulp3_support?).returns(true)
+      action = create_action KatelloTestAction
+
+      new_repo = FactoryBot.create(:katello_repository, :with_product)
+      new_repo.environment = repo.environment
+
+      ::Katello::RepositoryTypeManager.find(new_repo.content_type).stubs(:metadata_publish_matching_check).returns(false)
+      plan_action(action, new_repo, [repo])
+
+      refute_action_planed(action, Actions::Katello::Repository::CheckMatchingContent)
+    end
+  end
+end

--- a/test/actions/katello/repository/check_matching_content_test.rb
+++ b/test/actions/katello/repository/check_matching_content_test.rb
@@ -7,8 +7,12 @@ module Actions
     include FactoryBot::Syntax::Methods
 
     let(:action_class) { ::Actions::Katello::Repository::CheckMatchingContent }
+
     let(:yum_repo) { katello_repositories(:fedora_17_x86_64) }
     let(:yum_repo2) { katello_repositories(:fedora_17_x86_64_dev) }
+
+    let(:smart_proxy) { FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3) }
+    setup { SmartProxy.stubs(:pulp_primary).returns(smart_proxy) }
 
     def test_check_matching_content_false
       action = create_action(action_class)
@@ -20,7 +24,7 @@ module Actions
 
     def test_check_matching_content_false_unpublished
       action = create_action(action_class)
-      ::Katello::Repository.any_instance.expects(:published?).returns(false)
+      #::Katello::Repository.any_instance.expects(:published?).returns(false)
       plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo.id)
       run = run_action plan
 
@@ -29,7 +33,7 @@ module Actions
 
     def test_check_matching_content_true
       action = create_action(action_class)
-      ::Katello::Repository.any_instance.expects(:published?).returns(true)
+      ::Katello::Pulp3::Repository::Yum.any_instance.stubs(:published?).returns(true)
       plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo.id)
       run = run_action plan
 
@@ -44,7 +48,7 @@ module Actions
       action_class.any_instance.stubs(:package_groups_match?).returns(true)
       action_class.any_instance.stubs(:distributions_match?).returns(true)
       action_class.any_instance.stubs(:yum_metadata_files_match?).returns(true)
-      ::Katello::Repository.any_instance.expects(:published?).returns(true)
+      #::Katello::Repository.any_instance.expects(:published?).returns(true)
 
       yum_repo.update_attribute(:saved_checksum_type, "sha1")
       yum_repo2.update_attribute(:saved_checksum_type, "sha256")


### PR DESCRIPTION
This PR introduces the use of the "content_changed" input to index content actions in additional opportunities during a CV publish. The goal for this change is to eliminate unnecessary index operations when it's not needed (no changes detected).