### PR TITLE
Fixes #31498 - de-duplicate activation key names at registration time

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -368,7 +368,7 @@ module Katello
 
       if (ak_names = params[:activation_keys])
         fail HttpErrors::NotFound, _("Organization not found") if organization.nil?
-        ak_names        = ak_names.split(",")
+        ak_names        = ak_names.split(",").uniq.compact
         activation_keys = ak_names.map do |ak_name|
           activation_key = organization.activation_keys.find_by(:name => ak_name)
           fail HttpErrors::NotFound, _("Couldn't find activation key '%s'") % ak_name unless activation_key

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -2,6 +2,7 @@
 
 require "katello_test_helper"
 
+#rubocop:disable Metrics/ModuleLength
 module Katello
   #rubocop:disable Metrics/BlockLength
   describe Api::Rhsm::CandlepinProxiesController do
@@ -52,6 +53,19 @@ module Katello
         ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns(@host)
 
         post(:consumer_activate, params: { :organization_id => @activation_key.organization.label, :activation_keys => @activation_key.name, :facts => @facts })
+
+        assert_response :success
+      end
+
+      it "de-duplicates provided activation key names" do
+        Resources::Candlepin::Consumer.stubs(:get)
+
+        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns(@host)
+
+        key_names = "#{@activation_key.name},#{@activation_key.name}"
+
+        post(:consumer_activate, params: { :organization_id => @activation_key.organization.label,
+                                           :activation_keys => key_names, :facts => @facts })
 
         assert_response :success
       end


### PR DESCRIPTION
previously `subscription-manager register --activationkey="keyOne,keyOne"` would break. Now we sanitize the given keys!