### PR TITLE
Fixes #31427 - Smarter incremental update

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -356,32 +356,36 @@ module Actions
         end
 
         def copy_yum_content(new_repo, dep_solve, package_ids, errata_ids)
+          return [] unless new_repo.content_type == ::Katello::Repository::YUM_TYPE
+
           copy_outputs = []
-          if new_repo.content_type == ::Katello::Repository::YUM_TYPE
-            library_instance = new_repo.library_instance
-            content_present_in_this_repo = library_instance
-                                           .rpms
-                                           .with_identifiers(package_ids)
-                                           .exists?
 
-            content_present_in_this_repo ||= library_instance
-                                              .errata
-                                              .with_identifiers(errata_ids)
-                                              .exists?
-            return [] unless content_present_in_this_repo
-
-            unless errata_ids.blank?
+          unless errata_ids.blank?
+            content_present_in_this_repo = new_repo
+                                            .library_instance
+                                            .errata
+                                            .with_identifiers(errata_ids)
+                                            .exists?
+            if content_present_in_this_repo
               copy_outputs << plan_action(Pulp::Repository::CopyUnits, new_repo.library_instance, new_repo,
                                           ::Katello::Erratum.with_identifiers(errata_ids),
                                           incremental_update: dep_solve).output
             end
+          end
 
-            unless package_ids.blank?
+          unless package_ids.blank?
+            content_present_in_this_repo = new_repo
+                                            .library_instance
+                                            .rpms
+                                            .with_identifiers(package_ids)
+                                            .exists?
+            if content_present_in_this_repo
               copy_outputs << plan_action(Pulp::Repository::CopyUnits, new_repo.library_instance, new_repo,
                                           ::Katello::Rpm.with_identifiers(package_ids),
                                           incremental_update: dep_solve).output
             end
           end
+
           copy_outputs
         end
 

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -358,6 +358,18 @@ module Actions
         def copy_yum_content(new_repo, dep_solve, package_ids, errata_ids)
           copy_outputs = []
           if new_repo.content_type == ::Katello::Repository::YUM_TYPE
+            library_instance = new_repo.library_instance
+            content_present_in_this_repo = library_instance
+                                           .rpms
+                                           .with_identifiers(package_ids)
+                                           .exists?
+
+            content_present_in_this_repo ||= library_instance
+                                              .errata
+                                              .with_identifiers(errata_ids)
+                                              .exists?
+            return [] unless content_present_in_this_repo
+
             unless errata_ids.blank?
               copy_outputs << plan_action(Pulp::Repository::CopyUnits, new_repo.library_instance, new_repo,
                                           ::Katello::Erratum.with_identifiers(errata_ids),

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -25,7 +25,7 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     let(:library_repo) do
-      katello_repositories(:rhel_7_x86_64)
+      katello_repositories(:fedora_17_x86_64)
     end
 
     it 'plans' do
@@ -33,7 +33,7 @@ module ::Actions::Katello::ContentViewVersion
       SmartProxy.any_instance.stubs(:pulp3_support?).returns(false)
       ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.stubs(:pulp3_dest_base_version).returns(1)
       stub_remote_user
-      @rpm = katello_rpms(:one)
+      @rpm = library_repo.rpms.first
 
       new_repo = ::Katello::Repository.new(:pulp_id => 387, :library_instance_id => library_repo.id, :root => library_repo.root)
       repository_mapping = {}
@@ -50,6 +50,29 @@ module ::Actions::Katello::ContentViewVersion
                                 library_repo, new_repo,
                                 Katello::Rpm.with_identifiers(@rpm.id),
                                 :incremental_update => true)
+    end
+
+    it 'does not plan CopyUnits if rpm not there in repo.' do
+      SmartProxy.stubs(:pulp_primary).returns(SmartProxy.find_by(name: "Unused Proxy"))
+      SmartProxy.any_instance.stubs(:pulp3_support?).returns(false)
+      ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.stubs(:pulp3_dest_base_version).returns(1)
+      stub_remote_user
+      new_repo = ::Katello::Repository.new(:pulp_id => 387, :library_instance_id => library_repo.id, :root => library_repo.root)
+      repository_mapping = {}
+      repository_mapping[[library_repo]] = new_repo
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:repository_mapping).returns(repository_mapping)
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:new_puppet_environment).returns(Katello::ContentViewPuppetEnvironment)
+      ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.expects(:repos_to_copy).returns(repository_mapping.keys)
+      task = ForemanTasks::Task::DynflowTask.create!(state: :success, result: "good")
+      action.stubs(:task).returns(task)
+      action.expects(:action_subject).with(content_view_version.content_view)
+
+      # create a nonexistent rpm, and ask it to be incrementally copied over.
+      # Copy Units should not happen in that case since this rpm is not any of the repos in the cvv.
+      rpm = ::Katello::Rpm.create!(pulp_id: "I_dont_exist_really_in_a_repo")
+      plan_action(action, content_view_version, [library], :content => {:package_ids => [rpm.id]})
+
+      refute_action_planed action, ::Actions::Pulp::Repository::CopyUnits
     end
 
     it 'removes the correct puppet content during inc update' do
@@ -104,6 +127,10 @@ module ::Actions::Katello::ContentViewVersion
 
       let(:new_repo) do
         ::Katello::Repository.new(:pulp_id => 387, :library_instance_id => library_repo.id, :root => library_repo.root)
+      end
+
+      let(:library_repo) do
+        katello_repositories(:rhel_7_x86_64)
       end
 
       def pulp3_cvv_setup


### PR DESCRIPTION
This commit ensures that incremental update copies content units on only
repositories containing that content unit.
It copies the repo only if the specfied errata id or package id is in
the repo.