### PR TITLE
[WIP] Fixes #31644 - check ping 503 retry

### DIFF
--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -6,19 +6,21 @@ namespace :katello do
     ::User.current = ::User.anonymous_admin
     RETRIES = 3
     RETRY_INTERVAL = 2
+
     RETRIES.times do |retry_count|
       ping_results = Katello::Ping.ping
 
-      if ping_results[:status] != "ok"
+      if ping_results[:status] != 'ok'
         pp ping_results
         services = ping_results[:services]
-        if services.value?({:status => "FAIL", :message => "503 Service Unavailable"}) &&
+        if services.value?({:status => 'FAIL', :message => '503 Service Unavailable' }) &&
             retry_count < (RETRIES - 1)
           pp "Services unavailable - retrying..."
           sleep RETRY_INTERVAL
         else
           fail("Not all the services have been started. Check the status report above and try again.")
         end
+      else
         break
       end
     end

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -19,6 +19,7 @@ namespace :katello do
         else
           fail("Not all the services have been started. Check the status report above and try again.")
         end
+        break
       end
     end
   end

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -12,17 +12,15 @@ namespace :katello do
       if ping_results[:status] != "ok"
         pp ping_results
         services = ping_results[:services]
-        if services.has_value?({:status=>"FAIL", :message=>"503 Service Unavailable"}) &&
+        if services.value?({:status => "FAIL", :message => "503 Service Unavailable"}) &&
             retry_count < (RETRIES - 1)
           pp "Services unavailable - retrying..."
           sleep RETRY_INTERVAL
         else
           fail("Not all the services have been started. Check the status report above and try again.")
-          break
         end
       end
     end
-
   end
 
   desc "Reimports information from backend systems"

--- a/test/actions/pulp/repository/refresh_test.rb
+++ b/test/actions/pulp/repository/refresh_test.rb
@@ -18,7 +18,8 @@ module ::Actions::Pulp::Repository
         ping[service][:status] = ::Katello::Ping::OK_RETURN_CODE
       end
 
-      ::Katello::Ping.stubs(:ping).returns(:services => ping)
+      ::Katello::Ping.stubs(:ping).returns(
+        :services => ping, :status => ::Katello::Ping::OK_RETURN_CODE)
     end
 
     describe 'Refresh' do


### PR DESCRIPTION
This adds a simple check for 503 http responses and then retries for a given number of times before failing.

Tested this locally by modifying /etc/httpd/conf.d/05-foreman-ssl.conf:
```
 <Location "/pulp/api/v3">
    ...
    ProxyPass  http://localhost:8080/
    ProxyPassReverse http://localhost:8080/
   ...
  </Location>
```

At port 8080 a [simple web application](https://gist.github.com/jjeffers/8e3434ed674628ba5e6a23c65a4baf3f) returns a 503.

In some situations a pulp3 migration will fail because the environment might include pulp3 services that have started but are not yet serving requests. This change provides a little insurance in that case.