### PR TITLE
Fixes #31078 - Can import into default content view

### DIFF
--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -1,0 +1,59 @@
+module Katello
+  class Api::V2::ContentImportsController < Api::V2::ApiController
+    before_action :find_publishable_content_view, :only => [:version]
+    before_action :find_importable_organization, :only => [:library]
+    before_action :find_default_content_view, :only => [:library]
+
+    api :POST, "/content_imports/version", N_("Import a content view version")
+    param :content_view_id, :number, :desc => N_("Content view identifier"), :required => true
+    param :path, String, :desc => N_("Directory containing the exported Content View Version"), :required => true
+    param :metadata, Hash, :desc => N_("Metadata taken from the upstream export history for this Content View Version"), :required => true
+    def version
+      if @view.default?
+        fail HttpErrors::BadRequest, _("Cannot use this end point for importing to library. "\
+                                       "If you intented to upload to library, use the library endpoint.")
+      end
+
+      task = async_task(::Actions::Katello::ContentViewVersion::Import, @view, path: params[:path], metadata: metadata_params.to_h)
+      respond_for_async :resource => task
+    end
+
+    api :POST, "/content_imports/library", N_("Import a content view version to the library")
+    param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
+    param :path, String, :desc => N_("Directory containing the exported Content View Version"), :required => true
+    param :metadata, Hash, :desc => N_("Metadata taken from the upstream export history for this Content View Version"), :required => true
+    def library
+      task = async_task(::Actions::Katello::ContentViewVersion::ImportLibrary, @organization, path: params[:path], metadata: metadata_params.to_h)
+      respond_for_async :resource => task
+    end
+
+    private
+
+    def find_publishable_content_view
+      @view = ContentView.publishable.find(params[:content_view_id])
+      throw_resource_not_found(name: 'content_view', id: params[:content_view_id]) if @view.blank?
+    end
+
+    def find_default_content_view
+      @view = @organization&.default_content_view
+      throw_resource_not_found(name: 'organization', id: params[:organization_id]) if @view.blank?
+    end
+
+    def find_importable_organization
+      find_organization
+      throw_resource_not_found(name: 'organization', id: params[:organization_id]) unless @organization.can_import_library_content?
+    end
+
+    def metadata_params
+      params.require(:metadata).permit(
+        :organization,
+        :content_view,
+        :repository_mapping,
+        :toc,
+        content_view_version: [:major, :minor]
+      ).tap do |nested|
+        nested[:repository_mapping] = params[:metadata].require(:repository_mapping).permit!
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -71,7 +71,7 @@ module Actions
         private
 
         def sync_proxies?(environment)
-          Setting[:foreman_proxy_content_auto_sync] && ::SmartProxy.sync_needed?(environment)
+          ::SmartProxy.sync_needed?(environment)
         end
 
         def repos_to_delete(version, environment)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -137,7 +137,7 @@ module Actions
           history.save!
           environment = ::Katello::KTEnvironment.find(input[:environment_id])
           view = ::Katello::ContentView.find(input[:content_view_id])
-          if SmartProxy.sync_needed?(environment) && Setting[:foreman_proxy_content_auto_sync] && !input[:skip_promotion]
+          if SmartProxy.sync_needed?(environment) && !input[:skip_promotion]
             ForemanTasks.async_task(ContentView::CapsuleSync,
                                     view,
                                     environment)

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -5,10 +5,11 @@ module Actions
         def plan(content_view, path:, metadata:)
           content_view.check_ready_to_import!
           unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
-            fail ::Katello::HttpErrors::BadRequest, _("This API endpoint is only valid for Pulp 3 repositories.")
+            fail _("This action will become available after the Pulp 3 content migration")
           end
 
           ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: content_view, metadata: metadata, path: path)
+          ::Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: content_view, metadata: metadata)
 
           major = metadata[:content_view_version][:major]
           minor = metadata[:content_view_version][:minor]

--- a/app/lib/actions/katello/content_view_version/import_library.rb
+++ b/app/lib/actions/katello/content_view_version/import_library.rb
@@ -1,0 +1,68 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class ImportLibrary < Actions::EntryAction
+        def plan(organization, path:, metadata:)
+          action_subject(organization)
+          unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
+            fail _("This action will become available after the Pulp 3 content migration")
+          end
+          ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: organization.default_content_view, metadata: metadata, path: path)
+
+          version = organization.default_content_view_version
+          history = ::Katello::ContentViewHistory.create!(:content_view_version => version,
+            :user => ::User.current.login,
+            :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+            :action => ::Katello::ContentViewHistory.actions[:importing],
+            :task => self.task)
+
+          sequence do
+            plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Import, version, path: path, metadata: metadata)
+            concurrence do
+              version.importable_repositories.each do |repo|
+                sequence do
+                  plan_action(Actions::Pulp3::Repository::SaveVersion, repo)
+                  plan_action(Katello::Repository::MetadataGenerate, repo, :force => true)
+                  plan_action(Katello::Repository::IndexContent, id: repo.id)
+                end
+              end
+            end
+            plan_self(history_id: history.id, organization_id: organization.id)
+          end
+        end
+
+        def humanized_name
+          _("Import Default Content View")
+        end
+
+        def rescue_strategy_for_self
+          Dynflow::Action::Rescue::Skip
+        end
+
+        def finalize
+          org = ::Organization.find(input[:organization_id])
+          environment = org.library
+          view = org.default_content_view
+          version = org.default_content_view_version
+          version.update_content_counts!
+          # update errata applicability counts for all hosts in the CV & Library
+          ::Katello::Host::ContentFacet.where(:content_view_id => view.id,
+                                              :lifecycle_environment_id => environment.id).each do |facet|
+            facet.update_applicability_counts
+            facet.update_errata_status
+          end
+          ::Katello::ContentViewHistory.where(id: input[:history_id]).
+            update_all(status: ::Katello::ContentViewHistory::SUCCESSFUL)
+
+          if SmartProxy.sync_needed?(environment)
+            ForemanTasks.async_task(ContentView::CapsuleSync,
+                                    view,
+                                    environment)
+          end
+        rescue ::Katello::Errors::CapsuleCannotBeReached => e # skip any capsules that cannot be connected to
+          Rails.logger.warn e.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/save_version.rb
+++ b/app/lib/actions/pulp3/repository/save_version.rb
@@ -2,7 +2,7 @@ module Actions
   module Pulp3
     module Repository
       class SaveVersion < Pulp3::Abstract
-        def plan(repository, options)
+        def plan(repository, options = {})
           fail "Cannot accept tasks and repository_details into Save Version." if options[:tasks].present? && options[:repository_details].present?
           plan_self(:repository_id => repository.id, :tasks => options[:tasks], :repository_details => options[:repository_details], :force_fetch_version => options.fetch(:force_fetch_version, false))
         end

--- a/app/models/katello/authorization/organization.rb
+++ b/app/models/katello/authorization/organization.rb
@@ -12,6 +12,10 @@ module Katello
       authorized?(:import_manifest)
     end
 
+    def can_import_library_content?
+      authorized?(:import_library_content)
+    end
+
     def readable_promotion_paths
       permissible_promotion_paths(KTEnvironment.readable)
     end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -97,7 +97,7 @@ module Katello
         end
 
         def self.sync_needed?(environment)
-          unscoped.with_environment(environment).any?
+          Setting[:foreman_proxy_content_auto_sync] && unscoped.with_environment(environment).any?
         end
       end
 
@@ -107,9 +107,9 @@ module Katello
 
       def update_puppet_path
         if has_feature?(PULP_FEATURE)
-          path = ProxyAPI::Pulp.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
+          path = ::ProxyAPI::Pulp.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
         elsif has_feature?(PULP_NODE_FEATURE)
-          path = ProxyAPI::PulpNode.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
+          path = ::ProxyAPI::PulpNode.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
         end
         self.update_attribute(:puppet_path, path || '') if persisted?
         path

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -32,7 +32,8 @@ module Katello
       publish: 1,
       promotion: 2,
       removal: 3,
-      export: 4
+      export: 4,
+      importing: 5
     }
 
     def content_view

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -131,7 +131,13 @@ Katello::Engine.routes.draw do
           collection do
             get :auto_complete_search
             post :incremental_update
-            post :import
+          end
+        end
+
+        api_resources :content_imports, :only => [] do
+          collection do
+            post :version
+            post :library
           end
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -11,6 +11,7 @@ module Katello
       content_credential_permissions
       host_collections_permissions
       lifecycle_environment_permissions
+      organization_permissions
       product_permissions
       subscription_permissions
       sync_plan_permissions
@@ -140,7 +141,8 @@ module Katello
       @plugin.permission :publish_content_views,
                          {
                            'katello/api/v2/content_views' => [:publish],
-                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories, :import]
+                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories],
+                           'katello/api/v2/content_imports' => [:version]
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :publishable
@@ -418,6 +420,14 @@ module Katello
                            'katello/api/rhsm/candlepin_proxies' => [:list_owners]
                          },
                          :public => true
+    end
+
+    def organization_permissions
+      @plugin.permission :import_library_content,
+                         {
+                           'katello/api/v2/content_imports' => [:library]
+                         },
+                         :resource_type => 'Organization'
     end
   end
 end

--- a/test/controllers/api/v2/content_imports_controller_test.rb
+++ b/test/controllers/api/v2/content_imports_controller_test.rb
@@ -1,0 +1,78 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::ContentImportsControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+    METADATA = {
+      organization: "org name",
+      repository_mapping: {
+        'repo name' => {
+          repository: 'root repo name',
+          product: 'product name',
+          redhat: true
+        }
+      },
+      toc: "toc file name",
+      content_view: "cv name",
+      content_view_version: {
+        major: "4",
+        minor: "5"
+      }
+    }.with_indifferent_access
+
+    def models
+      @library_view = katello_content_views(:library_view)
+    end
+
+    def permissions
+      @view_permission = :view_content_views
+      @create_permission = :create_content_views
+      @update_permission = :edit_content_views
+      @destroy_permission = :destroy_content_views
+      @publish_permission = :publish_content_views
+      @export_permission = :export_content_views
+      @org_import_permission = :import_library_content
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+      permissions
+    end
+
+    def test_version_protected
+      allowed_perms = [@publish_permission]
+      denied_perms = [@create_permission, @update_permission,
+                      @destroy_permission, @view_permission, @export_permission]
+
+      assert_protected_action(:version, allowed_perms, denied_perms) do
+        post :version, params: { content_view_id: @library_view.id, path: '/tmp', metadata: METADATA}
+      end
+    end
+
+    def test_library_protected
+      allowed_perms = [{name: @org_import_permission, :resource_type => "Organization"}]
+      denied_perms = [@create_permission, @update_permission,
+                      @destroy_permission, @view_permission, @export_permission]
+
+      org = get_organization
+      assert_protected_action(:library, allowed_perms, denied_perms, [org]) do
+        post :library, params: { organization_id: org.id, path: '/tmp', metadata: METADATA}
+      end
+    end
+
+    def test_version
+      metadata_params = ActionController::Parameters.new(METADATA).permit!
+      path = "/tmp"
+      import_task = @controller.expects(:async_task).with do |action_class, content_view, options|
+        assert_equal ::Actions::Katello::ContentViewVersion::Import, action_class
+        assert_equal content_view.id, @library_view.id
+        assert_equal options[:path], path
+        assert_equal options[:metadata], METADATA
+      end
+      import_task.returns(build_task_stub)
+      post :version, params: { content_view_id: @library_view.id, path: path, metadata: metadata_params}
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -1,7 +1,6 @@
 require "katello_test_helper"
 
 module Katello
-  # rubocop:disable Metrics/ClassLength
   class Api::V2::ContentViewVersionsControllerTest < ActionController::TestCase
     include Support::ForemanTasks::Task
 
@@ -183,33 +182,6 @@ module Katello
       version = @library_dev_staging_view.versions.first
       post :export, params: { :id => version.id, :iso_mb_size => 5 }
       assert_response 400
-    end
-
-    def test_import
-      metadata = {
-        organization: "org name",
-        repository_mapping: {
-          'repo name' => {
-            repository: 'root repo name',
-            product: 'product name',
-            redhat: true
-          }
-        },
-        toc: "toc file name",
-        content_view: "cv name",
-        content_view_version: {
-          major: "4",
-          minor: "5"
-        }
-      }
-
-      metadata_params = ActionController::Parameters.new(metadata).permit!
-
-      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::Import, @library_view, path: '/tmp', metadata: metadata_params).returns({})
-
-      post :import, params: { content_view_id: @library_view.id, path: '/tmp', metadata: metadata}
-
-      assert_response :success
     end
 
     def test_show_protected

--- a/test/fixtures/models/katello_content_view_versions.yml
+++ b/test/fixtures/models/katello_content_view_versions.yml
@@ -10,6 +10,10 @@ library_view_version_2:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
   major: 2
 
+library_no_filter_view_version_1:
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_non_filter_view) %>
+  major: 1
+
 library_dev_view_version:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view) %>
   major: 1
@@ -29,3 +33,4 @@ composite_view_version_1:
 library_view_solve_deps_version:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view_solve_deps) %>
   major: 1
+

--- a/test/fixtures/models/katello_content_views.yml
+++ b/test/fixtures/models/katello_content_views.yml
@@ -30,6 +30,17 @@ library_view:
   updated_at: <%= Time.now %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
+library_non_filter_view:
+  name:           No Filter Published LIbrary view
+  description:    A content view
+  label:          'no_filter_published_library_view'
+  default:        false
+  next_version:   8
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  import_only:    true
+
 no_environment_view:
   name:           No environment view
   description:    A content view

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      module ContentViewVersion
+        class ImportTest < ActiveSupport::TestCase
+          include Support::Actions::Fixtures
+
+          it "Import correctly resets content_view_repositories from metadata" do
+            cv = katello_content_views(:library_view)
+            prior_repository_ids = cv.repository_ids
+            repo = katello_repositories(:rhel_7_x86_64)
+            metadata = { content_view: cv.name,
+                         repository_mapping: {
+                           "misc-24037": { "repository": repo.name,
+                                           "product": repo.product.name,
+                                           "redhat": repo.redhat?
+                                         }
+                         }
+            }.with_indifferent_access
+
+            Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: cv, metadata: metadata)
+            refute_equal prior_repository_ids, cv.repository_ids
+            assert_equal cv.repository_ids, [repo.id]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/content_view_version/import_validator_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_validator_test.rb
@@ -145,7 +145,7 @@ module Katello
               assert_match(/ does not exist/, exception.message)
             end
 
-            it "fails on metadata if the 'from' repositories in the content view does not match repositories in the metadata" do
+            it "fails on metadata if the repositories in the metadata are not in the library" do
               cv = katello_content_views(:acme_default)
               cvv = cv.versions.last
               exception = assert_raises(RuntimeError) do
@@ -160,7 +160,7 @@ module Katello
                 }
                 validator(content_view: cvv.content_view, metadata: metadata).check!
               end
-              assert_match(/importing content view do not match the repositories provided in the import metadata/, exception.message)
+              assert_match(/repositories provided in the import metadata are either not available in the Library or are of incorrect Respository Type./, exception.message)
             end
           end
         end

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -33,7 +33,6 @@ module Katello
         "or_remove_content_views_to_environment" => "Katello::KTEnvironment",
         "or_remove_content_view" => "Katello::ContentView"
       }
-
       mapping[resource_name] || verify_resource(resource_name.camelize)
     end
 


### PR DESCRIPTION
This commit enables one to import any content onto the library

In addition to that the commit does the following
1) Adds the content-imports controller and moves the existing
   functionality there.
2) Auto assigns content view repositories from the metadata. i.e. if the
   metadata had a dump for repoA and repoB. The import operation will
   check if the library has those repos and automatically add them to
   the content view.
3) Adds the library end point to conten0imports controller along with the
   Import-Default action.