### PR TITLE
Fixes #31624: host object may not always have a content facet

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -44,7 +44,7 @@ module Katello
 
       def kickstart_repos(host)
         distros = distribution_repositories(host).where(distribution_bootable: true)
-        if distros && host.content_facet.content_source
+        if distros && host&.content_facet&.content_source
           distros.map { |distro| distro.to_hash(host.content_facet.content_source) }
         else
           []


### PR DESCRIPTION
Addresses:

```
2021-01-13T19:08:59 [I|app|c87b0f64] Backtrace for 'Action failed' error (NoMethodError): undefined method `content_source' for nil:NilClass
 c87b0f64 | Did you mean?  contains_erb?
 c87b0f64 | /opt/theforeman/tfm/root/usr/share/gems/gems/katello-4.0.0.pre.master/app/models/katello/concerns/redhat_extensions.rb:47:in `kickstart_repos'
 c87b0f64 | /opt/theforeman/tfm/root/usr/share/gems/gems/katello-4.0.0.pre.master/app/models/katello/concerns/host_managed_extensions.rb:25:in `update_os_from_facts'
 c87b0f64 | /usr/share/foreman/app/models/host/managed.rb:500:in `populate_fields_from_facts'
 c87b0f64 | /usr/share/foreman/app/models/concerns/puppet_host_extensions.rb:3:in `populate_fields_from_facts'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:50:in `block (2 levels) in parse_facts'
 c87b0f64 | /usr/share/foreman/app/services/foreman/telemetry_helper.rb:27:in `telemetry_duration_histogram'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:49:in `block in parse_facts'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:90:in `block in skipping_orchestration'
 c87b0f64 | /usr/share/foreman/app/models/concerns/orchestration.rb:124:in `without_orchestration'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:89:in `skipping_orchestration'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:45:in `parse_facts'
 c87b0f64 | /usr/share/foreman/app/services/host_fact_importer.rb:34:in `import_facts'
 c87b0f64 | /usr/share/foreman/app/controllers/api/v2/hosts_controller.rb:307:in `facts'
```