### PR TITLE
Fixes #31615 - Document arch parameter for repositories

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -61,6 +61,7 @@ module Katello
       param :ansible_collection_requirements, String, :desc => N_("Contents of requirement yaml file to sync from URL")
       param :http_proxy_policy, ::Katello::RootRepository::HTTP_PROXY_POLICIES, :desc => N_("policies for HTTP proxy for content sync")
       param :http_proxy_id, :number, :desc => N_("ID of a HTTP Proxy")
+      param :arch, String, :desc => N_("Architecture of content in the repository")
     end
 
     def_param_group :repo_create do


### PR DESCRIPTION
This was preventing repo create and update from taking arch as a parameter via hammer