### PR TITLE
Fixes #7250 - New content view page filters tab

### DIFF
--- a/webpack/__mocks__/foremanReact/components/common/dates/LongDateTime.js
+++ b/webpack/__mocks__/foremanReact/components/common/dates/LongDateTime.js
@@ -1,0 +1,5 @@
+// This component uses the intl context from Foreman, we need to figure out how to mock that
+// context before using this component directly from Foreman in testing
+
+export default () => 'A Mocked Date';
+

--- a/webpack/components/Table/helpers.js
+++ b/webpack/components/Table/helpers.js
@@ -1,0 +1,14 @@
+// Can be included as a TableWrapper prop for selectable rows
+const onSelect = (rows, setRows) => (_event, isSelected, rowId) => {
+  let newRows;
+  if (rowId === -1) {
+    newRows = rows.map(row => ({ ...row, selected: isSelected }));
+  } else {
+    newRows = [...rows];
+    newRows[rowId].selected = isSelected;
+  }
+
+  setRows(newRows);
+};
+
+export default onSelect;

--- a/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.js
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.js
@@ -7,7 +7,6 @@ import keyPressHandler from '../helpers/helpers';
 import TypeAheadInput from './TypeAheadInput';
 import TypeAheadItems from './TypeAheadItems';
 import commonSearchPropTypes from '../helpers/commonPropTypes';
-import './TypeAheadSearch.scss';
 
 const TypeAheadSearch = ({
   userInputValue, clearSearch, getInputProps, getItemProps, isOpen, inputValue, highlightedIndex,

--- a/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.scss
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.scss
@@ -1,5 +1,0 @@
-// accounting for excess padding on search bar and aligning vertically
-.foreman-pf4-search-clear {
-  padding: 8px 5px 4px 5px;
-  margin-left: 10px; 
-}

--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -54,3 +54,9 @@ td, th {
     }
   }
 }
+
+// Override browser default outline ring on focus
+*:focus {
+  outline: none;
+}
+

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -5,6 +5,7 @@ export const UPDATE_CONTENT_VIEW_FAILURE = 'UPDATE_CONTENT_VIEW_FAILURE';
 
 export const cvDetailsKey = cvId => `${CONTENT_VIEWS_KEY}_${cvId}`;
 export const cvDetailsRepoKey = cvId => `${CONTENT_VIEWS_KEY}_REPOSITORIES_${cvId}`;
+export const cvDetailsFilterKey = cvId => `${CONTENT_VIEWS_KEY}_FILTERS_${cvId}`;
 
 // Repo added to content view status display and key
 export const ADDED = 'Added';

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -11,6 +11,7 @@ import {
   REPOSITORY_TYPES,
   cvDetailsKey,
   cvDetailsRepoKey,
+  cvDetailsFilterKey,
 } from '../ContentViewsConstants';
 import api from '../../../services/api';
 
@@ -67,8 +68,15 @@ export const getContentViewRepositories = (cvId, params, status) => {
 export const getRepositoryTypes = () => get({
   type: API_OPERATIONS.GET,
   key: REPOSITORY_TYPES,
-  errorToast: error => `Something went wrong while retrieving the repository types! ${error}`,
+  errorToast: error => __(`Something went wrong while retrieving the repository types! ${error}`),
   url: api.getApiUrl('/repositories/repository_types'),
+});
+
+export const getContentViewFilters = (cvId, params) => get({
+  key: cvDetailsFilterKey(cvId),
+  params: { content_view_id: cvId, ...params },
+  errorToast: error => __(`Something went wrong while retrieving the content view filters! ${error}`),
+  url: api.getApiUrl('/content_view_filters'),
 });
 
 export default getContentViewDetails;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -4,7 +4,12 @@ import {
   selectAPIResponse,
 } from 'foremanReact/redux/API/APISelectors';
 import { STATUS } from 'foremanReact/constants';
-import { cvDetailsKey, cvDetailsRepoKey, REPOSITORY_TYPES } from '../ContentViewsConstants';
+import {
+  cvDetailsKey,
+  cvDetailsRepoKey,
+  cvDetailsFilterKey,
+  REPOSITORY_TYPES,
+} from '../ContentViewsConstants';
 
 export const selectCVDetails = (state, cvId) =>
   selectAPIResponse(state, cvDetailsKey(cvId)) || {};
@@ -29,5 +34,14 @@ export const selectRepoTypes = state =>
 
 export const selectRepoTypesStatus = state =>
   selectAPIStatus(state, REPOSITORY_TYPES) || STATUS.PENDING;
+
+export const selectCVFilters = (state, cvId) =>
+  selectAPIResponse(state, cvDetailsFilterKey(cvId)) || {};
+
+export const selectCVFiltersStatus = (state, cvId) =>
+  selectAPIStatus(state, cvDetailsFilterKey(cvId)) || STATUS.PENDING;
+
+export const selectCVFiltersError = (state, cvId) =>
+  selectAPIError(state, cvDetailsFilterKey(cvId));
 
 export const selectIsCVUpdating = state => state.katello?.contentViewDetails?.updating;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import DetailsContainer from './DetailsContainer';
 import ContentViewInfo from './ContentViewInfo';
 import ContentViewRepositories from './Repositories/ContentViewRepositories';
+import ContentViewFilters from './Filters/ContentViewFilters';
 import { selectCVDetails } from './ContentViewDetailSelectors';
 import TabbedView from '../../../components/TabbedView';
 
@@ -30,7 +31,7 @@ const ContentViewDetails = ({ match }) => {
     },
     {
       title: __('Filters'),
-      content: <React.Fragment>Filters</React.Fragment>,
+      content: <ContentViewFilters cvId={cvId} />,
     },
     {
       title: __('History'),

--- a/webpack/scenes/ContentViews/Details/Filters/ContentType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentType.js
@@ -1,0 +1,40 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+import RepoIcon from '../Repositories/RepoIcon';
+import { capitalize } from '../../../../utils/helpers';
+
+const typeName = (type, errataByDate) => {
+  if (errataByDate) return 'Errata - by date range';
+  const nameMap = {
+    rpm: __('RPM'),
+    docker: __('Container image tag'),
+    modulemd: __('Module stream'),
+    erratum: __('Errata'),
+  };
+
+  if (Object.prototype.hasOwnProperty.call(nameMap, type)) return nameMap[type];
+  return capitalize(type.replace('_', ' '));
+};
+
+const ContentType = ({ type, errataByDate }) => {
+  const repoType = ['rpm', 'modulemd', 'rpm', 'erratum', 'package_group'].includes(type) ? 'yum' : type;
+  return (
+    <Fragment>
+      <span style={{ marginRight: '5px' }}><RepoIcon type={repoType} /></span>
+      {typeName(type, errataByDate)}
+    </Fragment>
+  );
+};
+
+ContentType.propTypes = {
+  type: PropTypes.string.isRequired,
+  errataByDate: PropTypes.bool,
+};
+
+ContentType.defaultProps = {
+  errataByDate: false,
+};
+
+export default ContentType;

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import { shallowEqual, useSelector } from 'react-redux';
+import { Label } from '@patternfly/react-core';
+import { TableVariant } from '@patternfly/react-table';
+import { STATUS } from 'foremanReact/constants';
+import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';
+import { translate as __ } from 'foremanReact/common/I18n';
+import PropTypes from 'prop-types';
+
+import TableWrapper from '../../../../components/Table/TableWrapper';
+import onSelect from '../../../../components/Table/helpers';
+import { getContentViewFilters } from '../ContentViewDetailActions';
+import {
+  selectCVFilters,
+  selectCVFiltersStatus,
+  selectCVFiltersError,
+} from '../ContentViewDetailSelectors';
+import { truncate } from '../../../../utils/helpers';
+import ContentType from './ContentType';
+
+// won't be needed when details pages are built, linking to old pages for now
+const cvFilterUrl = (cvId, filterId, type, errataByDate) => {
+  const repoType = type === 'docker' ? 'docker' : 'yum';
+  const filterType = errataByDate ? 'errata_by_date' : type;
+  const base = `/content_views/${cvId}/repositories/${repoType}/filters/${filterId}`;
+  const endings = {
+    rpm: '/package/details',
+    package_group: '/package-group/list',
+    erratum: '/errata/list',
+    errata_by_date: '/errata/date_type',
+    modulemd: '/module-stream/list',
+    docker: '/docker/details',
+  };
+
+  return base + endings[filterType];
+};
+
+const ContentViewFilters = ({ cvId }) => {
+  const response = useSelector(state => selectCVFilters(state, cvId), shallowEqual);
+  const status = useSelector(state => selectCVFiltersStatus(state, cvId), shallowEqual);
+  const error = useSelector(state => selectCVFiltersError(state, cvId), shallowEqual);
+  const [rows, setRows] = useState([]);
+  const [metadata, setMetadata] = useState({});
+  const [searchQuery, updateSearchQuery] = useState('');
+  const loading = status === STATUS.PENDING;
+
+  const columnHeaders = [
+    __('Name'),
+    __('Description'),
+    __('Updated'),
+    __('Content type'),
+    __('Inclusion type'),
+  ];
+
+  const buildRows = (results) => {
+    const newRows = [];
+    results.forEach((filter) => {
+      let errataByDate = false;
+      const {
+        id, name, type, description, updated_at: updatedAt, inclusion,
+      } = filter;
+      if (filter.type === 'erratum' && filter.rules[0].types) errataByDate = true;
+
+      const cells = [
+        { title: <a href={cvFilterUrl(cvId, id, type, errataByDate)}>{name}</a> },
+        truncate(description || ''),
+        { title: <LongDateTime date={updatedAt} showRelativeTimeTooltip /> },
+        { title: <ContentType type={type} errataByDate={errataByDate} /> },
+        {
+          title: (
+            <Label color={inclusion && 'blue'}>
+              {inclusion ? 'Include' : 'Exclude'}
+            </Label>),
+        },
+      ];
+
+      newRows.push({ cells });
+    });
+    return newRows;
+  };
+
+  useEffect(() => {
+    const { results, ...meta } = response;
+    setMetadata(meta);
+
+    if (!loading && results) {
+      const newRows = buildRows(results);
+      setRows(newRows);
+    }
+  }, [JSON.stringify(response)]);
+
+  const emptyContentTitle = __("You currently don't have any filters for this content view.");
+  const emptyContentBody = __("Add filters using the 'Add filter' button above."); // needs link
+  const emptySearchTitle = __('No matching filters found');
+  const emptySearchBody = __('Try changing your search settings.');
+
+  return (
+    <TableWrapper
+      {...{
+        rows,
+        metadata,
+        emptyContentTitle,
+        emptyContentBody,
+        emptySearchTitle,
+        emptySearchBody,
+        searchQuery,
+        updateSearchQuery,
+        error,
+        status,
+      }}
+      onSelect={onSelect(rows, setRows)}
+      cells={columnHeaders}
+      variant={TableVariant.compact}
+      autocompleteEndpoint="/content_view_filters/auto_complete_search"
+      fetchItems={params => getContentViewFilters(cvId, params)}
+    />);
+};
+
+
+ContentViewFilters.propTypes = {
+  cvId: PropTypes.number.isRequired,
+};
+
+export default ContentViewFilters;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.fixtures.json
@@ -1,0 +1,134 @@
+{
+  "total":6,
+  "subtotal":6,
+  "page":"1",
+  "per_page":"20",
+  "error":null,
+  "search":null,
+  "sort":{
+     "by":"name",
+     "order":"asc"
+  },
+  "results":[
+     {
+        "inclusion":true,
+        "id":4,
+        "name":"af1",
+        "description":"A really great filter",
+        "created_at":"2020-12-07 09:58:36 -0500",
+        "updated_at":"2020-12-07 10:42:05 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"rpm",
+        "rules":[
+           
+        ]
+     },
+     {
+        "inclusion":false,
+        "id":5,
+        "name":"Another filter",
+        "description":"hey",
+        "created_at":"2020-12-07 12:59:12 -0500",
+        "updated_at":"2020-12-07 12:59:12 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"package_group",
+        "rules":[
+           
+        ]
+     },
+     {
+        "inclusion":true,
+        "id":6,
+        "name":"f2",
+        "description":null,
+        "created_at":"2020-12-08 09:26:11 -0500",
+        "updated_at":"2020-12-08 09:26:11 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"erratum",
+        "rules":[
+           {
+              "content_view_filter_id":6,
+              "errata_id":"RHEA-2012:0059",
+              "date_type":"updated",
+              "id":3,
+              "created_at":"2020-12-08 10:32:25 -0500",
+              "updated_at":"2020-12-08 10:32:25 -0500"
+           }
+        ]
+     },
+     {
+        "inclusion":false,
+        "id":7,
+        "name":"f3",
+        "description":null,
+        "created_at":"2020-12-08 09:26:27 -0500",
+        "updated_at":"2020-12-08 09:26:27 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"erratum",
+        "rules":[
+           {
+              "content_view_filter_id":7,
+              "types":[
+                 "security",
+                 "enhancement",
+                 "bugfix"
+              ],
+              "date_type":"updated",
+              "id":2,
+              "created_at":"2020-12-08 09:26:27 -0500",
+              "updated_at":"2020-12-08 09:26:27 -0500"
+           }
+        ]
+     },
+     {
+        "inclusion":false,
+        "id":8,
+        "name":"f4",
+        "description":null,
+        "created_at":"2020-12-08 09:26:51 -0500",
+        "updated_at":"2020-12-08 09:26:51 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"modulemd",
+        "rules":[
+           
+        ]
+     },
+     {
+        "inclusion":true,
+        "id":9,
+        "name":"f5",
+        "description":null,
+        "created_at":"2020-12-08 09:32:53 -0500",
+        "updated_at":"2020-12-08 09:32:53 -0500",
+        "content_view":{
+        },
+        "repositories":[
+           
+        ],
+        "type":"docker",
+        "rules":[
+           
+        ]
+     }
+  ]
+}

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+
+import api from '../../../../../services/api';
+import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import ContentViewFilters from '../ContentViewFilters';
+import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
+
+const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+
+const cvFilters = api.getApiUrl('/content_view_filters');
+const autocompleteUrl = '/content_view_filters/auto_complete_search';
+const renderOptions = { apiNamespace: `${CONTENT_VIEWS_KEY}_1` };
+
+let firstFilter;
+let lastFilter;
+let searchDelayScope;
+let autoSearchScope;
+beforeEach(() => {
+  const { results } = cvFilterFixtures;
+  [firstFilter] = results;
+  [lastFilter] = results.slice(-1);
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  // Autosearch can cause some asynchronous issues with the typing timeout, using basic search
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', false);
+});
+
+afterEach(() => {
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autoSearchScope);
+  nock.cleanAll();
+});
+
+test('Can call API and show filters on page load', async (done) => {
+  const { name, description } = firstFilter;
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const scope = nockInstance
+    .get(cvFilters)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+
+  const { getByText, queryByText } =
+    renderWithRedux(<ContentViewFilters cvId={1} />, renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(name)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getByText(name)).toBeInTheDocument();
+    expect(getByText(description)).toBeInTheDocument();
+    expect(getByText(lastFilter.name)).toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can search for filter', async (done) => {
+  const { name, description } = firstFilter;
+  const searchQueryMatcher = actualParams => actualParams?.search?.includes(name);
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  const withSearchScope = mockAutocomplete(nockInstance, autocompleteUrl, searchQueryMatcher);
+  const initialScope = nockInstance
+    .get(cvFilters)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+  const searchResultScope = nockInstance
+    .get(cvFilters)
+    .query(searchQueryMatcher)
+    .reply(200, { results: [firstFilter] });
+
+  const { queryByText, getByLabelText, getByText } = renderWithRedux(
+    <ContentViewFilters cvId={1} />,
+    renderOptions,
+  );
+
+  // Looking for description because the name is in the search bar and could match
+  await patientlyWaitFor(() => expect(getByText(description)).toBeInTheDocument());
+  // Search for a filter by name
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: name } });
+  getByLabelText(/search button/i).click();
+  // Only the first filter should be showing, not the last one
+  await patientlyWaitFor(() => {
+    expect(getByText(description)).toBeInTheDocument();
+    expect(queryByText(lastFilter.name)).not.toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(withSearchScope);
+  assertNockRequest(initialScope);
+  assertNockRequest(searchResultScope, done);
+});

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -8,6 +8,7 @@ import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import PropTypes from 'prop-types';
 
 import TableWrapper from '../../../../components/Table/TableWrapper';
+import onSelect from '../../../../components/Table/helpers';
 import { getContentViewRepositories, getRepositoryTypes } from '../ContentViewDetailActions';
 import {
   selectCVRepos,
@@ -89,18 +90,6 @@ const ContentViewRepositories = ({ cvId }) => {
     return newRows;
   };
 
-  const onSelect = (_event, isSelected, rowId) => {
-    let newRows;
-    if (rowId === -1) {
-      newRows = rows.map(row => ({ ...row, selected: isSelected }));
-    } else {
-      newRows = [...rows];
-      newRows[rowId].selected = isSelected;
-    }
-
-    setRows(newRows);
-  };
-
   const getCVReposWithOptions = (params = {}) => {
     const allParams = { ...params };
     if (typeSelected !== 'All repositories') allParams.content_type = repoTypes[typeSelected];
@@ -149,7 +138,6 @@ const ContentViewRepositories = ({ cvId }) => {
       {...{
         rows,
         metadata,
-        onSelect,
         emptyContentTitle,
         emptyContentBody,
         emptySearchTitle,
@@ -160,6 +148,7 @@ const ContentViewRepositories = ({ cvId }) => {
         status,
         activeFilters,
       }}
+      onSelect={onSelect(rows, setRows)}
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/repositories/auto_complete_search"

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
@@ -13,6 +13,7 @@ const cvDetailsPath = api.getApiUrl('/content_views/1');
 
 // The Repositories tab will load in the background, prevent this by mocking
 jest.mock('../Repositories/ContentViewRepositories.js', () => () => 'mocked!');
+jest.mock('../Filters/ContentViewFilters.js', () => () => 'mocked!');
 
 test('Can call API and show details on page load', async (done) => {
   const { label, name, description } = cvDetailData;

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -98,6 +98,8 @@ export const apiError = (actionType, result, additionalData = {}) => (dispatch) 
 
 export const capitalize = s => s && s[0].toUpperCase() + s.slice(1);
 
+export const truncate = (str, truncateLimit = 50) => (str.length > truncateLimit ? `${str.substring(0, truncateLimit - 3)}...` : str);
+
 export default {
   getResponseErrorMsgs,
   apiError,


### PR DESCRIPTION
This is a read-only view of the filters for a content view in `labs/content_views/:id/`. The 'Add Filter' button will be a follow-up task and the details link links to the old page for now until they are built out.

![image](https://user-images.githubusercontent.com/5964462/102104718-848fc680-3dfc-11eb-9967-4887f3cfbf10.png)
