### PR TITLE
Fixes #31782 - Enable mirror_on_sync for available content types

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -156,7 +156,7 @@
             on-save="save(repository)">
         </dd>
       </span>
-      <span ng-show="repository.content_type === 'yum' || repository.content_type === 'deb' || repository.content_type === 'puppet'">
+      <span ng-hide="repository.content_type === 'ostree' || repository.content_type === 'puppet'">
         <dt translate>Mirror on Sync</dt>
         <dd bst-edit-checkbox="repository.mirror_on_sync"
             formatter="booleanToYesNo"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -221,7 +221,7 @@
         </p>
       </div>
 
-      <div class="checkbox" ng-if="repository.content_type === 'yum' || repository.content_type === 'deb' || repository.content_type === 'puppet'">
+      <div class="checkbox" ng-hide="repository.content_type === 'ostree' || repository.content_type === 'puppet'">
         <label>
           <input id="mirror_on_sync" name="mirror_on_sync" ng-model="repository.mirror_on_sync" type="checkbox"/>
           <span translate>Mirror on Sync</span>


### PR DESCRIPTION
All pulp3 content types have the mirror option on sync.

Ansible: https://docs.pulpproject.org/pulp_ansible/restapi.html#operation/repositories_ansible_ansible_sync
Deb: https://docs.pulpproject.org/pulp_deb/restapi.html#operation/repositories_deb_apt_sync
Container: https://docs.pulpproject.org/pulp_container/restapi.html#operation/repositories_container_container_sync
File: https://docs.pulpproject.org/pulp_file/restapi.html#operation/repositories_file_file_sync
Rpm: https://docs.pulpproject.org/pulp_rpm/restapi.html#operation/repositories_rpm_rpm_sync

Hence, hiding the flag only for puppet and ostree