### PR TITLE
Fixes #31406 - Can export library content + incrementals

### DIFF
--- a/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
+++ b/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
@@ -6,10 +6,11 @@ module Katello
     before_action :find_library_export_view, :only => [:library]
     before_action :find_history, :only => [:version, :library]
 
-    api :POST, "/content_export_incrementals/version", N_("Performs an incremental-export of a content view version.  Relevant only for Pulp 3 repositories")
+    api :POST, "/content_export_incrementals/version", N_("Performs an incremental-export of a content view version.")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
-    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
-    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :destination_server, String, :desc => N_("Destination Server name"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
+                                               "no greater than the specified size in megabytes."), :required => false
     param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
                                                  "If not provided the most recent export history will be used."), :required => false
     def version
@@ -22,10 +23,11 @@ module Katello
       respond_for_async :resource => tasks
     end
 
-    api :POST, "/content_export_incrementals/library", N_("Performs an incremental-export of the repositories in library.  Relevant only for Pulp 3 repositories")
+    api :POST, "/content_export_incrementals/library", N_("Performs an incremental-export of the repositories in library.")
     param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
-    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
-    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :destination_server, String, :desc => N_("Destination Server name"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
+                                               "no greater than the specified size in megabytes."), :required => false
     param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
                                                  "If not provided the most recent export history will be used."), :required => false
     def library
@@ -46,7 +48,7 @@ module Katello
     end
 
     def find_library_export_view
-      @view = ::Katello::ContentView.find_library_export_view(destination_server: params[:destination_server],
+      @view = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(destination_server: params[:destination_server],
                                                                 organization: @organization,
                                                                 create_by_default: false)
       if @view.blank?
@@ -57,27 +59,18 @@ module Katello
     end
 
     def find_history
-      if !params[:from_history_id].blank?
+      if params[:from_history_id].present?
         @history = ::Katello::ContentViewVersionExportHistory.find(params[:from_history_id])
         if @history.blank?
-          throw_resource_not_found(name: 'content view version export history',
+          throw_resource_not_found(name: 'export history',
                                    id: params[:from_history_id])
         end
       else
         @history = ::Katello::ContentViewVersionExportHistory.
-                      pick_recent_history(@view,
+                      latest(@view,
                                           destination_server: params[:destination_server])
         if @history.blank?
-          if params[:action] == :library
-            msg = _("Prior content view export history belonging to the library export content view was not found "\
-                    "in organization with id %{id} and destination_server %{server}. "\
-                    "Please choose the full export.") %
-                    {id: @organization.id, server: params[:destination_server]}
-          else
-            msg = _("Prior content view export history belonging to the content view '%{view}' was not found "\
-                    " for the destination_server '%{server}'. Please choose the full export.") %
-                    {view: @view.name, server: params[:destination_server]}
-          end
+          msg = _("No existing export history was found to perform an incremental export. A full export must be performed")
           fail HttpErrors::NotFound, msg
         end
       end

--- a/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
+++ b/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
@@ -1,0 +1,99 @@
+module Katello
+  class Api::V2::ContentExportIncrementalsController < Api::V2::ApiController
+    before_action :fail_if_not_pulp3, :only => [:version, :library]
+    before_action :find_exportable_organization, :only => [:library]
+    before_action :find_exportable_content_view_version, :only => [:version]
+    before_action :find_library_export_view, :only => [:library]
+    before_action :find_history, :only => [:version, :library]
+
+    api :POST, "/content_export_incrementals/version", N_("Performs an incremental-export of a content view version.  Relevant only for Pulp 3 repositories")
+    param :id, :number, :desc => N_("Content view version identifier"), :required => true
+    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
+                                                 "If not provided the most recent export history will be used."), :required => false
+    def version
+      tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
+                          content_view_version: @version,
+                          destination_server: params[:destination_server],
+                          chunk_size: params[:chunk_size_mb],
+                          from_history: @history)
+
+      respond_for_async :resource => tasks
+    end
+
+    api :POST, "/content_export_incrementals/library", N_("Performs an incremental-export of the repositories in library.  Relevant only for Pulp 3 repositories")
+    param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
+    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
+                                                 "If not provided the most recent export history will be used."), :required => false
+    def library
+      tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
+                          @organization,
+                          destination_server: params[:destination_server],
+                          chunk_size: params[:chunk_size_mb],
+                          from_history: @history)
+      respond_for_async :resource => tasks
+    end
+
+    private
+
+    def find_exportable_content_view_version
+      @version = ContentViewVersion.exportable.find_by_id(params[:id])
+      throw_resource_not_found(name: 'content view version', id: params[:id]) if @version.blank?
+      @view = @version.content_view
+    end
+
+    def find_library_export_view
+      @view = ::Katello::ContentView.find_library_export_view(destination_server: params[:destination_server],
+                                                                organization: @organization,
+                                                                create_by_default: false)
+      if @view.blank?
+        msg = _("Unable to incrementally export. Do a Full Export the library content "\
+                "before updating from the latest increment.")
+        fail HttpErrors::BadRequest, msg
+      end
+    end
+
+    def find_history
+      if !params[:from_history_id].blank?
+        @history = ::Katello::ContentViewVersionExportHistory.find(params[:from_history_id])
+        if @history.blank?
+          throw_resource_not_found(name: 'content view version export history',
+                                   id: params[:from_history_id])
+        end
+      else
+        @history = ::Katello::ContentViewVersionExportHistory.
+                      pick_recent_history(@view,
+                                          destination_server: params[:destination_server])
+        if @history.blank?
+          if params[:action] == :library
+            msg = _("Prior content view export history belonging to the library export content view was not found "\
+                    "in organization with id %{id} and destination_server %{server}. "\
+                    "Please choose the full export.") %
+                    {id: @organization.id, server: params[:destination_server]}
+          else
+            msg = _("Prior content view export history belonging to the content view '%{view}' was not found "\
+                    " for the destination_server '%{server}'. Please choose the full export.") %
+                    {view: @view.name, server: params[:destination_server]}
+          end
+          fail HttpErrors::NotFound, msg
+        end
+      end
+    end
+
+    def find_exportable_organization
+      find_organization
+      unless @organization.can_export_library_content?
+        throw_resource_not_found(name: 'organization', id: params[:organization_id])
+      end
+    end
+
+    def fail_if_not_pulp3
+      unless SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE)
+        fail HttpErrors::BadRequest, _("Invalid usage for Pulp 2 repositories. Use export for Yum repositories")
+      end
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -29,10 +29,11 @@ module Katello
       render json: { api_usable: SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE) }, status: :ok
     end
 
-    api :POST, "/content_exports/version", N_("Performs a full-export of a content view version.  Relevant only for Pulp 3 repositories")
+    api :POST, "/content_exports/version", N_("Performs a full-export of a content view version.")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
-    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
-    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :destination_server, String, :desc => N_("Destination Server name"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
+                                               "no greater than the specified size in megabytes."), :required => false
     def version
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
                           content_view_version: @version,
@@ -42,10 +43,11 @@ module Katello
       respond_for_async :resource => tasks
     end
 
-    api :POST, "/content_exports/library", N_("Performs a full-export of the repositories in library.  Relevant only for Pulp 3 repositories")
+    api :POST, "/content_exports/library", N_("Performs a full-export of the repositories in library.")
     param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
-    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
-    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    param :destination_server, String, :desc => N_("Destination Server name"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
+                                               "no greater than the specified size in megabytes."), :required => false
     def library
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
                           @organization,

--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -1,5 +1,7 @@
 module Katello
   class Api::V2::ContentExportsController < Api::V2::ApiController
+    before_action :fail_if_not_pulp3, :only => [:version, :library]
+    before_action :find_exportable_organization, :only => [:library]
     before_action :find_exportable_content_view_version, :only => [:version]
 
     api :GET, "/content_exports", N_("List export histories")
@@ -29,22 +31,26 @@ module Katello
 
     api :POST, "/content_exports/version", N_("Performs a full-export of a content view version.  Relevant only for Pulp 3 repositories")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
-    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => true
+    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
     param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
-    param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export."), :required => false
     def version
-      fail HttpErrors::BadRequest, _("Invalid usage for Pulp 2 repositories. Use export for Yum repositories") unless SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE)
+      tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
+                          content_view_version: @version,
+                          destination_server: params[:destination_server],
+                          chunk_size: params[:chunk_size_mb])
 
-      if params[:destination_server].blank?
-        fail HttpErrors::BadRequest, _("Destination Server Name required for Pulp3 repositories")
-      end
+      respond_for_async :resource => tasks
+    end
 
-      history = ::Katello::ContentViewVersionExportHistory.find(params[:from_history_id]) unless params[:from_history_id].blank?
-
-      tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @version, destination_server: params[:destination_server],
-                                                                                         chunk_size: params[:chunk_size_mb],
-                                                                                         from_history: history)
-
+    api :POST, "/content_exports/library", N_("Performs a full-export of the repositories in library.  Relevant only for Pulp 3 repositories")
+    param :organization_id, :number, :desc => N_("Organization identifier"), :required => true
+    param :destination_server, String, :desc => N_("Destination Server name, required for Pulp3"), :required => false
+    param :chunk_size_mb, :number, :desc => N_("Chunk export-tarfile into pieces of chunk_size mega bytes."), :required => false
+    def library
+      tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
+                          @organization,
+                          destination_server: params[:destination_server],
+                          chunk_size: params[:chunk_size_mb])
       respond_for_async :resource => tasks
     end
 
@@ -53,6 +59,19 @@ module Katello
     def find_exportable_content_view_version
       @version = ContentViewVersion.exportable.find_by_id(params[:id])
       throw_resource_not_found(name: 'content view version', id: params[:id]) if @version.blank?
+    end
+
+    def find_exportable_organization
+      find_organization
+      unless @organization.can_export_library_content?
+        throw_resource_not_found(name: 'organization', id: params[:organization_id])
+      end
+    end
+
+    def fail_if_not_pulp3
+      unless SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE)
+        fail HttpErrors::BadRequest, _("Invalid usage for Pulp 2 repositories. Use export for Yum repositories")
+      end
     end
   end
 end

--- a/app/lib/actions/katello/content_view_version/import_library.rb
+++ b/app/lib/actions/katello/content_view_version/import_library.rb
@@ -4,63 +4,12 @@ module Actions
       class ImportLibrary < Actions::EntryAction
         def plan(organization, path:, metadata:)
           action_subject(organization)
-          unless SmartProxy.pulp_primary.pulp3_repository_type_support?(::Katello::Repository::YUM_TYPE)
-            fail _("This action will become available after the Pulp 3 content migration")
-          end
-          ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: organization.default_content_view, metadata: metadata, path: path)
-
-          version = organization.default_content_view_version
-          history = ::Katello::ContentViewHistory.create!(:content_view_version => version,
-            :user => ::User.current.login,
-            :status => ::Katello::ContentViewHistory::IN_PROGRESS,
-            :action => ::Katello::ContentViewHistory.actions[:importing],
-            :task => self.task)
-
-          sequence do
-            plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Import, version, path: path, metadata: metadata)
-            concurrence do
-              version.importable_repositories.each do |repo|
-                sequence do
-                  plan_action(Actions::Pulp3::Repository::SaveVersion, repo)
-                  plan_action(Katello::Repository::MetadataGenerate, repo, :force => true)
-                  plan_action(Katello::Repository::IndexContent, id: repo.id)
-                end
-              end
-            end
-            plan_self(history_id: history.id, organization_id: organization.id)
-          end
+          library_view = ::Katello::Pulp3::ContentViewVersion::Import.find_or_create_library_import_view(organization)
+          plan_action(::Actions::Katello::ContentViewVersion::Import, library_view, path: path, metadata: metadata)
         end
 
         def humanized_name
           _("Import Default Content View")
-        end
-
-        def rescue_strategy_for_self
-          Dynflow::Action::Rescue::Skip
-        end
-
-        def finalize
-          org = ::Organization.find(input[:organization_id])
-          environment = org.library
-          view = org.default_content_view
-          version = org.default_content_view_version
-          version.update_content_counts!
-          # update errata applicability counts for all hosts in the CV & Library
-          ::Katello::Host::ContentFacet.where(:content_view_id => view.id,
-                                              :lifecycle_environment_id => environment.id).each do |facet|
-            facet.update_applicability_counts
-            facet.update_errata_status
-          end
-          ::Katello::ContentViewHistory.where(id: input[:history_id]).
-            update_all(status: ::Katello::ContentViewHistory::SUCCESSFUL)
-
-          if SmartProxy.sync_needed?(environment)
-            ForemanTasks.async_task(ContentView::CapsuleSync,
-                                    view,
-                                    environment)
-          end
-        rescue ::Katello::Errors::CapsuleCannotBeReached => e # skip any capsules that cannot be connected to
-          Rails.logger.warn e.to_s
         end
       end
     end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
@@ -9,7 +9,8 @@ module Actions
                 sequence do
                   copy_action = plan_action(Actions::Pulp3::Repository::CopyContent, repo, SmartProxy.pulp_primary!,
                                                     repo.library_instance,
-                                                    copy_all: true)
+                                                    copy_all: true,
+                                                    mirror: content_view_version.content_view.library_import?)
                   plan_action(Actions::Pulp3::Repository::SaveVersion, repo.library_instance,
                                 tasks: copy_action.output[:pulp_tasks])
                   plan_action(Katello::Repository::IndexContent, id: repo.library_instance_id)

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export.rb
@@ -20,7 +20,6 @@ module Actions
           # rubocop:disable Metrics/MethodLength
           def plan(content_view_version:, destination_server: nil,
                    chunk_size: nil, from_history: nil, validate_incremental: true)
-            content_view_version = ::Katello::ContentViewVersion.find(content_view_version) if content_view_version.is_a? Integer
             action_subject(content_view_version)
             unless File.directory?(Setting['pulpcore_export_destination'])
               fail ::Foreman::Exception, N_("Unable to export. 'pulpcore_export_destination' setting is not set to a valid directory.")

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -5,7 +5,7 @@ module Actions
         class ExportLibrary < Actions::EntryAction
           def plan(organization, destination_server: nil, chunk_size: nil, from_history: nil)
             action_subject(organization)
-            content_view = ::Katello::ContentView.find_library_export_view(destination_server: destination_server,
+            content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(destination_server: destination_server,
                                                                            organization: organization,
                                                                            create_by_default: true)
             repo_ids_in_library = organization.default_content_view_version.repositories.yum_type.pluck(:id)

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -8,7 +8,8 @@ module Actions
             content_view = ::Katello::ContentView.find_library_export_view(destination_server: destination_server,
                                                                            organization: organization,
                                                                            create_by_default: true)
-            content_view.update!(repository_ids: organization.default_content_view_version.repository_ids)
+            repo_ids_in_library = organization.default_content_view_version.repositories.yum_type.pluck(:id)
+            content_view.update!(repository_ids: repo_ids_in_library)
 
             sequence do
               publish_action = plan_action(::Actions::Katello::ContentView::Publish, content_view, '')

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -1,0 +1,40 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module ContentViewVersion
+        class ExportLibrary < Actions::EntryAction
+          def plan(organization, destination_server: nil, chunk_size: nil, from_history: nil)
+            action_subject(organization)
+            content_view = ::Katello::ContentView.find_library_export_view(destination_server: destination_server,
+                                                                           organization: organization,
+                                                                           create_by_default: true)
+            content_view.update!(repository_ids: organization.default_content_view_version.repository_ids)
+
+            sequence do
+              publish_action = plan_action(::Actions::Katello::ContentView::Publish, content_view, '')
+              export_action = plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
+                                          content_view_version: publish_action.version,
+                                          destination_server: destination_server,
+                                          chunk_size: chunk_size,
+                                          from_history: from_history,
+                                          validate_incremental: false)
+              plan_self(export_action_output: export_action.output)
+            end
+          end
+
+          def run
+            output[:export_history_id] = input[:export_action_output][:export_history_id]
+          end
+
+          def humanized_name
+            _("Export Library")
+          end
+
+          def rescue_strategy
+            Dynflow::Action::Rescue::Skip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/copy_content.rb
+++ b/app/lib/actions/pulp3/repository/copy_content.rb
@@ -13,7 +13,7 @@ module Actions
           target = ::Katello::Repository.find(input[:target_repository_id] || input[:target_repository])
           service = target.backend_service(smart_proxy)
           output[:pulp_tasks] = if input[:copy_all]
-                                  service.copy_all(source)
+                                  service.copy_all(source, mirror: input[:mirror] || false)
                                 else
                                   service.copy_content_for_source(source, input)
                                 end

--- a/app/models/katello/authorization/organization.rb
+++ b/app/models/katello/authorization/organization.rb
@@ -16,6 +16,10 @@ module Katello
       authorized?(:import_library_content)
     end
 
+    def can_export_library_content?
+      authorized?(:export_library_content)
+    end
+
     def readable_promotion_paths
       permissible_promotion_paths(KTEnvironment.readable)
     end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -8,6 +8,7 @@ module Katello
     include ForemanTasks::Concerns::ActionSubject
 
     CONTENT_DIR = "content_views".freeze
+    IMPORT_LIBRARY = "Import-Library".freeze
 
     belongs_to :organization, :inverse_of => :content_views, :class_name => "::Organization"
 
@@ -100,6 +101,10 @@ module Katello
 
     def to_s
       name
+    end
+
+    def library_import?
+      name == IMPORT_LIBRARY
     end
 
     def content_host_count

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -98,15 +98,6 @@ module Katello
       joins(:content_view_versions => :repositories).where("katello_repositories.root_id" => root_repository.id).uniq
     end
 
-    def self.find_library_export_view(create_by_default: false,
-                                      destination_server:,
-                                      organization:)
-      name = "Export-Library"
-      name += "-#{destination_server}" unless destination_server.blank?
-      select_method = create_by_default ? :first_or_create : :first
-      where(name: name, organization: organization).send(select_method)
-    end
-
     def to_s
       name
     end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -98,6 +98,15 @@ module Katello
       joins(:content_view_versions => :repositories).where("katello_repositories.root_id" => root_repository.id).uniq
     end
 
+    def self.find_library_export_view(create_by_default: false,
+                                      destination_server:,
+                                      organization:)
+      name = "Export-Library"
+      name += "-#{destination_server}" unless destination_server.blank?
+      select_method = create_by_default ? :first_or_create : :first
+      where(name: name, organization: organization).send(select_method)
+    end
+
     def to_s
       name
     end

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -21,10 +21,9 @@ module Katello
     scoped_search :on => :content_view_version_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
-    def self.pick_recent_history(content_view, destination_server: nil)
-      recent_history_id = where(content_view_version: content_view.versions,
-                                destination_server: destination_server).maximum(:id)
-      find(recent_history_id) unless recent_history_id.blank?
+    def self.latest(content_view, destination_server: nil)
+      where(content_view_version: content_view.versions,
+            destination_server: destination_server).order(:created_at).last
     end
   end
 end

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -5,7 +5,7 @@ module Katello
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :inverse_of => :export_histories
     validates_lengths_from_database
     validates :content_view_version_id, :presence => true
-    validates :destination_server, :presence => true, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
+    validates :destination_server, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
     validates :metadata, :presence => true
     serialize :metadata, Hash
 
@@ -20,5 +20,11 @@ module Katello
     scoped_search :on => :content_view_id, :relation => :content_view_version, :validator => ScopedSearch::Validators::INTEGER, :only_explicit => true
     scoped_search :on => :content_view_version_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+
+    def self.pick_recent_history(content_view, destination_server: nil)
+      recent_history_id = where(content_view_version: content_view.versions,
+                                destination_server: destination_server).maximum(:id)
+      find(recent_history_id) unless recent_history_id.blank?
+    end
   end
 end

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -99,7 +99,8 @@ module Katello
           ret = { organization: @content_view_version.organization.name,
                   repository_mapping: {},
                   content_view: @content_view_version.content_view.name,
-                  content_view_version: @content_view_version.slice(:major, :minor)
+                  content_view_version: @content_view_version.slice(:major, :minor),
+                  incremental: @from_content_view_version.present?
           }
 
           unless @from_content_view_version.blank?

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -121,6 +121,15 @@ module Katello
           end
           ret
         end
+
+        def self.find_library_export_view(create_by_default: false,
+                                          destination_server:,
+                                          organization:)
+          name = "Export-Library"
+          name += "-#{destination_server}" unless destination_server.blank?
+          select_method = create_by_default ? :first_or_create : :first
+          ::Katello::ContentView.where(name: name, organization: organization).send(select_method)
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -79,6 +79,13 @@ module Katello
           end
           content_view.update!(repository_ids: repo_ids)
         end
+
+        def self.find_or_create_library_import_view(organization)
+          name = ::Katello::ContentView::IMPORT_LIBRARY
+          ::Katello::ContentView.where(name: name,
+                                       organization: organization,
+                                       import_only: true).first_or_create
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -207,14 +207,20 @@ module Katello
           tasks
         end
 
-        def copy_all(source_repository)
-          data = PulpRpmClient::Copy.new
-          data.config = [{
-            source_repo_version: source_repository.version_href,
-            dest_repo: repository_reference.repository_href
-          }]
+        def copy_all(source_repository, mirror: false)
+          if mirror
+            data = PulpRpmClient::RepositoryAddRemoveContent.new(
+                      base_version: source_repository.version_href)
 
-          [api.copy_api.copy_content(data)]
+            [api.repositories_api.modify(repository_reference.repository_href, data)]
+          else
+            data = PulpRpmClient::Copy.new
+            data.config = [{
+              source_repo_version: source_repository.version_href,
+              dest_repo: repository_reference.repository_href
+            }]
+            [api.copy_api.copy_content(data)]
+          end
         end
 
         def remove_all_content_from_repo(repo_href)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -116,8 +116,16 @@ Katello::Engine.routes.draw do
         api_resources :content_exports, :only => [] do
           collection do
             post :version
+            post :library
             get :index
             get :api_status
+          end
+        end
+
+        api_resources :content_export_incrementals, :only => [] do
+          collection do
+            post :version
+            post :library
           end
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -156,7 +156,8 @@ module Katello
       @plugin.permission :export_content_views,
                          {
                            'katello/api/v2/content_view_versions' => [:export],
-                           'katello/api/v2/content_exports' => [:version, :index, :api_status]
+                           'katello/api/v2/content_exports' => [:version, :index, :api_status],
+                           'katello/api/v2/content_export_incrementals' => [:version]
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :exportable
@@ -426,6 +427,13 @@ module Katello
       @plugin.permission :import_library_content,
                          {
                            'katello/api/v2/content_imports' => [:library]
+                         },
+                         :resource_type => 'Organization'
+
+      @plugin.permission :export_library_content,
+                         {
+                           'katello/api/v2/content_exports' => [:library],
+                           'katello/api/v2/content_export_incrementals' => [:library]
                          },
                          :resource_type => 'Organization'
     end

--- a/test/actions/katello/content_view_version/import_library_test.rb
+++ b/test/actions/katello/content_view_version/import_library_test.rb
@@ -6,7 +6,6 @@ module ::Actions::Katello::ContentViewVersion
     include Support::Actions::Fixtures
     include FactoryBot::Syntax::Methods
     include Support::Actions::RemoteAction
-    include Support::ExportSupport
     let(:action_class) do
       ::Actions::Katello::ContentViewVersion::ImportLibrary
     end
@@ -17,10 +16,6 @@ module ::Actions::Katello::ContentViewVersion
 
     let(:organization) do
       get_organization
-    end
-
-    let(:content_view) do
-      organization.default_content_view
     end
 
     let(:content_view_version) do
@@ -44,6 +39,10 @@ module ::Actions::Katello::ContentViewVersion
       }.with_indifferent_access
     end
 
+    let(:path) do
+      "/tmp/foo"
+    end
+
     def setup_proxy
       proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
       SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
@@ -52,43 +51,41 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     before do
-      set_user
+      setup_proxy
       SmartProxy.any_instance.stubs(:ping_pulp).returns({})
       SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
       SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
       ::Katello::Repository.any_instance.stubs(:pulp_scratchpad_checksum_type).returns(nil)
-      setup_proxy
     end
 
     describe 'Import Default' do
-      it 'should plan the full tree appropriately' do
-        path = File.join(Katello::Engine.root, 'test/fixtures/import-export')
-        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view, metadata: metadata, path: path).returns
+      it 'should plan properly' do
+        assert_nil ::Katello::ContentView.where(organization: organization,
+                                                name: ::Katello::ContentView::IMPORT_LIBRARY).first
+        action_class.any_instance.expects(:action_subject).with(organization)
+        plan_action(action, organization, path: path, metadata: metadata)
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Import) do |view, options|
+          assert view.library_import?
+          assert view.import_only?
+          assert_equal options[:metadata], metadata
+          assert_equal options[:path], path
+        end
+      end
 
-        generated_cvv = nil
+      it 'should plan the full tree appropriately' do
+        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!)
         tree = plan_action_tree(action_class, organization, path: path, metadata: metadata)
 
         assert_empty tree.errors
-        assert_tree_planned_steps(tree, Actions::Pulp3::Orchestration::ContentViewVersion::Import)
-
-        assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::CreateImporter) do |input|
-          assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-          assert_equal path, input[:path]
-          generated_cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
-          assert_equal content_view_version.content_view.id, generated_cvv.content_view.id
-          assert_equal metadata[:content_view_version][:major], generated_cvv.major
-          assert_equal metadata[:content_view_version][:minor], generated_cvv.minor
+        assert_tree_planned_with(tree, Actions::Pulp3::Repository::CopyContent) do |input|
+          assert input[:copy_all]
+          assert input[:mirror]
+          refute_nil input[:source_repository_id]
+          refute_nil input[:target_repository_id]
+          refute_nil input[:smart_proxy_id]
         end
-
-        assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::Import) do |input|
-          assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-          assert_equal path, input[:path]
-          assert_equal generated_cvv.id, input[:content_view_version_id]
-          refute_nil input[:importer_data]
-        end
-        assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::DestroyImporter)
       end
     end
   end

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -63,6 +63,7 @@ module ::Actions::Katello::ContentViewVersion
       setup_proxy
       content_view.import_only = true
     end
+
     describe 'Import' do
       it 'should fail on importing content for an existing versions' do
         path = @import_export_dir

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -40,6 +40,10 @@ module ::Actions::Katello::ContentViewVersion
       }.with_indifferent_access
     end
 
+    let(:path) do
+      "/tmp/foo"
+    end
+
     def setup_proxy
       proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
       SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
@@ -66,7 +70,6 @@ module ::Actions::Katello::ContentViewVersion
 
     describe 'Import' do
       it 'should fail on importing content for an existing versions' do
-        path = @import_export_dir
         ::Katello::Pulp3::ContentViewVersion::ImportValidator.any_instance.expects(:check_permissions!).returns
 
         exception = assert_raises(RuntimeError) do
@@ -77,10 +80,9 @@ module ::Actions::Katello::ContentViewVersion
 
       it 'should plan properly' do
         metadata[:content_view_version][:major] += 10
-        path = @import_export_dir
         ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view, metadata: metadata, path: path).returns
 
-        plan_action(action, content_view, path: @import_export_dir, metadata: metadata)
+        plan_action(action, content_view, path: path, metadata: metadata)
         assert_action_planned_with(action,
                                     ::Actions::Katello::ContentView::Publish,
                                     content_view, '',
@@ -92,7 +94,6 @@ module ::Actions::Katello::ContentViewVersion
       end
 
       it 'should plan the full tree appropriately' do
-        path = @import_export_dir
         ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view, metadata: metadata, path: path).returns
 
         metadata[:content_view_version][:major] += 10
@@ -107,7 +108,7 @@ module ::Actions::Katello::ContentViewVersion
 
         assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::CreateImporter) do |input|
           assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-          assert_equal @import_export_dir, input[:path]
+          assert_equal path, input[:path]
           generated_cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
           assert_equal content_view_version.content_view.id, generated_cvv.content_view.id
           assert_equal metadata[:content_view_version][:major], generated_cvv.major
@@ -116,7 +117,7 @@ module ::Actions::Katello::ContentViewVersion
 
         assert_tree_planned_with(tree, Actions::Pulp3::ContentViewVersion::Import) do |input|
           assert_equal SmartProxy.pulp_primary.id, input[:smart_proxy_id]
-          assert_equal @import_export_dir, input[:path]
+          assert_equal path, input[:path]
           assert_equal generated_cvv.id, input[:content_view_version_id]
           refute_nil input[:importer_data]
         end
@@ -124,6 +125,7 @@ module ::Actions::Katello::ContentViewVersion
 
         assert_tree_planned_with(tree, Actions::Pulp3::Repository::CopyContent) do |input|
           assert input[:copy_all]
+          refute input[:mirror]
           refute_nil input[:source_repository_id]
           refute_nil input[:target_repository_id]
           refute_nil input[:smart_proxy_id]

--- a/test/actions/pulp3/content_view_version/export_library_test.rb
+++ b/test/actions/pulp3/content_view_version/export_library_test.rb
@@ -1,0 +1,47 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::ContentView
+  class ExportLibraryTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+    include Support::Actions::RemoteAction
+
+    let(:action_class) do
+      ::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary
+    end
+
+    let(:action) do
+      create_action action_class
+    end
+
+    let(:version) do
+      katello_content_view_versions(:library_view_version_1)
+    end
+
+    let(:organization) do
+      version.organization
+    end
+
+    let(:destination_server) do
+      "example.com"
+    end
+
+    it 'should plan properly' do
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:version).returns(version)
+      action_class.any_instance.expects(:action_subject).with(organization)
+      repo_ids_in_library = organization.default_content_view_version.repositories.yum_type.pluck(:id)
+
+      plan_action(action, organization, destination_server: destination_server)
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Publish) do |content_view, _|
+        assert_equal content_view.name, "Export-Library-#{destination_server}"
+        assert_equal content_view.repository_ids.sort, repo_ids_in_library.sort
+      end
+
+      assert_action_planned_with(action, ::Actions::Pulp3::Orchestration::ContentViewVersion::Export) do |**options|
+        assert_equal version, options[:content_view_version]
+        assert_equal destination_server, options[:destination_server]
+      end
+    end
+  end
+end

--- a/test/actions/pulp3/content_view_version/export_test.rb
+++ b/test/actions/pulp3/content_view_version/export_test.rb
@@ -60,7 +60,10 @@ module ::Actions::Pulp3::ContentView
       Actions::Pulp3::Orchestration::ContentViewVersion::Export.any_instance.expects(:action_subject).with(@content_view_version)
       File.expects(:directory?).returns(true).at_least_once
 
-      output = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, @content_view_version, destination_server: "foo", chunk_size: 0.1).output
+      output = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
+                                       content_view_version: @content_view_version,
+                                       destination_server: "foo",
+                                       chunk_size: 0.1).output
 
       export_history = Katello::ContentViewVersionExportHistory.find_by(content_view_version_id: @content_view_version.id, destination_server: 'foo')
 

--- a/test/controllers/api/v2/content_export_incrementals_controller_test.rb
+++ b/test/controllers/api/v2/content_export_incrementals_controller_test.rb
@@ -1,0 +1,182 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::ContentExportIncrementalsControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+
+    def permissions
+      @view_permission = :view_content_views
+      @create_permission = :create_content_views
+      @update_permission = :edit_content_views
+      @destroy_permission = :destroy_content_views
+      @export_permission = :export_content_views
+      @export_library_permission = :export_library_content
+    end
+
+    def setup
+      setup_controller_defaults_api
+      @library_dev_staging_view = ContentView.find(katello_content_views(:library_dev_staging_view).id)
+      @library_view_version = katello_content_view_versions(:library_dev_staging_view_version)
+      permissions
+    end
+
+    def test_export_with_pulp2repo_fail
+      SmartProxy.stubs(:pulp_primary).returns(FactoryBot.create(:smart_proxy, :default_smart_proxy))
+
+      version = @library_dev_staging_view.versions.first
+      post :version, params: { :id => version.id, :iso_mb_size => 5, :export_to_iso => "foo"}
+      response = JSON.parse(@response.body)['displayMessage']
+      assert_equal response, 'Invalid usage for Pulp 2 repositories. Use export for Yum repositories'
+      assert_response :bad_request
+    end
+
+    def test_version_protected
+      @controller.stubs(:fail_if_not_pulp3)
+      @controller.stubs(:find_library_export_view)
+      @controller.stubs(:find_history)
+
+      allowed_perms = [@export_permission]
+      denied_perms = [@create_permission, @update_permission,
+                      @destroy_permission, @view_permission]
+      version = @library_dev_staging_view.versions.first
+
+      assert_protected_action(:version, allowed_perms, denied_perms) do
+        post :version, params: { :id => version.id }
+      end
+    end
+
+    def test_library_protected
+      @controller.stubs(:fail_if_not_pulp3)
+      @controller.stubs(:find_library_export_view)
+      @controller.stubs(:find_history)
+
+      allowed_perms = [{name: @export_library_permission, :resource_type => "Organization"}]
+      denied_perms = [@create_permission, @update_permission,
+                      @destroy_permission, @view_permission, @export_permission]
+
+      org = get_organization
+      assert_protected_action(:library, allowed_perms, denied_perms, [org]) do
+        post :library, params: { organization_id: org.id}
+      end
+    end
+
+    def test_version_recent_history
+      @controller.stubs(:fail_if_not_pulp3)
+      chunk_size_mb = 100
+      destination = "example.com"
+      history = {foo: 100}
+      ContentViewVersionExportHistory.expects(:pick_recent_history)
+                                     .with(@library_view_version.content_view,
+                                           destination_server: destination)
+                                     .returns(history)
+      export_task = @controller.expects(:async_task).with do |action_class, options|
+        assert_equal ::Actions::Pulp3::Orchestration::ContentViewVersion::Export, action_class
+        assert_equal options[:content_view_version].id, @library_view_version.id
+        assert_equal options[:destination_server], destination
+        assert_equal options[:chunk_size], chunk_size_mb
+        assert_equal options[:from_history], history
+      end
+      export_task.returns(build_task_stub)
+      post :version, params: { id: @library_view_version.id,
+                               destination_server: destination,
+                               chunk_size_mb: chunk_size_mb
+                             }
+      assert_response :success
+    end
+
+    def test_version_recent_history_with_history_id
+      @controller.stubs(:fail_if_not_pulp3)
+      chunk_size_mb = 100
+      destination = "example.com"
+      history = {id: 100}
+      ContentViewVersionExportHistory.expects(:find)
+                                     .with(history[:id])
+                                     .returns(history)
+
+      export_task = @controller.expects(:async_task).with do |action_class, options|
+        assert_equal ::Actions::Pulp3::Orchestration::ContentViewVersion::Export, action_class
+        assert_equal options[:content_view_version].id, @library_view_version.id
+        assert_equal options[:destination_server], destination
+        assert_equal options[:chunk_size], chunk_size_mb
+        assert_equal options[:from_history], history
+      end
+      export_task.returns(build_task_stub)
+      post :version, params: { id: @library_view_version.id,
+                               destination_server: destination,
+                               chunk_size_mb: chunk_size_mb,
+                               from_history_id: history[:id]
+                             }
+      assert_response :success
+    end
+
+    def test_version_not_found_on_incremental
+      @controller.stubs(:fail_if_not_pulp3)
+      destination = "example.com"
+
+      ContentViewVersionExportHistory.expects(:pick_recent_history)
+                                     .with(@library_view_version.content_view,
+                                           destination_server: destination)
+                                     .returns
+
+      post :version, params: { id: @library_view_version.id,
+                               destination_server: destination
+                             }
+      response = JSON.parse(@response.body)['displayMessage']
+      assert_match(%r{Prior content view export history belonging to the content view '.*' was not found}, response)
+      assert_response :not_found
+    end
+
+    def test_library
+      @controller.stubs(:fail_if_not_pulp3)
+      org = get_organization
+      chunk_size_mb = 100
+      destination = "example.com"
+      history = {foo: 100}
+      ContentView.expects(:find_library_export_view)
+                 .with(create_by_default: false,
+                       destination_server: destination,
+                       organization: org)
+                 .returns(@library_dev_staging_view)
+
+      ContentViewVersionExportHistory.expects(:pick_recent_history)
+                                     .with(@library_dev_staging_view,
+                                           destination_server: destination)
+                                     .returns(history)
+
+      export_task = @controller.expects(:async_task).with do |action_class, organization, options|
+        assert_equal ::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary, action_class
+        assert_equal organization.id, org.id
+        assert_equal options[:destination_server], destination
+        assert_equal options[:chunk_size], chunk_size_mb
+        assert_equal options[:from_history], history
+      end
+      export_task.returns(build_task_stub)
+      post :library, params: { organization_id: org.id,
+                               destination_server: destination,
+                               chunk_size_mb: chunk_size_mb
+                             }
+      assert_response :success
+    end
+
+    def test_library_bad_request_on_incremental
+      @controller.stubs(:fail_if_not_pulp3)
+      org = get_organization
+      post :library, params: { organization_id: org.id,
+                               from_latest_increment: true
+                             }
+      response = JSON.parse(@response.body)['displayMessage']
+      assert_match(/Unable to incrementally export/, response)
+      assert_response :bad_request
+    end
+
+    def test_library_not_found_on_incremental
+      @controller.stubs(:fail_if_not_pulp3)
+      org = get_organization
+      post :library, params: { organization_id: org.id,
+                               from_latest_increment: true }
+      response = JSON.parse(@response.body)['displayMessage']
+      assert_match(/Unable to incrementally export/, response)
+      assert_response :bad_request
+    end
+  end
+end

--- a/test/controllers/api/v2/content_export_incrementals_controller_test.rb
+++ b/test/controllers/api/v2/content_export_incrementals_controller_test.rb
@@ -65,7 +65,7 @@ module Katello
       chunk_size_mb = 100
       destination = "example.com"
       history = {foo: 100}
-      ContentViewVersionExportHistory.expects(:pick_recent_history)
+      ContentViewVersionExportHistory.expects(:latest)
                                      .with(@library_view_version.content_view,
                                            destination_server: destination)
                                      .returns(history)
@@ -113,7 +113,7 @@ module Katello
       @controller.stubs(:fail_if_not_pulp3)
       destination = "example.com"
 
-      ContentViewVersionExportHistory.expects(:pick_recent_history)
+      ContentViewVersionExportHistory.expects(:latest)
                                      .with(@library_view_version.content_view,
                                            destination_server: destination)
                                      .returns
@@ -122,7 +122,7 @@ module Katello
                                destination_server: destination
                              }
       response = JSON.parse(@response.body)['displayMessage']
-      assert_match(%r{Prior content view export history belonging to the content view '.*' was not found}, response)
+      assert_match(%r{No existing export history was found to perform an incremental export}, response)
       assert_response :not_found
     end
 
@@ -132,13 +132,14 @@ module Katello
       chunk_size_mb = 100
       destination = "example.com"
       history = {foo: 100}
-      ContentView.expects(:find_library_export_view)
+      ::Katello::Pulp3::ContentViewVersion::Export
+                 .expects(:find_library_export_view)
                  .with(create_by_default: false,
                        destination_server: destination,
                        organization: org)
                  .returns(@library_dev_staging_view)
 
-      ContentViewVersionExportHistory.expects(:pick_recent_history)
+      ContentViewVersionExportHistory.expects(:latest)
                                      .with(@library_dev_staging_view,
                                            destination_server: destination)
                                      .returns(history)

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -672,5 +672,18 @@ module Katello
       cv.import_only = false
       refute cv.valid?
     end
+
+    def test_find_library_export_view
+      org =  get_organization
+      assert_nil ContentView.find_library_export_view(organization: org,
+                                                      create_by_default: false,
+                                                      destination_server: nil)
+      # now create it
+      destination_server = "example.com"
+      cv = ContentView.find_library_export_view(organization: org,
+                                                  create_by_default: true,
+                                                  destination_server: destination_server)
+      assert_equal cv.name, "Export-Library-#{destination_server}"
+    end
   end
 end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -672,18 +672,5 @@ module Katello
       cv.import_only = false
       refute cv.valid?
     end
-
-    def test_find_library_export_view
-      org =  get_organization
-      assert_nil ContentView.find_library_export_view(organization: org,
-                                                      create_by_default: false,
-                                                      destination_server: nil)
-      # now create it
-      destination_server = "example.com"
-      cv = ContentView.find_library_export_view(organization: org,
-                                                  create_by_default: true,
-                                                  destination_server: destination_server)
-      assert_equal cv.name, "Export-Library-#{destination_server}"
-    end
   end
 end

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -28,5 +28,22 @@ module Katello
                                                                 path: path)
       end
     end
+
+    def test_pick_recent_history_nil_if_no_history
+      assert_empty ContentViewVersionExportHistory.pick_recent_history(@cvv.content_view)
+    end
+
+    def test_pick_recent_history
+      content_view = @cvv.content_view
+      destination = "greatest"
+      path = "/tmp"
+      history = ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                        destination_server: destination,
+                                                        metadata: {foo: :bar},
+                                                        path: path)
+      assert_equal history, ContentViewVersionExportHistory.pick_recent_history(content_view,
+                                                                                destination_server: destination)
+      assert_nil ContentViewVersionExportHistory.pick_recent_history(@cvv.content_view)
+    end
   end
 end

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -29,11 +29,11 @@ module Katello
       end
     end
 
-    def test_pick_recent_history_nil_if_no_history
-      assert_empty ContentViewVersionExportHistory.pick_recent_history(@cvv.content_view)
+    def test_latest_nil_if_no_history
+      assert_empty ContentViewVersionExportHistory.latest(@cvv.content_view)
     end
 
-    def test_pick_recent_history
+    def test_latest
       content_view = @cvv.content_view
       destination = "greatest"
       path = "/tmp"
@@ -41,9 +41,9 @@ module Katello
                                                         destination_server: destination,
                                                         metadata: {foo: :bar},
                                                         path: path)
-      assert_equal history, ContentViewVersionExportHistory.pick_recent_history(content_view,
+      assert_equal history, ContentViewVersionExportHistory.latest(content_view,
                                                                                 destination_server: destination)
-      assert_nil ContentViewVersionExportHistory.pick_recent_history(@cvv.content_view)
+      assert_nil ContentViewVersionExportHistory.latest(@cvv.content_view)
     end
   end
 end

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -51,6 +51,19 @@ module Katello
             end
             assert_match(/cannot be incrementally updated/, exception.message)
           end
+
+          it 'finds the library export view correctly' do
+            org = get_organization
+            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
+                                                            create_by_default: false,
+                                                            destination_server: nil)
+            # now create it
+            destination_server = "example.com"
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
+                                                        create_by_default: true,
+                                                        destination_server: destination_server)
+            assert_equal cv.name, "Export-Library-#{destination_server}"
+          end
         end
       end
     end


### PR DESCRIPTION
This commit
1) Adds an API endpoint to export the Library content.
2) Adds an API endpoint for Incremental Export for both library and
   version.
3) Makes destination server and history id optional