### PR TITLE
Fixes #31470 - configure errata_ids as a required param

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -267,8 +267,9 @@ module Katello
     api :POST, "/hosts/bulk/available_incremental_updates", N_("Given a set of hosts and errata, lists the content view versions" \
                                                                  " and environments that need updating.")
     param_group :bulk_params
-    param :errata_ids, Array, :desc => N_("List of Errata ids")
+    param :errata_ids, Array, :desc => N_("List of Errata ids"), :required => true
     def available_incremental_updates
+      fail HttpErrors::BadRequest, _("errata_ids is a required parameter") if params[:errata_ids].empty?
       version_environments = {}
       content_facets = Katello::Host::ContentFacet.with_non_installable_errata(@errata, @hosts)
 

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -325,6 +325,11 @@ module Katello
       assert_response :success
     end
 
+    def test_incremental_updates_no_ids
+      post :available_incremental_updates, params: { :included => {:ids => [@host1.id]}, :organization_id => @org.id }
+      assert_response :bad_request
+    end
+
     def test_subscription_permissions
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]


### PR DESCRIPTION
Screenshot of updated API docs:

https://nimbusweb.me/s/share/4958108/kkcp3149abi7yr44d2nz