### PR TITLE
Fixes #31337 - Katello sends unauth. docker repos at proxy sync time

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -35,6 +35,15 @@ module Actions
               end
             end
           end
+          update_unauthenticated_repo_list(smart_proxy) if smart_proxy.has_feature?("Container_Gateway")
+        end
+
+        def update_unauthenticated_repo_list(smart_proxy)
+          unauthenticated_repo_list =
+            ::Katello::SmartProxyHelper.new(smart_proxy).combined_repos_available_to_capsule.select do |repo|
+              repo.docker? && repo.environment.registry_unauthenticated_pull
+            end
+          smart_proxy.update_unauthenticated_repo_list(unauthenticated_repo_list.map(&:container_repository_name))
         end
 
         def repos_to_sync(smart_proxy, environment, content_view, repository, skip_metatadata_check = false)

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -101,6 +101,10 @@ module Katello
         end
       end
 
+      def update_unauthenticated_repo_list(repo_names)
+        ProxyAPI::ContainerGateway.new(url: self.url).unauthenticated_repository_list("repositories": repo_names)
+      end
+
       def puppet_path
         self[:puppet_path] || update_puppet_path
       end

--- a/db/seeds.d/104-proxy.rb
+++ b/db/seeds.d/104-proxy.rb
@@ -16,7 +16,7 @@ User.as(::User.anonymous_api_admin.login) do
     fail "Unable to create proxy feature: #{format_errors feature}"
   end
 
-  ["Pulp", "Pulp Node", "Pulpcore"].each do |input|
+  ["Pulp", "Pulp Node", "Pulpcore", "Container_Gateway"].each do |input|
     f = Feature.where(:name => input).first_or_create
     fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
   end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -200,6 +200,7 @@ module Katello
       require "#{Katello::Engine.root}/app/services/katello/puppet_class_importer_extensions"
       require "#{Katello::Engine.root}/lib/proxy_api/pulp"
       require "#{Katello::Engine.root}/lib/proxy_api/pulp_node"
+      require "#{Katello::Engine.root}/lib/proxy_api/container_gateway"
 
       # We need to explicitly load this files because Foreman has
       # similar strucuture and if the Foreman files are loaded first,

--- a/lib/proxy_api/container_gateway.rb
+++ b/lib/proxy_api/container_gateway.rb
@@ -1,0 +1,21 @@
+module ProxyAPI
+  class ContainerGateway < ::ProxyAPI::Resource
+    def initialize(args)
+      @url = args[:url] + "/container_gateway/v2"
+      super args
+    end
+
+    def unauthenticated_repository_list(args = {})
+      # get '/v2/unauthenticated_repository_list/?'
+      # put '/v2/unauthenticated_repository_list/?'
+      @url += "/unauthenticated_repository_list"
+      if args.empty?
+        @unauthenticated_repo_list = parse get
+      else
+        parse put(args)
+      end
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to perform unauthenticated repository list operation"))
+    end
+  end
+end


### PR DESCRIPTION
To be tested with https://github.com/Katello/smart_proxy_container_gateway/pull/2 if it's not already merged.  Use the same setup instructions.  Test instructions become simpler.  Just sync your smart proxy and curl the smart proxy api for the unauthenticated repo list: 
```
curl https://`hostname`/v2/unauthenticated_repository_list
```