### PR TITLE
Fixes #31591 - Ensure Candlepin is updated when updating system purpose in bulk

### DIFF
--- a/app/lib/actions/katello/host/update_system_purpose.rb
+++ b/app/lib/actions/katello/host/update_system_purpose.rb
@@ -14,7 +14,7 @@ module Actions
             host.subscription_facet.purpose_addons = purpose_addon_objects
           end
 
-          host.subscription_facet.save!
+          host.save!
           plan_self(:hostname => host.name)
         end
 

--- a/test/actions/katello/host/update_system_purpose_test.rb
+++ b/test/actions/katello/host/update_system_purpose_test.rb
@@ -19,17 +19,19 @@ module Katello::Host
     end
 
     def test_update_system_purpose
+      @host.expects(:update_candlepin_associations)
+
       plan_action @action, @host, @service_level, @purpose_role, @purpose_usage, @purpose_addons
 
       assert_equal(@host.subscription_facet.service_level, @service_level)
       assert_equal(@host.subscription_facet.purpose_role, @purpose_role)
       assert_equal(@host.subscription_facet.purpose_usage, @purpose_usage)
-      assert_equal(@host.subscription_facet.purpose_addons.count, 2)
-      assert_equal(@host.subscription_facet.purpose_addons.first.name, 'Addon One')
-      assert_equal(@host.subscription_facet.purpose_addons.second.name, 'Addon Two')
+      assert_equal(['Addon One', 'Addon Two'], @host.subscription_facet.purpose_addons.pluck(:name))
     end
 
     def test_dont_clear_host_values_on_nil_params
+      @host.expects(:update_candlepin_associations)
+
       @host.subscription_facet.purpose_addons << katello_purpose_addons(:addon)
       @host.subscription_facet.service_level = @service_level
       @host.subscription_facet.purpose_role = @purpose_role
@@ -44,6 +46,8 @@ module Katello::Host
     end
 
     def test_unset_value_with_empty_string_array
+      @host.expects(:update_candlepin_associations)
+
       @host.subscription_facet.purpose_addons << katello_purpose_addons(:addon)
       @host.subscription_facet.service_level = @service_level
       @host.subscription_facet.purpose_role = @purpose_role


### PR DESCRIPTION
Current behavior:

- Set system purpose in bulk for a content host
- observe on the client (ie subscripton-manager role) that the attributes don't reach the host
- confirm that candlepin wasn't updated via rails console: `::Host.find($ID).subscription_facet.candlepin_consumer.consumer_attributes.slice(:role, :usage, :serviceLevel, :addOns)`

Checkout this PR and verify that the attributes reach the content host per steps above