### PR TITLE
Refs #31586 - load common.rake for pulp3 content switchover

### DIFF
--- a/lib/katello/tasks/pulp3_content_switchover.rake
+++ b/lib/katello/tasks/pulp3_content_switchover.rake
@@ -1,3 +1,5 @@
+load "#{Katello::Engine.root}/lib/katello/tasks/common.rake"
+
 require File.expand_path("../engine", File.dirname(__FILE__))
 require "#{Katello::Engine.root}/app/services/katello/pulp3/migration_switchover"
 


### PR DESCRIPTION
in b6532ce we added disable_dynflow to the switchover task, but didn't
load the common.rake that defines it.