### PR TITLE
Fixes #31812 - Avoid race conditions in CandlepinMessageHandler

### DIFF
--- a/app/services/katello/candlepin/message_handler.rb
+++ b/app/services/katello/candlepin/message_handler.rb
@@ -2,10 +2,12 @@ module Katello
   module Candlepin
     class MessageHandler
       # Service to handle parsing the messages we receive from candlepin
-      attr_accessor :message
+      attr_reader :subscription_facet, :message, :pool
 
       def initialize(message)
         @message = message
+        @subscription_facet = ::Katello::Host::SubscriptionFacet.find_by_uuid(consumer_uuid) if consumer_uuid
+        @pool = ::Katello::Pool.find_by_cp_id(pool_id) if pool_id
       end
 
       def subject
@@ -51,18 +53,9 @@ module Katello
         end
       end
 
-      def pool
-        Katello::Pool.find_by(:cp_id => pool_id)
-      end
-
-      def subscription_facet
-        return nil if self.consumer_uuid.nil?
-        ::Katello::Host::SubscriptionFacet.where(uuid: self.consumer_uuid).first
-      end
-
       def create_pool_on_host
-        return if self.subscription_facet.nil?
-        old_host_ids = pool.subscription_facets.pluck(:host_id)
+        return if self.subscription_facet.nil? || pool.nil?
+        old_host_ids = subscription_facet_host_ids
         ::Katello::SubscriptionFacetPool.where(subscription_facet_id: self.subscription_facet.id,
                                                pool_id: pool.id).first_or_create
         pool.import_audit_record(old_host_ids)
@@ -70,7 +63,7 @@ module Katello
 
       def remove_pool_from_host
         return if self.subscription_facet.nil? || pool.nil?
-        old_host_ids = pool.subscription_facets.pluck(:host_id)
+        old_host_ids = subscription_facet_host_ids
         ::Katello::SubscriptionFacetPool.where(subscription_facet_id: self.subscription_facet.id,
                                                pool_id: pool.id).destroy_all
         pool.import_audit_record(old_host_ids)
@@ -86,7 +79,7 @@ module Katello
 
       def delete_pool
         if Katello::Pool.where(:cp_id => pool_id).destroy_all.any?
-          Rails.logger.info "deleted pool #{pool_id} from Katello"
+          Rails.logger.info "Deleted Katello::Pool with cp_id=#{pool_id}"
         end
       end
 
@@ -118,6 +111,12 @@ module Katello
         end
 
         org.simple_content_access?(cached: false)
+      end
+
+      private
+
+      def subscription_facet_host_ids
+        ::Katello::SubscriptionFacetPool.where(pool_id: pool_id).joins(:subscription_facet).pluck(:host_id)
       end
     end
   end

--- a/test/services/candlepin/message_handler_test.rb
+++ b/test/services/candlepin/message_handler_test.rb
@@ -2,10 +2,11 @@ require 'katello_test_helper'
 
 module Katello
   class MessageHandlerTestBase < ActiveSupport::TestCase
+    let(:handler) { ::Katello::Candlepin::MessageHandler.new(@event) }
+
     def setup
       json = File.read("#{Katello::Engine.root}/test/fixtures/candlepin_messages/#{event_name}.json")
-      event = OpenStruct.new(subject: event_name, content: json)
-      @handler = ::Katello::Candlepin::MessageHandler.new(event)
+      @event = OpenStruct.new(subject: event_name, content: json)
       @pool = katello_pools(:pool_one)
 
       #from json files
@@ -24,11 +25,11 @@ module Katello
     let(:event_name) { 'system_purpose_compliance.created' }
 
     def test_system_purpose
-      assert_equal @handler.system_purpose.overall_status, :mismatched
-      assert_equal @handler.system_purpose.sla_status, :mismatched
-      assert_equal @handler.system_purpose.role_status, :not_specified
-      assert_equal @handler.system_purpose.usage_status, :not_specified
-      assert_equal @handler.system_purpose.addons_status, :not_specified
+      assert_equal handler.system_purpose.overall_status, :mismatched
+      assert_equal handler.system_purpose.sla_status, :mismatched
+      assert_equal handler.system_purpose.role_status, :not_specified
+      assert_equal handler.system_purpose.usage_status, :not_specified
+      assert_equal handler.system_purpose.addons_status, :not_specified
     end
   end
 
@@ -36,20 +37,20 @@ module Katello
     let(:event_name) { 'compliance.created' }
 
     def test_consumer_uuid
-      assert_equal @consumer_uuid, @handler.consumer_uuid
+      assert_equal @consumer_uuid, handler.consumer_uuid
     end
 
     def test_reasons
-      assert_equal 1, @handler.reasons.count
-      assert_equal 'Red Hat Enterprise Linux Server', @handler.reasons[0]['productName']
+      assert_equal 1, handler.reasons.count
+      assert_equal 'Red Hat Enterprise Linux Server', handler.reasons[0]['productName']
     end
 
     def test_status
-      assert_equal 'invalid', @handler.status
+      assert_equal 'invalid', handler.status
     end
 
     def test_subscription_facet
-      assert_equal @facet, @handler.subscription_facet
+      assert_equal @facet, handler.subscription_facet
     end
   end
 
@@ -57,17 +58,17 @@ module Katello
     let(:event_name) { 'entitlement.created' }
 
     def test_pool_id
-      assert_equal @pool_id, @handler.pool_id
+      assert_equal @pool_id, handler.pool_id
     end
 
     def test_consumer_uuid
-      assert_equal @consumer_uuid, @handler.consumer_uuid
+      assert_equal @consumer_uuid, handler.consumer_uuid
     end
 
     def test_create_pool_on_host
       @facet.pools = []
 
-      @handler.create_pool_on_host
+      handler.create_pool_on_host
       refute_empty @facet.pools.where(:cp_id => @pool_id)
     end
   end
@@ -76,16 +77,16 @@ module Katello
     let(:event_name) { 'entitlement.deleted' }
 
     def test_consumer_uuid
-      assert_equal @consumer_uuid, @handler.consumer_uuid
+      assert_equal @consumer_uuid, handler.consumer_uuid
     end
 
     def test_pool_id
-      assert_equal @pool_id, @handler.pool_id
+      assert_equal @pool_id, handler.pool_id
     end
 
     def test_remove_pool_from_host
       @facet.pools = [@pool]
-      @handler.remove_pool_from_host
+      handler.remove_pool_from_host
       assert_empty @facet.pools.where(:cp_id => @pool_id)
     end
   end
@@ -94,13 +95,13 @@ module Katello
     let(:event_name) { 'pool.created' }
 
     def test_pool_id
-      assert_equal @pool_id, @handler.pool_id
+      assert_equal @pool_id, handler.pool_id
     end
 
     def test_import_pool
       Katello::EventQueue.expects(:push_event).with('import_pool', @pool.id)
 
-      @handler.import_pool
+      handler.import_pool
     end
   end
 
@@ -108,19 +109,19 @@ module Katello
     let(:event_name) { 'pool.deleted' }
 
     def test_pool_id
-      assert_equal @pool_id, @handler.pool_id
+      assert_equal @pool_id, handler.pool_id
     end
 
     def test_delete_pool
-      @handler.delete_pool
+      handler.delete_pool
       assert_empty Katello::Pool.find_by(:cp_id => @pool_id)
     end
 
     def test_delete_pool_on_null
-      pool = @handler.pool
-      @handler.stubs(:pool).returns(pool).then.returns(nil)
+      pool = handler.pool
+      handler.stubs(:pool).returns(pool).then.returns(nil)
       # assert no errors are raised
-      @handler.delete_pool
+      handler.delete_pool
       assert_empty Katello::Pool.find_by(:cp_id => @pool_id)
     end
   end
@@ -146,21 +147,21 @@ module Katello
       Katello::HostStatusManager.expects(:update_subscription_status_to_sca)
       Organization.any_instance.expects(:simple_content_access?).with(cached: false)
 
-      @handler.handle_content_access_mode_modified
+      handler.handle_content_access_mode_modified
     end
 
     def test_sca_disabled
       Katello::HostStatusManager.expects(:clear_syspurpose_status).never
       Katello::HostStatusManager.expects(:update_subscription_status_to_sca).never
       Organization.any_instance.expects(:simple_content_access?).with(cached: false)
-      @handler.expects(:event_data).returns('contentAccessMode' => 'entitlement').twice
+      handler.expects(:event_data).returns('contentAccessMode' => 'entitlement').twice
 
       @org.hosts.joins(:subscription_facet).count.times do
         Katello::Resources::Candlepin::Consumer.expects(:compliance)
         Katello::Resources::Candlepin::Consumer.expects(:purpose_compliance)
       end
 
-      @handler.handle_content_access_mode_modified
+      handler.handle_content_access_mode_modified
     end
   end
 end


### PR DESCRIPTION
the `pool` and `subscription_facet` methods of CandlepinMessageHandler previously loaded from the db on each call. I refactored the code to use instance variables when the handler is initialized to avoid those and potential race conditions as a consequence where (for example) the Pool has already been deleted from the Katello db:
```
      def remove_pool_from_host
        return if self.subscription_facet.nil? || pool.nil?
        old_host_ids = pool.subscription_facets.pluck(:host_id)
        ::Katello::SubscriptionFacetPool.where(subscription_facet_id: self.subscription_facet.id,
                                               pool_id: pool.id).destroy_all
        pool.import_audit_record(old_host_ids)
      end
```

We could enter into the method (avoiding the first return) but get nil errors when referring to `pool.id` or `subscription_facet.id` again if those entities were deleted in that narrow window of time due to querying the db on each call.

There are also a few other defensive checks added!