### PR TITLE
Fixes #31321 - deleted host causes applicability error

### DIFF
--- a/app/lib/actions/katello/applicability/hosts/bulk_generate.rb
+++ b/app/lib/actions/katello/applicability/hosts/bulk_generate.rb
@@ -9,8 +9,12 @@ module Actions
 
           def run
             input[:host_ids].each do |host_id|
-              content_facet = ::Host.find(host_id).content_facet
-              content_facet.calculate_and_import_applicability
+              content_facet = ::Katello::Host::ContentFacet.find_by_host_id(host_id)
+              if content_facet.present?
+                content_facet.calculate_and_import_applicability
+              else
+                Rails.logger.warn(_("Content Facet for host with id %s is non-existent. Skipping applicability calculation.") % host_id)
+              end
             end
           end
 

--- a/test/actions/katello/applicability/generate_applicability_test.rb
+++ b/test/actions/katello/applicability/generate_applicability_test.rb
@@ -29,5 +29,23 @@ module ::Actions::Katello::Applicability::Host
         ForemanTasks.sync_task(action_class, [@host, @host, @host, @host, @host])
       end
     end
+
+    describe 'BulkGenerate does not error out with missing hosts' do
+      let(:action_class) { ::Actions::Katello::Applicability::Hosts::BulkGenerate }
+
+      it 'runs' do
+        deleted_id = @host.id
+        @host.subscription_facet.destroy
+        @host.content_facet.destroy
+        @host.destroy
+        host2 = FactoryBot.build(:host, :with_content, :with_subscription,
+                                 :content_view => katello_content_views(:library_dev_view),
+                                 :lifecycle_environment => katello_environments(:library))
+        host2.save!
+        host3 = FactoryBot.build(:host)
+        host3.save!
+        ForemanTasks.sync_task(action_class, host_ids: [deleted_id, host2.id, host3.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
If a host is missing, or if it doesn't have a content facet, the rescue block now will skip it instead of erroring out the entire task.

To test:

1) Make a content host
2) `ForemanTasks.sync_task(::Actions::Katello::Applicability::Hosts::BulkGenerate, host_ids: [<real id>,<random fake id>])`
3) Check the logs for `Host with ID <random fake id> does not exist. Skipping applicability calculation.`
4) Delete the content host's content facet
5) `ForemanTasks.sync_task(::Actions::Katello::Applicability::Hosts::BulkGenerate, host_ids: [<real id>])`
6) Check the logs for `Host with ID <read id> is not a content host. Skipping applicability calculation.`