### PR TITLE
Fixes #31496: Fix error when allSelected() not yet defined

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -54,10 +54,10 @@ angular.module('Bastion.products').controller('ProductsController',
         nutupane = new Nutupane(Product, params, undefined, nutupaneParams);
         $scope.controllerName = 'katello_products';
         nutupane.primaryOnly = true;
-        nutupane.refresh().then(function () {
+        $scope.table = nutupane.table;
+        nutupane.load().then(function () {
             $scope.disableRepoDiscovery = false;
         });
-        $scope.table = nutupane.table;
 
         $scope.$on('productDelete', function (event, taskId) {
             var message = translate("Product delete operation has been initiated in the background.");

--- a/engines/bastion_katello/test/products/products.controller.test.js
+++ b/engines/bastion_katello/test/products/products.controller.test.js
@@ -31,7 +31,14 @@ describe('Controller: ProductsController', function() {
                     $promise: deferred.promise,
                     then : function () {}
                 }
-            }
+            };
+            this.load = function () {
+                var deferred = $q.defer();
+                return {
+                    $promise: deferred.promise,
+                    then : function () {}
+                }
+            };
         };
         ProductBulkAction = {
             removeProducts: function () {


### PR DESCRIPTION
When assets are compiled, intermittently during the loading of
the products page, the self.table.allSelected() function is not
yet defined when this segment of code is first encountered. This
is a result of the products page calling refresh after disabling
load rather than calling load explicitly to enable repo discovery
button.