### PR TITLE
Fixes #31105 - Truncate description of CV env in candlepin

### DIFF
--- a/app/lib/actions/candlepin/environment/create.rb
+++ b/app/lib/actions/candlepin/environment/create.rb
@@ -13,7 +13,7 @@ module Actions
           ::Katello::Resources::Candlepin::Environment.create(input['organization_label'],
                                                    input['cp_id'],
                                                    input['name'],
-                                                   input['description'])
+                                                   input['description'].try(:truncate, 255))
         end
       end
     end


### PR DESCRIPTION
To test: create a CV with a very long description and publish.
You'll see action :  Actions::Candlepin::Environment::Create fail with error: `description: size must be between 0 and 255`

With this change we truncate the Candlepin env description to 255 chars.
