### PR TITLE
Fixes #31532 - Regenerate entitlement certs on custom repo update for RHEL 6.8 and older

### DIFF
--- a/app/lib/actions/candlepin/consumer/regenerate_entitlement_certificates.rb
+++ b/app/lib/actions/candlepin/consumer/regenerate_entitlement_certificates.rb
@@ -11,8 +11,8 @@ module Actions
         def plan(uuids, org_label)
           Rails.logger.info("Marking entitlement certs dirty for #{pluralize(uuids.length, 'client')}")
           sequence do
-            uuids.compact.uniq.each do |uuid|
-              plan_action(::Actions::Candlepin::Consumer::RegenerateEntitlementCertificate, uuid)
+            uuids.compact.uniq.in_groups_of(10, false) do |uuid_group|
+              plan_action(::Actions::Candlepin::Consumer::RegenerateEntitlementCertificateBatch, uuid_group)
             end
           end
 
@@ -22,23 +22,38 @@ module Actions
           )
         end
 
+        def finalize
+          output[:result] = "#{pluralize(input[:uuids].length, 'entitlement certificate')} marked dirty"
+        end
+
         def humanized_name
           "Regenerate entitlement certificates"
         end
 
       end
 
-      class RegenerateEntitlementCertificate < Candlepin::Abstract
+      class RegenerateEntitlementCertificateBatch < Candlepin::Abstract
         input_format do
-          param :uuid, String
+          param :uuids, Array
         end
 
-        def plan(uuid)
-          plan_self(uuid: uuid)
+        def plan(uuids)
+          if uuids.is_a?(String)
+            raise ::ArgumentError, "Must pass in an array of uuids, not a string"
+          end
+          if uuids.length > 10
+            raise ::ArgumentError, "#{self.class} can only accept 10 uuids at a time: #{uuids}"
+          end
+          plan_self(uuids: uuids)
         end
 
         def run
-          output[:result] = ::Katello::Candlepin::Consumer.new(input[:uuid], input[:org_label]).regenerate_entitlement_certificates
+          results = []
+          input[:uuids].each do |uuid|
+            result = ::Katello::Candlepin::Consumer.new(uuid, input[:org_label]).regenerate_entitlement_certificates
+            results << { uuid => result }
+          end
+          output[:results] = results
         end
 
         def humanized_name

--- a/app/lib/actions/candlepin/consumer/regenerate_entitlement_certificates.rb
+++ b/app/lib/actions/candlepin/consumer/regenerate_entitlement_certificates.rb
@@ -1,0 +1,50 @@
+module Actions
+  module Candlepin
+    module Consumer
+      class RegenerateEntitlementCertificates < Candlepin::Abstract
+        include ActionView::Helpers::TextHelper
+
+        input_format do
+          param :uuids, Array
+        end
+
+        def plan(uuids, org_label)
+          Rails.logger.info("Marking entitlement certs dirty for #{pluralize(uuids.length, 'client')}")
+          sequence do
+            uuids.compact.uniq.each do |uuid|
+              plan_action(::Actions::Candlepin::Consumer::RegenerateEntitlementCertificate, uuid)
+            end
+          end
+
+          plan_self(
+            uuids: uuids,
+            org_label: org_label
+          )
+        end
+
+        def humanized_name
+          "Regenerate entitlement certificates"
+        end
+
+      end
+
+      class RegenerateEntitlementCertificate < Candlepin::Abstract
+        input_format do
+          param :uuid, String
+        end
+
+        def plan(uuid)
+          plan_self(uuid: uuid)
+        end
+
+        def run
+          output[:result] = ::Katello::Candlepin::Consumer.new(input[:uuid], input[:org_label]).regenerate_entitlement_certificates
+        end
+
+        def humanized_name
+          "Regenerate entitlement certificates for consumer"
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -110,6 +110,11 @@ module Katello
             JSON.parse(response).with_indifferent_access
           end
 
+          def regenerate_entitlement_certificates(uuid, lazy_regen = true)
+            response = self.put(join_path(path(uuid), "certificates") + "?lazy_regen=#{lazy_regen}", nil, self.default_headers).body
+            response
+          end
+
           def export(uuid)
             # Export is a zip file
             headers = self.default_headers

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -111,7 +111,7 @@ module Katello
           end
 
           def regenerate_entitlement_certificates(uuid, lazy_regen = true)
-            response = self.put(join_path(path(uuid), "certificates") + "?lazy_regen=#{lazy_regen}", nil, self.default_headers).body
+            response = self.put(join_path(path(uuid), "certificates") + "?lazy_regen=#{lazy_regen}", nil, self.default_headers).code
             response
           end
 

--- a/app/lib/katello/resources/candlepin/entitlement.rb
+++ b/app/lib/katello/resources/candlepin/entitlement.rb
@@ -7,6 +7,10 @@ module Katello
             self.put("/candlepin/entitlements/product/#{product_id}", nil, self.default_headers).code.to_i
           end
 
+          def regenerate_entitlement_certificates_for_consumer(uuid, lazy_regen = true)
+            self.put("/candlepin/consumers/#{uuid}/certificates?lazy_regen=#{lazy_regen}", nil, self.default_headers).code.to_i
+          end
+
           def get(id = nil, params = '')
             json = Candlepin::CandlepinResource.get(path(id) + params, self.default_headers).body
             JSON.parse(json)

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -36,6 +36,10 @@ module Katello
         Resources::Candlepin::Consumer.regenerate_identity_certificates(self.uuid)
       end
 
+      def regenerate_entitlement_certificates(lazy_regen = true)
+        Resources::Candlepin::Consumer.regenerate_entitlement_certificates(self.uuid, lazy_regen)
+      end
+
       def checkin(checkin_time)
         Resources::Candlepin::Consumer.checkin(uuid, checkin_time)
       end


### PR DESCRIPTION
The "Restrict to OS Version" feature doesn't work for clients on RHEL 6.8 and older.

This fixes that by doing the following:

* When a custom repo is updated, see if the 'OS Versions' field was changed
* If so, and `rhel-6` is involved, get a list of Candlepin consumers for every client that uses RHEL 6.8 and older
* Send a request to Candlepin to regenerate the entitlement certificates for each consumer in the list

After this change, `subscription-manager refresh` should cause the certificates to be properly refreshed on RHEL 6.8 clients, including the 'Required Tags' field.  This will allow the "Restrict to OS Version" feature to work properly on these clients.

Opening this as a draft because this approach is not ideal.  Ideally, we would only send the request for the _relevant_ consumers, that is, those that are on the older OS _and_ ~~subscribe to the product containing the repo that was just changed~~.  (_update_: this would not work because of SCA) Even more ideally, we could send a single bulk request to Candlepin, but I don't think that's possible.