### PR TITLE
Fixes #31409 - Update pagination to use hook instead of context

### DIFF
--- a/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
+++ b/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
@@ -1,3 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
 export const useForemanSettings = () => ({ perPage: 20 });
-export const usePaginationOptions = () => [5, 10, 20, 50];

--- a/webpack/__mocks__/foremanReact/components/Pagination/PaginationHooks.js
+++ b/webpack/__mocks__/foremanReact/components/Pagination/PaginationHooks.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const usePaginationOptions = () => [5, 10, 20, 50];

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -3,7 +3,8 @@ import { Pagination, Flex, FlexItem } from '@patternfly/react-core';
 
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { usePaginationOptions, useForemanSettings } from 'foremanReact/Root/Context/ForemanContext';
+import { useForemanSettings } from 'foremanReact/Root/Context/ForemanContext';
+import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
 
 import MainTable from './MainTable';
 import Search from '../../components/Search';


### PR DESCRIPTION
Foreman is moving the pagination options to be completely client-side
and provided via a hook rather than part of the foreman context,
updating the katello usage accordingly.