### PR TITLE
Fixes #31447 - Validate download policy for export

### DIFF
--- a/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
+++ b/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
@@ -13,12 +13,15 @@ module Katello
                                                "no greater than the specified size in megabytes."), :required => false
     param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
                                                  "If not provided the most recent export history will be used."), :required => false
+    param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this version"\
+                                                         " are unexportable. False by default."), :required => false
     def version
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
                           content_view_version: @version,
                           destination_server: params[:destination_server],
                           chunk_size: params[:chunk_size_mb],
-                          from_history: @history)
+                          from_history: @history,
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
 
       respond_for_async :resource => tasks
     end
@@ -30,12 +33,15 @@ module Katello
                                                "no greater than the specified size in megabytes."), :required => false
     param :from_history_id, :number, :desc => N_("Export history identifier used for incremental export. "\
                                                  "If not provided the most recent export history will be used."), :required => false
+    param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this organization"\
+                                                         " are unexportable. False by default."), :required => false
     def library
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
                           @organization,
                           destination_server: params[:destination_server],
                           chunk_size: params[:chunk_size_mb],
-                          from_history: @history)
+                          from_history: @history,
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
       respond_for_async :resource => tasks
     end
 

--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -34,12 +34,14 @@ module Katello
     param :destination_server, String, :desc => N_("Destination Server name"), :required => false
     param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
                                                "no greater than the specified size in megabytes."), :required => false
+    param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this version"\
+                                                         " are unexportable. False by default."), :required => false
     def version
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::Export,
                           content_view_version: @version,
                           destination_server: params[:destination_server],
-                          chunk_size: params[:chunk_size_mb])
-
+                          chunk_size: params[:chunk_size_mb],
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
       respond_for_async :resource => tasks
     end
 
@@ -48,11 +50,14 @@ module Katello
     param :destination_server, String, :desc => N_("Destination Server name"), :required => false
     param :chunk_size_mb, :number, :desc => N_("Split the exported content into archives "\
                                                "no greater than the specified size in megabytes."), :required => false
+    param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this organization"\
+                                                         " are unexportable. False by default."), :required => false
     def library
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
                           @organization,
                           destination_server: params[:destination_server],
-                          chunk_size: params[:chunk_size_mb])
+                          chunk_size: params[:chunk_size_mb],
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
       respond_for_async :resource => tasks
     end
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -95,6 +95,7 @@ module Katello
     param :available_for, String, :desc => N_("interpret specified object to return only Repositories that can be associated with specified object.  Only 'content_view' & 'content_view_version' are supported."),
           :required => false
     param :with_content, RepositoryTypeManager.enabled_content_types, :desc => N_("only repositories having at least one of the specified content type ex: rpm , erratum")
+    param :download_policy, ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES, :desc => N_("limit to only repositories with this download policy")
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Repository)
     def index
@@ -138,6 +139,7 @@ module Katello
     def index_relation_product(query)
       query = query.joins(:root => :product).where("#{Product.table_name}.organization_id" => @organization) if @organization
       query = query.joins(:root).where("#{RootRepository.table_name}.product_id" => @product.id) if @product
+      query = query.joins(:root).where("#{RootRepository.table_name}.download_policy" => params[:download_policy]) if params[:download_policy]
       query
     end
 

--- a/app/lib/actions/pulp3/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/content_view_version/export.rb
@@ -15,8 +15,9 @@ module Actions
           from_cvv = ::Katello::ContentViewVersion.find(input[:from_content_view_version_id]) unless input[:from_content_view_version_id].blank?
           ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
                                                    content_view_version: cvv,
-                                                   from_content_view_version: from_cvv).create_export(input[:exporter_data][:pulp_href],
-                                                                                            chunk_size: input[:chunk_size])
+                                                   from_content_view_version: from_cvv)
+                                                   .create_export(input[:exporter_data][:pulp_href],
+                                                                        chunk_size: input[:chunk_size])
         end
       end
     end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -122,6 +122,8 @@ module Katello
 
     scope :has_url, -> { joins(:root).where.not("#{RootRepository.table_name}.url" => nil) }
     scope :on_demand, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND) }
+    scope :immediate, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE) }
+    scope :non_immediate, -> { joins(:root).where.not("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE) }
     scope :in_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => true) }
     scope :in_non_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => false) }
     scope :deb_type, -> { with_type(DEB_TYPE) }
@@ -154,6 +156,7 @@ module Katello
     scoped_search :on => :redhat, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_redhat
     scoped_search :on => :container_repository_name, :complete_value => true
     scoped_search :on => :description, :relation => :root, :only_explicit => true
+    scoped_search :on => :download_policy, :relation => :root, :only_explicit => true
     scoped_search :on => :name, :relation => :product, :rename => :product_name
     scoped_search :on => :id, :relation => :product, :rename => :product_id, :only_explicit => true
     scoped_search :on => :label, :relation => :root, :complete_value => true, :only_explicit => true
@@ -285,6 +288,10 @@ module Katello
 
     def on_demand?
       root.download_policy == Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+    end
+
+    def immediate?
+      root.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE
     end
 
     def yum_gpg_key_url

--- a/app/services/katello/pulp3/content_view_version/import_export_common.rb
+++ b/app/services/katello/pulp3/content_view_version/import_export_common.rb
@@ -19,22 +19,6 @@ module Katello
           repo_api.read(version_href_to_repository_href(version_href))
         end
 
-        def repository_hrefs
-          version_hrefs.map { |href| version_href_to_repository_href(href) }.uniq
-        end
-
-        def version_hrefs
-          repositories.pluck(:version_href).compact
-        end
-
-        def repositories
-          if @content_view_version.default?
-            @content_view_version.repositories.yum_type
-          else
-            @content_view_version.archived_repos.yum_type
-          end
-        end
-
         def version_href_to_repository_href(version_href)
           version_href.split("/")[0..-3].join("/") + "/"
         end

--- a/test/controllers/api/v2/content_export_incrementals_controller_test.rb
+++ b/test/controllers/api/v2/content_export_incrementals_controller_test.rb
@@ -98,6 +98,7 @@ module Katello
         assert_equal options[:content_view_version].id, @library_view_version.id
         assert_equal options[:destination_server], destination
         assert_equal options[:chunk_size], chunk_size_mb
+        refute options[:fail_on_missing_content]
         assert_equal options[:from_history], history
       end
       export_task.returns(build_task_stub)
@@ -150,11 +151,13 @@ module Katello
         assert_equal options[:destination_server], destination
         assert_equal options[:chunk_size], chunk_size_mb
         assert_equal options[:from_history], history
+        assert options[:fail_on_missing_content]
       end
       export_task.returns(build_task_stub)
       post :library, params: { organization_id: org.id,
                                destination_server: destination,
-                               chunk_size_mb: chunk_size_mb
+                               chunk_size_mb: chunk_size_mb,
+                               fail_on_missing_content: true
                              }
       assert_response :success
     end

--- a/test/controllers/api/v2/content_exports_controller_test.rb
+++ b/test/controllers/api/v2/content_exports_controller_test.rb
@@ -96,11 +96,13 @@ module Katello
         assert_equal options[:destination_server], destination
         assert_equal options[:chunk_size], chunk_size_mb
         assert_nil options[:from_history]
+        assert options[:fail_on_missing_content]
       end
       export_task.returns(build_task_stub)
       post :version, params: { id: @library_view_version.id,
                                destination_server: destination,
-                               chunk_size_mb: chunk_size_mb
+                               chunk_size_mb: chunk_size_mb,
+                               fail_on_missing_content: true
                              }
       assert_response :success
     end
@@ -115,6 +117,7 @@ module Katello
         assert_equal organization.id, org.id
         assert_equal options[:destination_server], destination
         assert_equal options[:chunk_size], chunk_size_mb
+        refute options[:fail_on_missing_content]
         assert_nil options[:from_history]
       end
       export_task.returns(build_task_stub)

--- a/test/support/export_support.rb
+++ b/test/support/export_support.rb
@@ -1,6 +1,6 @@
 module Support
   module ExportSupport
-    def fetch_exporter(smart_proxy:, content_view_version:, destination_server:, from_content_view_version: nil)
+    def fetch_exporter(smart_proxy:, content_view_version:, destination_server: nil, from_content_view_version: nil)
       export = ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
                                                                  content_view_version: content_view_version,
                                                                  destination_server: destination_server,


### PR DESCRIPTION
This commit validates and makes sure all the repos being exported are
immediate and not lazy synced.