### PR TITLE
Fixes #31479 - If org has SCA enabled, show SCA for hypervisors

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -282,6 +282,10 @@ module Katello
         name.gsub('_', '-').chomp('.').downcase
       end
 
+      def unsubscribed_hypervisor?
+        self.hypervisor && !self.candlepin_consumer.entitlements?
+      end
+
       def candlepin_consumer
         @candlepin_consumer ||= Katello::Candlepin::Consumer.new(self.uuid, self.host.organization.label)
       end

--- a/app/models/katello/subscription_status.rb
+++ b/app/models/katello/subscription_status.rb
@@ -43,9 +43,10 @@ module Katello
 
     def to_status(options = {})
       return UNKNOWN unless host.subscription_facet.try(:uuid)
-      status_override = 'unsubscribed_hypervisor' if host.subscription_facet.hypervisor && !host.subscription_facet.candlepin_consumer.entitlements?
+      return DISABLED if host.organization.simple_content_access?
+      status_override = 'unsubscribed_hypervisor' if host.subscription_facet.unsubscribed_hypervisor?
       status_override ||= options.fetch(:status_override, nil)
-      status = status_override || Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label).entitlement_status
+      status = status_override || host.subscription_facet.candlepin_consumer.entitlement_status
 
       case status
       when Katello::Candlepin::Consumer::ENTITLEMENTS_DISABLED

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -72,6 +72,7 @@ module Katello::Host
       data = data.with_indifferent_access
       create_org(org_label)
       org = Organization.find_by(label: org_label)
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
       host_names_expected = ["virt-who-2e78f643-1d2f-45d1-b191-d931147cbde1-#{org.id}", "virt-who-261c4dca-702f-42b3-b8ef-2a72b77f7ec2-#{org.id}"]
 
       assert_equal 0, org.hosts.count
@@ -92,6 +93,7 @@ module Katello::Host
       data = data.with_indifferent_access
       create_org(org_label)
       org = Organization.find_by(label: org_label)
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
       host_names_expected = ["virt-who-more-useful-identifier-#{org.id}", "virt-who-261c4dca-702f-42b3-b8ef-2a72b77f7ec2-#{org.id}"]
       reporter_id = 100
       task = Katello::Resources::Candlepin::Consumer.async_hypervisors(owner: org_label, reporter_id: reporter_id, raw_json: data.to_json)

--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -48,6 +48,8 @@ module Katello::Host
       @host.subscription_facet.destroy!
       @host.destroy!
 
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
+
       ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).never
 
       action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
@@ -78,6 +80,7 @@ module Katello::Host
 
       # Delete :guestIds to make katello to fetch the virtual guests from Candlepin
       @consumer.delete(:guestIds)
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
       ::Katello::Resources::Candlepin::Consumer.expects(:virtual_guests).once.returns(guest_uuids)
 
       action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
@@ -118,6 +121,7 @@ module Katello::Host
       @host.subscription_facet.delete
       @host.save!
       action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
       plan_action(action, :hypervisors => @hypervisor_results)
       action = run_action(action)
@@ -130,6 +134,7 @@ module Katello::Host
     end
 
     def test_existing_hypervisor_renamed
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
       @hypervisor_results[0][:name] = 'hypervisor.renamed'
       action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 

--- a/test/helpers/dashboard_helper_test.rb
+++ b/test/helpers/dashboard_helper_test.rb
@@ -12,6 +12,7 @@ class DashboardHelperTest < ActiveSupport::TestCase
                                :content_view => katello_content_views(:library_dev_view),
                                :lifecycle_environment => katello_environments(:library), :id => 101)
     @host.organization = taxonomies(:organization1)
+    @host.organization.stubs(:simple_content_access?).returns(false)
     @host.save!
     Organization.current = @host.organization
   end

--- a/test/models/subscription_status_test.rb
+++ b/test/models/subscription_status_test.rb
@@ -8,6 +8,10 @@ module Katello
 
     let(:status) { host.get_status(Katello::SubscriptionStatus) }
 
+    def setup
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
+    end
+
     def stub_status(status)
       Katello::Candlepin::Consumer.any_instance.stubs(:entitlement_status).returns(status)
     end
@@ -37,8 +41,13 @@ module Katello
     end
 
     def test_to_status_unsubscribed_hypervisor
-      stub_status('unsubscribed_hypervisor')
+      host.subscription_facet.stubs(:unsubscribed_hypervisor?).returns(true)
       assert_equal Katello::SubscriptionStatus::UNSUBSCRIBED_HYPERVISOR, status.to_status
+    end
+
+    def test_sca_enabled
+      ::Organization.any_instance.stubs(:simple_content_access?).returns(true)
+      assert_equal Katello::SubscriptionStatus::DISABLED, status.to_status
     end
 
     def test_no_subscription_facet

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -172,8 +172,10 @@ module Katello
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).returns(:uuid => 'fake-uuid-from-katello')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).twice.with('fake-uuid-from-katello').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
         ::Runcible::Extensions::Consumer.any_instance.expects(:create).with('fake-uuid-from-katello', :display_name => 'foobar')
+
+        ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
         ::Katello::RegistrationManager.register_host(new_host, rhsm_params, @content_view_environment)
       end
@@ -186,8 +188,10 @@ module Katello
 
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(cvpe.cp_id, rhsm_params, ["cp_name_baz"]).returns(:uuid => 'fake-uuid-from-katello')
         Katello::ActivationKey.any_instance.stubs(:cp_name).returns('cp_name_baz')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).twice.with('fake-uuid-from-katello').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
         ::Runcible::Extensions::Consumer.any_instance.expects(:create).with('fake-uuid-from-katello', :display_name => 'foobar')
+
+        ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
         ::Katello::RegistrationManager.register_host(new_host, rhsm_params, cvpe, [@activation_key])
 
@@ -207,8 +211,10 @@ module Katello
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).returns(:uuid => 'fake-uuid-from-katello')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).twice.with('fake-uuid-from-katello').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
         ::Runcible::Extensions::Consumer.any_instance.expects(:create)
+
+        ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
         ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)
       end
@@ -302,6 +308,7 @@ module Katello
 
         ::Host.expects(:find).returns(new_host)
         new_host.expects(:destroy)
+        new_host.organization.stubs(:simple_content_access?).returns(false)
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).raises("uhoh!")
         ::Runcible::Extensions::Consumer.any_instance.expects(:create).with('fake-uuid', :display_name => 'foobar').never
 
@@ -314,6 +321,7 @@ module Katello
 
       def test_registration_dead_pulp
         new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @library.organization)
+        new_host.organization.stubs(:simple_content_access?).returns(false)
 
         ::Katello::RegistrationManager.expects(:remove_host_artifacts).never
         ::Katello::RegistrationManager.expects(:remove_partially_registered_new_host)
@@ -335,12 +343,15 @@ module Katello
 
         @host.content_facet.expects(:destroy).never
         @host.expects(:destroy).never
+
         ::Katello::RegistrationManager.expects(:remove_host_artifacts).twice # once on original unregister, once again after failure during re-reg
         ::Katello::RegistrationManager.expects(:remove_partially_registered_new_host).never
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).raises("uhoh!")
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Runcible::Extensions::Consumer.any_instance.expects(:create).never
         ::Runcible::Extensions::Consumer.any_instance.expects(:delete)
+
+        ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
         failed = lambda do
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)


### PR DESCRIPTION
This PR adds the correct status message to hypervisors when an org has SCA enabled.

Screenshot with patch:

https://nimbusweb.me/s/share/4963201/5xp3idmmzci8nws453nl

To test:

* Create an org if not using a fresh devel box
* Import a manifest
* Toggle SCA on
* Register a content host
* Install virt-who on the content host and have it report in
* Check the subscription status of the hypervisor in the content host page. 