### PR TITLE
Fixes #30867 - Tag a manifest from hammer (pulp3)

### DIFF
--- a/app/lib/actions/pulp3/repository/upload_tag.rb
+++ b/app/lib/actions/pulp3/repository/upload_tag.rb
@@ -1,0 +1,18 @@
+module Actions
+  module Pulp3
+    module Repository
+      class UploadTag < Pulp3::AbstractAsyncTask
+        def plan(repository, smart_proxy, args)
+          plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :args => args)
+        end
+
+        def invoke_external_task
+          repo = ::Katello::Repository.find(input[:repository_id])
+          tag_name = input[:args].dig(:unit_key, :name)
+          manifest_digest = input[:args].dig(:unit_key, :digest)
+          output[:pulp_tasks] = [repo.backend_service(smart_proxy).tag_manifest(tag_name, manifest_digest)]
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/docker.rb
+++ b/app/services/katello/pulp3/api/docker.rb
@@ -32,6 +32,10 @@ module Katello
           PulpContainerClient::RecursiveManage
         end
 
+        def self.tag_image_class
+          PulpContainerClient::TagImage
+        end
+
         def api_client
           PulpContainerClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpContainerClient::Configuration))
         end

--- a/app/services/katello/pulp3/docker_manifest.rb
+++ b/app/services/katello/pulp3/docker_manifest.rb
@@ -2,6 +2,7 @@ module Katello
   module Pulp3
     class DockerManifest < PulpContentUnit
       include LazyAccessor
+      CONTENT_TYPE = "docker_manifest".freeze
 
       def self.content_api
         PulpContainerClient::ContentManifestsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_primary!).api_client)

--- a/app/services/katello/pulp3/docker_tag.rb
+++ b/app/services/katello/pulp3/docker_tag.rb
@@ -2,6 +2,7 @@ module Katello
   module Pulp3
     class DockerTag < PulpContentUnit
       include LazyAccessor
+      CONTENT_TYPE = "docker_tag".freeze
 
       def self.content_api
         PulpContainerClient::ContentTagsApi.new(Katello::Pulp3::Api::Docker.new(SmartProxy.pulp_primary!).api_client)

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -52,6 +52,11 @@ module Katello
                                       api.class.recursive_manage_class.new(content_units: options[:remove_content_units]))
         end
 
+        def tag_manifest(name, digest)
+          api.repositories_api.tag(repository_reference.repository_href,
+                                   api.class.tag_image_class.new(tag: name, digest: digest))
+        end
+
         def add_content(content_unit_href)
           content_unit_href = [content_unit_href] unless content_unit_href.is_a?(Array)
           api.repositories_api.add(repository_reference.repository_href, content_units: content_unit_href)


### PR DESCRIPTION
To test:

Create a docker repository fedora/ssh for example and sync
From hammer, try adding a new tag.
hammer -d repository update --id $repo_id --organization-id $org_id --docker-tag some_name --docker-digest sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e

This should create a new tag some_name in the repository.