### PR TITLE
Fixes #29838 - Add Red Hat Subscriptions Consumed macro

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -42,9 +42,8 @@ module Katello
     def index_response(reload_host = false)
       # Host needs to be reloaded because of lazy accessor
       @host.reload if reload_host
-      entitlements = @host.subscription_facet.candlepin_consumer.entitlements
-      subscriptions = entitlements.map { |entitlement| ::Katello::HostSubscriptionPresenter.new(entitlement) }
-      full_result_response(subscriptions)
+      presenter = ::Katello::HostSubscriptionsPresenter.new(@host)
+      full_result_response(presenter.subscriptions)
     end
 
     api :PUT, "/hosts/:host_id/subscriptions/auto_attach", N_("Trigger an auto-attach of subscriptions")

--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -19,6 +19,11 @@ module Katello
         host.subscriptions.redhat.pluck(:name)
       end
 
+      def host_redhat_subscriptions_consumed(host)
+        presenter = ::Katello::HostSubscriptionsPresenter.new(host)
+        presenter.subscriptions.select(&:redhat?).sum(&:quantity_consumed)
+      end
+
       def host_content_facet(host)
         host.content_facet
       end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -22,6 +22,7 @@ module Katello
       where(["end_date < ?", days.to_i.days.from_now.end_of_day])
     end
     scope :upstream, -> { where.not(upstream_pool_id: nil) }
+    scope :redhat, -> { joins(:products).merge(Katello::Product.redhat).distinct }
 
     include Glue::Candlepin::Pool
     include Glue::Candlepin::CandlepinObject
@@ -50,6 +51,10 @@ module Katello
     validates_lengths_from_database
 
     DAYS_RECENTLY_EXPIRED = 30
+
+    def redhat?
+      self.class.redhat.where(:id => self.id).exists?
+    end
 
     def active?
       active

--- a/app/presenters/katello/host_subscription_presenter.rb
+++ b/app/presenters/katello/host_subscription_presenter.rb
@@ -1,11 +1,10 @@
 module Katello
   class HostSubscriptionPresenter < SimpleDelegator
-    attr_accessor :quantity_consumed
+    attr_reader :quantity_consumed
 
-    def initialize(entitlement)
-      @subscription = Katello::Pool.find_by(:cp_id => entitlement['pool']['id'])
+    def initialize(pool:, entitlement:)
       @quantity_consumed = entitlement.try(:[], :quantity)
-      super(@subscription)
+      super(pool)
     end
   end
 end

--- a/app/presenters/katello/host_subscriptions_presenter.rb
+++ b/app/presenters/katello/host_subscriptions_presenter.rb
@@ -1,0 +1,22 @@
+module Katello
+  class HostSubscriptionsPresenter
+    def initialize(host)
+      @pools = host.subscription_facet.pools.group_by(&:cp_id)
+      @entitlements = host.subscription_facet.candlepin_consumer.entitlements if @pools.any?
+      @entitlements ||= []
+    end
+
+    def subscriptions
+      @entitlements.map do |e|
+        HostSubscriptionPresenter.new(pool: pool_for_entitlement(e), entitlement: e)
+      end
+    end
+
+    private
+
+    def pool_for_entitlement(entitlement)
+      pool_cp_id = entitlement['pool']['id']
+      @pools[pool_cp_id]&.first
+    end
+  end
+end

--- a/app/presenters/katello/host_subscriptions_presenter.rb
+++ b/app/presenters/katello/host_subscriptions_presenter.rb
@@ -1,13 +1,15 @@
 module Katello
   class HostSubscriptionsPresenter
-    def initialize(host)
-      @pools = host.subscription_facet.pools.group_by(&:cp_id)
-      @entitlements = host.subscription_facet.candlepin_consumer.entitlements if @pools.any?
-      @entitlements ||= []
-    end
+    attr_reader :subscriptions
 
-    def subscriptions
-      @entitlements.map do |e|
+    def initialize(host)
+      pools = host.subscription_facet&.pools || []
+      @pools = pools.group_by(&:cp_id)
+
+      entitlements = host.subscription_facet.candlepin_consumer.entitlements if @pools.any?
+      entitlements ||= []
+
+      @subscriptions = entitlements.map do |e|
         HostSubscriptionPresenter.new(pool: pool_for_entitlement(e), entitlement: e)
       end
     end

--- a/test/lib/concerns/base_template_scope_extensions_test.rb
+++ b/test/lib/concerns/base_template_scope_extensions_test.rb
@@ -22,31 +22,13 @@ module Katello
     end
 
     def test_host_redhat_subscriptions_consumed
-      redhat_product = katello_products(:redhat)
-      fedora_product = katello_products(:fedora)
-
-      redhat_pool = FactoryBot.create(:katello_pool, cp_id: '12345', products: [redhat_product])
-      custom_pool = FactoryBot.create(:katello_pool, cp_id: '6789', products: [fedora_product])
-
-      @host.subscription_facet.pools << redhat_pool
-      @host.subscription_facet.pools << custom_pool
-
-      entitlements = [
-        {
-          'pool' => {
-            'id' => redhat_pool.cp_id
-          },
-          quantity: 15
-        },
-        {
-          'pool' => {
-            'id' => custom_pool.cp_id
-          },
-          quantity: 4
-        }
+      subscriptions = [
+        stub(redhat?: false, quantity_consumed: 4),
+        stub(redhat?: true, quantity_consumed: 15)
       ]
 
-      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).returns(entitlements)
+      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).returns([])
+      ::Katello::HostSubscriptionsPresenter.any_instance.expects(:subscriptions).returns(subscriptions)
 
       source = ::Foreman::Renderer::Source::String.new(
         name: 'Parameter',

--- a/test/lib/concerns/base_template_scope_extensions_test.rb
+++ b/test/lib/concerns/base_template_scope_extensions_test.rb
@@ -5,6 +5,7 @@ require 'foreman/renderer/source/string'
 module Katello
   class BaseTemplateScopeExtensionsTest < ActiveSupport::TestCase
     def setup
+      @host = hosts(:one)
       @errata = katello_errata(:security)
     end
 
@@ -13,11 +14,49 @@ module Katello
         name: 'Parameter',
         content: "<%= errata('#{@errata.errata_id}')['id'] %>"
       )
-      scope = ::Foreman::Renderer.get_scope(host: ::Host.first)
+      scope = ::Foreman::Renderer.get_scope
       id = ::Foreman::Renderer.render(source, scope)
 
       refute_empty id
       assert_equal @errata.id.to_s, id
+    end
+
+    def test_host_redhat_subscriptions_consumed
+      redhat_product = katello_products(:redhat)
+      fedora_product = katello_products(:fedora)
+
+      redhat_pool = FactoryBot.create(:katello_pool, cp_id: '12345', products: [redhat_product])
+      custom_pool = FactoryBot.create(:katello_pool, cp_id: '6789', products: [fedora_product])
+
+      @host.subscription_facet.pools << redhat_pool
+      @host.subscription_facet.pools << custom_pool
+
+      entitlements = [
+        {
+          'pool' => {
+            'id' => redhat_pool.cp_id
+          },
+          quantity: 15
+        },
+        {
+          'pool' => {
+            'id' => custom_pool.cp_id
+          },
+          quantity: 4
+        }
+      ]
+
+      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).returns(entitlements)
+
+      source = ::Foreman::Renderer::Source::String.new(
+        name: 'Parameter',
+        content: "<%= host_redhat_subscriptions_consumed(@host) %>"
+      )
+      scope = ::Foreman::Renderer.get_scope(host: @host)
+      rendered = ::Foreman::Renderer.render(source, scope)
+
+      # the custom pool should not be included in the summation
+      assert_equal '15', rendered
     end
   end
 end

--- a/test/lib/concerns/base_template_scope_extensions_test.rb
+++ b/test/lib/concerns/base_template_scope_extensions_test.rb
@@ -24,10 +24,11 @@ module Katello
     def test_host_redhat_subscriptions_consumed
       subscriptions = [
         stub(redhat?: false, quantity_consumed: 4),
-        stub(redhat?: true, quantity_consumed: 15)
+        stub(redhat?: true, quantity_consumed: 15),
+        stub(redhat?: true, quantity_consumed: 2)
       ]
 
-      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).returns([])
+      ::Katello::Candlepin::Consumer.any_instance.stubs(:entitlements).returns([])
       ::Katello::HostSubscriptionsPresenter.any_instance.expects(:subscriptions).returns(subscriptions)
 
       source = ::Foreman::Renderer::Source::String.new(
@@ -38,7 +39,7 @@ module Katello
       rendered = ::Foreman::Renderer.render(source, scope)
 
       # the custom pool should not be included in the summation
-      assert_equal '15', rendered
+      assert_equal '17', rendered
     end
   end
 end

--- a/test/presenters/host_subscriptions_presenter_test.rb
+++ b/test/presenters/host_subscriptions_presenter_test.rb
@@ -1,0 +1,46 @@
+require 'katello_test_helper'
+
+module Katello
+  class HostSubscriptionsPresenterTest < ActiveSupport::TestCase
+    let(:presenter) { ::Katello::HostSubscriptionsPresenter.new(@host) }
+
+    def test_host_with_subscriptions
+      redhat_product = katello_products(:redhat)
+      fedora_product = katello_products(:fedora)
+
+      redhat_pool = FactoryBot.create(:katello_pool, cp_id: '12345', products: [redhat_product])
+      custom_pool = FactoryBot.create(:katello_pool, cp_id: '6789', products: [fedora_product])
+
+      @host = FactoryBot.create(:host, :with_subscription)
+      @host.subscription_facet.pools << redhat_pool
+      @host.subscription_facet.pools << custom_pool
+
+      entitlements = [
+        {
+          'pool' => {
+            'id' => redhat_pool.cp_id
+          },
+          quantity: 15
+        },
+        {
+          'pool' => {
+            'id' => custom_pool.cp_id
+          },
+          quantity: 4
+        }
+      ]
+
+      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).returns(entitlements)
+
+      assert_equal 2, presenter.subscriptions.length
+    end
+
+    def test_host_without_subscriptions
+      @host = FactoryBot.create(:host)
+
+      ::Katello::Candlepin::Consumer.any_instance.expects(:entitlements).never
+
+      assert_equal 0, presenter.subscriptions.length
+    end
+  end
+end


### PR DESCRIPTION
This PR resumes the work started by @snagoor in https://github.com/Katello/katello/pull/8714

It adds a macro for reporting templates that sums up the consumed quantities of red hat subscriptions for a host. It does so by refactoring the `HostSubscriptionPresenter` and introducing a `HostSubscriptionsPresenter` (note the plurality difference). My main design choices around `HostSubscriptionsPresenter` were:
- One interface to be used by the report template macro and subscriptions controller
- avoid 1 DB query per host pool. load them all at once instead
- avoid querying candlepin if there are no subscription facet pools (and therefore no candlepin entitlements)

There should be a small performance improvement for the `HostSubscriptionsController`, although the macro implies that there will be a candlepin call for each host in the report. Not ideal but there's no other way right now, since we don't track the consumed quantity of the entitlements in our DB.

**To test**

1. Verify the hammer output for subscriptions listing isn't broken:
```
hammer subscription list --host-id=1
---|----------------------------------|-----------------------------------------------------------------------|----------|----------|---------|----------|---------------------|---------------------|-----------|---------
ID | UUID                             | NAME                                                                  | TYPE     | CONTRACT | ACCOUNT | SUPPORT  | START DATE          | END DATE            | QUANTITY  | CONSUMED
---|----------------------------------|-----------------------------------------------------------------------|----------|----------|---------|----------|---------------------|---------------------|-----------|---------
6  | 4028fa6e76cea5f00176d47d80ae32e0 | MyProduct                                                             | Physical |          |         |          | 2021/01/05 21:39:23 | 2049/12/01 00:00:00 | Unlimited | 1       
5  | 4028fa6e76cea5f00176d2f1431532ca | Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes) | Physical | 12156828 | 941133  | Standard | 2020/03/11 04:00:00 | 2021/03/11 04:59:59 | 1         | 1       
---|----------------------------------|-----------------------------------------------------------------------|----------|----------|---------|----------|---------------------|---------------------|-----------|---------
```

2. Verify the macro works as expected
- clone one of the host report templates
- add a new column to show the macro output -> `host_redhat_subscriptions_consumed(host)`
- see that only the redhat subscriptions are summed up, and custom ones are ignored