### PR TITLE
Fixes #32093 - Remove registration template auto-assign to new OS

### DIFF
--- a/app/models/katello/concerns/operatingsystem_extensions.rb
+++ b/app/models/katello/concerns/operatingsystem_extensions.rb
@@ -17,8 +17,6 @@ module Katello
           TemplateKind.all.each do |kind|
             if name == ::Operatingsystem::REDHAT_ATOMIC_HOST_OS && kind.name == "provision"
               provisioning_template_name = Setting["katello_default_atomic_provision"]
-            elsif kind.name == 'registration'
-              provisioning_template_name = 'Linux registration default'
             else
               provisioning_template_name = Setting["katello_default_#{kind.name}"]
             end


### PR DESCRIPTION
Remove the auto-association of registration template to Red Hat OS,
Foreman now assigns the template to all operating systems.
See https://projects.theforeman.org/issues/31663