### PR TITLE
Refs #30832 - check for pulp2 presence rather than pulp3 yum support

### DIFF
--- a/app/lib/actions/katello/host/upload_package_profile.rb
+++ b/app/lib/actions/katello/host/upload_package_profile.rb
@@ -39,7 +39,7 @@ module Actions
             Rails.logger.warn("Host with ID %s has no content facet, continuing" % host_id)
           else
             begin
-              unless SmartProxy.pulp_primary&.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
+              if SmartProxy.pulp_primary&.has_feature?(SmartProxy::PULP_FEATURE)
                 ::Katello::Pulp::Consumer.new(host.content_facet.uuid).upload_package_profile(profile)
               end
               simple_packages = profile.map { |item| ::Katello::Pulp::SimplePackage.new(item) }

--- a/app/lib/actions/katello/host/upload_profiles.rb
+++ b/app/lib/actions/katello/host/upload_profiles.rb
@@ -60,7 +60,7 @@ module Actions
 
           module_stream_profile = updated_profiles + unassociated_profiles
 
-          unless SmartProxy.pulp_primary&.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
+          if SmartProxy.pulp_primary&.has_feature?(SmartProxy::PULP_FEATURE)
             unless module_stream_profile.empty?
               begin
                 ::Katello::Pulp::Consumer.new(host.content_facet.uuid).

--- a/test/actions/katello/host/upload_package_profile_test.rb
+++ b/test/actions/katello/host/upload_package_profile_test.rb
@@ -10,6 +10,9 @@ module Katello::Host
       User.current = users(:admin)
       @host = FactoryBot.build(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
                                  :lifecycle_environment => katello_environments(:library), :id => 343)
+      @mock_smart_proxy = mock
+      ::SmartProxy.stubs(:pulp_primary).returns(@mock_smart_proxy)
+      @mock_smart_proxy.stubs(:has_feature?).with(::SmartProxy::PULP_FEATURE).returns(true)
     end
 
     describe 'Host UploadPackageProfile' do
@@ -95,14 +98,12 @@ module Katello::Host
         run_action action
       end
 
-      it 'runs and skips Pulp::Consumer with Pulp 3 yum support' do
+      it 'runs and skips Pulp::Consumer if pulp2 is not present' do
         profile = [{:name => "foo", :version => "1", :release => "3"}]
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
 
-        mock_smart_proxy = mock
-        mock_smart_proxy.expects(:pulp3_repository_type_support?).returns(true)
-        ::SmartProxy.expects(:pulp_primary).returns(mock_smart_proxy)
+        @mock_smart_proxy.expects(:has_feature?).with(::SmartProxy::PULP_FEATURE).returns(false)
         ::Host.expects(:find_by).returns(@host)
         ::Katello::Pulp::Consumer.expects(:new).never
         @host.expects(:import_package_profile).with(any_parameters)


### PR DESCRIPTION
Can't install errata via pulp2 if there's no consumer profile, so check for presence of pulp2 instead of whether yum content is handled by pulp3