### PR TITLE
Fixes #31418 - avoid duplicating notifications

### DIFF
--- a/lib/katello/tasks/reports.rake
+++ b/lib/katello/tasks/reports.rake
@@ -1,4 +1,0 @@
-load "#{Rails.root}/lib/tasks/reports.rake"
-
-#Katello reports can generate a foreman task, so mark the task as a dynflow client
-["reports:daily", "reports:weekly", "reports:monthly"].each { |task| Rake::Task[task].enhance ["dynflow:client"] }


### PR DESCRIPTION
Please see https://github.com/theforeman/foreman/pull/8165 for more background. This is quite severe, all email notifications doubled. There's more issues like this thanks to wide use of `load` in katello tasks, but that's out of the scope for this PR.