### PR TITLE
Fixes #31655 - UX changes for create and copy modals

### DIFF
--- a/webpack/scenes/ContentViews/Copy/CopyContentViewModal.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewModal.js
@@ -5,17 +5,27 @@ import CopyContentViewForm from './CopyContentViewForm';
 
 const CopyContentViewModal = ({
   cvId, cvName, show, setIsOpen,
-}) => (
-  <Modal
-    title={`Copy content view ${cvName}`}
-    variant={ModalVariant.large}
-    isOpen={show}
-    width="50%"
-    onClose={() => { setIsOpen(false); }}
-    appendTo={document.body}
-  ><CopyContentViewForm cvId={cvId} setModalOpen={setIsOpen} />
-  </Modal>
-);
+}) => {
+  const description = (
+    <p>
+      This will create a copy of <b>{cvName}</b>, including details,
+      repositories, and filters. Generated data such
+      as history, tasks and versions will not be copied.
+    </p>
+  );
+  return (
+    <Modal
+      title="Copy content view"
+      variant={ModalVariant.small}
+      isOpen={show}
+      description={description}
+      onClose={() => {
+        setIsOpen(false);
+      }}
+      appendTo={document.body}
+    ><CopyContentViewForm cvId={cvId} setModalOpen={setIsOpen} />
+    </Modal>);
+};
 
 CopyContentViewModal.propTypes = {
   cvId: PropTypes.string,

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -3,10 +3,11 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import { Form, FormGroup, TextInput, TextArea, Checkbox, Radio, ActionGroup, Button } from '@patternfly/react-core';
+import { Form, FormGroup, TextInput, TextArea, Checkbox, ActionGroup, Button, Tile, Grid, GridItem } from '@patternfly/react-core';
 import { createContentView } from '../ContentViewsActions';
 import { selectCreateContentViews, selectCreateContentViewStatus, selectCreateContentViewError } from './ContentViewCreateSelectors';
-import { LabelComponent, LabelComposite, LabelDependencies, LabelAutoPublish, LabelImportOnly } from './ContentViewFormComponents';
+import { LabelDependencies, LabelAutoPublish, LabelImportOnly } from './ContentViewFormComponents';
+import ContentViewIcon from '../components/ContentViewIcon';
 
 const CreateContentViewForm = ({ setModalOpen }) => {
   const dispatch = useDispatch();
@@ -95,27 +96,35 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           onChange={value => setDescription(value)}
         />
       </FormGroup>
-      <FormGroup isInline fieldId="component">
-        <Radio
-          id="component"
-          name="component"
-          role="radio"
-          label={LabelComponent()}
-          isChecked={component}
-          onChange={(checked) => { setComponent(checked); setComposite(!checked); }}
-          description="Consists of repositories"
-        />
-      </FormGroup>
-      <FormGroup isInline fieldId="composite">
-        <Radio
-          id="composite"
-          name="composite"
-          role="radio"
-          label={LabelComposite()}
-          isChecked={composite}
-          onChange={(checked) => { setComposite(checked); setComponent(!checked); }}
-          description="Consists of more than one component view"
-        />
+      <FormGroup isInline fieldId="type" label="Type">
+        <Grid hasGutter>
+          <GridItem span={6}>
+            <Tile
+              isStacked
+              aria-label="component_tile"
+              icon={<ContentViewIcon composite={false} />}
+              id="component"
+              title="Component content view"
+              onClick={() => { setComponent(true); setComposite(false); }}
+              isSelected={component}
+            >
+              Single content view consisting of repositories
+            </Tile>
+          </GridItem>
+          <GridItem span={6}>
+            <Tile
+              isStacked
+              aria-label="composite_tile"
+              icon={<ContentViewIcon composite />}
+              id="composite"
+              title="Composite content view"
+              onClick={() => { setComposite(true); setComponent(false); }}
+              isSelected={composite}
+            >
+              Consists of component content views
+            </Tile>
+          </GridItem>
+        </Grid>
       </FormGroup>
       {!composite &&
         <FormGroup isInline fieldId="dependencies">
@@ -148,7 +157,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           />
         </FormGroup>}
       <ActionGroup>
-        <Button aria-label="create_content_view" variant="primary" isDisabled={saving} onClick={() => onSave()}>Create Content View</Button>
+        <Button aria-label="create_content_view" variant="primary" isDisabled={saving} onClick={() => onSave()}>Create content view</Button>
         <Button variant="link" onClick={() => setModalOpen(false)}>Cancel</Button>
       </ActionGroup>
     </Form>

--- a/webpack/scenes/ContentViews/Create/CreateContentViewModal.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewModal.js
@@ -6,9 +6,8 @@ import CreateContentViewForm from './CreateContentViewForm';
 const CreateContentViewModal = ({ show, setIsOpen }) => (
   <Modal
     title="Create content view"
-    variant={ModalVariant.large}
+    variant={ModalVariant.small}
     isOpen={show}
-    width="50%"
     onClose={() => { setIsOpen(false); }}
     appendTo={document.body}
   ><CreateContentViewForm setModalOpen={setIsOpen} />

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -64,14 +64,12 @@ test('Form closes itself upon save', async (done) => {
 });
 
 test('Displays dependent fields correctly', () => {
-  const {
-    getByText, queryByText, getByLabelText, getByRole,
-  } = renderWithRedux(form);
+  const { getByText, queryByText, getByLabelText } = renderWithRedux(form);
   expect(getByText('Description')).toBeInTheDocument();
   expect(getByText('Name')).toBeInTheDocument();
   expect(getByText('Label')).toBeInTheDocument();
-  expect(getByText('Composite Content View')).toBeInTheDocument();
-  expect(getByText('Component Content View')).toBeInTheDocument();
+  expect(getByText('Composite content view')).toBeInTheDocument();
+  expect(getByText('Component content view')).toBeInTheDocument();
   expect(getByText('Solve Dependencies')).toBeInTheDocument();
   expect(queryByText('Auto Publish')).not.toBeInTheDocument();
   expect(getByText('Import Only')).toBeInTheDocument();
@@ -81,13 +79,13 @@ test('Displays dependent fields correctly', () => {
   expect(getByLabelText('input_label')).toHaveAttribute('value', '123_2123');
 
   // display Auto Publish when Composite CV
-  fireEvent.click(getByRole('radio', { name: 'composite Composite Content View' }));
+  fireEvent.click(getByLabelText('composite_tile'));
   expect(queryByText('Solve Dependencies')).not.toBeInTheDocument();
   expect(getByText('Auto Publish')).toBeInTheDocument();
   expect(queryByText('Import Only')).not.toBeInTheDocument();
 
   // display Solve Dependencies when Component CV
-  fireEvent.click(getByRole('radio', { name: 'single Component Content View' }));
+  fireEvent.click(getByLabelText('component_tile'));
   expect(getByText('Solve Dependencies')).toBeInTheDocument();
   expect(queryByText('Auto Publish')).not.toBeInTheDocument();
   expect(getByText('Import Only')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -269,8 +269,8 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(queryByText('Description')).not.toBeInTheDocument();
   expect(queryByText('Name')).not.toBeInTheDocument();
   expect(queryByText('Label')).not.toBeInTheDocument();
-  expect(queryByText('Composite Content View')).not.toBeInTheDocument();
-  expect(queryByText('Component Content View')).not.toBeInTheDocument();
+  expect(queryByText('Composite content view')).not.toBeInTheDocument();
+  expect(queryByText('Component content view')).not.toBeInTheDocument();
   expect(queryByText('Solve Dependencies')).not.toBeInTheDocument();
   expect(queryByText('Auto Publish')).not.toBeInTheDocument();
   expect(queryByText('Import Only')).not.toBeInTheDocument();
@@ -280,8 +280,8 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(getByText('Description')).toBeInTheDocument();
   expect(getByText('Name')).toBeInTheDocument();
   expect(getByText('Label')).toBeInTheDocument();
-  expect(getByText('Composite Content View')).toBeInTheDocument();
-  expect(getByText('Component Content View')).toBeInTheDocument();
+  expect(getByText('Composite content view')).toBeInTheDocument();
+  expect(getByText('Component content view')).toBeInTheDocument();
   expect(getByText('Solve Dependencies')).toBeInTheDocument();
   expect(queryByText('Auto Publish')).not.toBeInTheDocument();
   expect(getByText('Import Only')).toBeInTheDocument();


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman-js/pull/253 to use Tile component.
Requirements:
Create Screen : https://marvelapp.com/prototype/1121a8de/screen/76054859

Copy Screen : https://marvelapp.com/prototype/1121a8de/screen/74756540

Create Form Updates:
![Create](https://user-images.githubusercontent.com/21146741/105764857-87b2c200-5f25-11eb-8f19-28c3bde9d3f3.png)

Copy Form Updates:
![Copy](https://user-images.githubusercontent.com/21146741/105764875-8ed9d000-5f25-11eb-9be2-9357598e7ec4.png)
