### PR TITLE
Fixes #31788 - Add type column to cvv export histories

### DIFF
--- a/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
+++ b/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
@@ -58,7 +58,7 @@ module Katello
                                                                 organization: @organization,
                                                                 create_by_default: false)
       if @view.blank?
-        msg = _("Unable to incrementally export. Do a Full Export the library content "\
+        msg = _("Unable to incrementally export. Do a Full Export on the library content "\
                 "before updating from the latest increment.")
         fail HttpErrors::BadRequest, msg
       end

--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -10,6 +10,9 @@ module Katello
     param :destination_server, String, :desc => N_("Destination Server name"), :required => false
     param :organization_id, :number, :desc => N_("Organization identifier"), :required => false
     param :id, :number, :desc => N_("Content view version export history identifier"), :required => false
+    param :type, ::Katello::ContentViewVersionExportHistory::EXPORT_TYPES,
+                                  :desc => N_("Export Types"),
+                                  :required => false
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(ContentViewVersionExportHistory)
     def index
@@ -17,6 +20,7 @@ module Katello
       history = history.where(:id => params[:id]) unless params[:id].blank?
       history = history.where(:content_view_version_id => params[:content_view_version_id]) unless params[:content_view_version_id].blank?
       history = history.where(:destination_server => params[:destination_server]) unless params[:destination_server].blank?
+      history = history.where(:export_type => params[:type]) unless params[:type].blank?
       history = history.with_organization_id(params[:organization_id]) unless params[:organization_id].blank?
       history = history.with_content_view_id(params[:content_view_id]) unless params[:content_view_id].blank?
       respond_with_template_collection("index", 'content_view_version_export_histories',

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -2,12 +2,23 @@ module Katello
   class ContentViewVersionExportHistory < Katello::Model
     include Authorization::ContentViewVersionExportHistory
 
+    COMPLETE = "complete".freeze
+    INCREMENTAL = "incremental".freeze
+    EXPORT_TYPES = [COMPLETE, INCREMENTAL].freeze
+
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :inverse_of => :export_histories
     validates_lengths_from_database
     validates :content_view_version_id, :presence => true
     validates :destination_server, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
+    validates :export_type, :inclusion => { :in => EXPORT_TYPES,
+                                            :allow_blank => false,
+                                            :message => _("Invalid export_type from one of the following: %s" % EXPORT_TYPES.join(', '))
+                                          }
+
     validates :metadata, :presence => true
     serialize :metadata, Hash
+
+    before_validation :set_export_type, :if => -> { export_type.blank? }
 
     scope :with_organization_id, ->(organization_id) do
       where(:content_view_version_id => ContentViewVersion.with_organization_id(organization_id))
@@ -20,10 +31,19 @@ module Katello
     scoped_search :on => :content_view_id, :relation => :content_view_version, :validator => ScopedSearch::Validators::INTEGER, :only_explicit => true
     scoped_search :on => :content_view_version_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :export_type, :rename => :type, :complete_value => EXPORT_TYPES
 
     def self.latest(content_view, destination_server: nil)
       where(content_view_version: content_view.versions,
             destination_server: destination_server).order(:created_at).last
+    end
+
+    def export_type_from_metadata
+      cvve.metadata[:incremental] ? INCREMENTAL : COMPLETE
+    end
+
+    def set_export_type
+      self.export_type = export_type_from_metadata
     end
   end
 end

--- a/app/views/katello/api/v2/content_view_version_export_histories/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_version_export_histories/show.json.rabl
@@ -1,6 +1,7 @@
 object @resource
 
 attributes :destination_server, :path, :id, :metadata
+attributes :export_type => :type
 
 node :content_view_version do |h|
   h.content_view_version.name

--- a/db/migrate/20210128231228_add_type_and_from_cvv_to_cvv_export_history.rb
+++ b/db/migrate/20210128231228_add_type_and_from_cvv_to_cvv_export_history.rb
@@ -1,0 +1,14 @@
+class AddTypeAndFromCvvToCvvExportHistory < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_content_view_version_export_histories,
+               :export_type, :string,
+               :default => ::Katello::ContentViewVersionExportHistory::COMPLETE, :null => false
+    add_index :katello_content_view_version_export_histories, :export_type, name: 'katello_cvveh_export_type'
+
+    ::Katello::ContentViewVersionExportHistory.reset_column_information
+    ::Katello::ContentViewVersionExportHistory.all.each do |cvve|
+      next if cvve.export_type == cvve.export_type_from_metadata
+      cvve.update!(export_type: cvve.export_type_from_metadata)
+    end
+  end
+end

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -73,13 +73,13 @@ module Katello
       ::Katello::ContentViewVersionExportHistory.destroy_all
       destination = "greatest"
       path = "/tmp"
-      assert_empty ContentViewVersionExportHistory.search_for("export_type = complete ")
+      assert_empty ContentViewVersionExportHistory.search_for("type = complete")
       ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
                                                             destination_server: destination,
                                                             metadata: {foo: :bar},
                                                             path: path)
 
-      refute_empty ContentViewVersionExportHistory.search_for("export_type = complete ")
+      refute_empty ContentViewVersionExportHistory.search_for("type = complete")
     end
   end
 end

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -45,5 +45,41 @@ module Katello
                                                                                 destination_server: destination)
       assert_nil ContentViewVersionExportHistory.latest(@cvv.content_view)
     end
+
+    def test_invalid_export_type
+      destination = "greatest"
+      path = "/tmp"
+      assert_raises ActiveRecord::RecordInvalid do
+        ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                              destination_server: destination,
+                                                              metadata: {foo: :bar},
+                                                              path: path,
+                                                              export_type: "Haha")
+      end
+    end
+
+    def test_valid_on_blank_export_type
+      destination = "greatest"
+      path = "/tmp"
+      assert_nothing_raised do
+        ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                              destination_server: destination,
+                                                              metadata: {foo: :bar},
+                                                              path: path)
+      end
+    end
+
+    def test_scoped_search_export_type
+      ::Katello::ContentViewVersionExportHistory.destroy_all
+      destination = "greatest"
+      path = "/tmp"
+      assert_empty ContentViewVersionExportHistory.search_for("export_type = complete ")
+      ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                            destination_server: destination,
+                                                            metadata: {foo: :bar},
+                                                            path: path)
+
+      refute_empty ContentViewVersionExportHistory.search_for("export_type = complete ")
+    end
   end
 end


### PR DESCRIPTION
Updates include
1) Migration to add column
2) Model changes to validate and be able to search on export_type
3) Api changes to accept the export_types
4) rabl to expose the type parameter