### PR TITLE
Fixes #30964 - Applicability wrong with multiple rpm versions installed using Pulp 3

### DIFF
--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -72,13 +72,17 @@ module Katello
             katello_host_available_module_streams.status = 'enabled'",
             :content_facet_id => self.content_facet.host.id).select(:id)
 
+        newest_distinct_installed_packages = fetch_newest_distinct_installed_packages
+        return [] if newest_distinct_installed_packages.empty?
+
         ::Katello::Rpm.
           joins("INNER JOIN katello_repository_rpms ON
             katello_rpms.id = katello_repository_rpms.rpm_id").
           joins("INNER JOIN katello_installed_packages ON
             katello_rpms.name = katello_installed_packages.name AND
             katello_rpms.arch = katello_installed_packages.arch AND
-            katello_rpms.evr > katello_installed_packages.evr").
+            katello_rpms.evr > katello_installed_packages.evr AND
+            katello_installed_packages.id in (#{newest_distinct_installed_packages.join(",")})").
           joins("LEFT JOIN katello_module_stream_rpms ON
             katello_rpms.id = katello_module_stream_rpms.rpm_id").
           joins("INNER JOIN katello_host_installed_packages ON
@@ -90,6 +94,20 @@ module Katello
           where("katello_module_stream_rpms.module_stream_id is null or
             katello_module_stream_rpms.module_stream_id in (:enabled_module_streams)",
             :enabled_module_streams => enabled_module_stream_ids).pluck(:id).uniq
+      end
+
+      def fetch_newest_distinct_installed_packages
+        newest_distinct_installed_packages_query =
+          "SELECT DISTINCT ON (name) katello_installed_packages.* " \
+          "FROM katello_installed_packages INNER JOIN " \
+          "katello_host_installed_packages ON " \
+          "katello_installed_packages.id = " \
+          "katello_host_installed_packages.installed_package_id " \
+          "WHERE katello_host_installed_packages.host_id = " \
+          ":content_facet_id ORDER BY name, evr DESC"
+
+        ::Katello::InstalledPackage.find_by_sql([newest_distinct_installed_packages_query,
+                                                 content_facet_id: content_facet.host.id]).map(&:id)
       end
 
       def applicable_differences


### PR DESCRIPTION
This PR addresses the issue by only using the latest versions of installed RPMs for applicability calculations.

To test (start on `master`):
1) Register a host to Katello
2) Sync the CentOS 7 OS mirror and give your host access to it
3) Check that your host's kernel version is older than the one in your synced CentOS 7 repo
4) Update your host's kernel
5) Ensure that there are multiple kernels installed on the system.  The host's latest kernel should not be older than the kernel in the synced CentOS 7 repo
6) Check the host's applicable packages.  There should be a kernel in there even though you have the latest version
7) Apply this PR and regenerate the host's applicability
8) There should be no kernels among the applicable packages