### PR TITLE
Fixes #31121 - add migration timing estimate to pulp 3 migration stats

### DIFF
--- a/lib/katello/tasks/pulp3_migration_stats.rake
+++ b/lib/katello/tasks/pulp3_migration_stats.rake
@@ -3,17 +3,37 @@ namespace :katello do
   task :pulp3_migration_stats => [:environment] do
     User.current = User.anonymous_admin
 
-    migrated_rpms = ::Katello::Rpm.where('pulp_id LIKE ?', '%/pulp/api/v3/content/rpm/packages/%').
+    migrated_rpm_count = ::Katello::Rpm.where('pulp_id LIKE ?', '%/pulp/api/v3/content/rpm/packages/%').
       or(::Katello::Rpm.where.not(migrated_pulp3_href: nil)).count
-    migrated_errata = ::Katello::RepositoryErratum.where.not(erratum_pulp3_href: nil).count
-    migrated_repos = ::Katello::Repository.where.not(version_href: nil).count
-    migratable_repos = ::Katello::Repository.count - ::Katello::Repository.puppet_type.count -
+    migrated_erratum_count = ::Katello::RepositoryErratum.where.not(erratum_pulp3_href: nil).count
+    migrated_repo_count = ::Katello::Repository.where.not(version_href: nil).count
+    migratable_repo_count = ::Katello::Repository.count - ::Katello::Repository.puppet_type.count -
       ::Katello::Repository.ostree_type.count - ::Katello::Repository.deb_type.count
 
+    on_demand_rpm_count = Katello::RepositoryRpm.where(:repository_id => Katello::Repository.yum_type.on_demand).distinct.count
+    on_demand_unmigrated_rpm_count = on_demand_rpm_count - migrated_rpm_count
+    immediate_unmigrated_rpm_count = ::Katello::Rpm.count - migrated_rpm_count - on_demand_unmigrated_rpm_count
+
+    # On Demand RPMs: (6.46E-04)*(#RPMs) + -3.22
+    # Immediate RPMs: (9.39E-04)*(#RPMs) + -3
+    # Repositories: 0.0746*(#Repos) + -2.07
+    migration_minutes = (0.000646 * on_demand_unmigrated_rpm_count - 3.22 +
+                         0.000943 * immediate_unmigrated_rpm_count - 3 +
+                         0.0746 * migratable_repo_count).to_i
+    hours = (migration_minutes / 60) % 60
+    minutes = migration_minutes % 60
+
     puts
-    puts "Migrated/Total RPMs: #{migrated_rpms}/#{::Katello::Rpm.count}"
-    puts "Migrated/Total errata: #{migrated_errata}/#{::Katello::RepositoryErratum.count}"
-    puts "Migrated/Total repositories: #{migrated_repos}/#{migratable_repos}"
+    puts "Migrated/Total RPMs: #{migrated_rpm_count}/#{::Katello::Rpm.count}"
+    puts "Migrated/Total errata: #{migrated_erratum_count}/#{::Katello::RepositoryErratum.count}"
+    puts "Migrated/Total repositories: #{migrated_repo_count}/#{migratable_repo_count}"
+    puts
+    # The timing formulas go negative if the amount of content is negligibly small
+    if migration_minutes >= 5
+      puts "Estimated migration time based on yum content: #{hours} hours, #{minutes} minutes"
+    else
+      puts "Estimated migration time based on yum content: fewer than 5 minutes"
+    end
     puts
     puts "\e[33mNote:\e[0m ensure there is sufficient storage space for /var/lib/pulp/published to double in size before starting the migration process."
     puts "Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'"


### PR DESCRIPTION
To test:

1) Have a Katello server running with Pulp 2 for yum
2) Sync a variety of yum content, both immediate and on-demand
3) Run `rake katello:pulp3_migration_stats` and see the timing estimate.  Check that it makes sense and adheres to the formula:
```
# On Demand RPMs: (6.46E-04)*(#RPMs) + -3.22
# Immediate RPMs: (9.39E-04)*(#RPMs) + -3
# Repositories: 0.0746*(#Repos) + -2.07

Total the 3 to find the estimate.  Note that the y-intercept is negative due to the linear trend lines.  Therefore, if negative, we assume it'll take fewer than 5 minutes.
```

Note that if you try testing the timing estimate on a development box, it is likely to take more time than estimated.