### PR TITLE
Refs #31550 - Add Timer class to Katello::Logging

### DIFF
--- a/app/lib/katello/logging.rb
+++ b/app/lib/katello/logging.rb
@@ -9,32 +9,37 @@ module Katello
       data_string = data.map { |k, v| "#{k}=#{v}" }.join(' ')
 
       logger.send(level, "#{message} #{data_string}")
-      "#{message} #{data_string}"
     end
 
     class Timer
       def initialize(key = "default")
         @key = key
         @start_time = Time.now
-        @@timers ||= {}
-        @@timers[key] = self
+        Thread.current[:timers] ||= {}
+        Thread.current[:timers][key] = self
       end
 
       def start
+        Rails.logger.info "Timer #{@key} already started; resetting start time" if @start_time
         Rails.logger.info "Timer #{@key} starting at #{Time.now}"
         @start_time = Time.now
         self
       end
 
       def stop
+        fail ::StandardError, "Timer #{@key} is not started" unless @start_time
         duration = (Time.now - @start_time).truncate(2)
         @start_time = nil
         Rails.logger.info "Timer #{@key} stopping at #{Time.now}: #{duration} sec"
-        "Timer #{@key} stopping at #{Time.now}: #{duration} sec"
       end
 
       def self.find_by_key(key)
-        @@timers[key]
+        if Thread.current&.[](:timers)&.[](key)
+          Thread.current[:timers][key]
+        else
+          Rails.logger.warn "Timer #{key} not found on current thread; creating a new timer"
+          self.new(key)
+        end
       end
     end
   end

--- a/app/lib/katello/logging.rb
+++ b/app/lib/katello/logging.rb
@@ -9,6 +9,33 @@ module Katello
       data_string = data.map { |k, v| "#{k}=#{v}" }.join(' ')
 
       logger.send(level, "#{message} #{data_string}")
+      "#{message} #{data_string}"
+    end
+
+    class Timer
+      def initialize(key = "default")
+        @key = key
+        @start_time = Time.now
+        @@timers ||= {}
+        @@timers[key] = self
+      end
+
+      def start
+        Rails.logger.info "Timer #{@key} starting at #{Time.now}"
+        @start_time = Time.now
+        self
+      end
+
+      def stop
+        duration = (Time.now - @start_time).truncate(2)
+        @start_time = nil
+        Rails.logger.info "Timer #{@key} stopping at #{Time.now}: #{duration} sec"
+        "Timer #{@key} stopping at #{Time.now}: #{duration} sec"
+      end
+
+      def self.find_by_key(key)
+        @@timers[key]
+      end
     end
   end
 end


### PR DESCRIPTION
Katello debugging tools: Currently you can do
```rb
::Katello::Logging.time('message', {data: mydata} ) do
  # code that takes time
end
```
But you have to pass in any variables used by the block to the data object.  Also you can only start and stop the timer within that single block.

This PR adds a Timer class to `Katello::Logging`.

Usage:
```rb
mytimer = ::Katello::Logging::Timer.new('my_timer').start
  # code that takes time
mytimer.stop
```

It will produce logs that look like this:
```
2020-12-23T18:39:04 [I|app|] Timer my_timer starting at 2020-12-23 18:39:04 +0000
2020-12-23T18:39:22 [I|app|] Timer my_timer stopping at 2020-12-23 18:39:22 +0000: 18.39 sec
```

Or, find the timer by key.  Useful for when you aren't in the same method / context:
```rb
def method_a
  ::Katello::Logging::Timer.new('my_timer').start
  # code that takes time
end

def method_b
  # more code that takes time
  ::Katello::Logging::Timer.find_by_key('my_timer').stop
end
```

Other benefits:
* `::Katello::Logging::Timer.new('my_timer')` and `::Katello::Logging::Timer.new('my_timer').start` will both return the timer object. 
* Unlimited number of concurrent timers
* `stop` method both logs and returns the log message (also updated the existing `time` class method to do the same)