### PR TITLE
Fixes #31654 - Support content migration reset

### DIFF
--- a/app/lib/actions/pulp3/content_migration_reset.rb
+++ b/app/lib/actions/pulp3/content_migration_reset.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Pulp3
+    class ContentMigrationReset < Pulp3::AbstractAsyncTask
+      def plan(smart_proxy)
+        plan_self(smart_proxy_id: smart_proxy.id)
+      end
+
+      def invoke_external_task
+        migration_service = ::Katello::Pulp3::Migration.new(smart_proxy)
+        migration_service.reset
+      end
+
+      def humanized_name
+        _("Content Migration Reset")
+      end
+
+      def rescue_strategy
+        Dynflow::Action::Rescue::Skip
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -114,6 +114,44 @@ module Katello
         Katello::Pulp3::MigrationPlan.new(@repository_types).generate.as_json
       end
 
+      def reset
+        if @repository_types.empty?
+          fail ::Katello::Errors::Pulp3MigrationError, 'There are no Pulp 3 content types to reset'
+        end
+
+        plugins = @repository_types.sort.map do |repository_type|
+          {
+            type: ::Katello::Pulp3::MigrationPlan.pulp2_repository_type(repository_type)
+          }
+        end
+        plan = { plugins: plugins }
+
+        # TODO: Don't provide the plan as a string once this is resolved: https://pulp.plan.io/issues/8211
+        migration_plan_api.reset(migration_plan_api.create(plan: plan).pulp_href, plan.to_json)
+
+        content_types_for_migration.each do |content_type|
+          if content_type.model_class == ::Katello::Erratum
+            ::Katello::RepositoryErratum.update_all(erratum_pulp3_href: nil)
+          else
+            content_type.model_class.update_all(migrated_pulp3_href: nil)
+          end
+        end
+
+        @repository_types.each do |repo_type|
+          if repo_type == "file"
+            ::Katello::Repository.file_type.update(remote_href: nil, publication_href: nil, version_href: nil)
+          elsif repo_type == "docker"
+            ::Katello::Repository.docker_type.update(remote_href: nil, publication_href: nil, version_href: nil)
+          elsif repo_type == "yum"
+            ::Katello::Repository.yum_type.update(remote_href: nil, publication_href: nil, version_href: nil)
+          end
+        end
+
+        ::Katello::Pulp3::RepositoryReference.destroy_all
+        ::Katello::Pulp3::DistributionReference.destroy_all
+        ::Katello::Pulp3::ContentGuard.destroy_all
+      end
+
       def create_migrations
         plan = migration_plan
         Rails.logger.info("Migration Plan: #{plan}")

--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -21,13 +21,13 @@ module Katello
       def generate_plugins
         @repository_types.sort.map do |repository_type|
           {
-            type: pulp2_repository_type(repository_type),
+            type: self.class.pulp2_repository_type(repository_type),
             repositories: repository_migrations(repository_type)
           }
         end
       end
 
-      def pulp2_repository_type(repository_type)
+      def self.pulp2_repository_type(repository_type)
         if repository_type == 'yum'
           return 'rpm' #migration plugin uses rpm
         else

--- a/lib/katello/tasks/pulp3_migration_reset.rake
+++ b/lib/katello/tasks/pulp3_migration_reset.rake
@@ -1,0 +1,26 @@
+namespace :katello do
+  desc "Reset the Pulp 2 -> Pulp 3 migration for content types that haven't been fully switched over"
+  task :pulp3_migration_reset => ["dynflow:client", "check_ping"] do
+    puts "Starting Content Migration Reset."
+    SmartProxy.pulp_primary.refresh
+
+    task = ForemanTasks.async_task(Actions::Pulp3::ContentMigrationReset, SmartProxy.pulp_primary)
+
+    if ENV['wait'].nil? || ::Foreman::Cast.to_bool(ENV['wait'])
+      until !task.pending? || task.paused?
+        sleep(20)
+        task = ForemanTasks::Task.find(task.id)
+      end
+
+      if task.result == 'warning' || task.result == 'pending'
+        msg = _("Content Migration Reset failed, You will want to investigate: https://#{Socket.gethostname}/foreman_tasks/tasks/#{task.id}\n")
+        $stderr.print(msg)
+        fail ForemanTasks::TaskError, task
+      else
+        puts _("Content Migration Reset completed successfully")
+      end
+    else
+      puts "Content Migration Reset started, you may monitor it at: https://#{Socket.gethostname}/foreman_tasks/tasks/#{task.id}"
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_migration/docker_migration_reset.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_migration/docker_migration_reset.yml
@@ -1,0 +1,3477 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:43 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '564'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJv
+        eC1saWJyYXJ5IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        ZXMvRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkv
+        IiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNvZGUiOiAiUExQ
+        MDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkifX0s
+        ICJkZXNjcmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0
+        b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5
+        IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVz
+        b3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LVRlc3QtYnVzeWJveC1saWJyYXJ5In19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:43 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJy
+        YXJ5IiwiZGlzcGxheV9uYW1lIjoiYnVzeWJveCIsImltcG9ydGVyX3R5cGVf
+        aWQiOiJkb2NrZXJfaW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVl
+        ZCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIuaW8iLCJ1cHN0cmVhbV9u
+        YW1lIjoiYnVzeWJveCIsInRhZ3MiOlsibGF0ZXN0Il0sImVuYWJsZV92MSI6
+        ZmFsc2UsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhf
+        cGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9o
+        b3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJub3RlcyI6eyJfcmVwby10
+        eXBlIjoiZG9ja2VyLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmli
+        dXRvcl90eXBlX2lkIjoiZG9ja2VyX2Rpc3RyaWJ1dG9yX3dlYiIsImRpc3Ry
+        aWJ1dG9yX2NvbmZpZyI6eyJwcm90ZWN0ZWQiOmZhbHNlLCJyZXBvLXJlZ2lz
+        dHJ5LWlkIjoiZW1wdHlfb3JnYW5pemF0aW9uLXB1cHBldF9wcm9kdWN0LWJ1
+        c3lib3gifSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5In1d
+        fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '676'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '378'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiYnVzeWJveCIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
+        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAiZG9ja2VyLXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmUx
+        ZDg3YWNjZTkzNTExMTIxYjY0In0sICJpZCI6ICJEZWZhdWx0X09yZ2FuaXph
+        dGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3Qt
+        YnVzeWJveC1saWJyYXJ5LyJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzMxY2U0YmMxLTU5ZGYtNDQ2NC1hZTg3LTBkNjk5ZGIyZjkyMC8iLCAi
+        dGFza19pZCI6ICIzMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:49 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:50 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/31ce4bc1-59df-4464-ae87-0d699db2f920/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0bfe94e874c9ceb724f920d345e00979-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWNlNGJjMS01OWRmLTQ0NjQtYWU4Ny0wZDY5OWRiMmY5
+        MjAvIiwgInRhc2tfaWQiOiAiMzFjZTRiYzEtNTlkZi00NDY0LWFlODctMGQ2
+        OTlkYjJmOTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1
+        OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRmOWUwMjA3NzcvIiwgInRhc2tf
+        aWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0ODItY2Y0ZjllMDIwNzc3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJkb2NrZXJfaW1wb3J0ZXIiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDExLCAiZGVzY3JpcHRpb24iOiAiRG93bmxvYWRpbmcg
+        bWFuaWZlc3RzIiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2JjN2EzYjYtN2I4Ni00YzJlLTgxMDUtNjUw
+        NzY1MTY5MTY4IiwgIm51bV9wcm9jZXNzZWQiOiAxMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0cyBhbHJlYWR5
+        IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2Y0ZTQ0Mi1mMDViLTQ0YzQtYjE0Yi0zMzczNDUwYjBjMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIkNvcHlpbmcgdW5pdHMgYWxyZWFkeSBpbiBwdWxwIiwg
+        InN0ZXBfdHlwZSI6ICJnZXRfbG9jYWwiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTVm
+        MTJlMTYtMmYyZi00OTBkLWI1ODMtMGJlNTcxMGM3ZGVlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24i
+        OiAiRG93bmxvYWRpbmcgcmVtb3RlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJz
+        eW5jX3N0ZXBfZG93bmxvYWQiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmM2JhMTE3
+        LWY5ZDMtNGM1Zi05Mjc4LTlmOTQ0NDAwODgxMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlNh
+        dmluZyBNYW5pZmVzdHMgYW5kIEJsb2JzIiwgInN0ZXBfdHlwZSI6ICJzeW5j
+        X3N0ZXBfc2F2ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI3YTdlOC1mNDY2LTQ1
+        ZDctYWVmYy03ZGQ2M2EyMWRmNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlNhdmluZyBUYWdz
+        IiwgInN0ZXBfdHlwZSI6ICJzeW5jX3N0ZXBfc2F2ZSIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZDNiYTc3OS04MThjLTRiMzQtOTI3Ny0yZDhjZjUwNGY5NmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAiZG9j
+        a2VyX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Iiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJkb2NrZXJfaW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJzeW5jX3N0ZXBfbWV0YWRhdGEiOiAiRklOSVNIRUQi
+        LCAic3luY19zdGVwX3NhdmUiOiAiRklOSVNIRUQiLCAiZ2V0X2xvY2FsIjog
+        IkZJTklTSEVEIiwgInN5bmNfc3RlcF9kb3dubG9hZCI6ICJGSU5JU0hFRCJ9
+        LCAiYWRkZWRfY291bnQiOiAzMiwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI2MDJmZTFkZDdhY2NlOTM0ZTI3ZTZl
+        MTUiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMTEsICJkZXNjcmlw
+        dGlvbiI6ICJEb3dubG9hZGluZyBtYW5pZmVzdHMiLCAic3RlcF90eXBlIjog
+        InN5bmNfc3RlcF9tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmM3YTNi
+        Ni03Yjg2LTRjMmUtODEwNS02NTA3NjUxNjkxNjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDExfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJD
+        b3B5aW5nIHVuaXRzIGFscmVhZHkgaW4gcHVscCIsICJzdGVwX3R5cGUiOiAi
+        Z2V0X2xvY2FsIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjRlNDQyLWYwNWItNDRj
+        NC1iMTRiLTMzNzM0NTBiMGMyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyB1bml0
+        cyBhbHJlYWR5IGluIHB1bHAiLCAic3RlcF90eXBlIjogImdldF9sb2NhbCIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNWYxMmUxNi0yZjJmLTQ5MGQtYjU4My0wYmU1
+        NzEwYzdkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMTgsICJkZXNjcmlwdGlvbiI6ICJEb3dubG9hZGluZyByZW1vdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9kb3dubG9hZCIsICJpdGVt
+        c190b3RhbCI6IDE4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2YzYmExMTctZjlkMy00YzVmLTkyNzgtOWY5NDQ0MDA4
+        ODEwIiwgIm51bV9wcm9jZXNzZWQiOiAxOH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiU2F2aW5nIE1hbmlmZXN0cyBhbmQgQmxvYnMi
+        LCAic3RlcF90eXBlIjogInN5bmNfc3RlcF9zYXZlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA0YjdhN2U4LWY0NjYtNDVkNy1hZWZjLTdkZDYzYTIxZGY3NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
+        cHRpb24iOiAiU2F2aW5nIFRhZ3MiLCAic3RlcF90eXBlIjogInN5bmNfc3Rl
+        cF9zYXZlIiwgIml0ZW1zX3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkM2JhNzc5LTgxOGMtNGIzNC05
+        Mjc3LTJkOGNmNTA0Zjk2YiIsICJudW1fcHJvY2Vzc2VkIjogMn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkOGY3M2I2OWE4
+        MzY2NTFjMjgifSwgImlkIjogIjYwMmZlMWQ4ZjczYjY5YTgzNjY1MWMyOCJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/58f83ce6-eaf3-4414-a482-cf4f9e020777/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1de4f670f09d6b54fb36de690b444395-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1113'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81OGY4M2NlNi1lYWYzLTQ0MTQtYTQ4Mi1jZjRm
+        OWUwMjA3NzcvIiwgInRhc2tfaWQiOiAiNThmODNjZTYtZWFmMy00NDE0LWE0
+        ODItY2Y0ZjllMDIwNzc3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJw
+        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAy
+        LTE5VDE2OjA1OjUxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDIxLTAyLTE5VDE2OjA1OjUwWiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSI6
+        IFt7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIiIsICJzdGVw
+        X3R5cGUiOiAicHVibGlzaF90b193ZWIiLCAic3ViX3N0ZXBzIjogW3sibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBJbWFn
+        ZSBGaWxlcy4iLCAic3RlcF90eXBlIjogInB1Ymxpc2hfaW1hZ2VzIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjYxNTE2NjI1LTY2ODktNGM5ZS1hYzEwLTBiNmI1Y2Ez
+        YmE1NSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiTWFraW5nIHYxIGZpbGVzIGF2YWlsYWJsZSB2
+        aWEgd2ViLiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9pbWFnZXNfb3Zlcl9o
+        dHRwIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE0NTFlN2YzLWVmMzEtNGMwYy1iNjZm
+        LWZjMjMwMGI3YmUyMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiN2I5ZTJkMzItMzliMy00YWEwLWFiYjMtNWU5MDE0ODBkYjg3
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfdG9fd2Vi
+        IiwgInN1Yl9zdGVwcyI6IFt7Im51bV9zdWNjZXNzIjogMTksICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIEJsb2JzLiIsICJzdGVwX3R5cGUiOiAicHVi
+        bGlzaF9ibG9icyIsICJpdGVtc190b3RhbCI6IDE5LCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2RmY2NiOWItZGViNC00
+        YmU4LTk2MDgtMWEwYTcyZDJlNDU4IiwgIm51bV9wcm9jZXNzZWQiOiAxOX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWFuaWZlc3RzLiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9tYW5pZmVz
+        dHMiLCAiaXRlbXNfdG90YWwiOiAxMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjVlOWJkMDhkLWUyNGUtNGNiZC1iOTMw
+        LWEzM2JjMTMxNzg1MyIsICJudW1fcHJvY2Vzc2VkIjogMTB9LCB7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWFuaWZl
+        c3QgTGlzdHMuIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX21hbmlmZXN0X2xp
+        c3RzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjZlMzhjNmFmLWVkNWUtNDdiMy1hNDk0
+        LTA4NjkyOTViZjYzMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBUYWdzLiIs
+        ICJzdGVwX3R5cGUiOiAicHVibGlzaF90YWdzIiwgIml0ZW1zX3RvdGFsIjog
+        MiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjliOWJkNTM2LWFiMjAtNDMzYi05ZTUyLTEwNzU1ZTIwM2YzZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX3JlZGlyZWN0X2ZpbGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNTRmMTdiYzgtNmFiNS00NDg5LTk4ODgtODhk
+        NjNkMTI3OGZmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJNYWtpbmcgdjIgZmlsZXMgYXZhaWxh
+        YmxlIHZpYSB3ZWIuIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2ltYWdlc19v
+        dmVyX2h0dHAiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjU3Y2MyYjYtZmE5NS00YTFh
+        LWEzMTMtN2ViYjFiNjU2N2Q1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV0sICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJhMzg1NjE0Ni0wNTA0LTRjYjgtYmFhNC00Mjc0OWQ2
+        NmE4NDUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVz
+        dC1idXN5Ym94LWxpYnJhcnkiLCAic3RhcnRlZCI6ICIyMDIxLTAyLTE5VDE2
+        OjA1OjUwWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMjEtMDItMTlUMTY6MDU6NTFaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImRvY2tlcl9kaXN0cmli
+        dXRvcl93ZWIiLCAic3VtbWFyeSI6IHsicHVibGlzaF90b193ZWIiOiAiRklO
+        SVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJh
+        cnkiLCAiaWQiOiAiNjAyZmUxZGY3YWNjZTkzNGUyN2U2ZTE2IiwgImRldGFp
+        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfdG9fd2ViIiwgInN1Yl9zdGVwcyI6IFt7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        SW1hZ2UgRmlsZXMuIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2ltYWdlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2MTUxNjYyNS02Njg5LTRjOWUtYWMxMC0wYjZi
+        NWNhM2JhNTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIk1ha2luZyB2MSBmaWxlcyBhdmFpbGFi
+        bGUgdmlhIHdlYi4iLCAic3RlcF90eXBlIjogInB1Ymxpc2hfaW1hZ2VzX292
+        ZXJfaHR0cCIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDUxZTdmMy1lZjMxLTRjMGMt
+        YjY2Zi1mYzIzMDBiN2JlMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XSwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjdiOWUyZDMyLTM5YjMtNGFhMC1hYmIzLTVlOTAxNDgw
+        ZGI4NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX3Rv
+        X3dlYiIsICJzdWJfc3RlcHMiOiBbeyJudW1fc3VjY2VzcyI6IDE5LCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBCbG9icy4iLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfYmxvYnMiLCAiaXRlbXNfdG90YWwiOiAxOSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkZmNjYjliLWRl
+        YjQtNGJlOC05NjA4LTFhMGE3MmQyZTQ1OCIsICJudW1fcHJvY2Vzc2VkIjog
+        MTl9LCB7Im51bV9zdWNjZXNzIjogMTAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1hbmlmZXN0cy4iLCAic3RlcF90eXBlIjogInB1Ymxpc2hfbWFu
+        aWZlc3RzIiwgIml0ZW1zX3RvdGFsIjogMTAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZTliZDA4ZC1lMjRlLTRjYmQt
+        YjkzMC1hMzNiYzEzMTc4NTMiLCAibnVtX3Byb2Nlc3NlZCI6IDEwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1h
+        bmlmZXN0IExpc3RzLiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9tYW5pZmVz
+        dF9saXN0cyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZTM4YzZhZi1lZDVlLTQ3YjMt
+        YTQ5NC0wODY5Mjk1YmY2MzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgVGFn
+        cy4iLCAic3RlcF90eXBlIjogInB1Ymxpc2hfdGFncyIsICJpdGVtc190b3Rh
+        bCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5YjliZDUzNi1hYjIwLTQzM2ItOWU1Mi0xMDc1NWUyMDNmM2UiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9yZWRpcmVjdF9m
+        aWxlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjU0ZjE3YmM4LTZhYjUtNDQ4OS05ODg4
+        LTg4ZDYzZDEyNzhmZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiTWFraW5nIHYyIGZpbGVzIGF2
+        YWlsYWJsZSB2aWEgd2ViLiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9pbWFn
+        ZXNfb3Zlcl9odHRwIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI1N2NjMmI2LWZhOTUt
+        NGExYS1hMzEzLTdlYmIxYjY1NjdkNSIsICJudW1fcHJvY2Vzc2VkIjogMX1d
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYTM4NTYxNDYtMDUwNC00Y2I4LWJhYTQtNDI3
+        NDlkNjZhODQ1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjYwMmZlMWRkZjczYjY5YTgzNjY1MWYy
+        MyJ9LCAiaWQiOiAiNjAyZmUxZGRmNzNiNjlhODM2NjUxZjIzIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfbWFuaWZlc3QiXSwi
+        bGltaXQiOjIwMDAsInNraXAiOjB9fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '67'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2491'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5pZmVzdC9iNC9jZWYyNjA4NjRl
+        ZDA0MDkzZTA4MjNjMzg0YTJlZGI4ZDhhNmQ0NzczNGRjOGYwOWVlYzc2NDAw
+        MTU0M2IxYi9zaGEyNTY6OGRjMWZiMzU5M2Y5YjVhNDlmNzBjN2Y4ZTU5ZDdh
+        MzFhMmQwM2E3YWU3MTcwMzUwZDlhN2JlODQ4Njk5M2I1MyIsICJfbnMiOiAi
+        dW5pdHNfZG9ja2VyX21hbmlmZXN0IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjEz
+        NzUwNzQ5LCAiZnNfbGF5ZXJzIjogW3sibGF5ZXJfdHlwZSI6ICJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwg
+        ImJsb2Jfc3VtIjogInNoYTI1NjphNTlkYjIxYWQ5YTM5NzA3YjQ4OGUxMDBi
+        ZTlmYjYyN2Y0NmU5MjhjZGI4YjkzOTY2YTE2OTJkYzU0ZjI3NjY2IiwgInNp
+        emUiOiA3MjU1MDF9XSwgInNjaGVtYV92ZXJzaW9uIjogMiwgImRvd25sb2Fk
+        ZWQiOiB0cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVu
+        dF90eXBlX2lkIjogImRvY2tlcl9tYW5pZmVzdCIsICJjb25maWdfbGF5ZXIi
+        OiAic2hhMjU2OmIwZTdmYThmMzkzOGZmM2UzNjkwYWQzMGExZDQ2OGM3M2E3
+        NmMzZGI3M2UzMTM2YWU4OTQ1NGQzMWIzNTkwMjgiLCAiX2lkIjogIjM5MDU2
+        MGJkLTljZTYtNDQ0YS1hNDI0LTg2OGVjYmQ4YWQyNCIsICJkaWdlc3QiOiAi
+        c2hhMjU2OjhkYzFmYjM1OTNmOWI1YTQ5ZjcwYzdmOGU1OWQ3YTMxYTJkMDNh
+        N2FlNzE3MDM1MGQ5YTdiZTg0ODY5OTNiNTMifSwgInVwZGF0ZWQiOiAiMjAy
+        MS0wMi0xOVQxNjowNTo0OVoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJjcmVhdGVkIjogIjIw
+        MjEtMDItMTlUMTY6MDU6NDlaIiwgInVuaXRfdHlwZV9pZCI6ICJkb2NrZXJf
+        bWFuaWZlc3QiLCAidW5pdF9pZCI6ICIzOTA1NjBiZC05Y2U2LTQ0NGEtYTQy
+        NC04NjhlY2JkOGFkMjQiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZlMWRkZjcz
+        YjY5YTgzNjY1MWVjZSJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0
+        aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvZG9ja2VyX21hbmlm
+        ZXN0L2Q3LzRlYjA2ODA5NmE3ZWEwZTExMWJiZjc2MWFjNTIxMDMwYzhiZDlk
+        NjAzZWVjZGJhMjE2YTllMTVjMDFlYWQ0L3NoYTI1NjphZjA1ZjNlY2RhYjZj
+        ODNlY2EzYWYwNGQ3Y2FmNGExMGY4MjI1YmMwMDZkY2Y1NWEyZTMyZWIwZDhj
+        MzY4Zjk0IiwgIl9ucyI6ICJ1bml0c19kb2NrZXJfbWFuaWZlc3QiLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MTM3NTA3NDksICJmc19sYXllcnMiOiBbeyJsYXll
+        cl90eXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZz
+        LmRpZmYudGFyLmd6aXAiLCAiYmxvYl9zdW0iOiAic2hhMjU2OmYxMDY0MjBk
+        MzNlZTEzYzdiZmY0M2FjMjQ0NjBhODQxM2UyOTEzMzkyNWM1MTFiNzdlN2Zi
+        YTkxYmZhZDE5ZTYiLCAic2l6ZSI6IDIxMzkzMDl9XSwgInNjaGVtYV92ZXJz
+        aW9uIjogMiwgImRvd25sb2FkZWQiOiB0cnVlLCAicHVscF91c2VyX21ldGFk
+        YXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImRvY2tlcl9tYW5pZmVz
+        dCIsICJjb25maWdfbGF5ZXIiOiAic2hhMjU2OmU1Y2MwZTlhMzA2NTY1MWZh
+        M2M1Y2NhYzM2MmNjMWM2MGFjOTg2NDZhN2IxNzU1MjViYWVlZmYxNjkyOWNi
+        NzYiLCAiX2lkIjogIjVhY2Y0OWI5LTFkYWItNDZiNC1hNzIwLWZhMjI0OWY1
+        NTdmNyIsICJkaWdlc3QiOiAic2hhMjU2OmFmMDVmM2VjZGFiNmM4M2VjYTNh
+        ZjA0ZDdjYWY0YTEwZjgyMjViYzAwNmRjZjU1YTJlMzJlYjBkOGMzNjhmOTQi
+        fSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAicmVwb19p
+        ZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFy
+        eSIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTY6MDU6NDlaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJkb2NrZXJfbWFuaWZlc3QiLCAidW5pdF9pZCI6ICI1YWNm
+        NDliOS0xZGFiLTQ2YjQtYTcyMC1mYTIyNDlmNTU3ZjciLCAiX2lkIjogeyIk
+        b2lkIjogIjYwMmZlMWRkZjczYjY5YTgzNjY1MWVlNyJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvZG9ja2VyX21hbmlmZXN0LzhmLzlkMTZlMWQwMTI3MTdlOWIxNTEz
+        ODk2NGVhMWVkYThjYjI2MTIwNzdjZTdjNTc3Y2MwYTVkNTY3YWExNTliL3No
+        YTI1Njo2ZTE5ODFhNjYzOWMyMjUxYWM3YzZkNzc3YTM0N2Y4Yzg5MDEyYjI1
+        NWQ0NGY4OTQ0N2I0NGE1N2IzOTZkZDViIiwgIl9ucyI6ICJ1bml0c19kb2Nr
+        ZXJfbWFuaWZlc3QiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3NTA3NDksICJm
+        c19sYXllcnMiOiBbeyJsYXllcl90eXBlIjogImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCAiYmxvYl9zdW0i
+        OiAic2hhMjU2Ojg4NzZjYjJjNGM3MDI2Mzg1ZWY5ZmI2Y2E2NTZhNmVhNjQ0
+        M2U0YWE5MTBmOWU1ZjBjZmVhZGM3ZWQ4OGZlNWIiLCAic2l6ZSI6IDk0MTM0
+        MX1dLCAic2NoZW1hX3ZlcnNpb24iOiAyLCAiZG93bmxvYWRlZCI6IHRydWUs
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAiZG9ja2VyX21hbmlmZXN0IiwgImNvbmZpZ19sYXllciI6ICJzaGEyNTY6
+        ZmJhNjkyOWY1Y2VjYzVhMzIzYTk4M2Q2MjZmN2ZiYmFiZmMxNDQ3N2UxNGM0
+        NzAyNzAwNzRkYWIwZTNjYTEyMCIsICJfaWQiOiAiNjA0MWEzYTAtNmQ5Mi00
+        NjBjLThjMGQtZmM1N2YzODAzOGQwIiwgImRpZ2VzdCI6ICJzaGEyNTY6NmUx
+        OTgxYTY2MzljMjI1MWFjN2M2ZDc3N2EzNDdmOGM4OTAxMmIyNTVkNDRmODk0
+        NDdiNDRhNTdiMzk2ZGQ1YiJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE2
+        OjA1OjQ5WiIsICJyZXBvX2lkIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
+        c3QtYnVzeWJveC1saWJyYXJ5IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NjowNTo0OVoiLCAidW5pdF90eXBlX2lkIjogImRvY2tlcl9tYW5pZmVzdCIs
+        ICJ1bml0X2lkIjogIjYwNDFhM2EwLTZkOTItNDYwYy04YzBkLWZjNTdmMzgw
+        MzhkMCIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmUxZGRmNzNiNjlhODM2NjUx
+        ZWI4In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIv
+        bGliL3B1bHAvY29udGVudC91bml0cy9kb2NrZXJfbWFuaWZlc3QvYjQvMTc1
+        NThlNmUwOTI4Yjg2NTMxNzhjMmM4ZTY2MTBmNzQxMjc0MzhjOWVjMGM2ZTA1
+        OTg0Y2RlYWE0NTgwMWUvc2hhMjU2OmVlNjRiYzZmMDZlZTY0NDAwYjE5ZWY4
+        NDQwYmIyNTVhNzU3YjdkYTU1M2UzZTYwYTZkMzZkMmQ1ZTAwNTZlZDEiLCAi
+        X25zIjogInVuaXRzX2RvY2tlcl9tYW5pZmVzdCIsICJfbGFzdF91cGRhdGVk
+        IjogMTYxMzc1MDc0OSwgImZzX2xheWVycyI6IFt7ImxheWVyX3R5cGUiOiAi
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIu
+        Z3ppcCIsICJibG9iX3N1bSI6ICJzaGEyNTY6NGVmNDdlNGQxZTBhOGMxMjdi
+        MDc4YjBmMTRjMjI0YTIyYzZjYjYwODYyZWQ3ZDg5MWQyZGI2NTk1MjVkY2Jk
+        MSIsICJzaXplIjogNzQ4NzUwfV0sICJzY2hlbWFfdmVyc2lvbiI6IDIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJkb2NrZXJfbWFuaWZlc3QiLCAiY29uZmln
+        X2xheWVyIjogInNoYTI1NjplMjZiMTA2OTJmYTAzMThiMDJjMmViOGQwNjUy
+        OTk1ZDcwMzE2Nzk0YTg2ZjJmNjc1YzY2ZGU1MTk2ZTYzNTdlIiwgIl9pZCI6
+        ICI2MzY2MDA1MS1kOWRmLTQzZWUtYmJhOS1mNWQ1MjMwNmVmY2IiLCAiZGln
+        ZXN0IjogInNoYTI1NjplZTY0YmM2ZjA2ZWU2NDQwMGIxOWVmODQ0MGJiMjU1
+        YTc1N2I3ZGE1NTNlM2U2MGE2ZDM2ZDJkNWUwMDU2ZWQxIn0sICJ1cGRhdGVk
+        IjogIjIwMjEtMDItMTlUMTY6MDU6NDlaIiwgInJlcG9faWQiOiAiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCAiY3JlYXRl
+        ZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJ1bml0X3R5cGVfaWQiOiAi
+        ZG9ja2VyX21hbmlmZXN0IiwgInVuaXRfaWQiOiAiNjM2NjAwNTEtZDlkZi00
+        M2VlLWJiYTktZjVkNTIzMDZlZmNiIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJm
+        ZTFkZGY3M2I2OWE4MzY2NTFlYjEifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9y
+        YWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL2RvY2tl
+        cl9tYW5pZmVzdC85Ni9mZWU4ZWQxNmU0NTg5ZjZlNDY4M2YwMjNiMzRhZjk4
+        ZTBjMjZlNDQ3ZDVlZWJmZDE1YzA0OTI1ZWRkZmE3MC9zaGEyNTY6YTFlNjY3
+        MjkzZTJlNDgyNjM0Y2Y5MTg5ZmY4NzZhOGI2ZmQxMTU4ZDBkNzMyNGYyNDFl
+        M2I4M2VjMmM4ODlmZiIsICJfbnMiOiAidW5pdHNfZG9ja2VyX21hbmlmZXN0
+        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjEzNzUwNzQ5LCAiZnNfbGF5ZXJzIjog
+        W3siYmxvYl9zdW0iOiAic2hhMjU2OmEzZWQ5NWNhZWIwMmZmZTY4Y2RkOWZk
+        ODQ0MDY2ODBhZTkzZDYzM2NiMTY0MjJkMDBlOGE3YzIyOTU1YjQ2ZDQifSwg
+        eyJibG9iX3N1bSI6ICJzaGEyNTY6NWM0MjEzYmU5YWY5MDRkZDc0NjQ5ZDI1
+        MGYyMjAyM2Y1MzJiMmY5MTc5ZmZjYjE1MjYwYjVlYWExMGQ3YTNiNCJ9XSwg
+        InNjaGVtYV92ZXJzaW9uIjogMSwgImRvd25sb2FkZWQiOiB0cnVlLCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImRv
+        Y2tlcl9tYW5pZmVzdCIsICJfaWQiOiAiNmIwMzBiMzUtZTBkZi00NTgwLTk4
+        ZGMtYTZlZTVhOGJmZDhmIiwgImRpZ2VzdCI6ICJzaGEyNTY6YTFlNjY3Mjkz
+        ZTJlNDgyNjM0Y2Y5MTg5ZmY4NzZhOGI2ZmQxMTU4ZDBkNzMyNGYyNDFlM2I4
+        M2VjMmM4ODlmZiJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5
+        WiIsICJyZXBvX2lkIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVz
+        eWJveC1saWJyYXJ5IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0
+        OVoiLCAidW5pdF90eXBlX2lkIjogImRvY2tlcl9tYW5pZmVzdCIsICJ1bml0
+        X2lkIjogIjZiMDMwYjM1LWUwZGYtNDU4MC05OGRjLWE2ZWU1YThiZmQ4ZiIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNjAyZmUxZGRmNzNiNjlhODM2NjUxZWVlIn19
+        LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1
+        bHAvY29udGVudC91bml0cy9kb2NrZXJfbWFuaWZlc3QvNTkvODc1NzRmY2U4
+        NzVjOGQ3Y2VkZjEyODAzMjMyNjAwZWIxNWE4NmFlNjgzNzc5NTFlMmRjMTlj
+        MGRiZjFjNzIvc2hhMjU2OjNkOGExOGM4MjhhNDBmODQ3ZmUxOTA1ZTE0MWIy
+        Y2JiNTEzMzRlNjhjYjUwYWJkOTc4M2U3YmQ3MTU5NTE5Y2UiLCAiX25zIjog
+        InVuaXRzX2RvY2tlcl9tYW5pZmVzdCIsICJfbGFzdF91cGRhdGVkIjogMTYx
+        Mzc1MDc0OSwgImZzX2xheWVycyI6IFt7ImxheWVyX3R5cGUiOiAiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIs
+        ICJibG9iX3N1bSI6ICJzaGEyNTY6ZjJmYThjYmFhNDUxNTQ2MjFiYzdjYjJm
+        MmMzZGUyOWY2ZTY3NWQyN2NmZWRlMDU0N2MwMTlkNWE0MzY4NWFjNCIsICJz
+        aXplIjogMjYyNTQxNn1dLCAic2NoZW1hX3ZlcnNpb24iOiAyLCAiZG93bmxv
+        YWRlZCI6IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAiZG9ja2VyX21hbmlmZXN0IiwgImNvbmZpZ19sYXll
+        ciI6ICJzaGEyNTY6Zjk4NTJkYzdhMmNjYzYxMjFjN2M1NzFiMTUyNTM0YWJm
+        ZmI0Mzk3YTM4N2YwZDc5NmM2ZmFiYmYzZWE3YzBlMSIsICJfaWQiOiAiNmVj
+        ODA4ZGItYjdiOS00ZjAwLTgzOWItOWNmY2RmYzI4NmQ5IiwgImRpZ2VzdCI6
+        ICJzaGEyNTY6M2Q4YTE4YzgyOGE0MGY4NDdmZTE5MDVlMTQxYjJjYmI1MTMz
+        NGU2OGNiNTBhYmQ5NzgzZTdiZDcxNTk1MTljZSJ9LCAidXBkYXRlZCI6ICIy
+        MDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJyZXBvX2lkIjogIkRlZmF1bHRfT3Jn
+        YW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5IiwgImNyZWF0ZWQiOiAi
+        MjAyMS0wMi0xOVQxNjowNTo0OVoiLCAidW5pdF90eXBlX2lkIjogImRvY2tl
+        cl9tYW5pZmVzdCIsICJ1bml0X2lkIjogIjZlYzgwOGRiLWI3YjktNGYwMC04
+        MzliLTljZmNkZmMyODZkOSIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmUxZGRm
+        NzNiNjlhODM2NjUxZWUwIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
+        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9kb2NrZXJfbWFu
+        aWZlc3QvYWYvMWIyZDYzOTViZjgzNzRkY2I4MDM1MjZjNWY5YzViMzY4NjYw
+        OWNjYjZlMTE0YzgxYzQwOGVkOTMxZTdiYjIvc2hhMjU2Ojc0ZTRhNjhkZmJh
+        NmY0MGIwMTc4N2EzODc2Y2MxYmUwZmIxZDkwMjVjMzU2N2NmODM2N2M2NTlm
+        MjE4NzIzNGYiLCAiX25zIjogInVuaXRzX2RvY2tlcl9tYW5pZmVzdCIsICJf
+        bGFzdF91cGRhdGVkIjogMTYxMzc1MDc0OSwgImZzX2xheWVycyI6IFt7Imxh
+        eWVyX3R5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290
+        ZnMuZGlmZi50YXIuZ3ppcCIsICJibG9iX3N1bSI6ICJzaGEyNTY6NWM0MjEz
+        YmU5YWY5MDRkZDc0NjQ5ZDI1MGYyMjAyM2Y1MzJiMmY5MTc5ZmZjYjE1MjYw
+        YjVlYWExMGQ3YTNiNCIsICJzaXplIjogNzY0NjU1fV0sICJzY2hlbWFfdmVy
+        c2lvbiI6IDIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRh
+        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkb2NrZXJfbWFuaWZl
+        c3QiLCAiY29uZmlnX2xheWVyIjogInNoYTI1Njo0OTExOTg4NTFmMGNjZGQw
+        ODgyY2I5MzIzZjM4NTYwNDNkNGU0YzY1Yjc3M2U4ZWFjM2UwZjZiYzk3OWEy
+        YWU3IiwgIl9pZCI6ICJhMDhhYjgwNy01YTYzLTQyZjAtOWIzYS00MWRkYWIx
+        ZjcxM2MiLCAiZGlnZXN0IjogInNoYTI1Njo3NGU0YTY4ZGZiYTZmNDBiMDE3
+        ODdhMzg3NmNjMWJlMGZiMWQ5MDI1YzM1NjdjZjgzNjdjNjU5ZjIxODcyMzRm
+        In0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTY6MDU6NDlaIiwgInJlcG9f
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJh
+        cnkiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJ1bml0
+        X3R5cGVfaWQiOiAiZG9ja2VyX21hbmlmZXN0IiwgInVuaXRfaWQiOiAiYTA4
+        YWI4MDctNWE2My00MmYwLTliM2EtNDFkZGFiMWY3MTNjIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI2MDJmZTFkZGY3M2I2OWE4MzY2NTFlYWEifX0sIHsibWV0YWRh
+        dGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50
+        L3VuaXRzL2RvY2tlcl9tYW5pZmVzdC8zMC84N2Y1Y2IxNTU1NmY2YjRkY2Qz
+        ZmNmZGIwZGMwYWRjNzM2ZjIzZWE5ZjBlY2NkZDgyMDU0MTYyMzM1OGZjZS9z
+        aGEyNTY6MDIyOGQwYmJkN2Y5ZDNjYjUwYzFjZWI2OWYwZDg0Mjg3NDUwMjgy
+        ZjNiYmZlZDJiZDJkYTU4MjY5ZGQzN2ZkZiIsICJfbnMiOiAidW5pdHNfZG9j
+        a2VyX21hbmlmZXN0IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjEzNzUwNzQ5LCAi
+        ZnNfbGF5ZXJzIjogW3sibGF5ZXJfdHlwZSI6ICJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwgImJsb2Jfc3Vt
+        IjogInNoYTI1NjoxODcyMTkwMTkxY2Q0YzViZmQ1OGVjMjQ4OWFjMDFmY2M4
+        NTNlMzFhYTZiMjFlNmJhNjNjOGRkMmVlNWMyMzM0IiwgInNpemUiOiA3MTcx
+        Njd9XSwgInNjaGVtYV92ZXJzaW9uIjogMiwgImRvd25sb2FkZWQiOiB0cnVl
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImRvY2tlcl9tYW5pZmVzdCIsICJjb25maWdfbGF5ZXIiOiAic2hhMjU2
+        OmI5NmZjYmI2Zjc3NDc2NmNmNTdlYzZkZDg4NzE0MzQ5YjJjMzY5NzQ3YjZm
+        MWJjMTAyY2Y1YjVmOWMwNDdmYzIiLCAiX2lkIjogImFiYjU2ZDJiLWQxYmQt
+        NGNiMC1iNGY5LTczN2M3Yzc4YTgxNCIsICJkaWdlc3QiOiAic2hhMjU2OjAy
+        MjhkMGJiZDdmOWQzY2I1MGMxY2ViNjlmMGQ4NDI4NzQ1MDI4MmYzYmJmZWQy
+        YmQyZGE1ODI2OWRkMzdmZGYifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NjowNTo0OVoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
+        ZXN0LWJ1c3lib3gtbGlicmFyeSIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlU
+        MTY6MDU6NDlaIiwgInVuaXRfdHlwZV9pZCI6ICJkb2NrZXJfbWFuaWZlc3Qi
+        LCAidW5pdF9pZCI6ICJhYmI1NmQyYi1kMWJkLTRjYjAtYjRmOS03MzdjN2M3
+        OGE4MTQiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZlMWRkZjczYjY5YTgzNjY1
+        MWViZiJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFy
+        L2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvZG9ja2VyX21hbmlmZXN0LzBjLzYy
+        NjZhODk2YTVkZDRkMDNkNjA4ZGVkNWUyMTM1YmVhZTkzNDhlY2FhMDk4YWJh
+        MGJlYjk0MzVhZjBmM2I5L3NoYTI1NjphNDc3NDBlOThkYzdlYTA0MzVjYmQz
+        ZTkzYTdjOGU5MjA5NTg5ODI2YTFkYzMxYTgwNWE2YzdmN2E0MDg0YWNkIiwg
+        Il9ucyI6ICJ1bml0c19kb2NrZXJfbWFuaWZlc3QiLCAiX2xhc3RfdXBkYXRl
+        ZCI6IDE2MTM3NTA3NDksICJmc19sYXllcnMiOiBbeyJsYXllcl90eXBlIjog
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFy
+        Lmd6aXAiLCAiYmxvYl9zdW0iOiAic2hhMjU2OmFhNDMxY2UzNTQ4NDJhZmM2
+        NTBmNGVmZjJjZDMyNTg3NWQyNzVhM2I2MzdmMTkwMDI2NTJiZjI2Y2Q0Y2Ez
+        YTMiLCAic2l6ZSI6IDk0ODgwMn1dLCAic2NoZW1hX3ZlcnNpb24iOiAyLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAiZG9ja2VyX21hbmlmZXN0IiwgImNvbmZp
+        Z19sYXllciI6ICJzaGEyNTY6OGU4YTQ0YTQ3ZTBiNjQ4NDJhY2M3YTJmOWUy
+        MTU0ZmIyNDQ1N2Y3ODM1NDViMDBiNTVmZWJkYjUxM2YzNWEzOSIsICJfaWQi
+        OiAiZGQxYTgyMzEtNGVlMC00NTZmLTgxMmYtMmFjYTk2NGU5ZDJhIiwgImRp
+        Z2VzdCI6ICJzaGEyNTY6YTQ3NzQwZTk4ZGM3ZWEwNDM1Y2JkM2U5M2E3Yzhl
+        OTIwOTU4OTgyNmExZGMzMWE4MDVhNmM3ZjdhNDA4NGFjZCJ9LCAidXBkYXRl
+        ZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJyZXBvX2lkIjogIkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5IiwgImNyZWF0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNjowNTo0OVoiLCAidW5pdF90eXBlX2lkIjog
+        ImRvY2tlcl9tYW5pZmVzdCIsICJ1bml0X2lkIjogImRkMWE4MjMxLTRlZTAt
+        NDU2Zi04MTJmLTJhY2E5NjRlOWQyYSIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmUxZGRmNzNiNjlhODM2NjUxZWQ3In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
+        cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9kb2Nr
+        ZXJfbWFuaWZlc3QvNjIvMTNkNTYxOTc4ZjQ1OTEyNmZlYWJkMzc1ZTZmZWNm
+        MjVlMDdiMTM4NTQ4OTNhYzRkMGNhYTRiZTc2MzM0MjAvc2hhMjU2OjA3Nzkx
+        NjRiNmUyMWFhNjM1YjRiMGVhYTJmNDA0MTliY2YxZmI0YjM0ODAzNDFiNzEz
+        NzU4NGRmMjBlNzFjYjgiLCAiX25zIjogInVuaXRzX2RvY2tlcl9tYW5pZmVz
+        dCIsICJfbGFzdF91cGRhdGVkIjogMTYxMzc1MDc0OSwgImZzX2xheWVycyI6
+        IFt7ImxheWVyX3R5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFn
+        ZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsICJibG9iX3N1bSI6ICJzaGEyNTY6
+        YmZkZjdiMDgyZWRiYzVhODE3NzBlNjIzOGM2ZDhjZDYwOTVlNzFkZTAzNGVi
+        ODk5MjU3ODVkOWY2ZTBhNjA3ZCIsICJzaXplIjogODE2OTcwfV0sICJzY2hl
+        bWFfdmVyc2lvbiI6IDIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkb2NrZXJf
+        bWFuaWZlc3QiLCAiY29uZmlnX2xheWVyIjogInNoYTI1NjpjYjFmYTk5ZWU1
+        NTBmZGNjOGU4OWRkMTI1ZGQ2OTQ0ODQ2YTY3MzRkMGJhZDViZjgxYTEzYzg3
+        MzEzNzNlM2U5IiwgIl9pZCI6ICJmZWY2YWJiMi0yY2U4LTQzMjUtYTQ5Mi0w
+        YTg3YmZjMzc3NGEiLCAiZGlnZXN0IjogInNoYTI1NjowNzc5MTY0YjZlMjFh
+        YTYzNWI0YjBlYWEyZjQwNDE5YmNmMWZiNGIzNDgwMzQxYjcxMzc1ODRkZjIw
+        ZTcxY2I4In0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTY6MDU6NDlaIiwg
+        InJlcG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94
+        LWxpYnJhcnkiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAiZG9ja2VyX21hbmlmZXN0IiwgInVuaXRfaWQi
+        OiAiZmVmNmFiYjItMmNlOC00MzI1LWE0OTItMGE4N2JmYzM3NzRhIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDJmZTFkZGY3M2I2OWE4MzY2NTFlYzYifX1d
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfbWFuaWZlc3QiXSwi
+        bGltaXQiOjIwMDAsInNraXAiOjIwMDB9fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '70'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfbWFuaWZlc3RfbGlz
+        dCJdLCJsaW1pdCI6MjAwMCwic2tpcCI6MH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '72'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '865'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5pZmVzdF9saXN0LzMxLzdjNjZk
+        YWQyMzJmOWE4MjI0NmRkZDAwMzg3ZDE4MDZlZTY3MTZmYTM1ZjYzZWZiZWY1
+        NTQ0MzRhYzk4ODNmL3NoYTI1NjpjNmI0NWE5NWY5MzIyMDJkYmIyN2MzMTMz
+        M2M0Nzg5ZjQ1MTg0YTc0NDA2MGY2ZTU2OWNjOWQyYmYxYjlhZDZmIiwgImFt
+        ZDY0X2RpZ2VzdCI6ICJzaGEyNTY6NzRlNGE2OGRmYmE2ZjQwYjAxNzg3YTM4
+        NzZjYzFiZTBmYjFkOTAyNWMzNTY3Y2Y4MzY3YzY1OWYyMTg3MjM0ZiIsICJf
+        bnMiOiAidW5pdHNfZG9ja2VyX21hbmlmZXN0X2xpc3QiLCAiX2xhc3RfdXBk
+        YXRlZCI6IDE2MTM3NTA3NDksICJhbWQ2NF9zY2hlbWFfdmVyc2lvbiI6IDIs
+        ICJzY2hlbWFfdmVyc2lvbiI6IDIsICJtYW5pZmVzdHMiOiBbeyJhcmNoIjog
+        ImFtZDY0IiwgIm9zIjogImxpbnV4IiwgImRpZ2VzdCI6ICJzaGEyNTY6NzRl
+        NGE2OGRmYmE2ZjQwYjAxNzg3YTM4NzZjYzFiZTBmYjFkOTAyNWMzNTY3Y2Y4
+        MzY3YzY1OWYyMTg3MjM0ZiJ9LCB7ImFyY2giOiAiYXJtIiwgIm9zIjogImxp
+        bnV4IiwgImRpZ2VzdCI6ICJzaGEyNTY6ZWU2NGJjNmYwNmVlNjQ0MDBiMTll
+        Zjg0NDBiYjI1NWE3NTdiN2RhNTUzZTNlNjBhNmQzNmQyZDVlMDA1NmVkMSJ9
+        LCB7ImFyY2giOiAiYXJtIiwgIm9zIjogImxpbnV4IiwgImRpZ2VzdCI6ICJz
+        aGEyNTY6NmUxOTgxYTY2MzljMjI1MWFjN2M2ZDc3N2EzNDdmOGM4OTAxMmIy
+        NTVkNDRmODk0NDdiNDRhNTdiMzk2ZGQ1YiJ9LCB7ImFyY2giOiAiYXJtIiwg
+        Im9zIjogImxpbnV4IiwgImRpZ2VzdCI6ICJzaGEyNTY6MDIyOGQwYmJkN2Y5
+        ZDNjYjUwYzFjZWI2OWYwZDg0Mjg3NDUwMjgyZjNiYmZlZDJiZDJkYTU4MjY5
+        ZGQzN2ZkZiJ9LCB7ImFyY2giOiAiYXJtNjQiLCAib3MiOiAibGludXgiLCAi
+        ZGlnZXN0IjogInNoYTI1NjowNzc5MTY0YjZlMjFhYTYzNWI0YjBlYWEyZjQw
+        NDE5YmNmMWZiNGIzNDgwMzQxYjcxMzc1ODRkZjIwZTcxY2I4In0sIHsiYXJj
+        aCI6ICIzODYiLCAib3MiOiAibGludXgiLCAiZGlnZXN0IjogInNoYTI1Njo4
+        ZGMxZmIzNTkzZjliNWE0OWY3MGM3ZjhlNTlkN2EzMWEyZDAzYTdhZTcxNzAz
+        NTBkOWE3YmU4NDg2OTkzYjUzIn0sIHsiYXJjaCI6ICJtaXBzNjRsZSIsICJv
+        cyI6ICJsaW51eCIsICJkaWdlc3QiOiAic2hhMjU2OmE0Nzc0MGU5OGRjN2Vh
+        MDQzNWNiZDNlOTNhN2M4ZTkyMDk1ODk4MjZhMWRjMzFhODA1YTZjN2Y3YTQw
+        ODRhY2QifSwgeyJhcmNoIjogInBwYzY0bGUiLCAib3MiOiAibGludXgiLCAi
+        ZGlnZXN0IjogInNoYTI1NjozZDhhMThjODI4YTQwZjg0N2ZlMTkwNWUxNDFi
+        MmNiYjUxMzM0ZTY4Y2I1MGFiZDk3ODNlN2JkNzE1OTUxOWNlIn0sIHsiYXJj
+        aCI6ICJzMzkweCIsICJvcyI6ICJsaW51eCIsICJkaWdlc3QiOiAic2hhMjU2
+        OmFmMDVmM2VjZGFiNmM4M2VjYTNhZjA0ZDdjYWY0YTEwZjgyMjViYzAwNmRj
+        ZjU1YTJlMzJlYjBkOGMzNjhmOTQifV0sICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJkb2NrZXJfbWFuaWZlc3RfbGlzdCIsICJfaWQiOiAiMTEzZjQzNWYtYjk5
+        NC00ZGM2LTgxOTMtN2MxNTczNmI2NGYxIiwgImRpZ2VzdCI6ICJzaGEyNTY6
+        YzZiNDVhOTVmOTMyMjAyZGJiMjdjMzEzMzNjNDc4OWY0NTE4NGE3NDQwNjBm
+        NmU1NjljYzlkMmJmMWI5YWQ2ZiJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5
+        VDE2OjA1OjQ5WiIsICJyZXBvX2lkIjogIkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LVRlc3QtYnVzeWJveC1saWJyYXJ5IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0x
+        OVQxNjowNTo0OVoiLCAidW5pdF90eXBlX2lkIjogImRvY2tlcl9tYW5pZmVz
+        dF9saXN0IiwgInVuaXRfaWQiOiAiMTEzZjQzNWYtYjk5NC00ZGM2LTgxOTMt
+        N2MxNTczNmI2NGYxIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZTFkZGY3M2I2
+        OWE4MzY2NTFlYTIifX1d
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfbWFuaWZlc3RfbGlz
+        dCJdLCJsaW1pdCI6MjAwMCwic2tpcCI6MjAwMH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '75'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfdGFnIl0sImxpbWl0
+        IjoyMDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '62'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7InJlcG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCAibWFuaWZlc3RfZGlnZXN0Ijog
+        InNoYTI1NjphMWU2NjcyOTNlMmU0ODI2MzRjZjkxODlmZjg3NmE4YjZmZDEx
+        NThkMGQ3MzI0ZjI0MWUzYjgzZWMyYzg4OWZmIiwgIm1hbmlmZXN0X3R5cGUi
+        OiAiaW1hZ2UiLCAiX25zIjogInVuaXRzX2RvY2tlcl90YWciLCAiX2xhc3Rf
+        dXBkYXRlZCI6IDE2MTM3NTA3NDksICJzY2hlbWFfdmVyc2lvbiI6IDEsICJw
+        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        ZG9ja2VyX3RhZyIsICJfaWQiOiAiYWIzZjFhMGItM2VkYy00NmE5LTkzOWYt
+        NjFlOWFjMWI2OGY2IiwgIm5hbWUiOiAibGF0ZXN0In0sICJ1cGRhdGVkIjog
+        IjIwMjEtMDItMTlUMTY6MDU6NDlaIiwgInJlcG9faWQiOiAiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJhcnkiLCAiY3JlYXRlZCI6
+        ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJ1bml0X3R5cGVfaWQiOiAiZG9j
+        a2VyX3RhZyIsICJ1bml0X2lkIjogImFiM2YxYTBiLTNlZGMtNDZhOS05Mzlm
+        LTYxZTlhYzFiNjhmNiIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmUxZGRmNzNi
+        NjlhODM2NjUxZWZiIn19LCB7Im1ldGFkYXRhIjogeyJyZXBvX2lkIjogIkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5IiwgIm1h
+        bmlmZXN0X2RpZ2VzdCI6ICJzaGEyNTY6YzZiNDVhOTVmOTMyMjAyZGJiMjdj
+        MzEzMzNjNDc4OWY0NTE4NGE3NDQwNjBmNmU1NjljYzlkMmJmMWI5YWQ2ZiIs
+        ICJtYW5pZmVzdF90eXBlIjogImxpc3QiLCAiX25zIjogInVuaXRzX2RvY2tl
+        cl90YWciLCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3NTA3NDksICJzY2hlbWFf
+        dmVyc2lvbiI6IDIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAiZG9ja2VyX3RhZyIsICJfaWQiOiAiY2ZjM2RmNjYt
+        NzhmNi00ZjkyLWE5NjUtYWRmNjQwY2IyODVlIiwgIm5hbWUiOiAibGF0ZXN0
+        In0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTY6MDU6NDlaIiwgInJlcG9f
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJh
+        cnkiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE2OjA1OjQ5WiIsICJ1bml0
+        X3R5cGVfaWQiOiAiZG9ja2VyX3RhZyIsICJ1bml0X2lkIjogImNmYzNkZjY2
+        LTc4ZjYtNGY5Mi1hOTY1LWFkZjY0MGNiMjg1ZSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNjAyZmUxZGRmNzNiNjlhODM2NjUxZWZmIn19XQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkb2NrZXJfdGFnIl0sImxpbWl0
+        IjoyMDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJkb2NrZXIiLCJyZXBvc2l0
+        b3JpZXMiOlt7Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        c3lib3gtbGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbnMiOlt7InB1bHAy
+        X3JlcG9zaXRvcnlfaWQiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1
+        c3lib3gtbGlicmFyeSIsInB1bHAyX2Rpc3RyaWJ1dG9yX3JlcG9zaXRvcnlf
+        aWRzIjpbIkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJy
+        YXJ5Il19XSwicHVscDJfaW1wb3J0ZXJfcmVwb3NpdG9yeV9pZCI6IkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5In1dfV19fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/635d7219-82f5-424e-82bc-a72a1057b15f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '484'
+      Correlation-Id:
+      - 96eb69d914b8416f8a3dd6bec7990ee0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zLzYz
+        NWQ3MjE5LTgyZjUtNDI0ZS04MmJjLWE3MmExMDU3YjE1Zi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE2OjA1OjUxLjg1NTUxM1oiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJkb2NrZXIiLCJyZXBvc2l0b3JpZXMiOlt7
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGli
+        cmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbnMiOlt7InB1bHAyX3JlcG9zaXRv
+        cnlfaWQiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGli
+        cmFyeSIsInB1bHAyX2Rpc3RyaWJ1dG9yX3JlcG9zaXRvcnlfaWRzIjpbIkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5Il19XSwi
+        cHVscDJfaW1wb3J0ZXJfcmVwb3NpdG9yeV9pZCI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5In1dfV19fQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/635d7219-82f5-424e-82bc-a72a1057b15f/run/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkcnlfcnVuIjpmYWxzZSwidmFsaWRhdGUiOnRydWV9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:51 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 86a95ac9e64c4838b3f6aeb32d08b100
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1MzRjOWI5LTZiYmMtNDgw
+        ZC1hNWU5LTI2MDdkZTFiZGEzYS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/a534c9b9-6bbc-480d-a5e9-2607de1bda3a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:53 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - cef5ffa694b947da9bd8e9b375a2dd69
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '742'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTUzNGM5YjktNmJi
+        Yy00ODBkLWE1ZTktMjYwN2RlMWJkYTNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTY6MDU6NTEuOTMzODA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI4NmE5NWFj
+        OWU2NGM0ODM4YjNmNmFlYjMyZDA4YjEwMCIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE2OjA1OjUyLjEwNTk3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTY6MDU6NTMuODA2NzAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wYjE2MjYxYi05ZTJhLTQ3NDItOWQw
+        OC0wZGY3OTBjY2Q0YzYvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9kNTc5MDJlZC1mMjhhLTQxMDQt
+        OGFkMS0wNjliYmRkZmExOWQvIl0sInRhc2tfZ3JvdXAiOiIvcHVscC9hcGkv
+        djMvdGFzay1ncm91cHMvNGJiOTAzNjMtZDZjZi00MTFhLTg4ZWItNzZhM2Qy
+        NDdjOTY3LyIsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJQcm9j
+        ZXNzaW5nIFB1bHAgMiByZXBvc2l0b3JpZXMsIGltcG9ydGVycywgZGlzdHJp
+        YnV0b3JzIiwiY29kZSI6InByb2Nlc3NpbmcucmVwb3NpdG9yaWVzIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBET0NLRVJf
+        QkxPQiBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InByZW1pZ3Jh
+        dGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjo0MywiZG9uZSI6NDMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        UHJlLW1pZ3JhdGluZyBQdWxwIDIgRE9DS0VSX0JMT0IgY29udGVudCAoZGV0
+        YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFp
+        bCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQzLCJkb25lIjo0Mywi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAg
+        MiBET0NLRVJfTUFOSUZFU1QgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6MjEsImRvbmUiOjIxLCJzdWZmaXgiOm51bGx9
+        LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9NQU5J
+        RkVTVCBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0
+        aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MjEsImRvbmUiOjIxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBy
+        ZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9NQU5JRkVTVF9MSVNUIGNvbnRl
+        bnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRl
+        bnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRv
+        bmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGlu
+        ZyBQdWxwIDIgRE9DS0VSX01BTklGRVNUX0xJU1QgY29udGVudCAoZGV0YWls
+        IGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFpbCIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRE9D
+        S0VSX1RBRyBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InByZW1p
+        Z3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9UQUcgY29udGVudCAoZGV0
+        YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFp
+        bCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ3JlYXRpbmcgcmVwb3NpdG9yaWVz
+        IGluIFB1bHAgMyIsImNvZGUiOiJjcmVhdGluZy5yZXBvc2l0b3JpZXMiLCJz
+        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBpbXBvcnRlcnMgdG8gUHVs
+        cCAzIiwiY29kZSI6Im1pZ3JhdGluZy5pbXBvcnRlcnMiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6Ik1pZ3JhdGluZyBkb2NrZXIgY29udGVudCB0byBQdWxwIDMg
+        ZG9ja2VyX2Jsb2IiLCJjb2RlIjoibWlncmF0aW5nLmRvY2tlci5jb250ZW50
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NDMsImRvbmUiOjQzLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBkb2NrZXIgY29u
+        dGVudCB0byBQdWxwIDMgZG9ja2VyX21hbmlmZXN0IiwiY29kZSI6Im1pZ3Jh
+        dGluZy5kb2NrZXIuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjIxLCJkb25lIjoyMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgZG9ja2VyIGNvbnRlbnQgdG8gUHVscCAzIGRvY2tlcl9tYW5p
+        ZmVzdF9saXN0IiwiY29kZSI6Im1pZ3JhdGluZy5kb2NrZXIuY29udGVudCIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGRvY2tlciBjb250ZW50
+        IHRvIFB1bHAgMyBkb2NrZXJfdGFnIiwiY29kZSI6Im1pZ3JhdGluZy5kb2Nr
+        ZXIuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRv
+        bmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGNv
+        bnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1pZ3JhdGluZy5jb250ZW50Iiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NzIsImRvbmUiOjcyLCJzdWZm
+        aXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3Yz
+        L3Rhc2stZ3JvdXBzLzRiYjkwMzYzLWQ2Y2YtNDExYS04OGViLTc2YTNkMjQ3
+        Yzk2Ny8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwdWxwXzJ0
+        bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:53 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/4bb90363-d6cf-411a-88eb-76a3d247c967/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:53 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 90150af0daf64ea78e2616c326bed521
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '270'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvNGJiOTAz
+        NjMtZDZjZi00MTFhLTg4ZWItNzZhM2QyNDdjOTY3LyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJj
+        b21wbGV0ZWQiOjEsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjox
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjEsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:53 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/a534c9b9-6bbc-480d-a5e9-2607de1bda3a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2548710b002c461aab5904572bc2c84e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '742'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTUzNGM5YjktNmJi
+        Yy00ODBkLWE1ZTktMjYwN2RlMWJkYTNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTY6MDU6NTEuOTMzODA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI4NmE5NWFj
+        OWU2NGM0ODM4YjNmNmFlYjMyZDA4YjEwMCIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE2OjA1OjUyLjEwNTk3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTY6MDU6NTMuODA2NzAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wYjE2MjYxYi05ZTJhLTQ3NDItOWQw
+        OC0wZGY3OTBjY2Q0YzYvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9kNTc5MDJlZC1mMjhhLTQxMDQt
+        OGFkMS0wNjliYmRkZmExOWQvIl0sInRhc2tfZ3JvdXAiOiIvcHVscC9hcGkv
+        djMvdGFzay1ncm91cHMvNGJiOTAzNjMtZDZjZi00MTFhLTg4ZWItNzZhM2Qy
+        NDdjOTY3LyIsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJQcm9j
+        ZXNzaW5nIFB1bHAgMiByZXBvc2l0b3JpZXMsIGltcG9ydGVycywgZGlzdHJp
+        YnV0b3JzIiwiY29kZSI6InByb2Nlc3NpbmcucmVwb3NpdG9yaWVzIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBET0NLRVJf
+        QkxPQiBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InByZW1pZ3Jh
+        dGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjo0MywiZG9uZSI6NDMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        UHJlLW1pZ3JhdGluZyBQdWxwIDIgRE9DS0VSX0JMT0IgY29udGVudCAoZGV0
+        YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFp
+        bCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQzLCJkb25lIjo0Mywi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAg
+        MiBET0NLRVJfTUFOSUZFU1QgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6MjEsImRvbmUiOjIxLCJzdWZmaXgiOm51bGx9
+        LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9NQU5J
+        RkVTVCBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0
+        aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MjEsImRvbmUiOjIxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBy
+        ZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9NQU5JRkVTVF9MSVNUIGNvbnRl
+        bnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRl
+        bnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRv
+        bmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGlu
+        ZyBQdWxwIDIgRE9DS0VSX01BTklGRVNUX0xJU1QgY29udGVudCAoZGV0YWls
+        IGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFpbCIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRE9D
+        S0VSX1RBRyBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InByZW1p
+        Z3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIERPQ0tFUl9UQUcgY29udGVudCAoZGV0
+        YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmRldGFp
+        bCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ3JlYXRpbmcgcmVwb3NpdG9yaWVz
+        IGluIFB1bHAgMyIsImNvZGUiOiJjcmVhdGluZy5yZXBvc2l0b3JpZXMiLCJz
+        dGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBpbXBvcnRlcnMgdG8gUHVs
+        cCAzIiwiY29kZSI6Im1pZ3JhdGluZy5pbXBvcnRlcnMiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6Ik1pZ3JhdGluZyBkb2NrZXIgY29udGVudCB0byBQdWxwIDMg
+        ZG9ja2VyX2Jsb2IiLCJjb2RlIjoibWlncmF0aW5nLmRvY2tlci5jb250ZW50
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NDMsImRvbmUiOjQzLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBkb2NrZXIgY29u
+        dGVudCB0byBQdWxwIDMgZG9ja2VyX21hbmlmZXN0IiwiY29kZSI6Im1pZ3Jh
+        dGluZy5kb2NrZXIuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOjIxLCJkb25lIjoyMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgZG9ja2VyIGNvbnRlbnQgdG8gUHVscCAzIGRvY2tlcl9tYW5p
+        ZmVzdF9saXN0IiwiY29kZSI6Im1pZ3JhdGluZy5kb2NrZXIuY29udGVudCIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRvbmUiOjQsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGRvY2tlciBjb250ZW50
+        IHRvIFB1bHAgMyBkb2NrZXJfdGFnIiwiY29kZSI6Im1pZ3JhdGluZy5kb2Nr
+        ZXIuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQsImRv
+        bmUiOjQsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGNv
+        bnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1pZ3JhdGluZy5jb250ZW50Iiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NzIsImRvbmUiOjcyLCJzdWZm
+        aXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3Yz
+        L3Rhc2stZ3JvdXBzLzRiYjkwMzYzLWQ2Y2YtNDExYS04OGViLTc2YTNkMjQ3
+        Yzk2Ny8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwdWxwXzJ0
+        bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/4bb90363-d6cf-411a-88eb-76a3d247c967/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2662df9079e248c981711819bd4b521b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '272'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvNGJiOTAz
+        NjMtZDZjZi00MTFhLTg4ZWItNzZhM2QyNDdjOTY3LyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjowLCJj
+        b21wbGV0ZWQiOjIsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjox
+        LCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2repositories/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 80f9cd9e49a04e97932b0e998c042303
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '425'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRv
+        cmllcy9kY2FlYjc5Yi1iNTdhLTQxN2ItYTY5Ni0zN2Y5NTQ5NWFiMDkvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNjowNTo1Mi4yOTE5MzFaIiwi
+        cHVscDJfb2JqZWN0X2lkIjoiNjAyZmUxZDg3YWNjZTkzNTExMTIxYjY0Iiwi
+        cHVscDJfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtYnVz
+        eWJveC1saWJyYXJ5IiwicHVscDJfcmVwb190eXBlIjoiZG9ja2VyIiwiaXNf
+        bWlncmF0ZWQiOnRydWUsIm5vdF9pbl9wbGFuIjpmYWxzZSwicHVscDNfcmVw
+        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9j
+        b250YWluZXIvY29udGFpbmVyL2VhNjY4Njc3LTBjM2MtNDhlOC05ZjViLTY2
+        ZjAwYTZmM2VkOS92ZXJzaW9ucy8xLyIsInB1bHAzX3JlbW90ZV9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlbW90ZXMvY29udGFpbmVyL2NvbnRhaW5lci8xMDdm
+        NTUyNy0yMDJlLTQwZjktYWI5NC03MjI5YzUxYjMwNTYvIiwicHVscDNfcHVi
+        bGljYXRpb25faHJlZiI6bnVsbCwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZz
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2NvbnRhaW5lci9jb250
+        YWluZXIvNzVjZmE4ZTctODFlMS00OTAwLWIyZDEtOWM5YzdhZWZjZTI1LyJd
+        LCJwdWxwM19yZXBvc2l0b3J5X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvZWE2Njg2NzctMGMzYy00OGU4
+        LTlmNWItNjZmMDBhNmYzZWQ5LyJ9XX0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/container/container/75cfa8e7-81e1-4900-b2d1-9c9c7aefce25/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.2.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a16527a2622844ab999ca1aa7838c13e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '337'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJuYW1lIjoiNjAyZmUxZDg3YWNjZTkzNTExMTIxYjY2LURlZmF1bHRfT3Jn
+        YW5pemF0aW9uLVRlc3QtYnVzeWJveC1saWJyYXJ5IiwicmVwb3NpdG9yeSI6
+        bnVsbCwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2VhNjY4Njc3LTBjM2MtNDhl
+        OC05ZjViLTY2ZjAwYTZmM2VkOS92ZXJzaW9ucy8xLyIsImJhc2VfcGF0aCI6
+        ImVtcHR5X29yZ2FuaXphdGlvbi1wdXBwZXRfcHJvZHVjdC1idXN5Ym94Iiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNjowNTo1My45OTE2MDJaIiwi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFp
+        bmVyL2NvbnRhaW5lci83NWNmYThlNy04MWUxLTQ5MDAtYjJkMS05YzljN2Fl
+        ZmNlMjUvIiwiY29udGVudF9ndWFyZCI6bnVsbCwicmVnaXN0cnlfcGF0aCI6
+        ImNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20v
+        ZW1wdHlfb3JnYW5pemF0aW9uLXB1cHBldF9wcm9kdWN0LWJ1c3lib3giLCJu
+        YW1lc3BhY2UiOm51bGx9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=,,,390560bd-9ce6-444a-a424-868ecbd8ad24,5acf49b9-1dab-46b4-a720-fa2249f557f7,6041a3a0-6d92-460c-8c0d-fc57f38038d0,63660051-d9df-43ee-bba9-f5d52306efcb,6b030b35-e0df-4580-98dc-a6ee5a8bfd8f,6ec808db-b7b9-4f00-839b-9cfcdfc286d9,a08ab807-5a63-42f0-9b3a-41ddab1f713c,abb56d2b-d1bd-4cb0-b4f9-737c7c78a814,dd1a8231-4ee0-456f-812f-2aca964e9d2a,fef6abb2-2ce8-4325-a492-0a87bfc3774a
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 75c6668d596d45f089b0bee2b48eecf0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1855'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTAsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50
+        L2MzNmRmNTM1LTU3YWQtNGY3OC04NjkzLTNiYWI4ODhjZDA5Ni8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE2OjA1OjUyLjM5ODAwMloiLCJwdWxw
+        Ml9pZCI6IjZiMDMwYjM1LWUwZGYtNDU4MC05OGRjLWE2ZWU1YThiZmQ4ZiIs
+        InB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6ImRvY2tlcl9tYW5pZmVzdCIsInB1
+        bHAyX2xhc3RfdXBkYXRlZCI6MTYxMzc1MDc0OSwicHVscDJfc3RvcmFnZV9w
+        YXRoIjoiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5p
+        ZmVzdC85Ni9mZWU4ZWQxNmU0NTg5ZjZlNDY4M2YwMjNiMzRhZjk4ZTBjMjZl
+        NDQ3ZDVlZWJmZDE1YzA0OTI1ZWRkZmE3MC9zaGEyNTY6YTFlNjY3MjkzZTJl
+        NDgyNjM0Y2Y5MTg5ZmY4NzZhOGI2ZmQxMTU4ZDBkNzMyNGYyNDFlM2I4M2Vj
+        MmM4ODlmZiIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzU1Njg4
+        NjQ0LTVmYTAtNGFjOS04ZTViLTYyZjQ2NTZlMmM1YS8ifSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvMTJjODMwYWMtODgwNy00
+        OTI4LWIxMTAtNzIzNjI0M2U5MjhmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEt
+        MDItMTlUMTY6MDU6NTIuMzk3OTY5WiIsInB1bHAyX2lkIjoiNWFjZjQ5Yjkt
+        MWRhYi00NmI0LWE3MjAtZmEyMjQ5ZjU1N2Y3IiwicHVscDJfY29udGVudF90
+        eXBlX2lkIjoiZG9ja2VyX21hbmlmZXN0IiwicHVscDJfbGFzdF91cGRhdGVk
+        IjoxNjEzNzUwNzQ5LCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xpYi9w
+        dWxwL2NvbnRlbnQvdW5pdHMvZG9ja2VyX21hbmlmZXN0L2Q3LzRlYjA2ODA5
+        NmE3ZWEwZTExMWJiZjc2MWFjNTIxMDMwYzhiZDlkNjAzZWVjZGJhMjE2YTll
+        MTVjMDFlYWQ0L3NoYTI1NjphZjA1ZjNlY2RhYjZjODNlY2EzYWYwNGQ3Y2Fm
+        NGExMGY4MjI1YmMwMDZkY2Y1NWEyZTMyZWIwZDhjMzY4Zjk0IiwiZG93bmxv
+        YWRlZCI6dHJ1ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2NvbnRhaW5lci9tYW5pZmVzdHMvMzc0NzMzM2MtYTU1My00MGIxLWE2
+        NGUtMmUyZGI1N2I3YjY5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3B1bHAyY29udGVudC8yMGE0MjZlYS0zMGM3LTQ2ZDAtYTczMC05NzM5ZTNi
+        Y2NkMGIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNjowNTo1Mi4z
+        OTc5MzdaIiwicHVscDJfaWQiOiI2ZWM4MDhkYi1iN2I5LTRmMDAtODM5Yi05
+        Y2ZjZGZjMjg2ZDkiLCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJkb2NrZXJf
+        bWFuaWZlc3QiLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NTA3NDksInB1
+        bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kb2NrZXJfbWFuaWZlc3QvNTkvODc1NzRmY2U4NzVjOGQ3Y2VkZjEyODAz
+        MjMyNjAwZWIxNWE4NmFlNjgzNzc5NTFlMmRjMTljMGRiZjFjNzIvc2hhMjU2
+        OjNkOGExOGM4MjhhNDBmODQ3ZmUxOTA1ZTE0MWIyY2JiNTEzMzRlNjhjYjUw
+        YWJkOTc4M2U3YmQ3MTU5NTE5Y2UiLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxw
+        M19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21h
+        bmlmZXN0cy9mOTExMmIxYi1iMDIxLTRhNmEtOWZmMC1lZjJlY2ZmODRhZmEv
+        In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50LzJm
+        NTc2MjdlLWRmNjAtNDJiMi05YjUwLTQ3MTQ1YzljMjdlNC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE2OjA1OjUyLjM5NzkwNVoiLCJwdWxwMl9p
+        ZCI6ImRkMWE4MjMxLTRlZTAtNDU2Zi04MTJmLTJhY2E5NjRlOWQyYSIsInB1
+        bHAyX2NvbnRlbnRfdHlwZV9pZCI6ImRvY2tlcl9tYW5pZmVzdCIsInB1bHAy
+        X2xhc3RfdXBkYXRlZCI6MTYxMzc1MDc0OSwicHVscDJfc3RvcmFnZV9wYXRo
+        IjoiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5pZmVz
+        dC8wYy82MjY2YTg5NmE1ZGQ0ZDAzZDYwOGRlZDVlMjEzNWJlYWU5MzQ4ZWNh
+        YTA5OGFiYTBiZWI5NDM1YWYwZjNiOS9zaGEyNTY6YTQ3NzQwZTk4ZGM3ZWEw
+        NDM1Y2JkM2U5M2E3YzhlOTIwOTU4OTgyNmExZGMzMWE4MDVhNmM3ZjdhNDA4
+        NGFjZCIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzNkYTdkOGZm
+        LWYzYzctNDEwMy04Yzc3LTQ4MzMxY2Q1ZDUwNC8ifSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvNzVkZmJhYmUtODYzYS00NTQ1
+        LWJjYmUtMWVhYWY0N2M1YWNmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDIt
+        MTlUMTY6MDU6NTIuMzk3ODcyWiIsInB1bHAyX2lkIjoiMzkwNTYwYmQtOWNl
+        Ni00NDRhLWE0MjQtODY4ZWNiZDhhZDI0IiwicHVscDJfY29udGVudF90eXBl
+        X2lkIjoiZG9ja2VyX21hbmlmZXN0IiwicHVscDJfbGFzdF91cGRhdGVkIjox
+        NjEzNzUwNzQ5LCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xpYi9wdWxw
+        L2NvbnRlbnQvdW5pdHMvZG9ja2VyX21hbmlmZXN0L2I0L2NlZjI2MDg2NGVk
+        MDQwOTNlMDgyM2MzODRhMmVkYjhkOGE2ZDQ3NzM0ZGM4ZjA5ZWVjNzY0MDAx
+        NTQzYjFiL3NoYTI1Njo4ZGMxZmIzNTkzZjliNWE0OWY3MGM3ZjhlNTlkN2Ez
+        MWEyZDAzYTdhZTcxNzAzNTBkOWE3YmU4NDg2OTkzYjUzIiwiZG93bmxvYWRl
+        ZCI6dHJ1ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2NvbnRhaW5lci9tYW5pZmVzdHMvYTBlNTIxOWEtMDI5ZS00MTY2LTg5OTct
+        NjMwOTUxZDM1ZjM5LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1
+        bHAyY29udGVudC85N2YyNzkyZi01NWExLTQzMjAtOTgxYS1mODY4NDhiZWJh
+        NDYvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNjowNTo1Mi4zOTc4
+        MzlaIiwicHVscDJfaWQiOiJmZWY2YWJiMi0yY2U4LTQzMjUtYTQ5Mi0wYTg3
+        YmZjMzc3NGEiLCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJkb2NrZXJfbWFu
+        aWZlc3QiLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NTA3NDksInB1bHAy
+        X3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9k
+        b2NrZXJfbWFuaWZlc3QvNjIvMTNkNTYxOTc4ZjQ1OTEyNmZlYWJkMzc1ZTZm
+        ZWNmMjVlMDdiMTM4NTQ4OTNhYzRkMGNhYTRiZTc2MzM0MjAvc2hhMjU2OjA3
+        NzkxNjRiNmUyMWFhNjM1YjRiMGVhYTJmNDA0MTliY2YxZmI0YjM0ODAzNDFi
+        NzEzNzU4NGRmMjBlNzFjYjgiLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19j
+        b250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlm
+        ZXN0cy9jNzFjMjMxZS03OTU2LTRmZWEtOGUyMC1hODBmNDY4NGYxZDQvIn0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50LzE1ZDZm
+        ZTNiLWNlMzMtNDBhYS04MDFjLTE3NjJkMTgwZTI3NC8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDIxLTAyLTE5VDE2OjA1OjUyLjM5NzgwN1oiLCJwdWxwMl9pZCI6
+        ImFiYjU2ZDJiLWQxYmQtNGNiMC1iNGY5LTczN2M3Yzc4YTgxNCIsInB1bHAy
+        X2NvbnRlbnRfdHlwZV9pZCI6ImRvY2tlcl9tYW5pZmVzdCIsInB1bHAyX2xh
+        c3RfdXBkYXRlZCI6MTYxMzc1MDc0OSwicHVscDJfc3RvcmFnZV9wYXRoIjoi
+        L3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5pZmVzdC8z
+        MC84N2Y1Y2IxNTU1NmY2YjRkY2QzZmNmZGIwZGMwYWRjNzM2ZjIzZWE5ZjBl
+        Y2NkZDgyMDU0MTYyMzM1OGZjZS9zaGEyNTY6MDIyOGQwYmJkN2Y5ZDNjYjUw
+        YzFjZWI2OWYwZDg0Mjg3NDUwMjgyZjNiYmZlZDJiZDJkYTU4MjY5ZGQzN2Zk
+        ZiIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzL2U5OTFhYzgyLTcw
+        MjUtNDNhZS1iZjc5LTRiOGY5NzJkZTYxYi8ifSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9wdWxwMmNvbnRlbnQvZTM4OWE1NTEtNGI1Mi00OTM4LThh
+        YjktMmQ4MDU3MmYzZDg2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlU
+        MTY6MDU6NTIuMzk3Nzc0WiIsInB1bHAyX2lkIjoiNjA0MWEzYTAtNmQ5Mi00
+        NjBjLThjMGQtZmM1N2YzODAzOGQwIiwicHVscDJfY29udGVudF90eXBlX2lk
+        IjoiZG9ja2VyX21hbmlmZXN0IiwicHVscDJfbGFzdF91cGRhdGVkIjoxNjEz
+        NzUwNzQ5LCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xpYi9wdWxwL2Nv
+        bnRlbnQvdW5pdHMvZG9ja2VyX21hbmlmZXN0LzhmLzlkMTZlMWQwMTI3MTdl
+        OWIxNTEzODk2NGVhMWVkYThjYjI2MTIwNzdjZTdjNTc3Y2MwYTVkNTY3YWEx
+        NTliL3NoYTI1Njo2ZTE5ODFhNjYzOWMyMjUxYWM3YzZkNzc3YTM0N2Y4Yzg5
+        MDEyYjI1NWQ0NGY4OTQ0N2I0NGE1N2IzOTZkZDViIiwiZG93bmxvYWRlZCI6
+        dHJ1ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Nv
+        bnRhaW5lci9tYW5pZmVzdHMvOTYwYTNmZTMtNzY5MC00OWM5LTk2ODQtNTI2
+        MTRhMzM5NmQ2LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAy
+        Y29udGVudC8yN2UzMmY4Yi1kMDFlLTRjN2UtODhkYS1kNzk4MjM1MGZjM2Yv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNjowNTo1Mi4zOTc3NDJa
+        IiwicHVscDJfaWQiOiI2MzY2MDA1MS1kOWRmLTQzZWUtYmJhOS1mNWQ1MjMw
+        NmVmY2IiLCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJkb2NrZXJfbWFuaWZl
+        c3QiLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NTA3NDksInB1bHAyX3N0
+        b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9kb2Nr
+        ZXJfbWFuaWZlc3QvYjQvMTc1NThlNmUwOTI4Yjg2NTMxNzhjMmM4ZTY2MTBm
+        NzQxMjc0MzhjOWVjMGM2ZTA1OTg0Y2RlYWE0NTgwMWUvc2hhMjU2OmVlNjRi
+        YzZmMDZlZTY0NDAwYjE5ZWY4NDQwYmIyNTVhNzU3YjdkYTU1M2UzZTYwYTZk
+        MzZkMmQ1ZTAwNTZlZDEiLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19jb250
+        ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvY29udGFpbmVyL21hbmlmZXN0
+        cy83ODdlMGM2ZC05Yzc0LTRiNTctYTY1Zi0xN2Y2NzQ4YzRmNDkvIn0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50LzMzNzBjMGRk
+        LTczOTUtNGZkYS04ODNjLTYzMTJlOTQyZjUxYi8iLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDIxLTAyLTE5VDE2OjA1OjUyLjM5NzcwOVoiLCJwdWxwMl9pZCI6ImEw
+        OGFiODA3LTVhNjMtNDJmMC05YjNhLTQxZGRhYjFmNzEzYyIsInB1bHAyX2Nv
+        bnRlbnRfdHlwZV9pZCI6ImRvY2tlcl9tYW5pZmVzdCIsInB1bHAyX2xhc3Rf
+        dXBkYXRlZCI6MTYxMzc1MDc0OSwicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zh
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL2RvY2tlcl9tYW5pZmVzdC9hZi8x
+        YjJkNjM5NWJmODM3NGRjYjgwMzUyNmM1ZjljNWIzNjg2NjA5Y2NiNmUxMTRj
+        ODFjNDA4ZWQ5MzFlN2JiMi9zaGEyNTY6NzRlNGE2OGRmYmE2ZjQwYjAxNzg3
+        YTM4NzZjYzFiZTBmYjFkOTAyNWMzNTY3Y2Y4MzY3YzY1OWYyMTg3MjM0ZiIs
+        ImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9jb250YWluZXIvbWFuaWZlc3RzLzEzMDRiMThjLTlhNzAt
+        NDRlNy1hYzFhLTY0MWQ3OGJiYzY4MC8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=113f435f-b994-4dc6-8193-7c15736b64f1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1f17b4e3cbb145739cdd54992abb0873
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        ZjNmNzVmY2YtNjVkZS00MTJlLWI1ZjItYjBmNzUyZjBmYjlkLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTY6MDU6NTIuNDQ2OTAyWiIsInB1bHAy
+        X2lkIjoiMTEzZjQzNWYtYjk5NC00ZGM2LTgxOTMtN2MxNTczNmI2NGYxIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoiZG9ja2VyX21hbmlmZXN0X2xpc3Qi
+        LCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NTA3NDksInB1bHAyX3N0b3Jh
+        Z2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9kb2NrZXJf
+        bWFuaWZlc3RfbGlzdC8zMS83YzY2ZGFkMjMyZjlhODIyNDZkZGQwMDM4N2Qx
+        ODA2ZWU2NzE2ZmEzNWY2M2VmYmVmNTU0NDM0YWM5ODgzZi9zaGEyNTY6YzZi
+        NDVhOTVmOTMyMjAyZGJiMjdjMzEzMzNjNDc4OWY0NTE4NGE3NDQwNjBmNmU1
+        NjljYzlkMmJmMWI5YWQ2ZiIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2Nv
+        bnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9jb250YWluZXIvbWFuaWZl
+        c3RzLzFiMWEyMDgzLWFhMDEtNGNhNy05NzE0LWZjYzM3N2RkNmZkZi8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=,,,ab3f1a0b-3edc-46a9-939f-61e9ac1b68f6,cfc3df66-78f6-4f92-a965-adf640cb285e
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9b2f69dae3ee4be5848424b7427b4540
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '290'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        OWZjMzY0NGUtZmViOS00ODUwLWJjZjItYWExZGE1ZDNkNzA1LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTY6MDU6NTIuNDg4NTEwWiIsInB1bHAy
+        X2lkIjoiY2ZjM2RmNjYtNzhmNi00ZjkyLWE5NjUtYWRmNjQwY2IyODVlIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoiZG9ja2VyX3RhZyIsInB1bHAyX2xh
+        c3RfdXBkYXRlZCI6MTYxMzc1MDc0OSwicHVscDJfc3RvcmFnZV9wYXRoIjpu
+        dWxsLCJkb3dubG9hZGVkIjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2NvbnRhaW5lci90YWdzLzJkYjRiMThhLTEyNDkt
+        NGMzNS04M2MwLTJmNzBiN2JlZmEzYi8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJkb2NrZXIifV19fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/fa28bb35-b5f6-4c7f-ab09-b3c92a199a27/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '166'
+      Correlation-Id:
+      - 32c994819b4349cb863ab5f7b616ba09
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zL2Zh
+        MjhiYjM1LWI1ZjYtNGM3Zi1hYjA5LWIzYzkyYTE5OWEyNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE2OjA1OjU0Ljg2Mzc2OVoiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJkb2NrZXIifV19fQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/fa28bb35-b5f6-4c7f-ab09-b3c92a199a27/reset/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbHVnaW5zIjpbeyJ0eXBlIjoiZG9ja2VyIn1dfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:54 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d5be4ce42a144f70939e59583266ff26
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4MzljYjYzLTc4Y2MtNDI0
+        OS1hODM5LWYwYmJlODBiYzEyZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:54 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2YzZTgwNjgwLWQ0N2UtNDA2MC05Yzk4LTJiMDc5ZDRkM2ZlMC8iLCAi
+        dGFza19pZCI6ICJmM2U4MDY4MC1kNDdlLTQwNjAtOWM5OC0yYjA3OWQ0ZDNm
+        ZTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/f3e80680-d47e-4060-9c98-2b079d4d3fe0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 16:05:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"bfdba858dce3baa29cb647f819cd7f7f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '396'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mM2U4MDY4MC1kNDdlLTQwNjAtOWM5OC0yYjA3OWQ0ZDNm
+        ZTAvIiwgInRhc2tfaWQiOiAiZjNlODA2ODAtZDQ3ZS00MDYwLTljOTgtMmIw
+        NzlkNGQzZmUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMTlUMTY6
+        MDU6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjEtMDItMTlUMTY6MDU6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDJmZTFlM2Y3M2I2OWE4MzY2NTIwY2YifSwg
+        ImlkIjogIjYwMmZlMWUzZjczYjY5YTgzNjY1MjBjZiJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 16:05:55 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration_reset.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration_reset.yml
@@ -1,0 +1,2286 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:24 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
+        RmlsZXMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzLyIsICJodHRw
+        X3N0YXR1cyI6IDQwNCwgImVycm9yIjogeyJjb2RlIjogIlBMUDAwMDkiLCAi
+        ZGF0YSI6IHsicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifX0sICJkZXNjcmlwdGlv
+        biI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PURlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCAic3ViX2Vycm9ycyI6
+        IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:24 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
+        LCJkaXNwbGF5X25hbWUiOiJNeSBGaWxlcyIsImltcG9ydGVyX3R5cGVfaWQi
+        OiJpc29faW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZp
+        bGU6Ly8vdmFyL2xpYi9wdWxwL3N5bmNfaW1wb3J0cy90ZXN0X3JlcG9zL2Zp
+        bGVfbWlncmF0aW9uLyIsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJh
+        c2ljX2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVl
+        LCJwcm94eV9ob3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xf
+        Y2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJkaXN0cmli
+        dXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJpc29fZGlzdHJpYnV0
+        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '603'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:24 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '344'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzljN2FjY2U5MzE2OWJiNGRmMCJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:24 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdjYmE3OWJjLTk2MGQtNDdkMC05MDFhLWY1ZjFhMjdlN2IxYS8iLCAi
+        dGFza19pZCI6ICI3Y2JhNzliYy05NjBkLTQ3ZDAtOTAxYS1mNWYxYTI3ZTdi
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/7cba79bc-960d-47d0-901a-f5f1a27e7b1a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1e1d7b45d38286a41bcf5b1d63d21bdc-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '679'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83Y2JhNzliYy05NjBkLTQ3ZDAtOTAxYS1mNWYxYTI3ZTdi
+        MWEvIiwgInRhc2tfaWQiOiAiN2NiYTc5YmMtOTYwZC00N2QwLTkwMWEtZjVm
+        MWEyN2U3YjFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6NDM6MjVa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEt
+        MDItMDVUMTU6NDM6MjVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2RkNDk5
+        YTZhLTc0NTUtNDM3My04MmFlLTU5NTQzM2Q0ODQwYi8iLCAidGFza19pZCI6
+        ICJkZDQ5OWE2YS03NDU1LTQzNzMtODJhZS01OTU0MzNkNDg0MGIifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDM6MjUiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNSIsICJjb21wbGV0ZSI6ICIyMDIx
+        LTAyLTA1VDE1OjQzOjI1IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMS0w
+        Mi0wNVQxNTo0MzoyNSJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJp
+        c29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDIxLTAyLTA1VDE1OjQzOjI1
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMjEtMDItMDVUMTU6NDM6MjVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        aXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVt
+        X2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21l
+        c3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90
+        aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNSIs
+        ICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQzOjI1
+        IiwgImNvbXBsZXRlIjogIjIwMjEtMDItMDVUMTU6NDM6MjUiLCAiaXNvc19p
+        bl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQzOjI1In19LCAiYWRkZWRf
+        Y291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
+        IjogMCwgImlkIjogIjYwMWQ2NzlkN2FjY2U5MzJkMmViODI1YSIsICJkZXRh
+        aWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAxZDY3OWQyODQ4ZDM4NGVkNmRkYjI0In0sICJpZCI6ICI2MDFkNjc5ZDI4
+        NDhkMzg0ZWQ2ZGRiMjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/dd499a6a-7455-4373-82ae-595433d4840b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d6255c531d65d742ae587cc3b96f619e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kZDQ5OWE2YS03NDU1LTQzNzMtODJhZS01OTU0
+        MzNkNDg0MGIvIiwgInRhc2tfaWQiOiAiZGQ0OTlhNmEtNzQ1NS00MzczLTgy
+        YWUtNTk1NDMzZDQ4NDBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVU
+        MTU6NDM6MjVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMjEtMDItMDVUMTU6NDM6MjVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIxLTAyLTA1VDE1OjQzOjI1
+        IiwgImluX3Byb2dyZXNzIjogIjIwMjEtMDItMDVUMTU6NDM6MjUiLCAiY29t
+        cGxldGUiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNSJ9LCAic3RhdGUiOiAiY29t
+        cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
+        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJzdGFydGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDM6MjVaIiwgIl9ucyI6ICJyZXBvX3B1Ymxp
+        c2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRlIjogImNv
+        bXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIxLTAy
+        LTA1VDE1OjQzOjI1IiwgImluX3Byb2dyZXNzIjogIjIwMjEtMDItMDVUMTU6
+        NDM6MjUiLCAiY29tcGxldGUiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNSJ9fSwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJpZCI6ICI2
+        MDFkNjc5ZDdhY2NlOTMyZDJlYjgyNWMiLCAiZGV0YWlscyI6IG51bGx9LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjYwMWQ2NzlkMjg0OGQz
+        ODRlZDZkZGI2NyJ9LCAiaWQiOiAiNjAxZDY3OWQyODQ4ZDM4NGVkNmRkYjY3
+        In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNf
+        RGV2IiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXNfRGV2In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '382'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzlkN2FjY2U5MzE2YTdmOTljYyJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0Zp
+        bGVzIiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0ZpbGVzIiwi
+        c2VydmVfaHR0cCI6dHJ1ZSwic2VydmVfaHR0cHMiOnRydWV9LCJhdXRvX3B1
+        Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '390'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzlkN2FjY2U5MzE2YTdmOTljZiJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1bSJd
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:25 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '278'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
+        ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
+        OTgiLCAiX2lkIjogIjM3Y2JlYmQyLWUzMDItNGExMC04ODAxLTlkOTdiZjMz
+        NTRlZSIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0
+        MzoyNVoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        NVoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjM3Y2Jl
+        YmQyLWUzMDItNGExMC04ODAxLTlkOTdiZjMzNTRlZSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAxZDY3OWQyODQ4ZDM4NGVkNmRkYjRjIn19XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1
+        bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtTXlfRmlsZXMiLCJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwi
+        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyIz
+        N2NiZWJkMi1lMzAyLTRhMTAtODgwMS05ZDk3YmYzMzU0ZWUiXX19fX0sIm92
+        ZXJyaWRlX2NvbmZpZyI6e319
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '198'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI2MmMyYmRlLWYxMTAtNDg2My04YTBjLWViNTQxMjg4MGE3ZC8iLCAi
+        dGFza19pZCI6ICIyNjJjMmJkZS1mMTEwLTQ4NjMtOGEwYy1lYjU0MTI4ODBh
+        N2QifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtTXlfRmlsZXMiLCJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwi
+        ZmlsdGVycyI6eyJhc3NvY2lhdGlvbiI6eyJ1bml0X2lkIjp7IiRpbiI6WyIz
+        N2NiZWJkMi1lMzAyLTRhMTAtODgwMS05ZDk3YmYzMzU0ZWUiXX19fX0sIm92
+        ZXJyaWRlX2NvbmZpZyI6e319
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '198'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzJhNjdlYjdiLWJhYjctNDJkNS05OWYyLTg0ZjcxNDg5MzgyYy8iLCAi
+        dGFza19pZCI6ICIyYTY3ZWI3Yi1iYWI3LTQyZDUtOTlmMi04NGY3MTQ4OTM4
+        MmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8ec6c6462faab7a266f5c3f14051def6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '465'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVw
+        b19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9G
+        aWxlcyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNVoi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy9kaXN0cmlidXRv
+        cnMvRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJpc29fZGlzdHJpYnV0
+        b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAxZDY3OWQ3YWNjZTkzMTZhN2Y5OWQxIn0sICJjb25maWciOiB7InNlcnZl
+        X2h0dHBzIjogdHJ1ZSwgInNlcnZlX2h0dHAiOiB0cnVlLCAicmVsYXRpdmVf
+        dXJsIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0Zp
+        bGVzIn0sICJpZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5l
+        dC1NeV9GaWxlcyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6ICIyMDIxLTAyLTA1
+        VDE1OjQzOjI2WiIsICJub3RlcyI6IHt9LCAibGFzdF91bml0X3JlbW92ZWQi
+        OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHsiaXNvIjogMX0sICJf
+        bnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJsYXN0
+        X3VwZGF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNVoiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy9pbXBvcnRlcnMvaXNvX2ltcG9ydGVy
+        LyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9p
+        ZCI6ICJpc29faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
+        fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDFkNjc5ZDdhY2NlOTMxNmE3Zjk5ZDAifSwgImNv
+        bmZpZyI6IHt9LCAiaWQiOiAiaXNvX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
+        dG9yZWRfdW5pdHMiOiAxLCAiX2lkIjogeyIkb2lkIjogIjYwMWQ2NzlkN2Fj
+        Y2U5MzE2YTdmOTljZiJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDEs
+        ICJpZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9G
+        aWxlcyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0Rl
+        ZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0ZpbGVzLyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0Zp
+        bGVzIiwib3ZlcnJpZGVfY29uZmlnIjp7ImZvcmNlX2Z1bGwiOmZhbHNlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzA2YTg0MzY0LWNjMWQtNGY2OS1iOGM4LWZmYWJjN2VmM2FkMi8iLCAi
+        dGFza19pZCI6ICIwNmE4NDM2NC1jYzFkLTRmNjktYjhjOC1mZmFiYzdlZjNh
+        ZDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/06a84364-cc1d-4f69-b8c8-ffabc7ef3ad2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"dc8832a779e595fa3dfa61a496a9bf48-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '569'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wNmE4NDM2NC1jYzFkLTRmNjktYjhjOC1mZmFi
+        YzdlZjNhZDIvIiwgInRhc2tfaWQiOiAiMDZhODQzNjQtY2MxZC00ZjY5LWI4
+        YzgtZmZhYmM3ZWYzYWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJw
+        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAy
+        LTA1VDE1OjQzOjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyI6
+        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjEtMDItMDVU
+        MTU6NDM6MjYiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        NiIsICJjb21wbGV0ZSI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2In0sICJzdGF0
+        ZSI6ICJjb21wbGV0ZSIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInRyYWNl
+        YmFjayI6IG51bGx9fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
+        ZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxl
+        cyIsICJzdGFydGVkIjogIjIwMjEtMDItMDVUMTU6NDM6MjZaIiwgIl9ucyI6
+        ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0w
+        Mi0wNVQxNTo0MzoyNloiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7
+        InN0YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRl
+        ZCI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2IiwgImluX3Byb2dyZXNzIjogIjIw
+        MjEtMDItMDVUMTU6NDM6MjYiLCAiY29tcGxldGUiOiAiMjAyMS0wMi0wNVQx
+        NTo0MzoyNiJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlf
+        RmlsZXMiLCAiaWQiOiAiNjAxZDY3OWU3YWNjZTkzMmQyZWI4MjVmIiwgImRl
+        dGFpbHMiOiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI2MDFkNjc5ZTI4NDhkMzg0ZWQ2ZGRjM2IifSwgImlkIjogIjYwMWQ2Nzll
+        Mjg0OGQzODRlZDZkZGMzYiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4024c057874a59c440a2d8eaf24678fd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '459'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVw
+        b19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVz
+        X0RldiIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MzoyNVoi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi9kaXN0cmlidXRv
+        cnMvRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJpc29fZGlzdHJpYnV0
+        b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAxZDY3OWQ3YWNjZTkzMTZhN2Y5OWNlIn0sICJjb25maWciOiB7InNlcnZl
+        X2h0dHBzIjogdHJ1ZSwgInNlcnZlX2h0dHAiOiB0cnVlLCAicmVsYXRpdmVf
+        dXJsIjogIkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyJ9LCAi
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19E
+        ZXYifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        NloiLCAibm90ZXMiOiB7fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwg
+        ImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7ImlzbyI6IDF9LCAiX25zIjogInJl
+        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRGVmYXVsdF9Pcmdh
+        bml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYiLCAibGFzdF91cGRhdGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDM6MjVaIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi9yZXBvc2l0b3JpZXMvRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
+        dC1NeV9GaWxlc19EZXYvaW1wb3J0ZXJzL2lzb19pbXBvcnRlci8iLCAiX25z
+        IjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAiaXNv
+        X2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0
+        X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAxZDY3OWQ3YWNjZTkzMTZhN2Y5OWNkIn0sICJjb25maWciOiB7
+        fSwgImlkIjogImlzb19pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3Vu
+        aXRzIjogMSwgIl9pZCI6IHsiJG9pZCI6ICI2MDFkNjc5ZDdhY2NlOTMxNmE3
+        Zjk5Y2MifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAxLCAiaWQiOiAi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYiLCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNf
+        RGV2Iiwib3ZlcnJpZGVfY29uZmlnIjp7ImZvcmNlX2Z1bGwiOmZhbHNlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QyOTcwNjA0LWIyZTktNDYyZS1hZTBmLTg3NGQ1N2VkMWU0Ni8iLCAi
+        dGFza19pZCI6ICJkMjk3MDYwNC1iMmU5LTQ2MmUtYWUwZi04NzRkNTdlZDFl
+        NDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d2970604-b2e9-462e-ae0f-874d57ed1e46/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:26 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4bcf345a79f6ab209ad267f797d988c4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '568'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kMjk3MDYwNC1iMmU5LTQ2MmUtYWUwZi04NzRk
+        NTdlZDFlNDYvIiwgInRhc2tfaWQiOiAiZDI5NzA2MDQtYjJlOS00NjJlLWFl
+        MGYtODc0ZDU3ZWQxZTQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJw
+        dWxwOmFjdGlvbjpwdWJsaXNoIl0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAy
+        LTA1VDE1OjQzOjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiI6
+        IHsic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVkIjogIjIwMjEtMDItMDVU
+        MTU6NDM6MjYiLCAiaW5fcHJvZ3Jlc3MiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        NiIsICJjb21wbGV0ZSI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2In0sICJzdGF0
+        ZSI6ICJjb21wbGV0ZSIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInRyYWNl
+        YmFjayI6IG51bGx9fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
+        ZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rl
+        diIsICJzdGFydGVkIjogIjIwMjEtMDItMDVUMTU6NDM6MjZaIiwgIl9ucyI6
+        ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0w
+        Mi0wNVQxNTo0MzoyNloiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7
+        InN0YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRl
+        ZCI6ICIyMDIxLTAyLTA1VDE1OjQzOjI2IiwgImluX3Byb2dyZXNzIjogIjIw
+        MjEtMDItMDVUMTU6NDM6MjYiLCAiY29tcGxldGUiOiAiMjAyMS0wMi0wNVQx
+        NTo0MzoyNiJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        c19EZXYiLCAiaWQiOiAiNjAxZDY3OWU3YWNjZTkzMmQyZWI4MjYxIiwgImRl
+        dGFpbHMiOiBudWxsfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI2MDFkNjc5ZTI4NDhkMzg0ZWQ2ZGRjODQifSwgImlkIjogIjYwMWQ2Nzll
+        Mjg0OGQzODRlZDZkZGM4NCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJpc28iLCJyZXBvc2l0b3Jp
+        ZXMiOlt7Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
+        X0ZpbGVzIiwicmVwb3NpdG9yeV92ZXJzaW9ucyI6W3sicHVscDJfcmVwb3Np
+        dG9yeV9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmls
+        ZXMiLCJwdWxwMl9kaXN0cmlidXRvcl9yZXBvc2l0b3J5X2lkcyI6WyJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIl19XSwicHVscDJf
+        aW1wb3J0ZXJfcmVwb3NpdG9yeV9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LUNhYmluZXQtTXlfRmlsZXMifSx7Im5hbWUiOiJwdWJsaXNoZWRfZGV2X3Zp
+        ZXctTXlfRmlsZXMiLCJyZXBvc2l0b3J5X3ZlcnNpb25zIjpbeyJwdWxwMl9y
+        ZXBvc2l0b3J5X2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmlu
+        ZXQtTXlfRmlsZXMiLCJwdWxwMl9kaXN0cmlidXRvcl9yZXBvc2l0b3J5X2lk
+        cyI6WyJEZWZhdWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxl
+        cyIsIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNfRGV2
+        Il19XX1dfV19fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/d6d6784a-1e2b-4e56-b815-8d725edef930/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '721'
+      Correlation-Id:
+      - 4287b99b73374d17b8d50ec8347571bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zL2Q2
+        ZDY3ODRhLTFlMmItNGU1Ni1iODE1LThkNzI1ZWRlZjkzMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTA1VDE1OjQzOjI3LjA3MzUxM1oiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJpc28iLCJyZXBvc2l0b3JpZXMiOlt7Im5h
+        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwi
+        cmVwb3NpdG9yeV92ZXJzaW9ucyI6W3sicHVscDJfcmVwb3NpdG9yeV9pZCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJwdWxw
+        Ml9kaXN0cmlidXRvcl9yZXBvc2l0b3J5X2lkcyI6WyJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIl19XSwicHVscDJfaW1wb3J0ZXJf
+        cmVwb3NpdG9yeV9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
+        TXlfRmlsZXMifSx7Im5hbWUiOiJwdWJsaXNoZWRfZGV2X3ZpZXctTXlfRmls
+        ZXMiLCJyZXBvc2l0b3J5X3ZlcnNpb25zIjpbeyJwdWxwMl9yZXBvc2l0b3J5
+        X2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmls
+        ZXMiLCJwdWxwMl9kaXN0cmlidXRvcl9yZXBvc2l0b3J5X2lkcyI6WyJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsIkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNfRGV2Il19XX1dfV19
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/d6d6784a-1e2b-4e56-b815-8d725edef930/run/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkcnlfcnVuIjpmYWxzZSwidmFsaWRhdGUiOnRydWV9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - ca2fd520df204ee19ef0d673735ae6ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3ZWI5OTY4LWNhMjQtNDky
+        ZS04YzNlLWY1ODNmYTA1MjIxZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/97eb9968-ca24-492e-8c3e-f583fa05221d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9b5b5ce231ba46a9ad12ac3c50a84542
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdlYjk5NjgtY2Ey
+        NC00OTJlLThjM2UtZjU4M2ZhMDUyMjFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMDVUMTU6NDM6MjcuMTQ5MTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiJjYTJmZDUy
+        MGRmMjA0ZWUxOWVmMGQ2NzM3MzVhZTZiYSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTA1VDE1OjQzOjI3LjMwOTg1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMDVUMTU6NDM6MjcuODY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wNDliMmNjNC00YzRhLTRkZDUtOTky
+        MC1hNjc4Njk2OTI2YzMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy8wOGNlYzRkNC01YTU2LTQyMDct
+        ODRiZC1lYTI3ODFmN2Q5MjUvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxZmU1
+        ZGRjLTU2MWItNGMyYi04YjUxLTk1MTkxMTZhMmJiZS8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy82MGI5ZmYzNi05Njg4LTQ3
+        ZGItYWM4Zi04YmU2MWY4ZTZmYTIvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25l
+        Ijo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIElTTyBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIElTTyBjb250ZW50IChkZXRhaWwg
+        aW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJDcmVhdGluZyByZXBvc2l0b3JpZXMgaW4g
+        UHVscCAzIiwiY29kZSI6ImNyZWF0aW5nLnJlcG9zaXRvcmllcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVs
+        bH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGltcG9ydGVycyB0byBQdWxwIDMi
+        LCJjb2RlIjoibWlncmF0aW5nLmltcG9ydGVycyIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiTWlncmF0aW5nIGNvbnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1p
+        Z3JhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRp
+        bmcgaXNvIGNvbnRlbnQgdG8gUHVscCAzIGlzbyIsImNvZGUiOiJtaWdyYXRp
+        bmcuaXNvLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzLzYwYjlmZjM2LTk2ODgtNDdk
+        Yi1hYzhmLThiZTYxZjhlNmZhMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/60b9ff36-9688-47db-ac8f-8be61f8e6fa2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:27 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6bd2029047c04b95b269ff22c240950a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '274'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvNjBiOWZm
+        MzYtOTY4OC00N2RiLWFjOGYtOGJlNjFmOGU2ZmEyLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjoxLCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJj
+        b21wbGV0ZWQiOjEsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjMsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/97eb9968-ca24-492e-8c3e-f583fa05221d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8f383b33e1bf43c29ed3a26a4cb0c6bb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdlYjk5NjgtY2Ey
+        NC00OTJlLThjM2UtZjU4M2ZhMDUyMjFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMDVUMTU6NDM6MjcuMTQ5MTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiJjYTJmZDUy
+        MGRmMjA0ZWUxOWVmMGQ2NzM3MzVhZTZiYSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTA1VDE1OjQzOjI3LjMwOTg1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMDVUMTU6NDM6MjcuODY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wNDliMmNjNC00YzRhLTRkZDUtOTky
+        MC1hNjc4Njk2OTI2YzMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy8wOGNlYzRkNC01YTU2LTQyMDct
+        ODRiZC1lYTI3ODFmN2Q5MjUvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxZmU1
+        ZGRjLTU2MWItNGMyYi04YjUxLTk1MTkxMTZhMmJiZS8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy82MGI5ZmYzNi05Njg4LTQ3
+        ZGItYWM4Zi04YmU2MWY4ZTZmYTIvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25l
+        Ijo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIElTTyBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIElTTyBjb250ZW50IChkZXRhaWwg
+        aW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJDcmVhdGluZyByZXBvc2l0b3JpZXMgaW4g
+        UHVscCAzIiwiY29kZSI6ImNyZWF0aW5nLnJlcG9zaXRvcmllcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVs
+        bH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGltcG9ydGVycyB0byBQdWxwIDMi
+        LCJjb2RlIjoibWlncmF0aW5nLmltcG9ydGVycyIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiTWlncmF0aW5nIGNvbnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1p
+        Z3JhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRp
+        bmcgaXNvIGNvbnRlbnQgdG8gUHVscCAzIGlzbyIsImNvZGUiOiJtaWdyYXRp
+        bmcuaXNvLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzLzYwYjlmZjM2LTk2ODgtNDdk
+        Yi1hYzhmLThiZTYxZjhlNmZhMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/60b9ff36-9688-47db-ac8f-8be61f8e6fa2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ca6eb285a5234da88ce77b1cd82cdf45
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '273'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvNjBiOWZm
+        MzYtOTY4OC00N2RiLWFjOGYtOGJlNjFmOGU2ZmEyLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJj
+        b21wbGV0ZWQiOjIsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjMsImRvbmUiOjIsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/97eb9968-ca24-492e-8c3e-f583fa05221d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e69ed39a04064f35bde726150a9889cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTdlYjk5NjgtY2Ey
+        NC00OTJlLThjM2UtZjU4M2ZhMDUyMjFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMDVUMTU6NDM6MjcuMTQ5MTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiJjYTJmZDUy
+        MGRmMjA0ZWUxOWVmMGQ2NzM3MzVhZTZiYSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTA1VDE1OjQzOjI3LjMwOTg1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMDVUMTU6NDM6MjcuODY1NDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wNDliMmNjNC00YzRhLTRkZDUtOTky
+        MC1hNjc4Njk2OTI2YzMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9lMWZlNWRkYy01NjFiLTRjMmIt
+        OGI1MS05NTE5MTE2YTJiYmUvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4Y2Vj
+        NGQ0LTVhNTYtNDIwNy04NGJkLWVhMjc4MWY3ZDkyNS8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy82MGI5ZmYzNi05Njg4LTQ3
+        ZGItYWM4Zi04YmU2MWY4ZTZmYTIvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0LCJkb25l
+        Ijo0LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIElTTyBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIElTTyBjb250ZW50IChkZXRhaWwg
+        aW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJDcmVhdGluZyByZXBvc2l0b3JpZXMgaW4g
+        UHVscCAzIiwiY29kZSI6ImNyZWF0aW5nLnJlcG9zaXRvcmllcyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZpeCI6bnVs
+        bH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGltcG9ydGVycyB0byBQdWxwIDMi
+        LCJjb2RlIjoibWlncmF0aW5nLmltcG9ydGVycyIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiTWlncmF0aW5nIGNvbnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1p
+        Z3JhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRp
+        bmcgaXNvIGNvbnRlbnQgdG8gUHVscCAzIGlzbyIsImNvZGUiOiJtaWdyYXRp
+        bmcuaXNvLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzLzYwYjlmZjM2LTk2ODgtNDdk
+        Yi1hYzhmLThiZTYxZjhlNmZhMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/60b9ff36-9688-47db-ac8f-8be61f8e6fa2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0b21f597a6d84178a101c87fa35794dd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '276'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvNjBiOWZm
+        MzYtOTY4OC00N2RiLWFjOGYtOGJlNjFmOGU2ZmEyLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjowLCJj
+        b21wbGV0ZWQiOjMsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2repositories/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - d000ffa060184b21937b6fab4cad9aa9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1301'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRv
+        cmllcy83NDA5NzE2MC0yYjE4LTQ2NTQtODc1Yy1iZjAwNTFjNzM0ZGYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wMi0wNVQxNTo0MzoyNy40NzI1NzRaIiwi
+        cHVscDJfb2JqZWN0X2lkIjoiNjAxZDY3OWQ3YWNjZTkzMTZhN2Y5OWNmIiwi
+        cHVscDJfcmVwb19pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJp
+        bmV0LU15X0ZpbGVzIiwicHVscDJfcmVwb190eXBlIjoiaXNvIiwiaXNfbWln
+        cmF0ZWQiOnRydWUsIm5vdF9pbl9wbGFuIjpmYWxzZSwicHVscDNfcmVwb3Np
+        dG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
+        L2ZpbGUvZmVmZjgwZjktMTBiZi00MjMxLWEwMTItYWZjMDI5NGY5N2ExL3Zl
+        cnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYiOm51bGwsInB1bHAzX3B1
+        YmxpY2F0aW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2Zp
+        bGUvZmlsZS9kZWU0OWEyNS1kNGU1LTQxYWItOThiMC1lNmNlZDhkYjQ3Yzcv
+        IiwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZzIjpbIi9wdWxwL2FwaS92My9k
+        aXN0cmlidXRpb25zL2ZpbGUvZmlsZS9kNGQ5ZDNjZi1iOTliLTQzMzEtYTdj
+        ZS0zZTc4NDc3MWQ2ZmMvIiwiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        ZmlsZS9maWxlLzE3MmUyNTU3LTQ5MDUtNDRkMy1iNjVjLTY5YzQyYzdmMjU5
+        OC8iXSwicHVscDNfcmVwb3NpdG9yeV9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9maWxlL2ZpbGUvZmVmZjgwZjktMTBiZi00MjMxLWEwMTIt
+        YWZjMDI5NGY5N2ExLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1
+        bHAycmVwb3NpdG9yaWVzLzEzYjliMDFmLTYwM2ItNDY2Yy1iZGU2LWRmZDdm
+        YjIzNTZlNS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTA1VDE1OjQzOjI3
+        LjQzMzg0OVoiLCJwdWxwMl9vYmplY3RfaWQiOiI2MDFkNjc5YzdhY2NlOTMx
+        NjliYjRkZjAiLCJwdWxwMl9yZXBvX2lkIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1NeV9GaWxlcyIsInB1bHAyX3JlcG9fdHlwZSI6ImlzbyIs
+        ImlzX21pZ3JhdGVkIjp0cnVlLCJub3RfaW5fcGxhbiI6ZmFsc2UsInB1bHAz
+        X3JlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZmlsZS9maWxlL2IwNDVkZDRjLTY5ODAtNGUwYi1iMjYwLWU2N2Q3YzU5
+        NTcxMS92ZXJzaW9ucy8xLyIsInB1bHAzX3JlbW90ZV9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzNjMDY4ZmM0LTAwYTYtNDEzOS1i
+        YTNiLTAzMzg2YWFlYzJlMC8iLCJwdWxwM19wdWJsaWNhdGlvbl9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZTA5MGYxMzQt
+        MGI3My00N2EwLThiNTktZDgzOTg0ODMyZjFjLyIsInB1bHAzX2Rpc3RyaWJ1
+        dGlvbl9ocmVmcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvNjczMDE0ZjQtM2YxNC00NjIwLTg1YzktYzRkZTA0ZjE2MDY1LyJd
+        LCJwdWxwM19yZXBvc2l0b3J5X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS9iMDQ1ZGQ0Yy02OTgwLTRlMGItYjI2MC1lNjdk
+        N2M1OTU3MTEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJy
+        ZXBvc2l0b3JpZXMvZWU5ODAzNDMtMWQ0MC00YjgzLTk2NDItNGEzNDFjZmNi
+        NzFkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMDRUMjE6NTY6NTAuNTAw
+        Mzk3WiIsInB1bHAyX29iamVjdF9pZCI6IjYwMWMzMGU0N2FjY2U5MWExZTcx
+        Njg5NSIsInB1bHAyX3JlcG9faWQiOiIxNDk0MThkOS0zM2NkLTQzNDItOTA2
+        OC0yOGUxNmMxODEzYjAiLCJwdWxwMl9yZXBvX3R5cGUiOiJycG0iLCJpc19t
+        aWdyYXRlZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBv
+        c2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3Jw
+        bS9ycG0vYmEwMTkwMDctYWM3Yi00ODI2LWE5YTktZWQ3ZmZlNGVlMDY1L3Zl
+        cnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVtb3Rlcy9ycG0vcnBtLzUxZTkwNTUwLTNkNTctNGZkOC1hZmYwLTY1NzMz
+        MmRkMTU0MS8iLCJwdWxwM19wdWJsaWNhdGlvbl9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzZiYzU5MTYzLWYwZmQtNDYzMS05
+        N2E0LWQ3NmM2NDQyMWI3YS8iLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS9jNzE3ODQ5
+        OS0wMjE4LTQ2YWYtYjQwZi04ZWM2ZGEzODlhZTUvIl0sInB1bHAzX3JlcG9z
+        aXRvcnlfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9iYTAxOTAwNy1hYzdiLTQ4MjYtYTlhOS1lZDdmZmU0ZWUwNjUvIn0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJyZXBvc2l0b3JpZXMvODkz
+        N2FhYWItNzVhOS00NjBkLTgyOTUtMDY2YmVmODljYTI5LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDItMDRUMjE6NTY6NTAuNDc1OTA1WiIsInB1bHAyX29i
+        amVjdF9pZCI6IjYwMWM0YjhkN2FjY2U5MzE2YjRmMzBjMCIsInB1bHAyX3Jl
+        cG9faWQiOiI3Yzg3MTg3OC03ZTI0LTRhNDUtYjUyZi01NTE0NDYwN2EwOTUi
+        LCJwdWxwMl9yZXBvX3R5cGUiOiJycG0iLCJpc19taWdyYXRlZCI6dHJ1ZSwi
+        bm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDY0ZWUxNmMt
+        YWVhNi00ODJlLTg3ODMtNTQwMGFhYjgwZWZhL3ZlcnNpb25zLzEvIiwicHVs
+        cDNfcmVtb3RlX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBt
+        LzZlMGNmNzEyLWNiODgtNDU1Yi1hMjc1LWFlN2VkMWNmN2Q0Yi8iLCJwdWxw
+        M19wdWJsaWNhdGlvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9ycG0vcnBtLzg2N2JkNjMzLTk1MzMtNGNhNS05OWFhLTkxMTFhM2U4ZGE0
+        Zi8iLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMiOlsiL3B1bHAvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvcnBtL3JwbS81ZWYwNDc0ZS0yMzc0LTRhMjQtYWY0
+        Mi0xZTk1OTA0ZDU4MGIvIl0sInB1bHAzX3JlcG9zaXRvcnlfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80NjRlZTE2Yy1hZWE2
+        LTQ4MmUtODc4My01NDAwYWFiODBlZmEvIn0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcHVscDJyZXBvc2l0b3JpZXMvZmY2NDQ5NzctODA1NS00MWIy
+        LTljN2EtY2ZjOTZhYTFkZDJiLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDIt
+        MDRUMjE6NTY6NTAuNDMxNjk0WiIsInB1bHAyX29iamVjdF9pZCI6IjYwMWMy
+        ZmI4N2FjY2U5MWExZGI5ZmY3ZCIsInB1bHAyX3JlcG9faWQiOiJkYWE5Mjdi
+        ZC0xN2NmLTQyOTgtOWIxMC01ZDBkZjJjZTMwZDEiLCJwdWxwMl9yZXBvX3R5
+        cGUiOiJpc28iLCJpc19taWdyYXRlZCI6dHJ1ZSwibm90X2luX3BsYW4iOnRy
+        dWUsInB1bHAzX3JlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvZmlsZS9maWxlLzExZjYzMTQwLTg0NTAtNDZiOC05MzU1
+        LThkN2M5ODg5MWMzNS92ZXJzaW9ucy8xLyIsInB1bHAzX3JlbW90ZV9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzJhNzdhOGQzLWEw
+        YjktNGI5ZC05MzFmLWJmZDI2YjRhMDdlMC8iLCJwdWxwM19wdWJsaWNhdGlv
+        bl9ocmVmIjpudWxsLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMiOltdLCJw
+        dWxwM19yZXBvc2l0b3J5X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS8xMWY2MzE0MC04NDUwLTQ2YjgtOTM1NS04ZDdjOTg4
+        OTFjMzUvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJyZXBv
+        c2l0b3JpZXMvYTY4ODdlMGQtZWM2Mi00ZTM3LWJhNWUtN2UyYjlkZTYwYmMx
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMDRUMjE6NTY6NTAuNDA5NDI5
+        WiIsInB1bHAyX29iamVjdF9pZCI6IjYwMWMyZmEzN2FjY2U5MWExZTcxNjg5
+        MiIsInB1bHAyX3JlcG9faWQiOiJjYWE3MGQ4OS0wZDVhLTQ5M2EtYjI2My02
+        YmVlZTQzZDQwOWUiLCJwdWxwMl9yZXBvX3R5cGUiOiJkb2NrZXIiLCJpc19t
+        aWdyYXRlZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZhbHNlLCJwdWxwM19yZXBv
+        c2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Nv
+        bnRhaW5lci9jb250YWluZXIvZjE4MzE5NjgtYmZjZC00NmQyLWFmMTQtMmUx
+        YTllNDlmZTI1L3ZlcnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyLzBlNTAz
+        MGY2LWNlMDctNDYzNy1hZjNjLTNmOTQwOTA1YzQxYS8iLCJwdWxwM19wdWJs
+        aWNhdGlvbl9ocmVmIjpudWxsLCJwdWxwM19kaXN0cmlidXRpb25faHJlZnMi
+        OlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvY29udGFpbmVyL2NvbnRh
+        aW5lci82MTVmZmRlMy05NWY2LTQ1ODktOGJhOC01MjM2MWQ5NzEzMjkvIl0s
+        InB1bHAzX3JlcG9zaXRvcnlfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9mMTgzMTk2OC1iZmNkLTQ2ZDIt
+        YWYxNC0yZTFhOWU0OWZlMjUvIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/file/file/673014f4-3f14-4620-85c9-c4de04f16065/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.5.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - bd691885f55c4573852b4666c58c77d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvNjczMDE0ZjQtM2YxNC00NjIwLTg1YzktYzRkZTA0ZjE2MDY1LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMDVUMTU6NDM6MjguMDYyMTYxWiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvTXlf
+        RmlsZXMiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRl
+        dmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVs
+        dF9Pcmdhbml6YXRpb24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1
+        YXJkIjpudWxsLCJuYW1lIjoiNjAxZDY3OWM3YWNjZTkzMTY5YmI0ZGYyLURl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJwdWJsaWNh
+        dGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlL2Uw
+        OTBmMTM0LTBiNzMtNDdhMC04YjU5LWQ4Mzk4NDgzMmYxYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/file/file/d4d9d3cf-b99b-4331-a7ce-3e784771d6fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.5.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e000c69ac2884d9babc61063d276f14a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvZDRkOWQzY2YtYjk5Yi00MzMxLWE3Y2UtM2U3ODQ3NzFkNmZjLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMDVUMTU6NDM6MjguMTY3MDgzWiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxl
+        cyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09y
+        Z2FuaXphdGlvbi9kZXYvTXlfRmlsZXMvIiwiY29udGVudF9ndWFyZCI6bnVs
+        bCwibmFtZSI6IjYwMWQ2NzlkN2FjY2U5MzE2YTdmOTljZS1EZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsInB1YmxpY2F0aW9u
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZGVlNDlh
+        MjUtZDRlNS00MWFiLTk4YjAtZTZjZWQ4ZGI0N2M3LyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/file/file/172e2557-4905-44d3-b65c-69c42c7f2598/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.5.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 10cfc3b5fa9c448e84442ddd8d5d53a5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '320'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvMTcyZTI1NTctNDkwNS00NGQzLWI2NWMtNjljNDJjN2YyNTk4LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMDVUMTU6NDM6MjguMTg5NjgyWiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5
+        L015X0ZpbGVzIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0Rl
+        ZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0ZpbGVzLyIsImNv
+        bnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiI2MDFkNjc5ZDdhY2NlOTMxNmE3
+        Zjk5ZDEtRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmls
+        ZXMiLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
+        ZmlsZS9maWxlL2RlZTQ5YTI1LWQ0ZTUtNDFhYi05OGIwLWU2Y2VkOGRiNDdj
+        Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=fjd89-ad8d8-sdkas-adjja,123983-123812-123812-2131,37cbebd2-e302-4a10-8801-9d97bf3354ee
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8d11403669744b47bb78cdba1aca8af5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '354'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        OTE4ODhlNWQtOThmMi00MzZlLWJjYzctNmRiMmM2YjI4YmFiLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMDRUMjE6NTY6NTEuMDAzMDgyWiIsInB1bHAy
+        X2lkIjoiMzdjYmViZDItZTMwMi00YTEwLTg4MDEtOWQ5N2JmMzM1NGVlIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoiaXNvIiwicHVscDJfbGFzdF91cGRh
+        dGVkIjoxNjEyNDY3NzE3LCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xp
+        Yi9wdWxwL2NvbnRlbnQvdW5pdHMvaXNvLzcyLzNlNzFiYjM3OWY5MzhhZDFk
+        ZmJhMmYyZDZiZDBjN2Q3NDAyNzY2MTViODYzN2RkNWI3OWUwMjBjZGIwOWMy
+        L21pZ3JhdGVfdGVzdC5iaW4iLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19j
+        b250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy9lNzYy
+        M2RlNy0wOTc0LTRkNDgtOGIwNy00OTk4MjljMGJmZDUvIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJpc28ifV19fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/ea98bfdf-5804-4a13-880f-8d5d602127d5/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '163'
+      Correlation-Id:
+      - 66e9c7c4c383433b88d4314946f14741
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zL2Vh
+        OThiZmRmLTU4MDQtNGExMy04ODBmLThkNWQ2MDIxMjdkNS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTA1VDE1OjQzOjI4Ljg5NzQwNVoiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJpc28ifV19fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/ea98bfdf-5804-4a13-880f-8d5d602127d5/reset/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbHVnaW5zIjpbeyJ0eXBlIjoiaXNvIn1dfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.6.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:28 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d8f4047a573a4f4780cb9b07b375fcba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1ZWVmZjUwLTVjMGQtNGRk
+        ZC04MDI4LWM4MjU2MzA2NTQ1Ny8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:28 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzUwMDkzODk2LTAwYTYtNDU3My05MzVkLTEwODljOTk4MWE5MC8iLCAi
+        dGFza19pZCI6ICI1MDA5Mzg5Ni0wMGE2LTQ1NzMtOTM1ZC0xMDg5Yzk5ODFh
+        OTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/50093896-00a6-4573-935d-1089c9981a90/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"101362f3110aa83e6da47ade32f5c162-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '398'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MDA5Mzg5Ni0wMGE2LTQ1NzMtOTM1ZC0xMDg5Yzk5ODFh
+        OTAvIiwgInRhc2tfaWQiOiAiNTAwOTM4OTYtMDBhNi00NTczLTkzNWQtMTA4
+        OWM5OTgxYTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMS0wMi0wNVQxNTo0Mzoy
+        OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
+        MS0wMi0wNVQxNTo0MzoyOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2N2ExMjg0OGQzODRlZDZkZGNlOSJ9LCAiaWQi
+        OiAiNjAxZDY3YTEyODQ4ZDM4NGVkNmRkY2U5In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2NmZWY3MTI4LWFjN2MtNDBhMi1hNGZjLTAzNGUxOTdlODNmOS8iLCAi
+        dGFza19pZCI6ICJjZmVmNzEyOC1hYzdjLTQwYTItYTRmYy0wMzRlMTk3ZTgz
+        ZjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/cfef7128-ac7c-40a2-a4fc-034e197e83f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8bb9778579cfd11df3945f1097555b56-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZmVmNzEyOC1hYzdjLTQwYTItYTRmYy0wMzRlMTk3ZTgz
+        ZjkvIiwgInRhc2tfaWQiOiAiY2ZlZjcxMjgtYWM3Yy00MGEyLWE0ZmMtMDM0
+        ZTE5N2U4M2Y5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6
+        NDM6MjlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjEtMDItMDVUMTU6NDM6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDFkNjdhMTI4NDhkMzg0ZWQ2ZGRkMjQifSwg
+        ImlkIjogIjYwMWQ2N2ExMjg0OGQzODRlZDZkZGQyNCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Q5MjNjYWY3LTkzY2QtNDBkMC1hMjg1LTU4Y2Y4MDVmM2I1Ni8iLCAi
+        dGFza19pZCI6ICJkOTIzY2FmNy05M2NkLTQwZDAtYTI4NS01OGNmODA1ZjNi
+        NTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d923caf7-93cd-40d0-a285-58cf805f3b56/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:43:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2f3294415b420754547993a6e255ecd7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '401'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kOTIzY2FmNy05M2NkLTQwZDAtYTI4NS01OGNmODA1ZjNi
+        NTYvIiwgInRhc2tfaWQiOiAiZDkyM2NhZjctOTNjZC00MGQwLWEyODUtNThj
+        ZjgwNWYzYjU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6
+        NDM6MjlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjEtMDItMDVUMTU6NDM6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDFkNjdhMTI4NDhkMzg0ZWQ2ZGRkNWYifSwg
+        ImlkIjogIjYwMWQ2N2ExMjg0OGQzODRlZDZkZGQ1ZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:43:29 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration_reset_errors_out_with_no_content_types.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration_reset_errors_out_with_no_content_types.yml
@@ -1,0 +1,857 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlf
+        RmlsZXMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzLyIsICJodHRw
+        X3N0YXR1cyI6IDQwNCwgImVycm9yIjogeyJjb2RlIjogIlBMUDAwMDkiLCAi
+        ZGF0YSI6IHsicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifX0sICJkZXNjcmlwdGlv
+        biI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PURlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCAic3ViX2Vycm9ycyI6
+        IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
+        LCJkaXNwbGF5X25hbWUiOiJNeSBGaWxlcyIsImltcG9ydGVyX3R5cGVfaWQi
+        OiJpc29faW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZp
+        bGU6Ly8vdmFyL2xpYi9wdWxwL3N5bmNfaW1wb3J0cy90ZXN0X3JlcG9zL2Zp
+        bGVfbWlncmF0aW9uLyIsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJh
+        c2ljX2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVl
+        LCJwcm94eV9ob3N0IjoiIiwic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xf
+        Y2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJkaXN0cmli
+        dXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJpc29fZGlzdHJpYnV0
+        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '603'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '344'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzYzN2FjY2U5MzE2YTdmOTljNiJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzMwOWJjZmRlLTYyMGQtNGY0YS04Y2RiLWQ2NDljZmQ2YTVjMC8iLCAi
+        dGFza19pZCI6ICIzMDliY2ZkZS02MjBkLTRmNGEtOGNkYi1kNjQ5Y2ZkNmE1
+        YzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/309bcfde-620d-4f4a-8cdb-d649cfd6a5c0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b2b0cfb3d9a18c0519b4ec54366824b6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '675'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMDliY2ZkZS02MjBkLTRmNGEtOGNkYi1kNjQ5Y2ZkNmE1
+        YzAvIiwgInRhc2tfaWQiOiAiMzA5YmNmZGUtNjIwZC00ZjRhLThjZGItZDY0
+        OWNmZDZhNWMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6NDI6Mjda
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEt
+        MDItMDVUMTU6NDI6MjdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2NmYTU0
+        YmI2LTJjN2QtNDY0Ni1iMTI0LTI0ZGVhMmYxZTBjNy8iLCAidGFza19pZCI6
+        ICJjZmE1NGJiNi0yYzdkLTQ2NDYtYjEyNC0yNGRlYTJmMWUwYzcifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDI6MjciLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyIsICJjb21wbGV0ZSI6ICIyMDIx
+        LTAyLTA1VDE1OjQyOjI3IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMS0w
+        Mi0wNVQxNTo0MjoyNyJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJp
+        c29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMjEtMDItMDVUMTU6NDI6MjdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        aXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVt
+        X2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21l
+        c3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90
+        aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyIs
+        ICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3
+        IiwgImNvbXBsZXRlIjogIjIwMjEtMDItMDVUMTU6NDI6MjciLCAiaXNvc19p
+        bl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3In19LCAiYWRkZWRf
+        Y291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
+        IjogMCwgImlkIjogIjYwMWQ2NzYzN2FjY2U5MzJkMmViODI1NyIsICJkZXRh
+        aWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAxZDY3NjMyODQ4ZDM4NGVkNmRkOGE1In0sICJpZCI6ICI2MDFkNjc2MzI4
+        NDhkMzg0ZWQ2ZGQ4YTUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/309bcfde-620d-4f4a-8cdb-d649cfd6a5c0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b2b0cfb3d9a18c0519b4ec54366824b6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '675'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMDliY2ZkZS02MjBkLTRmNGEtOGNkYi1kNjQ5Y2ZkNmE1
+        YzAvIiwgInRhc2tfaWQiOiAiMzA5YmNmZGUtNjIwZC00ZjRhLThjZGItZDY0
+        OWNmZDZhNWMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6NDI6Mjda
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEt
+        MDItMDVUMTU6NDI6MjdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2NmYTU0
+        YmI2LTJjN2QtNDY0Ni1iMTI0LTI0ZGVhMmYxZTBjNy8iLCAidGFza19pZCI6
+        ICJjZmE1NGJiNi0yYzdkLTQ2NDYtYjEyNC0yNGRlYTJmMWUwYzcifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDI6MjciLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyIsICJjb21wbGV0ZSI6ICIyMDIx
+        LTAyLTA1VDE1OjQyOjI3IiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAyMS0w
+        Mi0wNVQxNTo0MjoyNyJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJp
+        c29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMjEtMDItMDVUMTU6NDI6MjdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        aXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjogbnVsbCwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMiOiAwLCAibnVt
+        X2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNvX2Vycm9yX21l
+        c3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAsICJzdGF0ZV90
+        aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyIs
+        ICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3
+        IiwgImNvbXBsZXRlIjogIjIwMjEtMDItMDVUMTU6NDI6MjciLCAiaXNvc19p
+        bl9wcm9ncmVzcyI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3In19LCAiYWRkZWRf
+        Y291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
+        IjogMCwgImlkIjogIjYwMWQ2NzYzN2FjY2U5MzJkMmViODI1NyIsICJkZXRh
+        aWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAxZDY3NjMyODQ4ZDM4NGVkNmRkOGE1In0sICJpZCI6ICI2MDFkNjc2MzI4
+        NDhkMzg0ZWQ2ZGQ4YTUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/cfa54bb6-2c7d-4646-b124-24dea2f1e0c7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:27 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4455232569f964b224b807dbcab60194-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jZmE1NGJiNi0yYzdkLTQ2NDYtYjEyNC0yNGRl
+        YTJmMWUwYzcvIiwgInRhc2tfaWQiOiAiY2ZhNTRiYjYtMmM3ZC00NjQ2LWIx
+        MjQtMjRkZWEyZjFlMGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVU
+        MTU6NDI6MjdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMjEtMDItMDVUMTU6NDI6MjdaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIxLTAyLTA1VDE1OjQyOjI3
+        IiwgImluX3Byb2dyZXNzIjogIjIwMjEtMDItMDVUMTU6NDI6MjciLCAiY29t
+        cGxldGUiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyJ9LCAic3RhdGUiOiAiY29t
+        cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBj
+        ZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
+        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJzdGFydGVk
+        IjogIjIwMjEtMDItMDVUMTU6NDI6MjdaIiwgIl9ucyI6ICJyZXBvX3B1Ymxp
+        c2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0Mjoy
+        N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0YXRlIjogImNv
+        bXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDIxLTAy
+        LTA1VDE1OjQyOjI3IiwgImluX3Byb2dyZXNzIjogIjIwMjEtMDItMDVUMTU6
+        NDI6MjciLCAiY29tcGxldGUiOiAiMjAyMS0wMi0wNVQxNTo0MjoyNyJ9fSwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJpZCI6ICI2
+        MDFkNjc2MzdhY2NlOTMyZDJlYjgyNTkiLCAiZGV0YWlscyI6IG51bGx9LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjYwMWQ2NzYzMjg0OGQz
+        ODRlZDZkZDhlOCJ9LCAiaWQiOiAiNjAxZDY3NjMyODQ4ZDM4NGVkNmRkOGU4
+        In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXNf
+        RGV2IiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uL2Rldi9NeV9GaWxlcyIsInNlcnZlX2h0
+        dHAiOnRydWUsInNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtTXlfRmlsZXNfRGV2In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '382'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzY0N2FjY2U5MzE2OWJiNGRlYiJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlc19EZXYi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0Rldi8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLTFfMC1DYWJpbmV0LU15X0Zp
+        bGVzIiwiZGlzcGxheV9uYW1lIjoiTXkgRmlsZXMiLCJpbXBvcnRlcl90eXBl
+        X2lkIjoiaXNvX2ltcG9ydGVyIiwiaW1wb3J0ZXJfY29uZmlnIjp7fSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoiaXNvX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        IkRlZmF1bHRfT3JnYW5pemF0aW9uLzEuMC9saWJyYXJ5L015X0ZpbGVzIiwi
+        c2VydmVfaHR0cCI6dHJ1ZSwic2VydmVfaHR0cHMiOnRydWV9LCJhdXRvX3B1
+        Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '390'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '352'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzY0N2FjY2U5MzE2YTdmOTljOSJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tMV8wLUNhYmluZXQtTXlfRmlsZXMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcy8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1bSJd
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '278'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
+        ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
+        OTgiLCAiX2lkIjogIjM3Y2JlYmQyLWUzMDItNGExMC04ODAxLTlkOTdiZjMz
+        NTRlZSIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0
+        MjoyN1oiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0wNVQxNTo0Mjoy
+        N1oiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjM3Y2Jl
+        YmQyLWUzMDItNGExMC04ODAxLTlkOTdiZjMzNTRlZSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAxZDY3NjMyODQ4ZDM4NGVkNmRkOGNkIn19XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1
+        bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRhNzg4MTc5LTk0ODItNGU0MC05ZmQ0LTBiZmJkMWNlZTBlMC8iLCAi
+        dGFza19pZCI6ICI0YTc4ODE3OS05NDgyLTRlNDAtOWZkNC0wYmZiZDFjZWUw
+        ZTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/4a788179-9482-4e40-9fd4-0bfbd1cee0e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"279290568429e7d0ce910d37341f71e8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '397'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80YTc4ODE3OS05NDgyLTRlNDAtOWZkNC0wYmZiZDFjZWUw
+        ZTAvIiwgInRhc2tfaWQiOiAiNGE3ODgxNzktOTQ4Mi00ZTQwLTlmZDQtMGJm
+        YmQxY2VlMGUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAyMS0wMi0wNVQxNTo0Mjoy
+        OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAy
+        MS0wMi0wNVQxNTo0MjoyOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMWQ2NzY0Mjg0OGQzODRlZDZkZDk2OSJ9LCAiaWQi
+        OiAiNjAxZDY3NjQyODQ4ZDM4NGVkNmRkOTY5In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-1_0-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzhiYmQyZjEyLWJjMmMtNDMwZi04MjFjLWNiODM3YWY2N2E4NC8iLCAi
+        dGFza19pZCI6ICI4YmJkMmYxMi1iYzJjLTQzMGYtODIxYy1jYjgzN2FmNjdh
+        ODQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/8bbd2f12-bc2c-430f-821c-cb837af67a84/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"375d6cdf30c7d9df9897301794d4d757-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '400'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84YmJkMmYxMi1iYzJjLTQzMGYtODIxYy1jYjgzN2FmNjdh
+        ODQvIiwgInRhc2tfaWQiOiAiOGJiZDJmMTItYmMyYy00MzBmLTgyMWMtY2I4
+        MzdhZjY3YTg0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi0xXzAtQ2FiaW5ldC1NeV9GaWxlcyIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6
+        NDI6MjlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjEtMDItMDVUMTU6NDI6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDFkNjc2NDI4NDhkMzg0ZWQ2ZGQ5YTQifSwg
+        ImlkIjogIjYwMWQ2NzY0Mjg0OGQzODRlZDZkZDlhNCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files_Dev/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:29 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzNkYjI2OGRmLTkwODUtNGUzZC05OTNjLTNiMThlM2VjOWFiNS8iLCAi
+        dGFza19pZCI6ICIzZGIyNjhkZi05MDg1LTRlM2QtOTkzYy0zYjE4ZTNlYzlh
+        YjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3db268df-9085-4e3d-993c-3b18e3ec9ab5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2021 15:42:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"60612a7ac2faf47bec6e714a5280eb87-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '398'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZGIyNjhkZi05MDg1LTRlM2QtOTkzYy0zYjE4ZTNlYzlh
+        YjUvIiwgInRhc2tfaWQiOiAiM2RiMjY4ZGYtOTA4NS00ZTNkLTk5M2MtM2Ix
+        OGUzZWM5YWI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzX0RldiIsICJwdWxwOmFj
+        dGlvbjpkZWxldGUiXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMDVUMTU6
+        NDI6MjlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMjEtMDItMDVUMTU6NDI6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0
+        ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDFkNjc2NTI4NDhkMzg0ZWQ2ZGQ5ZGYifSwg
+        ImlkIjogIjYwMWQ2NzY1Mjg0OGQzODRlZDZkZDlkZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2021 15:42:29 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/yum_migration/yum_migration_reset.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/yum_migration/yum_migration_reset.yml
@@ -1,0 +1,6841 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:04 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
+        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
+        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
+        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
+        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
+        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
+        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:04 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwiZGlzcGxheV9uYW1l
+        IjoiUkhFTCA2IHg4Nl82NCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1w
+        b3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoi
+        aW1tZWRpYXRlIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJmaWxl
+        Oi8vL3Zhci9saWIvcHVscC9zeW5jX2ltcG9ydHMvdGVzdF9yZXBvcy96b28i
+        LCJ0eXBlX3NraXBfbGlzdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6
+        bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlkYXRp
+        b24iOnRydWUsInByb3h5X2hvc3QiOiIifSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkv
+        cmhlbF82X2xhYmVsIiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90
+        ZWN0ZWQiOnRydWUsImNoZWNrc3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoicHVscC11dWlkLXJoZWxfNl94
+        ODZfNjQifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25f
+        ZGlzdHJpYnV0b3JfaWQiOiJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9LCJh
+        dXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6InB1bHAtdXVp
+        ZC1yaGVsXzZfeDg2XzY0X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lk
+        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
+        Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFD
+        TUVfQ29ycG9yYXRpb24vbGlicmFyeS9yaGVsXzZfbGFiZWwifSwiYXV0b19w
+        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJp
+        YnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1044'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:04 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '345'
+      Location:
+      - "/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDA3YWNjZTkzNTExMTIxYjQxIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:04 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QyNWRhOWJlLWVmYjMtNGY2Zi1iZDM5LTZmNzg5MjQ3OTQyNC8iLCAi
+        dGFza19pZCI6ICJkMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d25da9be-efb3-4f6f-bd39-6f7892479424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"704ea1098a00987a0e1ece8769d57426-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '726'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQvIiwgInRhc2tfaWQiOiAiZDI1ZGE5YmUtZWZiMy00ZjZmLWJkMzktNmY3
+        ODkyNDc5NDI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjkt
+        ODAzYy0xY2IxMzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVl
+        OC00YTI5LTgwM2MtMWNiMTM2OGFlMjc0In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJtb2R1bGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
+        InN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
+        Y291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
+        dCI6IDAsICJpZCI6ICI2MDJmZGZkMTdhY2NlOTM0ZTI3ZTZlMDYiLCAiZGV0
+        YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDdmYiJ9
+        LCAiaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwN2ZiIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d25da9be-efb3-4f6f-bd39-6f7892479424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"704ea1098a00987a0e1ece8769d57426-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '726'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQvIiwgInRhc2tfaWQiOiAiZDI1ZGE5YmUtZWZiMy00ZjZmLWJkMzktNmY3
+        ODkyNDc5NDI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjkt
+        ODAzYy0xY2IxMzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVl
+        OC00YTI5LTgwM2MtMWNiMTM2OGFlMjc0In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJtb2R1bGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
+        InN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
+        Y291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
+        dCI6IDAsICJpZCI6ICI2MDJmZGZkMTdhY2NlOTM0ZTI3ZTZlMDYiLCAiZGV0
+        YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDdmYiJ9
+        LCAiaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwN2ZiIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d25da9be-efb3-4f6f-bd39-6f7892479424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"704ea1098a00987a0e1ece8769d57426-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '726'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQvIiwgInRhc2tfaWQiOiAiZDI1ZGE5YmUtZWZiMy00ZjZmLWJkMzktNmY3
+        ODkyNDc5NDI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjkt
+        ODAzYy0xY2IxMzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVl
+        OC00YTI5LTgwM2MtMWNiMTM2OGFlMjc0In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJtb2R1bGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
+        InN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
+        Y291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
+        dCI6IDAsICJpZCI6ICI2MDJmZGZkMTdhY2NlOTM0ZTI3ZTZlMDYiLCAiZGV0
+        YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDdmYiJ9
+        LCAiaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwN2ZiIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d25da9be-efb3-4f6f-bd39-6f7892479424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"704ea1098a00987a0e1ece8769d57426-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '726'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQvIiwgInRhc2tfaWQiOiAiZDI1ZGE5YmUtZWZiMy00ZjZmLWJkMzktNmY3
+        ODkyNDc5NDI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjkt
+        ODAzYy0xY2IxMzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVl
+        OC00YTI5LTgwM2MtMWNiMTM2OGFlMjc0In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJtb2R1bGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
+        InN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
+        Y291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
+        dCI6IDAsICJpZCI6ICI2MDJmZGZkMTdhY2NlOTM0ZTI3ZTZlMDYiLCAiZGV0
+        YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDdmYiJ9
+        LCAiaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwN2ZiIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d25da9be-efb3-4f6f-bd39-6f7892479424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"704ea1098a00987a0e1ece8769d57426-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '726'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjVkYTliZS1lZmIzLTRmNmYtYmQzOS02Zjc4OTI0Nzk0
+        MjQvIiwgInRhc2tfaWQiOiAiZDI1ZGE5YmUtZWZiMy00ZjZmLWJkMzktNmY3
+        ODkyNDc5NDI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjkt
+        ODAzYy0xY2IxMzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVl
+        OC00YTI5LTgwM2MtMWNiMTM2OGFlMjc0In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJtb2R1bGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJpbXBvcnRlcl90eXBl
+        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
+        InN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
+        Y291bnQiOiA0MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
+        dCI6IDAsICJpZCI6ICI2MDJmZGZkMTdhY2NlOTM0ZTI3ZTZlMDYiLCAiZGV0
+        YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDdmYiJ9
+        LCAiaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwN2ZiIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/303807bf-4ee8-4a29-803c-1cb1368ae274/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"21f6ae1fe5f55ea5c28410514da0e840-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1386'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zMDM4MDdiZi00ZWU4LTRhMjktODAzYy0xY2Ix
+        MzY4YWUyNzQvIiwgInRhc2tfaWQiOiAiMzAzODA3YmYtNGVlOC00YTI5LTgw
+        M2MtMWNiMTM2OGFlMjc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpw
+        dWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpwdWJsaXNo
+        Il0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJf
+        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5
+        VDE1OjU3OjA1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJwdWxwLXV1aWQtcmhlbF82
+        X3g4Nl82NCI6IFt7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IkluaXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJp
+        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzE0
+        ZjNkMzgtNTI2Ny00NjlkLWFmMzMtNDVjYmZlMmQzN2MxIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg1NDI2YmJmLTgz
+        ZWEtNDYwYi1iNDVjLTQ1YmIxYjE4M2U2ZSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxOSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDE5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNjIyN2FkZDEtZTA2Ni00NTU5LTg1YWMtNmM1MjlhM2I5ZDFjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxOX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
+        UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlZjZkNWYzLTk2NTAtNDYz
+        Zi1hMGEwLTgyNjE3M2I5MGU2MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiA2LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBF
+        cnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6
+        IDYsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIwZjIwMjZhMS1iZjYwLTQzNjgtODlhYy00NjAxZjQ1YmU5NDciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDZ9LCB7Im51bV9zdWNjZXNzIjogOSwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9k
+        dWxlcyIsICJpdGVtc190b3RhbCI6IDksICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMmI0NzVmZC04OWIzLTRlNTctYjhi
+        Ni0wMDVmNWU3MzE2NzkiLCAibnVtX3Byb2Nlc3NlZCI6IDl9LCB7Im51bV9z
+        dWNjZXNzIjogNCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMg
+        ZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiA0
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OWFkNjc2OGYtOWMzZS00NTJlLTkxNzYtNzJiZDE0ZjA5NjFhIiwgIm51bV9w
+        cm9jZXNzZWQiOiA0fSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjk5OTQyNDUtMjM1MS00YmIxLTgx
+        YTMtNjZhNDI2Mjk4ZTUxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0
+        YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiN2QzMjJmMTYtMjY4My00YWMyLWFlMjQtMjVmNDRi
+        YjliNTJmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNDBkNGM1MTctMGE2Yy00OWRkLTg3ODctOTZlNzQyMTNkMzFiIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjog
+        InJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjMxMmQ1
+        YzktODQzNy00ZTNkLWFhNmUtMmRhNTliNTBjNTc3IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
+        ZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiODM0MWY2YWQtOGE1My00YTljLThjOWMtYzAx
+        YmFlYTlhYjA4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdl
+        YiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiYjA4ODcyZjEtNjdiNi00MTBhLWFlNDEtYWE2YWViYzAzNGRl
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90
+        eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJmNDMzMTBjYi1mOTkzLTQ1MTUtODZhNC1mNTNiNzFlMjU3MWMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCAic3RhcnRl
+        ZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJfbnMiOiAicmVwb19wdWJs
+        aXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjEtMDItMTlUMTU6NTc6
+        MDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBz
+        cWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNIRUQi
+        LCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6
+        ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlv
+        biI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxp
+        c2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hF
+        RCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6
+        IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4
+        Nl82NCIsICJpZCI6ICI2MDJmZGZkMjdhY2NlOTM0ZTI3ZTZlMDciLCAiZGV0
+        YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzE0ZjNk
+        MzgtNTI2Ny00NjlkLWFmMzMtNDVjYmZlMmQzN2MxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg1NDI2YmJmLTgzZWEt
+        NDYwYi1iNDVjLTQ1YmIxYjE4M2U2ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxOSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6
+        IDE5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNjIyN2FkZDEtZTA2Ni00NTU5LTg1YWMtNmM1MjlhM2I5ZDFjIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxOX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6
+        ICJkcnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlZjZkNWYzLTk2NTAtNDYzZi1h
+        MGEwLTgyNjE3M2I5MGU2MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiA2LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJh
+        dGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDYs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
+        ZjIwMjZhMS1iZjYwLTQzNjgtODlhYy00NjAxZjQ1YmU5NDciLCAibnVtX3By
+        b2Nlc3NlZCI6IDZ9LCB7Im51bV9zdWNjZXNzIjogOSwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxl
+        cyIsICJpdGVtc190b3RhbCI6IDksICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhMmI0NzVmZC04OWIzLTRlNTctYjhiNi0w
+        MDVmNWU3MzE2NzkiLCAibnVtX3Byb2Nlc3NlZCI6IDl9LCB7Im51bV9zdWNj
+        ZXNzIjogNCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmls
+        ZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiA0LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWFk
+        Njc2OGYtOWMzZS00NTJlLTkxNzYtNzJiZDE0ZjA5NjFhIiwgIm51bV9wcm9j
+        ZXNzZWQiOiA0fSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjk5OTQyNDUtMjM1MS00YmIxLTgxYTMt
+        NjZhNDI2Mjk4ZTUxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
+        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2QzMjJmMTYtMjY4My00YWMyLWFlMjQtMjVmNDRiYjli
+        NTJmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJz
+        dGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NDBkNGM1MTctMGE2Yy00OWRkLTg3ODctOTZlNzQyMTNkMzFiIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJl
+        bW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjMxMmQ1Yzkt
+        ODQzNy00ZTNkLWFhNmUtMmRhNTliNTBjNTc3IiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3Iiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiODM0MWY2YWQtOGE1My00YTljLThjOWMtYzAxYmFl
+        YTlhYjA4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIs
+        ICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjA4ODcyZjEtNjdiNi00MTBhLWFlNDEtYWE2YWViYzAzNGRlIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
+        cmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBl
+        IjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmNDMzMTBjYi1mOTkzLTQ1MTUtODZhNC1mNTNiNzFlMjU3MWMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwYjllIn0sICJpZCI6ICI2MDJm
+        ZGZkMWY3M2I2OWE4MzY2NTBiOWUifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfdmlldzFfYXJjaGl2ZSIsImRpc3BsYXlfbmFtZSI6IlJIRUwg
+        NiB4ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwi
+        aW1wb3J0ZXJfY29uZmlnIjp7fSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJw
+        bS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJy
+        ZWxhdGl2ZV91cmwiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9h
+        cmNoaXZlL3JoZWxfNl9sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1
+        ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0
+        b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjhfdmlldzFfYXJj
+        aGl2ZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0
+        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9k
+        aXN0cmlidXRvcl9pZCI6IjhfdmlldzFfYXJjaGl2ZSJ9LCJhdXRvX3B1Ymxp
+        c2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjhfdmlldzFfYXJjaGl2ZV9j
+        bG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmli
+        dXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0
+        cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01FX0NvcnBvcmF0aW9uL2xp
+        YnJhcnlfdmlldy9hcmNoaXZlL3JoZWxfNl9sYWJlbCJ9LCJhdXRvX3B1Ymxp
+        c2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRv
+        ciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '815'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '329'
+      Location:
+      - "/pulp/api/v2/repositories/8_view1_archive/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDI3YWNjZTkzNTEyODEzZTY0In0sICJpZCI6ICI4X3ZpZXcxX2FyY2hp
+        dmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy84X3Zp
+        ZXcxX2FyY2hpdmUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJSSEVMIDYgeDg2XzY0
+        IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9ydGVy
+        X2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9
+        LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
+        ZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVf
+        dXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5X3ZpZXcvcmhlbF82X2xh
+        YmVsIiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRy
+        dWUsImNoZWNrc3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUs
+        ImRpc3RyaWJ1dG9yX2lkIjoiOF92aWV3MSJ9LHsiZGlzdHJpYnV0b3JfdHlw
+        ZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
+        bmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IjhfdmlldzEi
+        fSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiI4X3Zp
+        ZXcxX2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rp
+        c3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNl
+        LCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRp
+        b24vbGlicmFyeV92aWV3L3JoZWxfNl9sYWJlbCJ9LCJhdXRvX3B1Ymxpc2gi
+        OmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9
+        XX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '767'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '313'
+      Location:
+      - "/pulp/api/v2/repositories/8_view1/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDI3YWNjZTkzNTExMTIxYjQ2In0sICJpZCI6ICI4X3ZpZXcxIiwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOF92aWV3MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmUiLCJkaXNwbGF5
+        X25hbWUiOiJSSEVMIDYgeDg2XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1
+        bV9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9y
+        ZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3Ry
+        aWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRv
+        cl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9j
+        b21wb3NpdGUvYXJjaGl2ZS9yaGVsXzZfbGFiZWwiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlwZSI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiI4
+        X2NvbXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIn0seyJkaXN0cmlidXRvcl90
+        eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3Jf
+        Y29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiOF9jb21w
+        b3NpdGVfdmVyc2lvbjFfYXJjaGl2ZSJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNl
+        LCJkaXN0cmlidXRvcl9pZCI6IjhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hp
+        dmVfY2xvbmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlz
+        dHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2Us
+        Imh0dHBzIjpmYWxzZSwicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlv
+        bi9jb21wb3NpdGUvYXJjaGl2ZS9yaGVsXzZfbGFiZWwifSwiYXV0b19wdWJs
+        aXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0
+        b3IifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '861'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '355'
+      Location:
+      - "/pulp/api/v2/repositories/8_composite_version1_archive/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDI3YWNjZTkzNTExMTIxYjRiIn0sICJpZCI6ICI4X2NvbXBvc2l0ZV92
+        ZXJzaW9uMV9hcmNoaXZlIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBv
+        c2l0b3JpZXMvOF9jb21wb3NpdGVfdmVyc2lvbjFfYXJjaGl2ZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfY29tcG9zaXRlX3ZlcnNpb24xIiwiZGlzcGxheV9uYW1lIjoi
+        UkhFTCA2IHg4Nl82NCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0
+        ZXIiLCJpbXBvcnRlcl9jb25maWciOnt9LCJub3RlcyI6eyJfcmVwby10eXBl
+        IjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90
+        eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9j
+        b21wb3NpdGUvcmhlbF82X2xhYmVsIiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0
+        cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNrc3VtX3R5cGUiOm51bGx9LCJh
+        dXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiOF9jb21wb3Np
+        dGVfdmVyc2lvbjEifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xv
+        bmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiI4X2NvbXBvc2l0ZV92ZXJzaW9uMSJ9
+        LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjhfY29t
+        cG9zaXRlX3ZlcnNpb24xX2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lk
+        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
+        Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFD
+        TUVfQ29ycG9yYXRpb24vbGlicmFyeS9jb21wb3NpdGUvcmhlbF82X2xhYmVs
+        In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhw
+        b3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '829'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:06 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '339'
+      Location:
+      - "/pulp/api/v2/repositories/8_composite_version1/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDI3YWNjZTkzNTExMTIxYjUwIn0sICJpZCI6ICI4X2NvbXBvc2l0ZV92
+        ZXJzaW9uMSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        LzhfY29tcG9zaXRlX3ZlcnNpb24xLyJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsibW9kdWxlbWQiXSwiZmlsdGVycyI6
+        e319LCJvdmVycmlkZV9jb25maWciOnt9fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI5MzZlODQ5LTBhYjYtNGEyMC1hOWZhLWM0OTJlMDcwNTRiYy8iLCAi
+        dGFza19pZCI6ICIyOTM2ZTg0OS0wYWI2LTRhMjAtYTlmYS1jNDkyZTA3MDU0
+        YmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsic3JwbSJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '90'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2E1MjRmMDgxLTFlYjQtNGU4OS1hMjZlLTYzZDVmNzlmYjBkYi8iLCAi
+        dGFza19pZCI6ICJhNTI0ZjA4MS0xZWI0LTRlODktYTI2ZS02M2Q1Zjc5ZmIw
+        ZGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsiZXJyYXR1bSJdLCJmaWx0ZXJzIjp7
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Q2MGYyNGY0LTQwODktNGMxZi1iMmMzLTRlOTRlMzdhZjJlZS8iLCAi
+        dGFza19pZCI6ICJkNjBmMjRmNC00MDg5LTRjMWYtYjJjMy00ZTk0ZTM3YWYy
+        ZWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsicGFja2FnZV9ncm91cCJdLCJmaWx0
+        ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZmZTMxNDdkLWQ0ZWItNDhjNy05NWQzLTA2OTMzMzMyNmEyNC8iLCAi
+        dGFza19pZCI6ICJmZmUzMTQ3ZC1kNGViLTQ4YzctOTVkMy0wNjkzMzMzMjZh
+        MjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsicGFja2FnZV9lbnZpcm9ubWVudCJd
+        LCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '105'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk5NjNmZTBkLTEyZWYtNGY1NS05MTM4LWNhNTEyZTlhNWExOS8iLCAi
+        dGFza19pZCI6ICI5OTYzZmUwZC0xMmVmLTRmNTUtOTEzOC1jYTUxMmU5YTVh
+        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsieXVtX3JlcG9fbWV0YWRhdGFfZmls
+        ZSJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '108'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzE3MjBkZTZmLTIxNTYtNDlhNy1hNThmLTQ4OWI5ODExYjQ1OS8iLCAi
+        dGFza19pZCI6ICIxNzIwZGU2Zi0yMTU2LTQ5YTctYTU4Zi00ODliOTgxMWI0
+        NTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsiZGlzdHJpYnV0aW9uIl0sImZpbHRl
+        cnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzFhOTc2YWJhLTI4ZWYtNDIxNi1iNWY5LWU2NGQwY2I0NTA1NS8iLCAi
+        dGFza19pZCI6ICIxYTk3NmFiYS0yOGVmLTQyMTYtYjVmOS1lNjRkMGNiNDUw
+        NTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsibW9kdWxlbWRfZGVmYXVsdHMiXSwi
+        ZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '103'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2NlNTQxNjE3LTMwYWEtNGJjOC05Mzg1LWMwZWRjNWU4ZmQxYi8iLCAi
+        dGFza19pZCI6ICJjZTU0MTYxNy0zMGFhLTRiYzgtOTM4NS1jMGVkYzVlOGZk
+        MWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        Y3JpdGVyaWEiOnsidHlwZV9pZHMiOlsiZHJwbSJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '90'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Y2MDE3YTg3LWU4NDgtNGQ2OC1iNDU3LWU1ODhmNDU5ODhmYy8iLCAi
+        dGFza19pZCI6ICJmNjAxN2E4Ny1lODQ4LTRkNjgtYjQ1Ny1lNTg4ZjQ1OTg4
+        ZmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b9d28e8e4d2714d6f2d0c0e791582779-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '824'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIlJIRUwgNiB4ODZfNjQiLCAiZGVzY3JpcHRpb24i
+        OiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0x
+        OVQxNTo1NzowNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cmllcy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NC9kaXN0cmlidXRvcnMvcHVs
+        cC11dWlkLXJoZWxfNl94ODZfNjRfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVf
+        Y29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19w
+        dWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVw
+        b19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQwN2Fj
+        Y2U5MzUxMTEyMWI0NCJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0
+        cmlidXRvcl9pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9LCAiaWQi
+        OiAicHVscC11dWlkLXJoZWxfNl94ODZfNjRfY2xvbmUifSwgeyJyZXBvX2lk
+        IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
+        ICIyMDIxLTAyLTE5VDE1OjU3OjA0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2Rpc3Ry
+        aWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NC8iLCAibGFzdF9vdmVy
+        cmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6ICIyMDIxLTAyLTE5
+        VDE1OjU3OjA2WiIsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI2MDJmZGZkMDdhY2NlOTM1MTExMjFiNDMifSwgImNvbmZpZyI6IHsi
+        cHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgImh0dHBzIjogdHJ1
+        ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkv
+        cmhlbF82X2xhYmVsIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
+        NCJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCAi
+        bGFzdF91cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDRaIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
+        Nl94ODZfNjQvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51
+        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
+        ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NjAyZmRmZDA3YWNjZTkzNTExMTIxYjQ1In0sICJjb25maWciOiB7Imh0dHAi
+        OiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xp
+        YnJhcnkvcmhlbF82X2xhYmVsIiwgImh0dHBzIjogZmFsc2V9LCAiaWQiOiAi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIw
+        MjEtMDItMTlUMTU6NTc6MDVaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjog
+        InJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250
+        ZW50X3VuaXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJl
+        cnJhdHVtIjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAicGFja2FnZV9jYXRl
+        Z29yeSI6IDEsICJwYWNrYWdlX2Vudmlyb25tZW50IjogMSwgImRpc3RyaWJ1
+        dGlvbiI6IDEsICJtb2R1bGVtZCI6IDYsICJycG0iOiAxOSwgInl1bV9yZXBv
+        X21ldGFkYXRhX2ZpbGUiOiAxfSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRl
+        cnMiOiBbeyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA0WiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVs
+        XzZfeDg2XzY0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJy
+        ZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
+        cnRlciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5j
+        IjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInNjcmF0Y2hwYWQiOiB7InJl
+        cG9tZF9yZXZpc2lvbiI6IDE1ODgxNTgwMzgsICJyZXBvbWRfY2hlY2tzdW0i
+        OiAiZGM0NzRiMzY1NDRiZWNiYTE3Nzk1YmIyNTEwMTQ1M2UyNWI0MGZjZDQ4
+        MTFmYTU5NDY4NjMzNGVlYWJkNWYwOSJ9LCAiX2lkIjogeyIkb2lkIjogIjYw
+        MmZkZmQwN2FjY2U5MzUxMTEyMWI0MiJ9LCAiY29uZmlnIjogeyJmZWVkIjog
+        ImZpbGU6Ly8vdmFyL2xpYi9wdWxwL3N5bmNfaW1wb3J0cy90ZXN0X3JlcG9z
+        L3pvbyIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2lu
+        ZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAiaW1tZWRpYXRlIiwgInBy
+        b3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2Nh
+        bGx5X3N0b3JlZF91bml0cyI6IDQwLCAiX2lkIjogeyIkb2lkIjogIjYwMmZk
+        ZmQwN2FjY2U5MzUxMTEyMWI0MSJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0
+        cyI6IDQwLCAiaWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NC8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwib3ZlcnJpZGVfY29u
+        ZmlnIjp7ImZvcmNlX2Z1bGwiOmZhbHNlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '71'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2RmY2VkODQ2LTQ5MWQtNDMzYy05NTE3LTQxODJlNzkzNWYxYy8iLCAi
+        dGFza19pZCI6ICJkZmNlZDg0Ni00OTFkLTQzM2MtOTUxNy00MTgyZTc5MzVm
+        MWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/dfced846-491d-433c-9517-4182e7935f1c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ce67a320f392275fd2619ddf8f13ad1a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '527'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kZmNlZDg0Ni00OTFkLTQzM2MtOTUxNy00MTgy
+        ZTc5MzVmMWMvIiwgInRhc2tfaWQiOiAiZGZjZWQ4NDYtNDkxZC00MzNjLTk1
+        MTctNDE4MmU3OTM1ZjFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpw
+        dWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpwdWJsaXNo
+        Il0sICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA3WiIsICJf
+        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5
+        VDE1OjU3OjA3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItM0BjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        M0BjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInNraXBwZWQiLCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAic3RhcnRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA3WiIsICJfbnMiOiAi
+        cmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMjEtMDIt
+        MTlUMTU6NTc6MDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRv
+        cl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogIlNr
+        aXBwZWQ6IFJlcG9zaXRvcnkgY29udGVudCBoYXMgbm90IGNoYW5nZWQgc2lu
+        Y2UgbGFzdCBwdWJsaXNoLiIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImlk
+        IjogIjYwMmZkZmQzN2FjY2U5MzRlNzg2MDk0ZCIsICJkZXRhaWxzIjogIlNr
+        aXBwZWQ6IFJlcG9zaXRvcnkgY29udGVudCBoYXMgbm90IGNoYW5nZWQgc2lu
+        Y2UgbGFzdCBwdWJsaXNoLiJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjYwMmZkZmQzZjczYjY5YTgzNjY1MGVlMCJ9LCAiaWQiOiAiNjAy
+        ZmRmZDNmNzNiNjlhODM2NjUwZWUwIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a04c984515e0c9abffa3d7b58fd75a50-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '636'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfdmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3Jz
+        L2V4cG9ydF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWci
+        OiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBm
+        YWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEz
+        ZTY4In0sICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3Vy
+        bCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3Jo
+        ZWxfNl9sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9k
+        aXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiOF92aWV3MV9hcmNoaXZlIiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfdmlldzFfYXJjaGl2
+        ZS9kaXN0cmlidXRvcnMvOF92aWV3MV9hcmNoaXZlX2Nsb25lLyIsICJsYXN0
+        X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9y
+        IiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjcifSwgImNvbmZpZyI6IHsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiAiOF92aWV3MV9hcmNoaXZlIn0sICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmVfY2xvbmUifSwgeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3JzLzhfdmlldzFfYXJjaGl2
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmli
+        dXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9
+        LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
+        ICI2MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjYifSwgImNvbmZpZyI6IHsicHJv
+        dGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgImh0dHBzIjogdHJ1ZSwg
+        InJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmll
+        dy9hcmNoaXZlL3JoZWxfNl9sYWJlbCJ9LCAiaWQiOiAiOF92aWV3MV9hcmNo
+        aXZlIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMjEtMDItMTlUMTU6NTc6
+        MDdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1yZXBvIn0sICJs
+        YXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3VuaXRfY291bnRz
+        IjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMsICJlcnJhdHVtIjogNiwgInBh
+        Y2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQiOiA2LCAicGFja2FnZV9lbnZp
+        cm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24iOiAxLCAicnBtIjogNiwgInl1
+        bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwgIl9ucyI6ICJyZXBvcyIsICJp
+        bXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjhfdmlldzFfYXJjaGl2ZSIsICJs
+        YXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUv
+        aW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0
+        ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxh
+        c3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiBudWxsLCAi
+        c2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3
+        YWNjZTkzNTEyODEzZTY1In0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9p
+        bXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMjYsICJfaWQi
+        OiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEzZTY0In0sICJ0b3Rh
+        bF9yZXBvc2l0b3J5X3VuaXRzIjogMjYsICJpZCI6ICI4X3ZpZXcxX2FyY2hp
+        dmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy84X3Zp
+        ZXcxX2FyY2hpdmUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfdmlldzFfYXJjaGl2ZSIsIm92ZXJyaWRlX2NvbmZpZyI6eyJm
+        b3JjZV9mdWxsIjpmYWxzZX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAwZWNlZDMyLWE1YTgtNDkzYi05MGY1LTI0NDUwY2NhMGQ2ZS8iLCAi
+        dGFza19pZCI6ICIwMGVjZWQzMi1hNWE4LTQ5M2ItOTBmNS0yNDQ1MGNjYTBk
+        NmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/00eced32-a5a8-493b-90f5-24450cca0d6e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"535f6285d31ef12f0710f939979962cd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1371'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wMGVjZWQzMi1hNWE4LTQ5M2ItOTBmNS0yNDQ1
+        MGNjYTBkNmUvIiwgInRhc2tfaWQiOiAiMDBlY2VkMzItYTVhOC00OTNiLTkw
+        ZjUtMjQ0NTBjY2EwZDZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4
+        X3ZpZXcxX2FyY2hpdmUiLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmlu
+        aXNoX3RpbWUiOiAiMjAyMS0wMi0xOVQxNTo1NzowOFoiLCAiX25zIjogInRh
+        c2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMS0wMi0xOVQxNTo1Nzow
+        N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
+        InByb2dyZXNzX3JlcG9ydCI6IHsiOF92aWV3MV9hcmNoaXZlIjogW3sibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJl
+        cG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MGI3ZWQ0OC02MGUwLTQ0YTkt
+        YmI1MC01ZDU1N2ZkZDhjMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlz
+        dHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24i
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiM2IxNGNiNDktNDk3Ni00MDkwLTk4MDQtMTcy
+        ZjY0YzY3OTBkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3Rl
+        cF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDNlOWMxMjItMGYz
+        NC00ZDg3LTg3YjMtMGU5YzhlNjRkMTllIiwgIm51bV9wcm9jZXNzZWQiOiA2
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDM0MGFmZDEtY2FjMS00MjA1LThlMGEtZTgyN2U3ZTFiZDUz
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUi
+        OiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlhNTlmODliLTIwNWQtNDQz
+        My04YjY3LWUyMTg5NzIyMGQ3NSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsi
+        bnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        b2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFs
+        IjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjg0NGE1NGY0LWM3OWUtNDBmOS1iZjc5LTdhMDMxMThjNzg1NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzgzNDBiNi1iNzNjLTRiYmIt
+        OWVjNC0wNDg1MDMxMWM3YjYiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51
+        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJiNzMwMDQyMi1kZTViLTRhNjUtOWE4YS1kM2IxOWU4MGY3ZTEiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
+        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZmJl
+        NTYwZS1jNTA0LTQ1NWItODU0OC02OWYzMGI1OGY3ZmUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5l
+        cmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJ
+        UFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YWRhYzYyYi1hNjI4LTQ4
+        MTMtOTFlMC05ZTE1MzZhNjZjN2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9s
+        ZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNjJjN2M1NS1jYTYyLTQwYWEtOWM4OC01
+        NGEwNWE4ZWQwNTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
+        cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJl
+        MzgyZmM4Yy0zODkxLTRmY2MtYjM5Mi0xNjEwYzEwOWEzZWYiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJw
+        dWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGQ5ODk2ZS0w
+        YzczLTRiNWEtOTM1Ni1kZGJmYmRjYjk4ODMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRp
+        bmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIyZWEwYTkwLTg2ZWMt
+        NDc4Ny1hMmU2LTMzNTViY2IxNTU0YSIsICJudW1fcHJvY2Vzc2VkIjogMX1d
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNh
+        bm5vbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI4X3ZpZXcx
+        X2FyY2hpdmUiLCAic3RhcnRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA3WiIs
+        ICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMjEtMDItMTlUMTU6NTc6MDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJk
+        aXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1t
+        YXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjog
+        IkZJTklTSEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5J
+        U0hFRCIsICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1v
+        ZHVsZXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJG
+        SU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklT
+        SEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6
+        ICJTS0lQUEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwg
+        ImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI4
+        X3ZpZXcxX2FyY2hpdmUiLCAiaWQiOiAiNjAyZmRmZDQ3YWNjZTkzNGUyN2U2
+        ZTExIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjYwYjdlZDQ4LTYwZTAtNDRhOS1iYjUwLTVkNTU3ZmRkOGMyZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYjE0
+        Y2I0OS00OTc2LTQwOTAtOTgwNC0xNzJmNjRjNjc5MGQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogNiwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDYsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0M2U5YzEyMi0wZjM0LTRkODctODdiMy0wZTljOGU2NGQx
+        OWUiLCAibnVtX3Byb2Nlc3NlZCI6IDZ9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzQwYWZkMS1jYWMx
+        LTQyMDUtOGUwYS1lODI3ZTdlMWJkNTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogNiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiA2LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiOWE1OWY4OWItMjA1ZC00NDMzLThiNjctZTIxODk3MjIwZDc1Iiwg
+        Im51bV9wcm9jZXNzZWQiOiA2fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODQ0YTU0ZjQtYzc5ZS00MGY5
+        LWJmNzktN2EwMzExOGM3ODU3IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJu
+        dW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjAzODM0MGI2LWI3M2MtNGJiYi05ZWM0LTA0ODUwMzExYzdiNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3MzAwNDIyLWRlNWItNGE2
+        NS05YThhLWQzYjE5ZTgwZjdlMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImZmYmU1NjBlLWM1MDQtNDU1Yi04NTQ4LTY5
+        ZjMwYjU4ZjdmZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjRhZGFjNjJiLWE2MjgtNDgxMy05MWUwLTllMTUzNmE2NmM3ZSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU2
+        MmM3YzU1LWNhNjItNDBhYS05Yzg4LTU0YTA1YThlZDA1MSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImUzODJmYzhjLTM4OTEtNGZjYy1iMzky
+        LTE2MTBjMTA5YTNlZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjA4ZDk4OTZlLTBjNzMtNGI1YS05MzU2LWRkYmZiZGNi
+        OTg4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiYjJlYTBhOTAtODZlYy00Nzg3LWEyZTYtMzM1NWJjYjE1NTRh
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMmZkZmQzZjczYjY5YTgzNjY1MGY3NyJ9LCAiaWQi
+        OiAiNjAyZmRmZDNmNzNiNjlhODM2NjUwZjc3In0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"23471cd6a6954feba246592cb2d77242-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfdmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3Jz
+        L2V4cG9ydF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWci
+        OiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBm
+        YWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEz
+        ZTY4In0sICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3Vy
+        bCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3Jo
+        ZWxfNl9sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9k
+        aXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiOF92aWV3MV9hcmNoaXZlIiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfdmlldzFfYXJjaGl2
+        ZS9kaXN0cmlidXRvcnMvOF92aWV3MV9hcmNoaXZlX2Nsb25lLyIsICJsYXN0
+        X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9y
+        IiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjcifSwgImNvbmZpZyI6IHsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiAiOF92aWV3MV9hcmNoaXZlIn0sICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmVfY2xvbmUifSwgeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3JzLzhfdmlldzFfYXJjaGl2
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA4WiIsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVl
+        LCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjYi
+        fSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxz
+        ZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBv
+        cmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3JoZWxfNl9sYWJlbCJ9LCAi
+        aWQiOiAiOF92aWV3MV9hcmNoaXZlIn1dLCAibGFzdF91bml0X2FkZGVkIjog
+        IjIwMjEtMDItMTlUMTU6NTc6MDdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBl
+        IjogInJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMs
+        ICJlcnJhdHVtIjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQi
+        OiA2LCAicGFja2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24i
+        OiAxLCAicnBtIjogNiwgInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwg
+        Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAi
+        X25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJs
+        YXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEzZTY1In0sICJjb25maWci
+        OiB7fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVk
+        X3VuaXRzIjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkz
+        NTEyODEzZTY0In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjYsICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7f5905ae26862a37722314d9d10c6242-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIwMjEt
+        MDItMTlUMTU6NTc6MDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBv
+        c2l0b3JpZXMvOF92aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1
+        dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rp
+        c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBh
+        ZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTExMjFiNGEifSwgImNvbmZpZyI6
+        IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9y
+        YXRpb24vbGlicmFyeV92aWV3L3JoZWxfNl9sYWJlbCIsICJodHRwcyI6IGZh
+        bHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQi
+        OiAiOF92aWV3MSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1
+        NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy84
+        X3ZpZXcxL2Rpc3RyaWJ1dG9ycy84X3ZpZXcxX2Nsb25lLyIsICJsYXN0X292
+        ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwg
+        ImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25z
+        IjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJm
+        ZGZkMjdhY2NlOTM1MTExMjFiNDkifSwgImNvbmZpZyI6IHsiZGVzdGluYXRp
+        b25fZGlzdHJpYnV0b3JfaWQiOiAiOF92aWV3MSJ9LCAiaWQiOiAiOF92aWV3
+        MV9jbG9uZSJ9LCB7InJlcG9faWQiOiAiOF92aWV3MSIsICJsYXN0X3VwZGF0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxL2Rpc3RyaWJ1dG9ycy84X3Zp
+        ZXcxLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjog
+        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
+        IjogIjYwMmZkZmQyN2FjY2U5MzUxMTEyMWI0OCJ9LCAiY29uZmlnIjogeyJw
+        cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
+        LCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeV92
+        aWV3L3JoZWxfNl9sYWJlbCJ9LCAiaWQiOiAiOF92aWV3MSJ9XSwgImxhc3Rf
+        dW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJy
+        cG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVu
+        dF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVy
+        cyI6IFt7InJlcG9faWQiOiAiOF92aWV3MSIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy84X3ZpZXcxL2ltcG9ydGVycy95dW1faW1wb3J0ZXIv
+        IiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9
+        LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMmZkZmQyN2FjY2U5MzUxMTEyMWI0NyJ9LCAiY29u
+        ZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0
+        b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNj
+        ZTkzNTExMTIxYjQ2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwg
+        ImlkIjogIjhfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        aXRvcmllcy84X3ZpZXcxLyJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfdmlldzFfY2xvbmUiLCJvdmVycmlkZV9jb25maWciOnsic291
+        cmNlX3JlcG9faWQiOiI4X3ZpZXcxX2FyY2hpdmUiLCJzb3VyY2VfZGlzdHJp
+        YnV0b3JfaWQiOiI4X3ZpZXcxX2FyY2hpdmUiLCJmb3JjZV9mdWxsIjpmYWxz
+        ZX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '138'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdjMGU0OWE2LWRjOTMtNDNlZS1iMGYzLWJlOTJlMmFjOThiZC8iLCAi
+        dGFza19pZCI6ICI3YzBlNDlhNi1kYzkzLTQzZWUtYjBmMy1iZTkyZTJhYzk4
+        YmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/7c0e49a6-dc93-43ee-b0f3-be92e2ac98bd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4529f3242d7bee035b63da1c20ba6d94-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83YzBlNDlhNi1kYzkzLTQzZWUtYjBmMy1iZTky
+        ZTJhYzk4YmQvIiwgInRhc2tfaWQiOiAiN2MwZTQ5YTYtZGM5My00M2VlLWIw
+        ZjMtYmU5MmUyYWM5OGJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4
+        X3ZpZXcxIiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1l
+        IjogIjIwMjEtMDItMTlUMTU6NTc6MDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6MDhaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7IjhfdmlldzFfY2xvbmUiOiB7ImVycm9ycyI6IFtdfX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5u
+        b2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiOF92aWV3MSIs
+        ICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDhaIiwgIl9ucyI6ICJy
+        ZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0wMi0x
+        OVQxNTo1NzowOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnki
+        OiB7ImVycm9ycyI6IFtdfSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlz
+        dHJpYnV0b3JfaWQiOiAiOF92aWV3MV9jbG9uZSIsICJpZCI6ICI2MDJmZGZk
+        NDdhY2NlOTM0ZTI3ZTZlMTIiLCAiZGV0YWlscyI6IHt9fSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkNGY3M2I2OWE4MzY2NTEw
+        NzYifSwgImlkIjogIjYwMmZkZmQ0ZjczYjY5YTgzNjY1MTA3NiJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"23471cd6a6954feba246592cb2d77242-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfdmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3Jz
+        L2V4cG9ydF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWci
+        OiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBm
+        YWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEz
+        ZTY4In0sICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3Vy
+        bCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3Jo
+        ZWxfNl9sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9k
+        aXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiOF92aWV3MV9hcmNoaXZlIiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfdmlldzFfYXJjaGl2
+        ZS9kaXN0cmlidXRvcnMvOF92aWV3MV9hcmNoaXZlX2Nsb25lLyIsICJsYXN0
+        X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9y
+        IiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjcifSwgImNvbmZpZyI6IHsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiAiOF92aWV3MV9hcmNoaXZlIn0sICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmVfY2xvbmUifSwgeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3JzLzhfdmlldzFfYXJjaGl2
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA4WiIsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVl
+        LCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjYi
+        fSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxz
+        ZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBv
+        cmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3JoZWxfNl9sYWJlbCJ9LCAi
+        aWQiOiAiOF92aWV3MV9hcmNoaXZlIn1dLCAibGFzdF91bml0X2FkZGVkIjog
+        IjIwMjEtMDItMTlUMTU6NTc6MDdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBl
+        IjogInJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMs
+        ICJlcnJhdHVtIjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQi
+        OiA2LCAicGFja2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24i
+        OiAxLCAicnBtIjogNiwgInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwg
+        Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAi
+        X25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJs
+        YXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEzZTY1In0sICJjb25maWci
+        OiB7fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVk
+        X3VuaXRzIjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkz
+        NTEyODEzZTY0In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjYsICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1_archive/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"c5b338d5b180b1efa1df86a793459fcd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '565'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmUiLCAi
+        bGFzdF91cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDZaIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOF9jb21wb3NpdGVfdmVy
+        c2lvbjFfYXJjaGl2ZS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9y
+        LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNo
+        IjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTExMjFiNGYifSwgImNvbmZpZyI6IHsi
+        aHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRp
+        b24vY29tcG9zaXRlL2FyY2hpdmUvcmhlbF82X2xhYmVsIiwgImh0dHBzIjog
+        ZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVwb19p
+        ZCI6ICI4X2NvbXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwgImxhc3RfdXBk
+        YXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfY29tcG9zaXRlX3ZlcnNpb24xX2Fy
+        Y2hpdmUvZGlzdHJpYnV0b3JzLzhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hp
+        dmVfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0
+        X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1f
+        Y2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJz
+        Y3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAi
+        X2lkIjogeyIkb2lkIjogIjYwMmZkZmQyN2FjY2U5MzUxMTEyMWI0ZSJ9LCAi
+        Y29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICI4X2Nv
+        bXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIn0sICJpZCI6ICI4X2NvbXBvc2l0
+        ZV92ZXJzaW9uMV9hcmNoaXZlX2Nsb25lIn0sIHsicmVwb19pZCI6ICI4X2Nv
+        bXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwgImxhc3RfdXBkYXRlZCI6ICIy
+        MDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        cmVwb3NpdG9yaWVzLzhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmUvZGlz
+        dHJpYnV0b3JzLzhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmUvIiwgImxh
+        c3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAi
+        YXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6
+        ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRm
+        ZDI3YWNjZTkzNTExMTIxYjRkIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6
+        IHRydWUsICJodHRwIjogZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2
+        ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9jb21wb3NpdGUvYXJjaGl2ZS9y
+        aGVsXzZfbGFiZWwifSwgImlkIjogIjhfY29tcG9zaXRlX3ZlcnNpb24xX2Fy
+        Y2hpdmUifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBudWxsLCAibm90ZXMiOiB7
+        Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxhc3RfdW5pdF9yZW1vdmVk
+        IjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7fSwgIl9ucyI6ICJy
+        ZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjhfY29tcG9zaXRl
+        X3ZlcnNpb24xX2FyY2hpdmUiLCAibGFzdF91cGRhdGVkIjogIjIwMjEtMDIt
+        MTlUMTU6NTc6MDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvOF9jb21wb3NpdGVfdmVyc2lvbjFfYXJjaGl2ZS9pbXBvcnRlcnMv
+        eXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMiLCAiaW1w
+        b3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9vdmVycmlk
+        ZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGwsICJzY3JhdGNocGFk
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTEx
+        MjFiNGMifSwgImNvbmZpZyI6IHt9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1d
+        LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjog
+        IjYwMmZkZmQyN2FjY2U5MzUxMTEyMWI0YiJ9LCAidG90YWxfcmVwb3NpdG9y
+        eV91bml0cyI6IDAsICJpZCI6ICI4X2NvbXBvc2l0ZV92ZXJzaW9uMV9hcmNo
+        aXZlIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOF9j
+        b21wb3NpdGVfdmVyc2lvbjFfYXJjaGl2ZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1_archive/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmVfY2xvbmUiLCJv
+        dmVycmlkZV9jb25maWciOnsic291cmNlX3JlcG9faWQiOiI4X3ZpZXcxX2Fy
+        Y2hpdmUiLCJzb3VyY2VfZGlzdHJpYnV0b3JfaWQiOiI4X3ZpZXcxX2FyY2hp
+        dmUiLCJmb3JjZV9mdWxsIjpmYWxzZX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '159'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2IzMDIzYjE5LTUyNzgtNDljYS05MzVkLTUyMzI1Mzk4OWM1ZS8iLCAi
+        dGFza19pZCI6ICJiMzAyM2IxOS01Mjc4LTQ5Y2EtOTM1ZC01MjMyNTM5ODlj
+        NWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/b3023b19-5278-49ca-935d-523253989c5e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"04ad61a863b1c7d854465bab1b755b01-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '514'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMzAyM2IxOS01Mjc4LTQ5Y2EtOTM1ZC01MjMy
+        NTM5ODljNWUvIiwgInRhc2tfaWQiOiAiYjMwMjNiMTktNTI3OC00OWNhLTkz
+        NWQtNTIzMjUzOTg5YzVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4
+        X2NvbXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwgInB1bHA6YWN0aW9uOnB1
+        Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6MDha
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEt
+        MDItMTlUMTU6NTc6MDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IjhfY29tcG9zaXRl
+        X3ZlcnNpb24xX2FyY2hpdmVfY2xvbmUiOiB7ImVycm9ycyI6IFtdfX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3Mi
+        LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiOF9jb21wb3NpdGVf
+        dmVyc2lvbjFfYXJjaGl2ZSIsICJzdGFydGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21w
+        bGV0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowOFoiLCAidHJhY2ViYWNrIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3Ry
+        aWJ1dG9yIiwgInN1bW1hcnkiOiB7ImVycm9ycyI6IFtdfSwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiOF9jb21wb3NpdGVf
+        dmVyc2lvbjFfYXJjaGl2ZV9jbG9uZSIsICJpZCI6ICI2MDJmZGZkNDdhY2Nl
+        OTM0ZTI3ZTZlMTMiLCAiZGV0YWlscyI6IHt9fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkNGY3M2I2OWE4MzY2NTEwYzYifSwg
+        ImlkIjogIjYwMmZkZmQ0ZjczYjY5YTgzNjY1MTBjNiJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"23471cd6a6954feba246592cb2d77242-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfdmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3Jz
+        L2V4cG9ydF9kaXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWci
+        OiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogImV4cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBm
+        YWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEz
+        ZTY4In0sICJjb25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3Vy
+        bCI6ICJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3Jo
+        ZWxfNl9sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9k
+        aXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiOF92aWV3MV9hcmNoaXZlIiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfdmlldzFfYXJjaGl2
+        ZS9kaXN0cmlidXRvcnMvOF92aWV3MV9hcmNoaXZlX2Nsb25lLyIsICJsYXN0
+        X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9y
+        IiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjcifSwgImNvbmZpZyI6IHsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiAiOF92aWV3MV9hcmNoaXZlIn0sICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmVfY2xvbmUifSwgeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvZGlzdHJpYnV0b3JzLzhfdmlldzFfYXJjaGl2
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA4WiIsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVl
+        LCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMjdhY2NlOTM1MTI4MTNlNjYi
+        fSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxz
+        ZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBv
+        cmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3JoZWxfNl9sYWJlbCJ9LCAi
+        aWQiOiAiOF92aWV3MV9hcmNoaXZlIn1dLCAibGFzdF91bml0X2FkZGVkIjog
+        IjIwMjEtMDItMTlUMTU6NTc6MDdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBl
+        IjogInJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjogeyJtb2R1bGVtZF9kZWZhdWx0cyI6IDMs
+        ICJlcnJhdHVtIjogNiwgInBhY2thZ2VfZ3JvdXAiOiAyLCAibW9kdWxlbWQi
+        OiA2LCAicGFja2FnZV9lbnZpcm9ubWVudCI6IDEsICJkaXN0cmlidXRpb24i
+        OiAxLCAicnBtIjogNiwgInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAxfSwg
+        Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIjhf
+        dmlldzFfYXJjaGl2ZSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy84X3ZpZXcxX2FyY2hpdmUvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAi
+        X25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJs
+        YXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTEyODEzZTY1In0sICJjb25maWci
+        OiB7fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVk
+        X3VuaXRzIjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkz
+        NTEyODEzZTY0In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjYsICJp
+        ZCI6ICI4X3ZpZXcxX2FyY2hpdmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy84X3ZpZXcxX2FyY2hpdmUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"c92eb1ac6116d71dfb1d71a8cbd98209-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '562'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjhfY29tcG9zaXRlX3ZlcnNpb24xIiwgImxhc3RfdXBk
+        YXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA2WiIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhfY29tcG9zaXRlX3ZlcnNpb24xL2Rp
+        c3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rfb3ZlcnJp
+        ZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAiYXV0b19w
+        dWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVw
+        b19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQyN2Fj
+        Y2U5MzUxMTEyMWI1NCJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFsc2UsICJy
+        ZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2NvbXBv
+        c2l0ZS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJl
+        eHBvcnRfZGlzdHJpYnV0b3IifSwgeyJyZXBvX2lkIjogIjhfY29tcG9zaXRl
+        X3ZlcnNpb24xIiwgImxhc3RfdXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3
+        OjA2WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzhf
+        Y29tcG9zaXRlX3ZlcnNpb24xL2Rpc3RyaWJ1dG9ycy84X2NvbXBvc2l0ZV92
+        ZXJzaW9uMV9jbG9uZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwg
+        Imxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
+        Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxz
+        ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9y
+        cyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTExMTIxYjUz
+        In0sICJjb25maWciOiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjog
+        IjhfY29tcG9zaXRlX3ZlcnNpb24xIn0sICJpZCI6ICI4X2NvbXBvc2l0ZV92
+        ZXJzaW9uMV9jbG9uZSJ9LCB7InJlcG9faWQiOiAiOF9jb21wb3NpdGVfdmVy
+        c2lvbjEiLCAibGFzdF91cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDZa
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOF9jb21w
+        b3NpdGVfdmVyc2lvbjEvZGlzdHJpYnV0b3JzLzhfY29tcG9zaXRlX3ZlcnNp
+        b24xLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjog
+        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
+        IjogIjYwMmZkZmQyN2FjY2U5MzUxMTEyMWI1MiJ9LCAiY29uZmlnIjogeyJw
+        cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
+        LCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9j
+        b21wb3NpdGUvcmhlbF82X2xhYmVsIn0sICJpZCI6ICI4X2NvbXBvc2l0ZV92
+        ZXJzaW9uMSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6
+        IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92
+        ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjog
+        InJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiOF9jb21wb3Np
+        dGVfdmVyc2lvbjEiLCAibGFzdF91cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        OF9jb21wb3NpdGVfdmVyc2lvbjEvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8i
+        LCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30s
+        ICJsYXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNjAyZmRmZDI3YWNjZTkzNTExMTIxYjUxIn0sICJjb25m
+        aWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3Rv
+        cmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMjdhY2Nl
+        OTM1MTExMjFiNTAifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAwLCAi
+        aWQiOiAiOF9jb21wb3NpdGVfdmVyc2lvbjEiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy84X2NvbXBvc2l0ZV92ZXJzaW9uMS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjhfY29tcG9zaXRlX3ZlcnNpb24xX2Nsb25lIiwib3ZlcnJpZGVf
+        Y29uZmlnIjp7InNvdXJjZV9yZXBvX2lkIjoiOF92aWV3MV9hcmNoaXZlIiwi
+        c291cmNlX2Rpc3RyaWJ1dG9yX2lkIjoiOF92aWV3MV9hcmNoaXZlIiwiZm9y
+        Y2VfZnVsbCI6ZmFsc2V9fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '151'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzVjMmRiMzJmLTQ0ZGEtNGMzZC1hOTYwLWJkYzlhYWVjNDkxOS8iLCAi
+        dGFza19pZCI6ICI1YzJkYjMyZi00NGRhLTRjM2QtYTk2MC1iZGM5YWFlYzQ5
+        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/5c2db32f-44da-4c3d-a960-bdc9aaec4919/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"857de6d55a3e1f35769a180f28ce30be-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '508'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81YzJkYjMyZi00NGRhLTRjM2QtYTk2MC1iZGM5
+        YWFlYzQ5MTkvIiwgInRhc2tfaWQiOiAiNWMyZGIzMmYtNDRkYS00YzNkLWE5
+        NjAtYmRjOWFhZWM0OTE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4
+        X2NvbXBvc2l0ZV92ZXJzaW9uMSIsICJwdWxwOmFjdGlvbjpwdWJsaXNoIl0s
+        ICJmaW5pc2hfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjA5WiIsICJfbnMi
+        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1
+        OjU3OjA5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
+        IFtdLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyI4X2NvbXBvc2l0ZV92ZXJzaW9u
+        MV9jbG9uZSI6IHsiZXJyb3JzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNh
+        bm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNl
+        bnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBu
+        dWxsLCAicmVwb19pZCI6ICI4X2NvbXBvc2l0ZV92ZXJzaW9uMSIsICJzdGFy
+        dGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDlaIiwgIl9ucyI6ICJyZXBvX3B1
+        Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1
+        NzowOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImVy
+        cm9ycyI6IFtdfSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiOF9jb21wb3NpdGVfdmVyc2lvbjFfY2xvbmUiLCAiaWQiOiAi
+        NjAyZmRmZDU3YWNjZTkzNGUyN2U2ZTE0IiwgImRldGFpbHMiOiB7fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDVmNzNiNjlh
+        ODM2NjUxMTE2In0sICJpZCI6ICI2MDJmZGZkNWY3M2I2OWE4MzY2NTExMTYi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9uIiwi
+        cmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2VycG0i
+        LCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2184'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJhcm1hZGlsbG8tMC4xLTEu
+        c3JjLnJwbSIsICJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJh
+        ZjQ3ODEzMmY4ODJlNDJkNGY1NWI5NTNjYjg0NjgyN2M0OGYyZDI5YjdjNmU5
+        YmJhODk4YTYxZGRjMjdiNTg5IiwgInN1bW1hcnkiOiAiRmFrZSBwcm92aWRl
+        IGZvciBhcm1hZGlsbG8uIiwgImZpbGVuYW1lIjogImFybWFkaWxsby0wLjEt
+        MS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjEi
+        LCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
+        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIwZWRjMTA4MC02OGQ4LTQ0
+        YTgtOGFlNi0wM2ExYWZlZDU2NTQiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJw
+        dWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDIt
+        MTlUMTU6NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICIwZWRjMTA4MC02OGQ4LTQ0YTgtOGFlNi0wM2ExYWZlZDU2NTQiLCAi
+        X2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDg3ZCJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImVsZXBoYW50LTAuMi0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzMzM1
+        MWZkNmMyYTM4ZTVkNDlhZWE3ODhhMmU4MzhlYWNkNjU0Y2Y2MWQ0NzZiYTVi
+        NjVkZTQzOWRkZDEyNWI5IiwgInN1bW1hcnkiOiAiRmFrZSBwcm92aWRlIGZv
+        ciBlbGVwaGFudC4iLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4yLTEubm9h
+        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlz
+        X21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiMjY3YTYzZjgtNTFhYy00ZGUyLTk1
+        ZmYtMzllYmQxNDc3YWRjIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
+        IjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11
+        dWlkLXJoZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1
+        OjU3OjA1WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
+        MjY3YTYzZjgtNTFhYy00ZGUyLTk1ZmYtMzllYmQxNDc3YWRjIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4YmMifX0sIHsibWV0
+        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5zcmMucnBt
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMzYWY1OTRi
+        YzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRk
+        NjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBr
+        YW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNfbW9k
+        dWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogIjNmOWEyYmVjLTEzNWUtNGM4OS1iNzhmLTU0
+        YmUyOTExMTU4YiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIxLTAyLTE5VDE1OjU3OjA1WiIsICJyZXBvX2lkIjogInB1bHAtdXVpZC1y
+        aGVsXzZfeDg2XzY0IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1Nzow
+        NVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjNmOWEy
+        YmVjLTEzNWUtNGM4OS1iNzhmLTU0YmUyOTExMTU4YiIsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwODg2In19LCB7Im1ldGFkYXRh
+        IjogeyJzb3VyY2VycG0iOiAic3F1aXJyZWwtMC4zLTAuOC5zcmMucnBtIiwg
+        Im5hbWUiOiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVm
+        MTNkNzg0ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4
+        NzhhMTdkMiIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBzcXVp
+        cnJlbCIsICJmaWxlbmFtZSI6ICJzcXVpcnJlbC0wLjMtMC44Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
+        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjAuOCIsICJfaWQiOiAiNThmN2YzZDYtMGY1ZC00NGEwLTkxNWEt
+        YTUxZDM3OWQ2YWMyIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlk
+        LXJoZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3
+        OjA1WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNThm
+        N2YzZDYtMGY1ZC00NGEwLTkxNWEtYTUxZDM3OWQ2YWMyIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4NTkifX0sIHsibWV0YWRh
+        dGEiOiB7InNvdXJjZXJwbSI6ICJ0cm91dC0wLjEyLTEuc3JjLnJwbSIsICJu
+        YW1lIjogInRyb3V0IiwgImNoZWNrc3VtIjogImFlYTkxZDczZDhkZjIxNTAy
+        ZmVjYmMxYmJmNjRlN2NmZGQ2MTc1MWExYmEyNzMwOTM5ZDU3ZmM4NDI2MDJl
+        MTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgdHJvdXQiLCAi
+        ZmlsZW5hbWUiOiAidHJvdXQtMC4xMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMTIiLCAiaXNfbW9kdWxhciI6IGZhbHNl
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwg
+        Il9pZCI6ICI1OTY1Y2FkOC1lNjBjLTQ2MDctYWVmZC1lNWNhY2QxZWMyOTYi
+        LCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
+        NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI1OTY1Y2FkOC1lNjBjLTQ2
+        MDctYWVmZC1lNWNhY2QxZWMyOTYiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZk
+        ZmQxZjczYjY5YTgzNjY1MDhjZSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        cnBtIjogIndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYw
+        MTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtNS4yMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjUuMjEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjYw
+        Zjk5MWM4LWU0ODQtNGExOC1iOTU0LWIwMGJlZDU0Njg3MCIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIs
+        ICJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImNyZWF0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogIjYwZjk5MWM4LWU0ODQtNGExOC1iOTU0LWIw
+        MGJlZDU0Njg3MCIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDFmNzNiNjlh
+        ODM2NjUwOGIzIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAicGVu
+        Z3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJwZW5ndWluIiwgImNo
+        ZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNl
+        NWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAic3VtbWFyeSI6ICJB
+        IGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsICJmaWxlbmFtZSI6ICJwZW5n
+        dWluLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
+        b24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI2NWNl
+        MzdiZC1jOGUwLTQ3OWUtOGI1Yy0xMTA1ZTQ2NWRmMTIiLCAiYXJjaCI6ICJu
+        b2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAi
+        cmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVk
+        IjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJy
+        cG0iLCAidW5pdF9pZCI6ICI2NWNlMzdiZC1jOGUwLTQ3OWUtOGI1Yy0xMTA1
+        ZTQ2NWRmMTIiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgz
+        NjY1MDg4ZiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2st
+        MC43LTEuc3JjLnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAi
+        NWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEy
+        MWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJzdW1tYXJ5IjogIlF1YWNrIGxpa2Ug
+        YSBkdWNrIGF0IHRoZSBwYXJrLiIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0x
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIs
+        ICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNmExNDA4NDItYjM0OS00M2U0
+        LWFjMTItYTYxYzcxZGU2MmJmIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
+        dGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVs
+        cC11dWlkLXJoZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5
+        VDE1OjU3OjA1WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
+        OiAiNmExNDA4NDItYjM0OS00M2U0LWFjMTItYTYxYzcxZGU2MmJmIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4ZTEifX0sIHsi
+        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJkdWNrLTAuNi0xLnNyYy5ycG0i
+        LCAibmFtZSI6ICJkdWNrIiwgImNoZWNrc3VtIjogIjk2ZjM3ODc3NTE4YTFm
+        ZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3
+        NzRiYzciLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIs
+        ICJmaWxlbmFtZSI6ICJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNiIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiOTM2ZDFlMjctMTBkOS00Nzk3LWEzODEtZjk0Y2M3Yzc0MDZjIiwg
+        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOTM2ZDFlMjctMTBkOS00Nzk3
+        LWEzODEtZjk0Y2M3Yzc0MDZjIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZk
+        MWY3M2I2OWE4MzY2NTA4MzkifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
+        bSI6ICJrYW5nYXJvby0wLjMtMS5zcmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fy
+        b28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3Mjgw
+        YzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJzdW1t
+        YXJ5IjogImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwgImZp
+        bGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogdHJ1ZSwg
+        Il9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiYTUzNDBmZTgtNzBhZi00NDZiLWE4NTctNzlmODhiOTI2NzM5Iiwg
+        ImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQi
+        LCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1bml0X3R5
+        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYTUzNDBmZTgtNzBhZi00NDZi
+        LWE4NTctNzlmODhiOTI2NzM5IiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZk
+        MWY3M2I2OWE4MzY2NTA4NGUifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
+        bSI6ICJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibW9ua2V5
+        IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJjN2NjYzU2MzJlM2Zh
+        MjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFkYjEiLCAic3VtbWFy
+        eSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbW9ua2V5IiwgImZpbGVuYW1lIjog
+        Im1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
+        YTkxNGVkY2QtZjNhYS00ZWFiLTg4MjYtMzgwZGNlYjdkODAzIiwgImFyY2gi
+        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVa
+        IiwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCAiY3Jl
+        YXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1bml0X3R5cGVfaWQi
+        OiAicnBtIiwgInVuaXRfaWQiOiAiYTkxNGVkY2QtZjNhYS00ZWFiLTg4MjYt
+        MzgwZGNlYjdkODAzIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2
+        OWE4MzY2NTA4YzUifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJj
+        aGVldGFoLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAi
+        Y2hlY2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdm
+        NTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5Ijog
+        IkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNo
+        ZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImJj
+        MmU0YWRkLTM3NDItNGMyMS04OTk3LWFjODE1MmYwNDk2OSIsICJhcmNoIjog
+        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIs
+        ICJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImNyZWF0
+        ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSIsICJ1bml0X2lkIjogImJjMmU0YWRkLTM3NDItNGMyMS04OTk3LWFj
+        ODE1MmYwNDk2OSIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDFmNzNiNjlh
+        ODM2NjUwODk4In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAibGlv
+        bi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3Vt
+        IjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgx
+        NTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        ImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBt
+        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjZTM4ZTY4OC1lZGJjLTQy
+        MGMtYmMyMS0wY2M0NmZkM2Q4NGYiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
+        ZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJw
+        dWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDIt
+        MTlUMTU6NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
+        ZCI6ICJjZTM4ZTY4OC1lZGJjLTQyMGMtYmMyMS0wY2M0NmZkM2Q4NGYiLCAi
+        X2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDg3NCJ9fSwg
+        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogIndhbHJ1cy0wLjcxLTEuc3Jj
+        LnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJj
+        Y2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3Yjcz
+        M2FhNTY1MjMxNDJjIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9m
+        IHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC43MS0xLm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAiaXNfbW9k
+        dWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogImQyOTQzYThkLWQwYmQtNDFhNy1hNzU2LWQ0
+        YzQ5YzVmNWE3YyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDIxLTAyLTE5VDE1OjU3OjA1WiIsICJyZXBvX2lkIjogInB1bHAtdXVpZC1y
+        aGVsXzZfeDg2XzY0IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1Nzow
+        NVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImQyOTQz
+        YThkLWQwYmQtNDFhNy1hNzU2LWQ0YzQ5YzVmNWE3YyIsICJfaWQiOiB7IiRv
+        aWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwODYyIn19LCB7Im1ldGFkYXRh
+        IjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMi0xLnNyYy5ycG0iLCAi
+        bmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiOGQzMTk5MDVlZWRi
+        NWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4N2I2ZjUx
+        YWIzYjY1YSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJtYWRp
+        bGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4yLTEubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlzX21vZHVs
+        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiZGEzNGU2OGQtODhkZC00MGJhLWFlNDYtYzM3
+        MzdmMDlmZDMwIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJo
+        ZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZGEzNGU2
+        OGQtODhkZC00MGJhLWFlNDYtYzM3MzdmMDlmZDMwIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4YWEifX0sIHsibWV0YWRhdGEi
+        OiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAi
+        bmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIx
+        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
+        YTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
+        YW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVs
+        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
+        c2UiOiAiMC44IiwgIl9pZCI6ICJlNzk2MjE1NS1lOGIxLTRkNGEtYjAyYS1k
+        MjQxM2UyYzQ0YzciLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
+        MjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQt
+        cmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6
+        MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJlNzk2
+        MjE1NS1lOGIxLTRkNGEtYjAyYS1kMjQxM2UyYzQ0YzciLCAiX2lkIjogeyIk
+        b2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDg0MyJ9fSwgeyJtZXRhZGF0
+        YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwg
+        Im5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEw
+        NGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAw
+        OWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFm
+        ZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFy
+        IjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNl
+        IjogIjAuOCIsICJfaWQiOiAiZWI2MDRlMzEtYWJmZi00NGQyLWJiMzctNzBi
+        MGE0ZGIzNTJkIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJo
+        ZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWI2MDRl
+        MzEtYWJmZi00NGQyLWJiMzctNzBiMGE0ZGIzNTJkIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4NmIifX0sIHsibWV0YWRhdGEi
+        OiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwgIm5h
+        bWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4
+        MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFk
+        ZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwg
+        ImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFs
+        c2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAu
+        OCIsICJfaWQiOiAiZWJiMTM0NjctYzc2NC00OTZlLWE2NGYtNzIwMTNjM2U4
+        NzE0IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMjEtMDIt
+        MTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94
+        ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1
+        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZWJiMTM0NjctYzc2
+        NC00OTZlLWE2NGYtNzIwMTNjM2U4NzE0IiwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkMWY3M2I2OWE4MzY2NTA4YTEifX0sIHsibWV0YWRhdGEiOiB7InNv
+        dXJjZXJwbSI6ICJhcm1hZGlsbG8tMi4xLTEuc3JjLnJwbSIsICJuYW1lIjog
+        ImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJhYmY2OTFlZTViNDhlNDQ2MzI2
+        ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNkOGQxZmYzOTlm
+        IiwgInN1bW1hcnkiOiAiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwg
+        ImZpbGVuYW1lIjogImFybWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIyLjEiLCAiaXNfbW9kdWxhciI6IGZh
+        bHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
+        IiwgIl9pZCI6ICJmMzAyMWRjNy0xMjBiLTQyZjYtYTNiNS0xNmU5OTQ3NTI4
+        OTAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0x
+        OVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4
+        Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJmMzAyMWRjNy0xMjBi
+        LTQyZjYtYTNiNS0xNmU5OTQ3NTI4OTAiLCAiX2lkIjogeyIkb2lkIjogIjYw
+        MmZkZmQxZjczYjY5YTgzNjY1MDhkNyJ9fV0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9u
+        IiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2Vy
+        cG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '177'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
+        MjAwMCwic2tpcCI6MH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '60'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1325'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFhY2QwOWVk
+        NGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5
+        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwgImFydGlm
+        YWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5NWZkOThi
+        OWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVkIjogMTYx
+        Mzc0NzczMywgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBlciI6IFsi
+        d2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1bGUiLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMs
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiYzBmZmVl
+        NDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6
+        IFtdLCAiX2lkIjogIjAxZmM1NDc2LWRjMWYtNGMyZi05MGZiLTZkYmIwZjMy
+        YjVlZCIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6ICJBIG1v
+        ZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lk
+        IjogIjAxZmM1NDc2LWRjMWYtNGMyZi05MGZiLTZkYmIwZjMyYjVlZCIsICJf
+        aWQiOiB7IiRvaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwOTYwIn19LCB7
+        Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAv
+        Y29udGVudC91bml0cy9tb2R1bGVtZC85MC82NmY2YjQzYjFiNGRmMDlmOGE2
+        ODc5N2EwN2E4NGZkM2Y1NWU0NzRmN2QzOTkzZWYyYThkYzc0MThkMTAwMSIs
+        ICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0
+        cyI6IFsia2FuZ2Fyb28tMDowLjItMS5ub2FyY2giXSwgImNoZWNrc3VtIjog
+        ImU4MjBlMDhjMDVhYTczNmNlNTMwMDY2YzY4ODI4OGJmNTc0NjA5ODI2N2My
+        ODI0Mjc5ZTM2YzlhNzJlNmI5Y2UiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3
+        NDc3MzMsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2Zp
+        bGVzIjogeyJkZWZhdWx0IjogWyJrYW5nYXJvbyJdfSwgInN1bW1hcnkiOiAi
+        S2FuZ2Fyb28gMC4yIG1vZHVsZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZl
+        cnNpb24iOiAyMDE4MDcwNDExMTcxOSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMiOiAidW5pdHNfbW9k
+        dWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAiM2IxNWViNjgt
+        MTM2My00YTUyLTk4YWUtOTgyMmRhNDg4NDdiIiwgImFyY2giOiAibm9hcmNo
+        IiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUga2FuZ2Fyb28g
+        MC4yIHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1Nzow
+        NVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJj
+        cmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjNiMTVlYjY4LTEzNjMtNGE1
+        Mi05OGFlLTk4MjJkYTQ4ODQ3YiIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRm
+        ZDFmNzNiNjlhODM2NjUwOTM3In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFn
+        ZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVt
+        ZC80MS85YzI2Y2EwMzIyZjA0NThhYjc0ZjU4NzZlMjlhMzY2ZjgwYzJiNDkw
+        MjBmNjYzYWJiOWZmNGJiZGNiZDZjYyIsICJuYW1lIjogIndhbHJ1cyIsICJz
+        dHJlYW0iOiAiNS4yMSIsICJhcnRpZmFjdHMiOiBbIndhbHJ1cy0wOjUuMjEt
+        MS5ub2FyY2giXSwgImNoZWNrc3VtIjogImZjMGNiOTUwZTUzYzVlYTk5YjAz
+        YmNhYzQyNzI1YzYwMjk1ZjE0OGFhYWRlMWE3Y2U2YzdkODAyOGEwNzNiNTki
+        LCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3NDc3MzMsICJfY29udGVudF90eXBl
+        X2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJ3
+        YWxydXMiXX0sICJzdW1tYXJ5IjogIldhbHJ1cyA1LjIxIG1vZHVsZSIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
+        ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
+        W10sICJfaWQiOiAiNDMzN2I3MjEtOWE3MC00MjA3LWJlZTEtNDQwMjk1NDNh
+        YTE0IiwgImFyY2giOiAieDg2XzY0IiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
+        dWxlIGZvciB0aGUgd2FscnVzIDUuMjEgcGFja2FnZSJ9LCAidXBkYXRlZCI6
+        ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJyZXBvX2lkIjogInB1bHAtdXVp
+        ZC1yaGVsXzZfeDg2XzY0IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1
+        NzowNVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRfaWQi
+        OiAiNDMzN2I3MjEtOWE3MC00MjA3LWJlZTEtNDQwMjk1NDNhYTE0IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA5NTQifX0sIHsi
+        bWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9j
+        b250ZW50L3VuaXRzL21vZHVsZW1kLzc4LzY4NzI3YmNjMmE5ZDlhNjAzYmUx
+        YmQ0MDdmNDdlZDg3Yjk2YjEyZWQ2Y2Q1NTU2YmNkY2VhOTFkYTk4MGUwIiwg
+        Im5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZhY3Rz
+        IjogWyJrYW5nYXJvby0wOjAuMy0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAi
+        MDkwMGRkMGZhYTY3ZjkzODY3N2M0YmFhY2YwMDVlYzlkMjQ4MjdhZmEyMTFj
+        YjQxNTdlZDg2ZDM1Y2M4M2ZkZSIsICJfbGFzdF91cGRhdGVkIjogMTYxMzc0
+        NzczMiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmls
+        ZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9vIl19LCAic3VtbWFyeSI6ICJL
+        YW5nYXJvbyAwLjMgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVy
+        c2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAicHVscF91c2VyX21ldGFkYXRhIjog
+        e30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1
+        bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICI1NjgwYzFmMS00
+        Y2M2LTQwMjQtYTcyYy00YTNhNTU2YWM5ODEiLCAiYXJjaCI6ICJub2FyY2gi
+        LCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSBrYW5nYXJvbyAw
+        LjMgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImNy
+        ZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAidW5pdF90eXBlX2lk
+        IjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAiNTY4MGMxZjEtNGNjNi00MDI0
+        LWE3MmMtNGEzYTU1NmFjOTgxIiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZk
+        MWY3M2I2OWE4MzY2NTA5MmUifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdl
+        X3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1k
+        LzFiLzJmMDAzOTY0YmI2NDIxZGU3NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5
+        MzkxMGM3ODBlNTcwMGRjOGE4M2EzIiwgIm5hbWUiOiAiZHVjayIsICJzdHJl
+        YW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImR1Y2stMDowLjYtMS5ub2FyY2gi
+        XSwgImNoZWNrc3VtIjogIjZiZDlkOTA5YzkyNzA1NzFiODExZTUwMjcwOWVh
+        N2I1NjE1MGQ0NGEyYjRiMzRjZmQyNWU1MmE4MWM1YmZjZTciLCAiX2xhc3Rf
+        dXBkYXRlZCI6IDE2MTM3NDc3MzMsICJfY29udGVudF90eXBlX2lkIjogIm1v
+        ZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJkdWNrIl19LCAi
+        c3VtbWFyeSI6ICJEdWNrIDAuNiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRy
+        dWUsICJ2ZXJzaW9uIjogMjAxODA3MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0
+        YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVu
+        aXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogImJm
+        OGI0Y2IxLTliYmEtNDQ1My04M2M1LTViNTI2YTc2YjhjYSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1
+        Y2sgMC42IHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1
+        NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
+        ICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogImJmOGI0Y2IxLTliYmEt
+        NDQ1My04M2M1LTViNTI2YTc2YjhjYSIsICJfaWQiOiB7IiRvaWQiOiAiNjAy
+        ZmRmZDFmNzNiNjlhODM2NjUwOTQ5In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
+        cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1
+        bGVtZC8wNC9mNTU4NmVlMTRkZTRlMzVjNjdhYjA4ZDI2Y2I3YTA1ZTdmZmYw
+        ZGUwN2RjZWFiNjYxMzNhNTgyMGMzODJjZSIsICJuYW1lIjogImR1Y2siLCAi
+        c3RyZWFtIjogIjAiLCAiYXJ0aWZhY3RzIjogWyJkdWNrLTA6MC43LTEubm9h
+        cmNoIl0sICJjaGVja3N1bSI6ICJkZDYyMWMwNThjZGUxZTY3NTc4ZmRjMTcx
+        MzMyNDVhNjUxNzk2YWZjMDg3M2Q4NTZiNzkwYTdmNzAyODI1MDIxIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNjEzNzQ3NzMzLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVsdCI6IFsiZHVjayJd
+        fSwgInN1bW1hcnkiOiAiRHVjayAwLjcgbW9kdWxlIiwgImRvd25sb2FkZWQi
+        OiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzMwMjMzMTAyLCAicHVscF91c2Vy
+        X21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6
+        ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6
+        ICJlNTA4YTU5MS0wODg5LTQ4OTctOGQ5My1iOTkwZmRhMGQyNmIiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRo
+        ZSBkdWNrIDAuNyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlU
+        MTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
+        NjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1bml0
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlNTA4YTU5MS0w
+        ODg5LTQ4OTctOGQ5My1iOTkwZmRhMGQyNmIiLCAiX2lkIjogeyIkb2lkIjog
+        IjYwMmZkZmQxZjczYjY5YTgzNjY1MDk0MCJ9fV0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
+        MjAwMCwic2tpcCI6MjAwMH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
+        MDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '59'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1975'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
+        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAy
+        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
+        ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6ICJ1
+        bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBb
+        eyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2pl
+        Y3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
+        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAi
+        c2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjog
+        IiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE2MTM3NTAyMjUsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
+        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
+        IjogIjIzYjAyNzk1LTI5YmEtNDQ1MC04NTNiLWJiMTNmYjI5YjM3YiJ9LCAi
+        dXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJyZXBvX2lkIjog
+        InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImNyZWF0ZWQiOiAiMjAyMS0w
+        Mi0xOVQxNTo1NzowNVoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAi
+        dW5pdF9pZCI6ICIyM2IwMjc5NS0yOWJhLTQ0NTAtODUzYi1iYjEzZmIyOWIz
+        N2IiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDlk
+        MyJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgtMDEtMjcgMTY6
+        MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5j
+        ZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEy
+        OjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0LmNvbSIsICJzZXZlcml0
+        eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJvb19FcnJhdHVtIiwgIl9u
+        cyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rf
+        c3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50IiwgInBr
+        Z2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZl
+        ZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVjayIsICJzdW0iOiBudWxs
+        LCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gucnBtIiwgImVwb2No
+        IjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJlbGVhc2UiOiAiMSIsICJh
+        cmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0wIiwgIm1v
+        ZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIw
+        MTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZHVj
+        ayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn0sIHsicGFja2FnZXMi
+        OiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJu
+        YW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJr
+        YW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZl
+        cnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
+        aCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwgIm1vZHVsZSI6IHsiY29u
+        dGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIwMTgwNzMwMjIzNDA3
+        IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3Ry
+        ZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUi
+        LCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVUQyIsICJkZXNj
+        cmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlwdGlvbiIs
+        ICJfbGFzdF91cGRhdGVkIjogMTYxMzc1MDIyNSwgInJlc3RhcnRfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAi
+        c29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIs
+        ICJfaWQiOiAiNmI2NWUzODUtMWQyMS00MGMyLWFmODMtNjc4MzIwMjA3M2Fj
+        In0sICJ1cGRhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9f
+        aWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIy
+        MDIxLTAyLTE5VDE1OjU3OjA1WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1
+        bSIsICJ1bml0X2lkIjogIjZiNjVlMzg1LTFkMjEtNDBjMi1hZjgzLTY3ODMy
+        MDIwNzNhYyIsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2
+        NjUwYTI2In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0w
+        MSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVm
+        ZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29u
+        dGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVB
+        LTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAi
+        c2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5IGVycmF0YSIsICJfbnMi
+        OiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1
+        Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0
+        IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjog
+        MTYxMzc1MDIyNSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNo
+        Y291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1
+        bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiN2Y4NGRhYzAt
+        MDI2My00MGY2LWEwMjEtNzljNTZlNzBhM2E4In0sICJ1cGRhdGVkIjogIjIw
+        MjEtMDItMTlUMTU6NTc6MDVaIiwgInJlcG9faWQiOiAicHVscC11dWlkLXJo
+        ZWxfNl94ODZfNjQiLCAiY3JlYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3OjA1
+        WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lkIjogIjdm
+        ODRkYWMwLTAyNjMtNDBmNi1hMDIxLTc5YzU2ZTcwYTNhOCIsICJfaWQiOiB7
+        IiRvaWQiOiAiNjAyZmRmZDFmNzNiNjlhODM2NjUwOTlmIn19LCB7Im1ldGFk
+        YXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxv
+        Z2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVy
+        cmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMiLCAiZnJv
+        bSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0
+        aXRsZSI6ICJBcm1hZGlsbG8iLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5
+        cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJhcm1hZGlsbG8iLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImFybWFk
+        aWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIn1d
+        LCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3Rh
+        dHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6
+        ICJBcm1hZGlsbG8iLCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3NTAyMjUsICJy
+        ZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJy
+        aWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJy
+        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjk4OTNjNWRiLWQ3OGQtNGFmYy1iOTNj
+        LWM4NTU1YTYzNGZiZSJ9LCAidXBkYXRlZCI6ICIyMDIxLTAyLTE5VDE1OjU3
+        OjA1WiIsICJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwg
+        ImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAidW5pdF90eXBl
+        X2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICI5ODkzYzVkYi1kNzhkLTRh
+        ZmMtYjkzYy1jODU1NWE2MzRmYmUiLCAiX2lkIjogeyIkb2lkIjogIjYwMmZk
+        ZmQxZjczYjY5YTgzNjY1MDlmMiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVk
+        IjogIjIwMTItMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjog
+        IktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCAiZnJvbSI6ICJsemFwK3B1YkBy
+        ZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdXBsaWNh
+        dGVkIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0
+        eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7
+        InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUi
+        OiAibGlvbiIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMt
+        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
+        MyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNy
+        YyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAi
+        ZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50
+        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1d
+        LCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3Rh
+        dHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6
+        ICJEdXBsaWNhdGUgT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0
+        ZWQiOiAxNjEzNzUwMjI1LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwg
+        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIi
+        LCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJjZTc4
+        MWMwMS01N2NmLTQ5YjEtOTk4OS1hMDhiZjc2ZThlMmQifSwgInVwZGF0ZWQi
+        OiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6
+        NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQi
+        OiAiY2U3ODFjMDEtNTdjZi00OWIxLTk5ODktYTA4YmY3NmU4ZTJkIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTBhMGMifX0sIHsi
+        bWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwg
+        InJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW3si
+        aHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIw
+        MTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0
+        aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9i
+        dWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02
+        Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAi
+        dGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVyZmxv
+        dyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRwczov
+        L3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0
+        MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1
+        IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0dHA6
+        Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0
+        aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8t
+        UkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQuY29t
+        IiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBvcnRh
+        bnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNfZXJy
+        YXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZh
+        bHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2Fn
+        ZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwg
+        Im5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4MDJm
+        NDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhj
+        NjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEu
+        MC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
+        b24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAi
+        eDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJw
+        bSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2Iiwg
+        ImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4MjQx
+        ODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRl
+        dmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNo
+        IjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMu
+        cnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIs
+        ICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJkZjJl
+        ZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlwMi1s
+        aWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNo
+        IjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMu
+        cnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUz
+        ZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        ZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAi
+        YXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZf
+        MC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQz
+        MTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        MS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6
+        ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEwLTEx
+        LTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEgZnJl
+        ZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nvci4g
+        SXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0
+        YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0
+        X3VwZGF0ZWQiOiAxNjEzNzUwMjI1LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBm
+        YWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAy
+        MDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWlu
+        ZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVh
+        c2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVu
+        IGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhl
+        IFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUg
+        UmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFp
+        bGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RP
+        Qy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMg
+        dGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwg
+        Il9pZCI6ICJmYzM2YWRiYS03NTMyLTQwYmQtYWViYi03Yjc2NmYwZjIwYzYi
+        fSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19p
+        ZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIw
+        MjEtMDItMTlUMTU6NTc6MDVaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVt
+        IiwgInVuaXRfaWQiOiAiZmMzNmFkYmEtNzUzMi00MGJkLWFlYmItN2I3NjZm
+        MGYyMGM2IiwgIl9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2
+        NTA5YjkifX1d
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
+        MDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '62'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:09 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
+        bWl0IjoyMDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '528'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJj
+        b2NrYXRlZWwiLCAiZHVjayIsICJwZW5ndWluIiwgInN0b3JrIl0sICJyZXBv
+        X2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIm5hbWUiOiAiYmly
+        ZCIsICJ1c2VyX3Zpc2libGUiOiB0cnVlLCAiZGVmYXVsdCI6IHRydWUsICJf
+        bnMiOiAidW5pdHNfcGFja2FnZV9ncm91cCIsICJfbGFzdF91cGRhdGVkIjog
+        MTYxMzc0NzczMywgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRy
+        YW5zbGF0ZWRfbmFtZSI6IHt9LCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6
+        IHt9LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2th
+        Z2VfbmFtZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9n
+        cm91cCIsICJpZCI6ICJiaXJkIiwgIl9pZCI6ICIxN2RkNjIwNi05ZDI0LTQ5
+        ZjUtYmM1Mi1jNGE0YzZjMjY2Y2QiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQs
+        ICJjb25kaXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119LCAidXBkYXRlZCI6
+        ICIyMDIxLTAyLTE5VDE1OjU3OjA1WiIsICJyZXBvX2lkIjogInB1bHAtdXVp
+        ZC1yaGVsXzZfeDg2XzY0IiwgImNyZWF0ZWQiOiAiMjAyMS0wMi0xOVQxNTo1
+        NzowNVoiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAidW5p
+        dF9pZCI6ICIxN2RkNjIwNi05ZDI0LTQ5ZjUtYmM1Mi1jNGE0YzZjMjY2Y2Qi
+        LCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MGEzNiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBb
+        ImJlYXIiLCAiY2FtZWwiLCAiY2F0IiwgImNoZWV0YWgiLCAiY2hpbXBhbnpl
+        ZSIsICJjb3ciLCAiZG9nIiwgImRvbHBoaW4iLCAiZWxlcGhhbnQiLCAiZm94
+        IiwgImdpcmFmZmUiLCAiZ29yaWxsYSIsICJob3JzZSIsICJrYW5nYXJvbyIs
+        ICJsaW9uIiwgIm1vdXNlIiwgInNxdWlycmVsIiwgInRpZ2VyIiwgIndhbHJ1
+        cyIsICJ3aGFsZSIsICJ3b2xmIiwgInplYnJhIl0sICJyZXBvX2lkIjogInB1
+        bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIm5hbWUiOiAibWFtbWFsIiwgInVz
+        ZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1
+        bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNjEzNzQ3
+        NzMzLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRl
+        ZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJw
+        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9uYW1l
+        cyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwg
+        ImlkIjogIm1hbW1hbCIsICJfaWQiOiAiMTdmMTBhMWEtOWZlZi00MWZjLWFl
+        ZTAtYzU0Mjk4ZjcyMWExIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29u
+        ZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAy
+        MS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVa
+        IiwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgInVuaXRfaWQi
+        OiAiMTdmMTBhMWEtOWZlZi00MWZjLWFlZTAtYzU0Mjk4ZjcyMWExIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTBhNDIifX1d
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
+        bWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '68'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
+        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '74'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '410'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvM2YvYmIx
+        MTZhN2EwNTRiYTlhMmViYjU1YmNkNWRkN2E3OTg0MzFjNWIyMTY4MjEyMTE3
+        Yzc3MjdjYWJhYzJjODgvYmE4MmQ0YzdhN2MwYjBhNmE1NzUwNmUyNzc1YWEw
+        ZGUwMzYyY2E2YWNmZTVhNWZhZGVkOGU4NzU5OWI5NTIzMi1wcm9kdWN0aWQu
+        Z3oiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJk
+        YXRhX3R5cGUiOiAicHJvZHVjdGlkIiwgImNoZWNrc3VtIjogImJhODJkNGM3
+        YTdjMGIwYTZhNTc1MDZlMjc3NWFhMGRlMDM2MmNhNmFjZmU1YTVmYWRlZDhl
+        ODc1OTliOTUyMzIiLCAiX2xhc3RfdXBkYXRlZCI6IDE2MTM3NTAyMjUsICJf
+        Y29udGVudF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwg
+        Il9ucyI6ICJ1bml0c195dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImNoZWNr
+        c3VtX3R5cGUiOiAic2hhMjU2IiwgIl9pZCI6ICJjMWFkNmY5Mi1lYTMwLTQx
+        Y2MtOGZhOC0yMTdiYjljYmYxOWQifSwgInVwZGF0ZWQiOiAiMjAyMS0wMi0x
+        OVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4
+        Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRf
+        aWQiOiAiYzFhZDZmOTItZWEzMC00MWNjLThmYTgtMjE3YmI5Y2JmMTlkIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI2MDJmZGZkMWY3M2I2OWE4MzY2NTA4MWYifX1d
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
+        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImxpbWl0IjoyMDAw
+        LCJza2lwIjowLCJmaWVsZHMiOnsidW5pdCI6WyJuYW1lIiwidmVyc2lvbiIs
+        InJlbGVhc2UiLCJhcmNoIiwiZXBvY2giLCJzdW1tYXJ5IiwiY2hlY2tzdW0i
+        LCJmaWxlbmFtZSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '150'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
+
+'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '538'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
+        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
+        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
+        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
+        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
+        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
+        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
+        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
+        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
+        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
+        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
+        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNjEzNzUw
+        MjI1LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
+        aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiZTcyY2NjNTYtMDE4
+        ZS00MWEzLTg2NDctMTkzNTY3OGQ3YWYzIiwgImFyY2giOiAieDg2XzY0Iiwg
+        Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAy
+        MS0wMi0xOVQxNTo1NzowNVoiLCAicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NCIsICJjcmVhdGVkIjogIjIwMjEtMDItMTlUMTU6NTc6MDVa
+        IiwgInVuaXRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6
+        ICJlNzJjY2M1Ni0wMThlLTQxYTMtODY0Ny0xOTM1Njc4ZDdhZjMiLCAiX2lk
+        IjogeyIkb2lkIjogIjYwMmZkZmQxZjczYjY5YTgzNjY1MDkyMiJ9fV0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJycG0iLCJyZXBvc2l0b3Jp
+        ZXMiOlt7Im5hbWUiOiJwdWJsaXNoZWRfbGlicmFyeV92aWV3LXJoZWxfNl94
+        ODZfNjRfbGFiZWwiLCJyZXBvc2l0b3J5X3ZlcnNpb25zIjpbeyJwdWxwMl9y
+        ZXBvc2l0b3J5X2lkIjoiOF92aWV3MV9hcmNoaXZlIiwicHVscDJfZGlzdHJp
+        YnV0b3JfcmVwb3NpdG9yeV9pZHMiOlsiOF9jb21wb3NpdGVfdmVyc2lvbjEi
+        LCI4X2NvbXBvc2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwiOF92aWV3MSIsIjhf
+        dmlldzFfYXJjaGl2ZSJdfV19LHsibmFtZSI6InB1bHAtdXVpZC1yaGVsXzZf
+        eDg2XzY0IiwicmVwb3NpdG9yeV92ZXJzaW9ucyI6W3sicHVscDJfcmVwb3Np
+        dG9yeV9pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwicHVscDJfZGlz
+        dHJpYnV0b3JfcmVwb3NpdG9yeV9pZHMiOlsicHVscC11dWlkLXJoZWxfNl94
+        ODZfNjQiXX1dLCJwdWxwMl9pbXBvcnRlcl9yZXBvc2l0b3J5X2lkIjoicHVs
+        cC11dWlkLXJoZWxfNl94ODZfNjQifV19XX19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/4c3aba8b-7ee5-4a70-b97d-1bdcbb6377dc/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '648'
+      Correlation-Id:
+      - 770ec11fd30f46cc9901770b1e6c82b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zLzRj
+        M2FiYThiLTdlZTUtNGE3MC1iOTdkLTFiZGNiYjYzNzdkYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEwLjUzMzY3OFoiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJycG0iLCJyZXBvc2l0b3JpZXMiOlt7Im5h
+        bWUiOiJwdWJsaXNoZWRfbGlicmFyeV92aWV3LXJoZWxfNl94ODZfNjRfbGFi
+        ZWwiLCJyZXBvc2l0b3J5X3ZlcnNpb25zIjpbeyJwdWxwMl9yZXBvc2l0b3J5
+        X2lkIjoiOF92aWV3MV9hcmNoaXZlIiwicHVscDJfZGlzdHJpYnV0b3JfcmVw
+        b3NpdG9yeV9pZHMiOlsiOF9jb21wb3NpdGVfdmVyc2lvbjEiLCI4X2NvbXBv
+        c2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwiOF92aWV3MSIsIjhfdmlldzFfYXJj
+        aGl2ZSJdfV19LHsibmFtZSI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0Iiwi
+        cmVwb3NpdG9yeV92ZXJzaW9ucyI6W3sicHVscDJfcmVwb3NpdG9yeV9pZCI6
+        InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwicHVscDJfZGlzdHJpYnV0b3Jf
+        cmVwb3NpdG9yeV9pZHMiOlsicHVscC11dWlkLXJoZWxfNl94ODZfNjQiXX1d
+        LCJwdWxwMl9pbXBvcnRlcl9yZXBvc2l0b3J5X2lkIjoicHVscC11dWlkLXJo
+        ZWxfNl94ODZfNjQifV19XX19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/4c3aba8b-7ee5-4a70-b97d-1bdcbb6377dc/run/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkcnlfcnVuIjpmYWxzZSwidmFsaWRhdGUiOnRydWV9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:10 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7aeaa093a7c649d7ab07383cfa7b8e15
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwYmQ0YTkxLThjOTAtNDVk
+        OS1hOThiLTk5OGVhZDQyYzk4Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/30bd4a91-8c90-45d9-a98b-998ead42c98c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - dbf077330c514bcfbb5a89887b2d27ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1034'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBiZDRhOTEtOGM5
+        MC00NWQ5LWE5OGItOTk4ZWFkNDJjOThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTU6NTc6MTAuNTk2NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI3YWVhYTA5
+        M2E3YzY0OWQ3YWIwNzM4M2NmYTdiOGUxNSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE1OjU3OjEwLjcxMzcwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTU6NTc6MTcuMjI4MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy83ZGY5NTAzNi1mN2UxLTQyN2YtYTRh
+        OS1hNjkxMDFmZDNkYzkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9kY2MzZGRlMy01MmYwLTQxNmMt
+        OWQ1MC0xMTVlMjc2ODA5ZmIvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyODZi
+        NTgxLTIxMDQtNDAxNS04ZThjLWYzZTcwMjBjZGExMy8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy9jOThmODZkYS05OTk4LTQy
+        MDctOTExMC1kMzExODU0Nzg5NmUvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25l
+        Ijo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIFJQTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjoxNDAxLCJkb25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFJQTSBjb250ZW50IChk
+        ZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0
+        YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTQwMSwiZG9uZSI6
+        MTQwMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5n
+        IFB1bHAgMiBTUlBNIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoi
+        cHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgU1JQTSBjb250ZW50IChkZXRh
+        aWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWls
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBE
+        SVNUUklCVVRJT04gY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJw
+        cmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBESVNUUklCVVRJT04gY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUi
+        OjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgRVJSQVRVTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6
+        InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxMiwiZG9uZSI6MTIsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRVJSQVRVTSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTIsImRvbmUi
+        OjEyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIE1PRFVMRU1EIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2Rl
+        IjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgTU9EVUxFTUQgY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYsImRvbmUi
+        OjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgTU9EVUxFTURfREVGQVVMVFMgY29udGVudCAoZ2VuZXJhbCBpbmZv
+        KSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBNT0RVTEVN
+        RF9ERUZBVUxUUyBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJl
+        bWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQcmUtbWlncmF0aW5nIFB1bHAgMiBZVU1fUkVQT19NRVRBREFUQV9GSUxF
+        IGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5n
+        LmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1p
+        Z3JhdGluZyBQdWxwIDIgWVVNX1JFUE9fTUVUQURBVEFfRklMRSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6
+        Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0xBTkdQQUNLUyBjb250ZW50IChnZW5lcmFsIGluZm8p
+        IiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0Vf
+        TEFOR1BBQ0tTIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfR1JPVVAgY29udGVudCAo
+        Z2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5n
+        ZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0dST1VQIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfQ0FURUdP
+        UlkgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRp
+        bmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUt
+        bWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0NBVEVHT1JZIGNvbnRlbnQgKGRl
+        dGFpbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRh
+        aWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAy
+        IFBBQ0tBR0VfRU5WSVJPTk1FTlQgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIs
+        ImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0VO
+        VklST05NRU5UIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IkNyZWF0aW5nIHJlcG9zaXRvcmllcyBpbiBQdWxwIDMiLCJjb2RlIjoiY3Jl
+        YXRpbmcucmVwb3NpdG9yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdy
+        YXRpbmcgaW1wb3J0ZXJzIHRvIFB1bHAgMyIsImNvZGUiOiJtaWdyYXRpbmcu
+        aW1wb3J0ZXJzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9u
+        ZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBt
+        IGNvbnRlbnQgdG8gUHVscCAzIHJwbSIsImNvZGUiOiJtaWdyYXRpbmcucnBt
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDAxLCJk
+        b25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgc3JwbSIsImNvZGUiOiJtaWdyYXRp
+        bmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgZGlzdHJpYnV0aW9uIiwiY29kZSI6
+        Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        TWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBlcnJhdHVtIiwiY29k
+        ZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOjEyLCJkb25lIjoxMiwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIG1vZHVsZW1k
+        IiwiY29kZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiTWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBtb2R1
+        bGVtZF9kZWZhdWx0cyIsImNvZGUiOiJtaWdyYXRpbmcucnBtLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBycG0gY29udGVudCB0
+        byBQdWxwIDMgeXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsImNvZGUiOiJtaWdy
+        YXRpbmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3Jh
+        dGluZyBycG0gY29udGVudCB0byBQdWxwIDMgcGFja2FnZV9sYW5ncGFja3Mi
+        LCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIHBhY2th
+        Z2VfZ3JvdXAiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVs
+        cCAzIHBhY2thZ2VfY2F0ZWdvcnkiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5j
+        b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNv
+        bnRlbnQgdG8gUHVscCAzIHBhY2thZ2VfZW52aXJvbm1lbnQiLCJjb2RlIjoi
+        bWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgY29udGVudCB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDM2LCJk
+        b25lIjoxNDM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzL2M5OGY4NmRhLTk5OTgtNDIw
+        Ny05MTEwLWQzMTE4NTQ3ODk2ZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/c98f86da-9998-4207-9110-d3118547896e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2d925dd9fdd6485da174b099969e0a67
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '275'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYzk4Zjg2
+        ZGEtOTk5OC00MjA3LTkxMTAtZDMxMTg1NDc4OTZlLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjoxLCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJj
+        b21wbGV0ZWQiOjEsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjUsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/30bd4a91-8c90-45d9-a98b-998ead42c98c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 68a094c3689c42c1a5c11d41c11f4dec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1034'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBiZDRhOTEtOGM5
+        MC00NWQ5LWE5OGItOTk4ZWFkNDJjOThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTU6NTc6MTAuNTk2NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI3YWVhYTA5
+        M2E3YzY0OWQ3YWIwNzM4M2NmYTdiOGUxNSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE1OjU3OjEwLjcxMzcwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTU6NTc6MTcuMjI4MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy83ZGY5NTAzNi1mN2UxLTQyN2YtYTRh
+        OS1hNjkxMDFmZDNkYzkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9lMjg2YjU4MS0yMTA0LTQwMTUt
+        OGU4Yy1mM2U3MDIwY2RhMTMvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzNk
+        ZGUzLTUyZjAtNDE2Yy05ZDUwLTExNWUyNzY4MDlmYi8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy9jOThmODZkYS05OTk4LTQy
+        MDctOTExMC1kMzExODU0Nzg5NmUvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25l
+        Ijo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIFJQTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjoxNDAxLCJkb25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFJQTSBjb250ZW50IChk
+        ZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0
+        YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTQwMSwiZG9uZSI6
+        MTQwMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5n
+        IFB1bHAgMiBTUlBNIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoi
+        cHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgU1JQTSBjb250ZW50IChkZXRh
+        aWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWls
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBE
+        SVNUUklCVVRJT04gY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJw
+        cmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBESVNUUklCVVRJT04gY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUi
+        OjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgRVJSQVRVTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6
+        InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxMiwiZG9uZSI6MTIsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRVJSQVRVTSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTIsImRvbmUi
+        OjEyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIE1PRFVMRU1EIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2Rl
+        IjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgTU9EVUxFTUQgY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYsImRvbmUi
+        OjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgTU9EVUxFTURfREVGQVVMVFMgY29udGVudCAoZ2VuZXJhbCBpbmZv
+        KSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBNT0RVTEVN
+        RF9ERUZBVUxUUyBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJl
+        bWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQcmUtbWlncmF0aW5nIFB1bHAgMiBZVU1fUkVQT19NRVRBREFUQV9GSUxF
+        IGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5n
+        LmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1p
+        Z3JhdGluZyBQdWxwIDIgWVVNX1JFUE9fTUVUQURBVEFfRklMRSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6
+        Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0xBTkdQQUNLUyBjb250ZW50IChnZW5lcmFsIGluZm8p
+        IiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0Vf
+        TEFOR1BBQ0tTIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfR1JPVVAgY29udGVudCAo
+        Z2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5n
+        ZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0dST1VQIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfQ0FURUdP
+        UlkgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRp
+        bmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUt
+        bWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0NBVEVHT1JZIGNvbnRlbnQgKGRl
+        dGFpbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRh
+        aWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAy
+        IFBBQ0tBR0VfRU5WSVJPTk1FTlQgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIs
+        ImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0VO
+        VklST05NRU5UIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IkNyZWF0aW5nIHJlcG9zaXRvcmllcyBpbiBQdWxwIDMiLCJjb2RlIjoiY3Jl
+        YXRpbmcucmVwb3NpdG9yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdy
+        YXRpbmcgaW1wb3J0ZXJzIHRvIFB1bHAgMyIsImNvZGUiOiJtaWdyYXRpbmcu
+        aW1wb3J0ZXJzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9u
+        ZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBt
+        IGNvbnRlbnQgdG8gUHVscCAzIHJwbSIsImNvZGUiOiJtaWdyYXRpbmcucnBt
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDAxLCJk
+        b25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgc3JwbSIsImNvZGUiOiJtaWdyYXRp
+        bmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgZGlzdHJpYnV0aW9uIiwiY29kZSI6
+        Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        TWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBlcnJhdHVtIiwiY29k
+        ZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOjEyLCJkb25lIjoxMiwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIG1vZHVsZW1k
+        IiwiY29kZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiTWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBtb2R1
+        bGVtZF9kZWZhdWx0cyIsImNvZGUiOiJtaWdyYXRpbmcucnBtLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBycG0gY29udGVudCB0
+        byBQdWxwIDMgeXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsImNvZGUiOiJtaWdy
+        YXRpbmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3Jh
+        dGluZyBycG0gY29udGVudCB0byBQdWxwIDMgcGFja2FnZV9sYW5ncGFja3Mi
+        LCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIHBhY2th
+        Z2VfZ3JvdXAiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVs
+        cCAzIHBhY2thZ2VfY2F0ZWdvcnkiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5j
+        b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNv
+        bnRlbnQgdG8gUHVscCAzIHBhY2thZ2VfZW52aXJvbm1lbnQiLCJjb2RlIjoi
+        bWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgY29udGVudCB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDM2LCJk
+        b25lIjoxNDM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzL2M5OGY4NmRhLTk5OTgtNDIw
+        Ny05MTEwLWQzMTE4NTQ3ODk2ZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/c98f86da-9998-4207-9110-d3118547896e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c3b099a2b00745cb9c7eab8f2c2df99f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '277'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYzk4Zjg2
+        ZGEtOTk5OC00MjA3LTkxMTAtZDMxMTg1NDc4OTZlLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJj
+        b21wbGV0ZWQiOjEsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjUsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/30bd4a91-8c90-45d9-a98b-998ead42c98c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c0e0662e41e149e1810bb9eca6c871a8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1034'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBiZDRhOTEtOGM5
+        MC00NWQ5LWE5OGItOTk4ZWFkNDJjOThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTU6NTc6MTAuNTk2NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI3YWVhYTA5
+        M2E3YzY0OWQ3YWIwNzM4M2NmYTdiOGUxNSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE1OjU3OjEwLjcxMzcwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTU6NTc6MTcuMjI4MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy83ZGY5NTAzNi1mN2UxLTQyN2YtYTRh
+        OS1hNjkxMDFmZDNkYzkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9lMjg2YjU4MS0yMTA0LTQwMTUt
+        OGU4Yy1mM2U3MDIwY2RhMTMvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzNk
+        ZGUzLTUyZjAtNDE2Yy05ZDUwLTExNWUyNzY4MDlmYi8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy9jOThmODZkYS05OTk4LTQy
+        MDctOTExMC1kMzExODU0Nzg5NmUvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25l
+        Ijo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIFJQTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjoxNDAxLCJkb25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFJQTSBjb250ZW50IChk
+        ZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0
+        YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTQwMSwiZG9uZSI6
+        MTQwMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5n
+        IFB1bHAgMiBTUlBNIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoi
+        cHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgU1JQTSBjb250ZW50IChkZXRh
+        aWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWls
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBE
+        SVNUUklCVVRJT04gY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJw
+        cmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBESVNUUklCVVRJT04gY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUi
+        OjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgRVJSQVRVTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6
+        InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxMiwiZG9uZSI6MTIsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRVJSQVRVTSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTIsImRvbmUi
+        OjEyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIE1PRFVMRU1EIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2Rl
+        IjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgTU9EVUxFTUQgY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYsImRvbmUi
+        OjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgTU9EVUxFTURfREVGQVVMVFMgY29udGVudCAoZ2VuZXJhbCBpbmZv
+        KSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBNT0RVTEVN
+        RF9ERUZBVUxUUyBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJl
+        bWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQcmUtbWlncmF0aW5nIFB1bHAgMiBZVU1fUkVQT19NRVRBREFUQV9GSUxF
+        IGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5n
+        LmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1p
+        Z3JhdGluZyBQdWxwIDIgWVVNX1JFUE9fTUVUQURBVEFfRklMRSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6
+        Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0xBTkdQQUNLUyBjb250ZW50IChnZW5lcmFsIGluZm8p
+        IiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0Vf
+        TEFOR1BBQ0tTIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfR1JPVVAgY29udGVudCAo
+        Z2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5n
+        ZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0dST1VQIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfQ0FURUdP
+        UlkgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRp
+        bmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUt
+        bWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0NBVEVHT1JZIGNvbnRlbnQgKGRl
+        dGFpbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRh
+        aWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAy
+        IFBBQ0tBR0VfRU5WSVJPTk1FTlQgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIs
+        ImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0VO
+        VklST05NRU5UIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IkNyZWF0aW5nIHJlcG9zaXRvcmllcyBpbiBQdWxwIDMiLCJjb2RlIjoiY3Jl
+        YXRpbmcucmVwb3NpdG9yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdy
+        YXRpbmcgaW1wb3J0ZXJzIHRvIFB1bHAgMyIsImNvZGUiOiJtaWdyYXRpbmcu
+        aW1wb3J0ZXJzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9u
+        ZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBt
+        IGNvbnRlbnQgdG8gUHVscCAzIHJwbSIsImNvZGUiOiJtaWdyYXRpbmcucnBt
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDAxLCJk
+        b25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgc3JwbSIsImNvZGUiOiJtaWdyYXRp
+        bmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgZGlzdHJpYnV0aW9uIiwiY29kZSI6
+        Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        TWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBlcnJhdHVtIiwiY29k
+        ZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOjEyLCJkb25lIjoxMiwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIG1vZHVsZW1k
+        IiwiY29kZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiTWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBtb2R1
+        bGVtZF9kZWZhdWx0cyIsImNvZGUiOiJtaWdyYXRpbmcucnBtLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBycG0gY29udGVudCB0
+        byBQdWxwIDMgeXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsImNvZGUiOiJtaWdy
+        YXRpbmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3Jh
+        dGluZyBycG0gY29udGVudCB0byBQdWxwIDMgcGFja2FnZV9sYW5ncGFja3Mi
+        LCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIHBhY2th
+        Z2VfZ3JvdXAiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVs
+        cCAzIHBhY2thZ2VfY2F0ZWdvcnkiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5j
+        b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNv
+        bnRlbnQgdG8gUHVscCAzIHBhY2thZ2VfZW52aXJvbm1lbnQiLCJjb2RlIjoi
+        bWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgY29udGVudCB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDM2LCJk
+        b25lIjoxNDM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzL2M5OGY4NmRhLTk5OTgtNDIw
+        Ny05MTEwLWQzMTE4NTQ3ODk2ZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/c98f86da-9998-4207-9110-d3118547896e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 105e4ebca98449b88d91097902db58c2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '278'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYzk4Zjg2
+        ZGEtOTk5OC00MjA3LTkxMTAtZDMxMTg1NDc4OTZlLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJj
+        b21wbGV0ZWQiOjIsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjUsImRvbmUiOjQsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/tasks/30bd4a91-8c90-45d9-a98b-998ead42c98c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:17 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f1a42c484329491cae00dbe07de7c4fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1034'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzBiZDRhOTEtOGM5
+        MC00NWQ5LWE5OGItOTk4ZWFkNDJjOThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDItMTlUMTU6NTc6MTAuNTk2NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwibG9nZ2luZ19jaWQiOiI3YWVhYTA5
+        M2E3YzY0OWQ3YWIwNzM4M2NmYTdiOGUxNSIsInN0YXJ0ZWRfYXQiOiIyMDIx
+        LTAyLTE5VDE1OjU3OjEwLjcxMzcwMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEt
+        MDItMTlUMTU6NTc6MTcuMjI4MzI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy83ZGY5NTAzNi1mN2UxLTQyN2YtYTRh
+        OS1hNjkxMDFmZDNkYzkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        c2tzIjpbIi9wdWxwL2FwaS92My90YXNrcy9lMjg2YjU4MS0yMTA0LTQwMTUt
+        OGU4Yy1mM2U3MDIwY2RhMTMvIiwiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjYzNk
+        ZGUzLTUyZjAtNDE2Yy05ZDUwLTExNWUyNzY4MDlmYi8iXSwidGFza19ncm91
+        cCI6Ii9wdWxwL2FwaS92My90YXNrLWdyb3Vwcy9jOThmODZkYS05OTk4LTQy
+        MDctOTExMC1kMzExODU0Nzg5NmUvIiwicHJvZ3Jlc3NfcmVwb3J0cyI6W3si
+        bWVzc2FnZSI6IlByb2Nlc3NpbmcgUHVscCAyIHJlcG9zaXRvcmllcywgaW1w
+        b3J0ZXJzLCBkaXN0cmlidXRvcnMiLCJjb2RlIjoicHJvY2Vzc2luZy5yZXBv
+        c2l0b3JpZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo3LCJkb25l
+        Ijo3LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIFJQTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InBy
+        ZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjoxNDAxLCJkb25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFJQTSBjb250ZW50IChk
+        ZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0
+        YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTQwMSwiZG9uZSI6
+        MTQwMSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5n
+        IFB1bHAgMiBTUlBNIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoi
+        cHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxl
+        dGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgU1JQTSBjb250ZW50IChkZXRh
+        aWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZGV0YWls
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBE
+        SVNUUklCVVRJT04gY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJw
+        cmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBESVNUUklCVVRJT04gY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUi
+        OjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgRVJSQVRVTSBjb250ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6
+        InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxMiwiZG9uZSI6MTIsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgRVJSQVRVTSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTIsImRvbmUi
+        OjEyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcg
+        UHVscCAyIE1PRFVMRU1EIGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2Rl
+        IjoicHJlbWlncmF0aW5nLmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQdWxwIDIgTU9EVUxFTUQgY29udGVu
+        dCAoZGV0YWlsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50
+        LmRldGFpbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjYsImRvbmUi
+        OjYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGluZyBQ
+        dWxwIDIgTU9EVUxFTURfREVGQVVMVFMgY29udGVudCAoZ2VuZXJhbCBpbmZv
+        KSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBNT0RVTEVN
+        RF9ERUZBVUxUUyBjb250ZW50IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJl
+        bWlncmF0aW5nLmNvbnRlbnQuZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJQcmUtbWlncmF0aW5nIFB1bHAgMiBZVU1fUkVQT19NRVRBREFUQV9GSUxF
+        IGNvbnRlbnQgKGdlbmVyYWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5n
+        LmNvbnRlbnQuZ2VuZXJhbCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJlLW1p
+        Z3JhdGluZyBQdWxwIDIgWVVNX1JFUE9fTUVUQURBVEFfRklMRSBjb250ZW50
+        IChkZXRhaWwgaW5mbykiLCJjb2RlIjoicHJlbWlncmF0aW5nLmNvbnRlbnQu
+        ZGV0YWlsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9uZSI6
+        Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0xBTkdQQUNLUyBjb250ZW50IChnZW5lcmFsIGluZm8p
+        IiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250ZW50LmdlbmVyYWwiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0Vf
+        TEFOR1BBQ0tTIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfR1JPVVAgY29udGVudCAo
+        Z2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5n
+        ZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6
+        NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1
+        bHAgMiBQQUNLQUdFX0dST1VQIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNv
+        ZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsi
+        bWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIFBBQ0tBR0VfQ0FURUdP
+        UlkgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRp
+        bmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQcmUt
+        bWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0NBVEVHT1JZIGNvbnRlbnQgKGRl
+        dGFpbCBpbmZvKSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRh
+        aWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAy
+        IFBBQ0tBR0VfRU5WSVJPTk1FTlQgY29udGVudCAoZ2VuZXJhbCBpbmZvKSIs
+        ImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5nZW5lcmFsIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJQcmUtbWlncmF0aW5nIFB1bHAgMiBQQUNLQUdFX0VO
+        VklST05NRU5UIGNvbnRlbnQgKGRldGFpbCBpbmZvKSIsImNvZGUiOiJwcmVt
+        aWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IkNyZWF0aW5nIHJlcG9zaXRvcmllcyBpbiBQdWxwIDMiLCJjb2RlIjoiY3Jl
+        YXRpbmcucmVwb3NpdG9yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdy
+        YXRpbmcgaW1wb3J0ZXJzIHRvIFB1bHAgMyIsImNvZGUiOiJtaWdyYXRpbmcu
+        aW1wb3J0ZXJzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9u
+        ZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBt
+        IGNvbnRlbnQgdG8gUHVscCAzIHJwbSIsImNvZGUiOiJtaWdyYXRpbmcucnBt
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDAxLCJk
+        b25lIjoxNDAxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgc3JwbSIsImNvZGUiOiJtaWdyYXRp
+        bmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjow
+        LCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGlu
+        ZyBycG0gY29udGVudCB0byBQdWxwIDMgZGlzdHJpYnV0aW9uIiwiY29kZSI6
+        Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        TWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBlcnJhdHVtIiwiY29k
+        ZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOjEyLCJkb25lIjoxMiwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIG1vZHVsZW1k
+        IiwiY29kZSI6Im1pZ3JhdGluZy5ycG0uY29udGVudCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjYsImRvbmUiOjYsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiTWlncmF0aW5nIHJwbSBjb250ZW50IHRvIFB1bHAgMyBtb2R1
+        bGVtZF9kZWZhdWx0cyIsImNvZGUiOiJtaWdyYXRpbmcucnBtLmNvbnRlbnQi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo2LCJkb25lIjo2LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBycG0gY29udGVudCB0
+        byBQdWxwIDMgeXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsImNvZGUiOiJtaWdy
+        YXRpbmcucnBtLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3Jh
+        dGluZyBycG0gY29udGVudCB0byBQdWxwIDMgcGFja2FnZV9sYW5ncGFja3Mi
+        LCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVscCAzIHBhY2th
+        Z2VfZ3JvdXAiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNvbnRlbnQgdG8gUHVs
+        cCAzIHBhY2thZ2VfY2F0ZWdvcnkiLCJjb2RlIjoibWlncmF0aW5nLnJwbS5j
+        b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJNaWdyYXRpbmcgcnBtIGNv
+        bnRlbnQgdG8gUHVscCAzIHBhY2thZ2VfZW52aXJvbm1lbnQiLCJjb2RlIjoi
+        bWlncmF0aW5nLnJwbS5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJN
+        aWdyYXRpbmcgY29udGVudCB0byBQdWxwIDMiLCJjb2RlIjoibWlncmF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxNDM2LCJk
+        b25lIjoxNDM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzL2M5OGY4NmRhLTk5OTgtNDIw
+        Ny05MTEwLWQzMTE4NTQ3ODk2ZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3Jl
+        Y29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/task-groups/c98f86da-9998-4207-9110-d3118547896e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.9.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1573fee87d3c491c86099fe38267062f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '278'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYzk4Zjg2
+        ZGEtOTk5OC00MjA3LTkxMTAtZDMxMTg1NDc4OTZlLyIsImRlc2NyaXB0aW9u
+        IjoiTWlncmF0aW9uIFN1Yi10YXNrcyIsImFsbF90YXNrc19kaXNwYXRjaGVk
+        Ijp0cnVlLCJ3YWl0aW5nIjowLCJza2lwcGVkIjowLCJydW5uaW5nIjowLCJj
+        b21wbGV0ZWQiOjMsImNhbmNlbGVkIjowLCJmYWlsZWQiOjAsImdyb3VwX3By
+        b2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJSZXBvIHZlcnNpb24gY3Jl
+        YXRpb24iLCJjb2RlIjoiY3JlYXRlLnJlcG9fdmVyc2lvbiIsInRvdGFsIjoy
+        LCJkb25lIjoyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRpc3RyaWJ1
+        dGlvbiBjcmVhdGlvbiIsImNvZGUiOiJjcmVhdGUuZGlzdHJpYnV0aW9uIiwi
+        dG90YWwiOjUsImRvbmUiOjUsInN1ZmZpeCI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2repositories/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0d95b4a71c144d119886555e36f0f011
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '653'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMnJlcG9zaXRv
+        cmllcy8wMmUyYTg2MS1jMmVhLTQ4MTMtYmY1NC0yNDAyYjAzYTk0OTUvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMC45MDIzODhaIiwi
+        cHVscDJfb2JqZWN0X2lkIjoiNjAyZmRmZDI3YWNjZTkzNTEyODEzZTY0Iiwi
+        cHVscDJfcmVwb19pZCI6IjhfdmlldzFfYXJjaGl2ZSIsInB1bHAyX3JlcG9f
+        dHlwZSI6InJwbSIsImlzX21pZ3JhdGVkIjp0cnVlLCJub3RfaW5fcGxhbiI6
+        ZmFsc2UsInB1bHAzX3JlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xNjc1YTViYi1hNmFhLTQ4NWYtOGE5
+        OC0wNTQ1ZTZlMmM2OTAvdmVyc2lvbnMvMS8iLCJwdWxwM19yZW1vdGVfaHJl
+        ZiI6bnVsbCwicHVscDNfcHVibGljYXRpb25faHJlZiI6Ii9wdWxwL2FwaS92
+        My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9iNzFjYzE1Ni1lYzJjLTQ0YWYtOTc2
+        OC1lZTE5ZTU0ZjU2ZGUvIiwicHVscDNfZGlzdHJpYnV0aW9uX2hyZWZzIjpb
+        Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vOWVlNWQ4OWIt
+        M2RlMy00NDRjLThlYzEtMjgxOWVmZTlhZjVmLyIsIi9wdWxwL2FwaS92My9k
+        aXN0cmlidXRpb25zL3JwbS9ycG0vOTIyYTk5MzktZmI4NC00MWVlLTk3ZmYt
+        NDRmMzg1YzVjODNjLyIsIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3Jw
+        bS9ycG0vNzYxYzcyMTMtZDdiNS00NTYwLWE1YjAtMmM3NzBhODUwOWYxLyIs
+        Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYzJmZmE1ZWIt
+        Nzk3OS00NmQ4LWFjOTctNGQxMDFhMDA3ZjhjLyJdLCJwdWxwM19yZXBvc2l0
+        b3J5X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
+        MTY3NWE1YmItYTZhYS00ODVmLThhOTgtMDU0NWU2ZTJjNjkwLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAycmVwb3NpdG9yaWVzL2VhYzE1
+        NmMwLTkxNWItNDUyOC1iMzMwLTk5YzcxMjc2ZWVhNS8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEwLjg3NjIwNVoiLCJwdWxwMl9vYmpl
+        Y3RfaWQiOiI2MDJmZGZkMDdhY2NlOTM1MTExMjFiNDEiLCJwdWxwMl9yZXBv
+        X2lkIjoicHVscC11dWlkLXJoZWxfNl94ODZfNjQiLCJwdWxwMl9yZXBvX3R5
+        cGUiOiJycG0iLCJpc19taWdyYXRlZCI6dHJ1ZSwibm90X2luX3BsYW4iOmZh
+        bHNlLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYjAzNzYzZmItNmY0NC00OWRkLWI1YjUt
+        ZDYwYjI3ODBmYmE5L3ZlcnNpb25zLzEvIiwicHVscDNfcmVtb3RlX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc1NjYyZjRmLTgyMjYt
+        NDYxOC05NTlmLWM5NjZkOTEwNjBkOS8iLCJwdWxwM19wdWJsaWNhdGlvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtL2JmZjFi
+        YzIzLTJkZDctNGM0Yi1iYTFlLWZiY2Y0NTlmODJjOS8iLCJwdWxwM19kaXN0
+        cmlidXRpb25faHJlZnMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        cnBtL3JwbS9mNGJmNzkyMy04MTQ1LTQwMmEtOGI5My1mMzllNDE0NjFkZDMv
+        Il0sInB1bHAzX3JlcG9zaXRvcnlfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcnBtL3JwbS9iMDM3NjNmYi02ZjQ0LTQ5ZGQtYjViNS1kNjBi
+        Mjc4MGZiYTkvIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/9ee5d89b-3de3-444c-8ec1-2819efe9af5f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 953981a87f044519a8b20aa27bb62412
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '317'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzllZTVkODliLTNkZTMtNDQ0Yy04ZWMxLTI4MTllZmU5YWY1Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE3LjY0MjkzMloiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNo
+        aXZlL3JoZWxfNl9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29u
+        dGVudC9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9hcmNoaXZlL3Jo
+        ZWxfNl9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiNjAy
+        ZmRmZDI3YWNjZTkzNTEyODEzZTY2LThfdmlldzFfYXJjaGl2ZSIsInB1Ymxp
+        Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtL2I3
+        MWNjMTU2LWVjMmMtNDRhZi05NzY4LWVlMTllNTRmNTZkZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/922a9939-fb84-41ee-97ff-44f385c5c83c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - dbc8345c0d704579a152aaac661f68bb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '309'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzkyMmE5OTM5LWZiODQtNDFlZS05N2ZmLTQ0ZjM4NWM1YzgzYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE3LjY1ODU5MVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnlfdmlldy9yaGVs
+        XzZfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNN
+        RV9Db3Jwb3JhdGlvbi9saWJyYXJ5X3ZpZXcvcmhlbF82X2xhYmVsLyIsImNv
+        bnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiI2MDJmZGZkMjdhY2NlOTM1MTEx
+        MjFiNDgtOF92aWV3MSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
+        YmxpY2F0aW9ucy9ycG0vcnBtL2I3MWNjMTU2LWVjMmMtNDRhZi05NzY4LWVl
+        MTllNTRmNTZkZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/761c7213-d7b5-4560-a5b0-2c770a8509f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e97cb5846708468fa997514e0a410cae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '320'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzc2MWM3MjEzLWQ3YjUtNDU2MC1hNWIwLTJjNzcwYTg1MDlmMS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE3LjY3MzA1MFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2NvbXBvc2l0ZS9hcmNoaXZl
+        L3JoZWxfNl9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29udGVu
+        dC9BQ01FX0NvcnBvcmF0aW9uL2NvbXBvc2l0ZS9hcmNoaXZlL3JoZWxfNl9s
+        YWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiNjAyZmRmZDI3
+        YWNjZTkzNTExMTIxYjRkLThfY29tcG9zaXRlX3ZlcnNpb24xX2FyY2hpdmUi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS9iNzFjYzE1Ni1lYzJjLTQ0YWYtOTc2OC1lZTE5ZTU0ZjU2ZGUvIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/c2ffa5eb-7979-46d8-ac97-4d101a007f8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 90f6764ee4fc4abfb5492608c9e64925
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '317'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2MyZmZhNWViLTc5NzktNDZkOC1hYzk3LTRkMTAxYTAwN2Y4Yy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE3LjY4NjEyN1oiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvY29tcG9zaXRl
+        L3JoZWxfNl9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29udGVu
+        dC9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvY29tcG9zaXRlL3JoZWxfNl9s
+        YWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiNjAyZmRmZDI3
+        YWNjZTkzNTExMTIxYjUyLThfY29tcG9zaXRlX3ZlcnNpb24xIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYjcx
+        Y2MxNTYtZWMyYy00NGFmLTk3NjgtZWUxOWU1NGY1NmRlLyJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/f4bf7923-8145-402a-8b93-f39e41461dd3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c2b80a5cd7d54d139087d49efc8c6bf7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2Y0YmY3OTIzLTgxNDUtNDAyYS04YjkzLWYzOWU0MTQ2MWRkMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE3Ljc3MzQ4NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF82X2xh
+        YmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczcta2F0ZWxsby1kZXZl
+        bC0yLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9yaGVsXzZfbGFiZWwvIiwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwibmFtZSI6IjYwMmZkZmQwN2FjY2U5MzUxMTEyMWI0My1wdWxw
+        LXV1aWQtcmhlbF82X3g4Nl82NCIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtL2JmZjFiYzIzLTJkZDctNGM0Yi1i
+        YTFlLWZiY2Y0NTlmODJjOS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=three-uuid,two-uuid,one-uuid,modular,one-uuid-two,0edc1080-68d8-44a8-8ae6-03a1afed5654,267a63f8-51ac-4de2-95ff-39ebd1477adc,3f9a2bec-135e-4c89-b78f-54be2911158b,58f7f3d6-0f5d-44a0-915a-a51d379d6ac2,5965cad8-e60c-4607-aefd-e5cacd1ec296,60f991c8-e484-4a18-b954-b00bed546870,65ce37bd-c8e0-479e-8b5c-1105e465df12,6a140842-b349-43e4-ac12-a61c71de62bf,936d1e27-10d9-4797-a381-f94cc7c7406c,a5340fe8-70af-446b-a857-79f88b926739,a914edcd-f3aa-4eab-8826-380dceb7d803,bc2e4add-3742-4c21-8997-ac8152f04969,ce38e688-edbc-420c-bc21-0cc46fd3d84f,d2943a8d-d0bd-41a7-a756-d4c49c5f5a7c,da34e68d-88dd-40ba-ae46-c3737f09fd30,e7962155-e8b1-4d4a-b02a-d2413e2c44c7,eb604e31-abff-44d2-bb37-70b0a4db352d,ebb13467-c764-496e-a64f-72013c3e8714,f3021dc7-120b-42f6-a3b5-16e994752890
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:18 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e0c8ac7bb57c499394eb86e2ccffebca
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '2644'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTksIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50
+        LzBlY2U0YmVjLWJmMzctNDgwMS1hODhiLTBkODUxYTMyNTI3ZS8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEyLjAzNDc3N1oiLCJwdWxw
+        Ml9pZCI6IjYwZjk5MWM4LWU0ODQtNGExOC1iOTU0LWIwMGJlZDU0Njg3MCIs
+        InB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6InJwbSIsInB1bHAyX2xhc3RfdXBk
+        YXRlZCI6MTYxMzc0NzczMywicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9jNC8xMWUxZDE0N2I2NTY3ZTU3
+        ZDBlNjU4ZmQ0ZjU1Zjc0ZWViYzY4ZDUwMGViYTFiNGJkMjRkMDM1MzA1Nzc4
+        MC93YWxydXMtNS4yMS0xLm5vYXJjaC5ycG0iLCJkb3dubG9hZGVkIjp0cnVl
+        LCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Bh
+        Y2thZ2VzLzFlOWFjNjVhLTM2M2MtNDM2OS05YWM0LTViMDYyMDU2N2UwYi8i
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvZTk0
+        MDFkYTAtYzQ1ZC00MzlhLWJhNzMtZmIzZWNiMjgzN2Y5LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTIuMDM0NzU2WiIsInB1bHAyX2lk
+        IjoiZDI5NDNhOGQtZDBiZC00MWE3LWE3NTYtZDRjNDljNWY1YTdjIiwicHVs
+        cDJfY29udGVudF90eXBlX2lkIjoicnBtIiwicHVscDJfbGFzdF91cGRhdGVk
+        IjoxNjEzNzQ3NzMzLCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xpYi9w
+        dWxwL2NvbnRlbnQvdW5pdHMvcnBtLzQ2L2ZjZTZjNTQwMzU5ODU0YjU4MjBk
+        NDQ0YTQ3ZDFiN2E5NDcxYTBlMmQ3MTczMDA0OTU4NGQ1Njk3NTk1YmI1L3dh
+        bHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsImRvd25sb2FkZWQiOnRydWUsInB1
+        bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvYjUzNTU3ODgtNTMzMS00ZTUyLTgxZmQtY2FmYjQyNTc0MjRjLyJ9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC8zZGMzODU4
+        ZC1lYjJlLTQxNjgtOTc0OC1hNGJjNzIyMjExOGMvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyMS0wMi0xOVQxNTo1NzoxMi4wMzQ3MzVaIiwicHVscDJfaWQiOiJh
+        NTM0MGZlOC03MGFmLTQ0NmItYTg1Ny03OWY4OGI5MjY3MzkiLCJwdWxwMl9j
+        b250ZW50X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2
+        MTM3NDc3MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAv
+        Y29udGVudC91bml0cy9ycG0vMmYvZDFiMjMzMGI5OTk5Mzk4MmU2M2Q1ZGQy
+        OGQ1YzYwZmYxNjkzMmIwZTlhNmZhNTE4NGQ0NmVkMmI1NTQyOTYva2FuZ2Fy
+        b28tMC4zLTEubm9hcmNoLnJwbSIsImRvd25sb2FkZWQiOnRydWUsInB1bHAz
+        X2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        YTE4ODk0ZjgtMDg2NC00MGRlLTkzODAtMzRhMDMwODViYjAwLyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC8zZjRjNWY3OC04
+        ZjljLTQxMWUtODg5MC1jNDFhOTI0YjM0MTUvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wMi0xOVQxNTo1NzoxMi4wMzQ3MTVaIiwicHVscDJfaWQiOiIzZjlh
+        MmJlYy0xMzVlLTRjODktYjc4Zi01NGJlMjkxMTE1OGIiLCJwdWxwMl9jb250
+        ZW50X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3
+        NDc3MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29u
+        dGVudC91bml0cy9ycG0vOTAvNDM3OTI4YWUwOTk0ZjA0NWU0ZmMxMDE2ODdh
+        MDU0ZWYzMGZlZWE4YzYyYTlhMWZlMmUwMjFiOWZkMjEyYmMva2FuZ2Fyb28t
+        MC4yLTEubm9hcmNoLnJwbSIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2Nv
+        bnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvYzJm
+        MzlkMDUtZGRhMy00YTNhLWIwM2YtODA3MjdhNDE4MTA3LyJ9LHsicHVscF9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC81MzU2YzcxNi01YzFk
+        LTQ5MTctYjZiZC1lZGNkMGM0ZWIxMDkvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0wMi0xOVQxNTo1NzoxMi4wMzQ2OTRaIiwicHVscDJfaWQiOiI2YTE0MDg0
+        Mi1iMzQ5LTQzZTQtYWMxMi1hNjFjNzFkZTYyYmYiLCJwdWxwMl9jb250ZW50
+        X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NDc3
+        MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVu
+        dC91bml0cy9ycG0vNDkvMTFjMjMyZDliNzIwYzU0OTVhNzIyNjE0NTY3NmFj
+        ZDQzNzk5MzI2OGU4MzEyMGY2ZjY4NzQ2YTlkY2RjYWYvZHVjay0wLjctMS5u
+        b2FyY2gucnBtIiwiZG93bmxvYWRlZCI6dHJ1ZSwicHVscDNfY29udGVudCI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81MDNhNzRiNC0w
+        OTE3LTQ5MTAtOTZhZC02OTE5MzA2YzgwZmMvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcHVscDJjb250ZW50L2QwMzNjYWUzLTA3ZjAtNGYyNC1i
+        NTBhLTc2NDY5ZTYyMzFiZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5
+        VDE1OjU3OjEyLjAzNDY3NFoiLCJwdWxwMl9pZCI6IjkzNmQxZTI3LTEwZDkt
+        NDc5Ny1hMzgxLWY5NGNjN2M3NDA2YyIsInB1bHAyX2NvbnRlbnRfdHlwZV9p
+        ZCI6InJwbSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6MTYxMzc0NzczMywicHVs
+        cDJfc3RvcmFnZV9wYXRoIjoiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRz
+        L3JwbS83ZS85NDE0ZjFlZDY3NzZkZjllODliYjMyMjAwMjE2OWQ4OWFhNjc4
+        YzdhNWQ5NDdmZjc2MjA1Njk1NGEyYzZhNy9kdWNrLTAuNi0xLm5vYXJjaC5y
+        cG0iLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19jb250ZW50IjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzL2YzMGVjNTgyLTUxMmUtNGQ1
+        ZS1hOWE0LWUzNDgyYzNlZmM1NC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9wdWxwMmNvbnRlbnQvYjM4NjE0M2QtNDljZS00YzMxLTg5ZjEtMGYw
+        NTExNzE1ZjczLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6
+        MTIuMDM0NjUzWiIsInB1bHAyX2lkIjoiZWJiMTM0NjctYzc2NC00OTZlLWE2
+        NGYtNzIwMTNjM2U4NzE0IiwicHVscDJfY29udGVudF90eXBlX2lkIjoicnBt
+        IiwicHVscDJfbGFzdF91cGRhdGVkIjoxNjEzNzQ3NzMyLCJwdWxwMl9zdG9y
+        YWdlX3BhdGgiOiIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzA5
+        L2I2NTMxZmIzZDZmZDBhZjRlZWMwNzhkM2YzYjhiYTFjN2U0ZGM3YzJmM2Jk
+        ZjZjZGQ1ZjU3OTJlOWExYTRhL3dhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzU1ODY0MjM0LTY2ZDUtNGQ5ZS1h
+        NDBjLWZhZTM1NTNjZGM1NS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9wdWxwMmNvbnRlbnQvNzE3YTNhOTktYjEwYi00MGI5LTgwODItYzNmZjQ2
+        MmI2ZDc2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTIu
+        MDM0NjMyWiIsInB1bHAyX2lkIjoiNThmN2YzZDYtMGY1ZC00NGEwLTkxNWEt
+        YTUxZDM3OWQ2YWMyIiwicHVscDJfY29udGVudF90eXBlX2lkIjoicnBtIiwi
+        cHVscDJfbGFzdF91cGRhdGVkIjoxNjEzNzQ3NzMyLCJwdWxwMl9zdG9yYWdl
+        X3BhdGgiOiIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzZhLzU5
+        M2JiZTVlMTUwNWEyZTc5ZGVmODYxNDczMTgzYTFjZmQxZTBjNDZiZDRhNTgw
+        NDQ1MzljZDg2OWUwMDFkL3NxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvNzg2YzE2ZjMtY2E1Yi00NWUxLWI5
+        NGItMWY5NDgwY2I1YmIyLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3B1bHAyY29udGVudC9lODk2ZTE1MC01MWU3LTRjMDMtYmJhZS1jMDcwNzRj
+        ZjE4NmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMi4w
+        MzQ2MTFaIiwicHVscDJfaWQiOiI2NWNlMzdiZC1jOGUwLTQ3OWUtOGI1Yy0x
+        MTA1ZTQ2NWRmMTIiLCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJycG0iLCJw
+        dWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NDc3MzIsInB1bHAyX3N0b3JhZ2Vf
+        cGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9ycG0vZmEvNDI2
+        ZTFmNWJmYWE3N2EzNTU2ZjNkMWZkZGY1N2U4ZDE4MmZjYzk5YjU5MjQ5Zjhl
+        MTBiYzVjMmYzODQ2ZmUvcGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCJk
+        b3dubG9hZGVkIjp0cnVlLCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzL2Q5NjhkZmQ0LWExODUtNDQ5YS04ZWEz
+        LTE5OWY5Y2UzZjZlYS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9w
+        dWxwMmNvbnRlbnQvNzA1NWM4YjUtYTNkZS00MTBiLTlkMDMtMzgwYWRiN2Mx
+        MGE5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTIuMDM0
+        NTkxWiIsInB1bHAyX2lkIjoiYTkxNGVkY2QtZjNhYS00ZWFiLTg4MjYtMzgw
+        ZGNlYjdkODAzIiwicHVscDJfY29udGVudF90eXBlX2lkIjoicnBtIiwicHVs
+        cDJfbGFzdF91cGRhdGVkIjoxNjEzNzQ3NzMyLCJwdWxwMl9zdG9yYWdlX3Bh
+        dGgiOiIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzBhLzU2NjVi
+        MzBlNDVhYWM5OTY1Njk0YjQxY2I3MGE2MDMwMDRhYjBhMTliZTY3ZGJjNDgw
+        ZjUxNjA3NTI2YTYwL21vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCJkb3du
+        bG9hZGVkIjp0cnVlLCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvcnBtL3BhY2thZ2VzLzhkMjdiNTdjLWQyMDQtNDQwNi04NmU5LWUz
+        MGI1Mjg5NjE2Ny8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxw
+        MmNvbnRlbnQvOTlmNDY2M2ItNmMwZS00OWMxLTgyNTEtNDNiYjk4Zjg2MDU5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTIuMDM0NTY3
+        WiIsInB1bHAyX2lkIjoiY2UzOGU2ODgtZWRiYy00MjBjLWJjMjEtMGNjNDZm
+        ZDNkODRmIiwicHVscDJfY29udGVudF90eXBlX2lkIjoicnBtIiwicHVscDJf
+        bGFzdF91cGRhdGVkIjoxNjEzNzQ3NzMyLCJwdWxwMl9zdG9yYWdlX3BhdGgi
+        OiIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzVjL2QwN2E5NmMz
+        ZThlM2U2ZWQ3ZTk4NjRhOTc5ODU0N2E0OTdhZTM3MzMwMTg5ZDRiMTVmZDVh
+        NTkwNGUwNmFhL2xpb24tMC4zLTAuOC5ub2FyY2gucnBtIiwiZG93bmxvYWRl
+        ZCI6dHJ1ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlcy9iNjYyODc5YS1jNmY1LTQ3NmMtODA0MC1mNGYwZjc4
+        NGNhZTgvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250
+        ZW50LzlkMzJiOTVlLTAwZjgtNDI0Ny1iNmU3LWE4MWIwYTA2MzIyYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEyLjAzNDU0N1oiLCJw
+        dWxwMl9pZCI6ImViNjA0ZTMxLWFiZmYtNDRkMi1iYjM3LTcwYjBhNGRiMzUy
+        ZCIsInB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6InJwbSIsInB1bHAyX2xhc3Rf
+        dXBkYXRlZCI6MTYxMzc0NzczMiwicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zh
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS8yMi9kNjQyN2RiNzdkYmM5
+        MDk5ZmFkNjYzNzljODA4NzE1MTRjZDk5ZmIwMTRlMjdhMmQzMzliZTE3ODIx
+        Y2NmZC9naXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsImRvd25sb2FkZWQi
+        OnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvM2Q0M2JhYWYtYjg1OS00NTU2LWExZDctYTM1ZWRmYTU0
+        ZGY3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVu
+        dC8xOGY5ZmU4Yy1hNjNlLTQ2YjktOTAwNC0zNDZhOGFhMmM1ZDQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMi4wMzQ1MjZaIiwicHVs
+        cDJfaWQiOiJlNzk2MjE1NS1lOGIxLTRkNGEtYjAyYS1kMjQxM2UyYzQ0Yzci
+        LCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3Vw
+        ZGF0ZWQiOjE2MTM3NDc3MzIsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIv
+        bGliL3B1bHAvY29udGVudC91bml0cy9ycG0vZmIvNDBlN2Y3Y2I0MDFjMzkw
+        M2ExMzI5MDBkNjIzNDEwOGY3ZjQ1ODMxMzY0OGEyMmVmMmRhMzEzYzY4YWM2
+        ZDIvZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwiZG93bmxvYWRlZCI6
+        dHJ1ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
+        bS9wYWNrYWdlcy9jZTYzMDBiMi01NGVjLTQ1ZGYtOThhNy1iN2I4OTBkODAw
+        ZjQvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50
+        Lzg3OTBmMzVjLTYyYzYtNGY3OC04NmI2LTJkNDQxZjU3ODRlNi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEyLjAzNDUwNVoiLCJwdWxw
+        Ml9pZCI6IjI2N2E2M2Y4LTUxYWMtNGRlMi05NWZmLTM5ZWJkMTQ3N2FkYyIs
+        InB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6InJwbSIsInB1bHAyX2xhc3RfdXBk
+        YXRlZCI6MTYxMzc0NzczMiwicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9jZS84MWUwNjM4ZDM5ZjAyMzNi
+        ZDNlMzIxNmQ3MGM3OTlmNGYxZmQ0N2JiMmNmOTZkMDY0YmMwMTliYmIxMGJh
+        NC9lbGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwiZG93bmxvYWRlZCI6dHJ1
+        ZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy8wMjliMDhmNi1kZDgwLTQzYzEtYjY5MS1iMDNiZjA0ZDI2MGUv
+        In0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50Lzk5
+        MTEzNGM3LTM5N2QtNGVlMi1iMjIwLWE3YmY2Njg4NThkOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEyLjAzNDQ4NFoiLCJwdWxwMl9p
+        ZCI6ImJjMmU0YWRkLTM3NDItNGMyMS04OTk3LWFjODE1MmYwNDk2OSIsInB1
+        bHAyX2NvbnRlbnRfdHlwZV9pZCI6InJwbSIsInB1bHAyX2xhc3RfdXBkYXRl
+        ZCI6MTYxMzc0NzczMiwicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zhci9saWIv
+        cHVscC9jb250ZW50L3VuaXRzL3JwbS8yMy80ODRiNjNkMjhhZmFkNzA0NzVh
+        Mjg3ZDAxOTk2ZWIwN2Y2ZWYyNmRiNGVmZjhkMGUzZmM5ZDdiYTYxNDEwMi9j
+        aGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsImRvd25sb2FkZWQiOnRydWUs
+        InB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvYThmODJjMzQtMmEyNi00MTJjLWE5YTYtOGU4YTJkNDI2ZmFhLyJ9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC85ZjRh
+        ZTY1ZS1iNTczLTQ5MzYtYWUwOS0xOTBmOGZkNzhlYjgvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMi4wMzQ0NjNaIiwicHVscDJfaWQi
+        OiJmMzAyMWRjNy0xMjBiLTQyZjYtYTNiNS0xNmU5OTQ3NTI4OTAiLCJwdWxw
+        Ml9jb250ZW50X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQi
+        OjE2MTM3NDc3MzIsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1
+        bHAvY29udGVudC91bml0cy9ycG0vNDgvNjQzZGFlNTJkYTVhNjZmZTY0NjYy
+        MzA2NTA3MTFlOTVjY2E5N2JiOGIyMzVkODg0ODA0YzNkMDkwMjBhOTQvYXJt
+        YWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCJkb3dubG9hZGVkIjp0cnVlLCJw
+        dWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzLzgyMWJjN2FmLTY3ZTQtNGU2Ny1iNDUyLTljZWM1MDVjMDBkNC8ifSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvZWEzMjBi
+        ZDUtODc0Yy00MTViLWFiNWMtMGNlYzIzOTY1YmFiLyIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjEtMDItMTlUMTU6NTc6MTIuMDM0NDM3WiIsInB1bHAyX2lkIjoi
+        ZGEzNGU2OGQtODhkZC00MGJhLWFlNDYtYzM3MzdmMDlmZDMwIiwicHVscDJf
+        Y29udGVudF90eXBlX2lkIjoicnBtIiwicHVscDJfbGFzdF91cGRhdGVkIjox
+        NjEzNzQ3NzMyLCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFyL2xpYi9wdWxw
+        L2NvbnRlbnQvdW5pdHMvcnBtL2I2L2UyMDlhY2E3OWE1YzJlNzA3YzM2NDdm
+        OTUwODZhZTBjMDZjZDQ3ZWFkNTM0MjcwZjcxMGYwYmFlNTFiYjE2L2FybWFk
+        aWxsby0wLjItMS5ub2FyY2gucnBtIiwiZG93bmxvYWRlZCI6dHJ1ZSwicHVs
+        cDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy82NzMzMWVjNy1jMjk2LTQwODQtOTM3ZC01YWQzZWFkMTU5OTUvIn0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50LzdlMWFlYTY2
+        LTg5ZTktNGIxYS1hMGM0LTZlYWY3MDZmMzgzYi8iLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDIxLTAyLTE5VDE1OjU3OjEyLjAzNDQxNloiLCJwdWxwMl9pZCI6IjBl
+        ZGMxMDgwLTY4ZDgtNDRhOC04YWU2LTAzYTFhZmVkNTY1NCIsInB1bHAyX2Nv
+        bnRlbnRfdHlwZV9pZCI6InJwbSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6MTYx
+        Mzc0NzczMiwicHVscDJfc3RvcmFnZV9wYXRoIjoiL3Zhci9saWIvcHVscC9j
+        b250ZW50L3VuaXRzL3JwbS84My80NGZkM2M2MDQ4MDliNzdiMjM0ZmJmNTQ3
+        Nzc1MzBlN2YxYmQ1YWUxY2ZhY2U3YWFiZmJjNjk0YzQ2NTNiOC9hcm1hZGls
+        bG8tMC4xLTEubm9hcmNoLnJwbSIsImRvd25sb2FkZWQiOnRydWUsInB1bHAz
+        X2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMv
+        MWQ1OTc2MjctNGVlYS00ZjNlLTlhYTgtZWU5MDIwMGM4Y2Q4LyJ9LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC83MGEzMzI5My1m
+        ZmViLTQxYWMtYTQxOC03NWU2MWRlYzI3MjgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wMi0xOVQxNTo1NzoxMi4wMzQyOTJaIiwicHVscDJfaWQiOiI1OTY1
+        Y2FkOC1lNjBjLTQ2MDctYWVmZC1lNWNhY2QxZWMyOTYiLCJwdWxwMl9jb250
+        ZW50X3R5cGVfaWQiOiJycG0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTI0
+        NjcwOTcsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29u
+        dGVudC91bml0cy9ycG0vMDIvNGQ0NmM1MjgxMzYzNWQ5MzIyZjA3OGRmNDMw
+        OTA4MWM0NmU1YmIyNDI2ZDNiZThhZDQ2NjZhZmI2OTVmZWUvdHJvdXQtMC4x
+        Mi0xLm5vYXJjaC5ycG0iLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxwM19jb250
+        ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzc1OWQw
+        ZTA3LTA2MDItNDI0NC1iZDUwLTYwNDZjMjNjN2E0NC8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=three,two,itsempty,thatriver,thatriver,one,01fc5476-dc1f-4c2f-90fb-6dbb0f32b5ed,3b15eb68-1363-4a52-98ae-9822da48847b,4337b721-9a70-4207-bee1-44029543aa14,5680c1f1-4cc6-4024-a72c-4a3a556ac981,bf8b4cb1-9bba-4453-83c5-5b526a76b8ca,e508a591-0889-4897-8d93-b990fda0d26b
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 91b609c702f749828cb31cee0f2aedac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '950'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        MDI3NGUzZDAtYmUwOS00YWJjLWFhODQtYWMzMzJjY2UwZDA2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNTczNTE0WiIsInB1bHAy
+        X2lkIjoiMDFmYzU0NzYtZGMxZi00YzJmLTkwZmItNmRiYjBmMzJiNWVkIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoibW9kdWxlbWQiLCJwdWxwMl9sYXN0
+        X3VwZGF0ZWQiOjE2MTM3NDc3MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC9lYS9hODcyMDNh
+        YTcxYWNkMDllZDRjODcwZTA4NzU0OWRhMmE1ZDJjYWM3Y2I5ZWVkN2U3YjA2
+        M2JmOWY0OTdhOSIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzMzNDY5ZjEx
+        LTY1YTYtNDcyNi1iMmFkLWVkNzVkN2E5Zjk5Mi8ifSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvZTRkYWI2YzgtMzkzMC00ZDVm
+        LWI2ZTQtOWIyMGZmNzU2NzdmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDIt
+        MTlUMTU6NTc6MTMuNTczNDc4WiIsInB1bHAyX2lkIjoiNDMzN2I3MjEtOWE3
+        MC00MjA3LWJlZTEtNDQwMjk1NDNhYTE0IiwicHVscDJfY29udGVudF90eXBl
+        X2lkIjoibW9kdWxlbWQiLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NDc3
+        MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVu
+        dC91bml0cy9tb2R1bGVtZC80MS85YzI2Y2EwMzIyZjA0NThhYjc0ZjU4NzZl
+        MjlhMzY2ZjgwYzJiNDkwMjBmNjYzYWJiOWZmNGJiZGNiZDZjYyIsImRvd25s
+        b2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9ycG0vbW9kdWxlbWRzLzVjNzdlYWIxLTMwODgtNGFjNy1iN2JlLWEz
+        ZmVlNjgwM2Y4ZS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxw
+        MmNvbnRlbnQvZmQxMTJhMWQtYzkwZC00NWFlLWI0MTAtNjYyZDFkZTUzMTMy
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNTczNDE5
+        WiIsInB1bHAyX2lkIjoiYmY4YjRjYjEtOWJiYS00NDUzLTgzYzUtNWI1MjZh
+        NzZiOGNhIiwicHVscDJfY29udGVudF90eXBlX2lkIjoibW9kdWxlbWQiLCJw
+        dWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NDc3MzMsInB1bHAyX3N0b3JhZ2Vf
+        cGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC8x
+        Yi8yZjAwMzk2NGJiNjQyMWRlNzQyNzdkYjE5YzljYThkMzMzYWJhOTYzOTM5
+        MTBjNzgwZTU3MDBkYzhhODNhMyIsImRvd25sb2FkZWQiOnRydWUsInB1bHAz
+        X2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRz
+        LzQ4NTBlYTliLTI0OGItNDlhZS1iY2I2LTE3YWJiM2RkMzRlMi8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvYTNhMjM2YmUt
+        Mzc1Yi00Y2M5LTk2MjAtNGM4ZTA5NDhlOTE5LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjEtMDItMTlUMTU6NTc6MTMuNTczMzgzWiIsInB1bHAyX2lkIjoiZTUw
+        OGE1OTEtMDg4OS00ODk3LThkOTMtYjk5MGZkYTBkMjZiIiwicHVscDJfY29u
+        dGVudF90eXBlX2lkIjoibW9kdWxlbWQiLCJwdWxwMl9sYXN0X3VwZGF0ZWQi
+        OjE2MTM3NDc3MzMsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1
+        bHAvY29udGVudC91bml0cy9tb2R1bGVtZC8wNC9mNTU4NmVlMTRkZTRlMzVj
+        NjdhYjA4ZDI2Y2I3YTA1ZTdmZmYwZGUwN2RjZWFiNjYxMzNhNTgyMGMzODJj
+        ZSIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLzczNTM2OWEzLTY1YjYtNGIw
+        MS1hZGFhLTE0YmQ2ZDViMTAzMi8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9wdWxwMmNvbnRlbnQvYTZjNGUxMDMtNWVlZi00ZDZjLWJkYzUtYTAx
+        ZDYzM2Q5Mzg3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6
+        MTMuNTczMzQ1WiIsInB1bHAyX2lkIjoiM2IxNWViNjgtMTM2My00YTUyLTk4
+        YWUtOTgyMmRhNDg4NDdiIiwicHVscDJfY29udGVudF90eXBlX2lkIjoibW9k
+        dWxlbWQiLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NDc3MzMsInB1bHAy
+        X3N0b3JhZ2VfcGF0aCI6Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9t
+        b2R1bGVtZC85MC82NmY2YjQzYjFiNGRmMDlmOGE2ODc5N2EwN2E4NGZkM2Y1
+        NWU0NzRmN2QzOTkzZWYyYThkYzc0MThkMTAwMSIsImRvd25sb2FkZWQiOnRy
+        dWUsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        bW9kdWxlbWRzLzQ4NzM3MGJjLWMxMDgtNDcwNS04M2ZmLWJhZThhYzQ1NWI2
+        Yy8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        ZGVkNmU3ZmUtZTJhOS00ZDM1LTlmNzMtOGE1Y2JmMzJkMzA3LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNTczMjgyWiIsInB1bHAy
+        X2lkIjoiNTY4MGMxZjEtNGNjNi00MDI0LWE3MmMtNGEzYTU1NmFjOTgxIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoibW9kdWxlbWQiLCJwdWxwMl9sYXN0
+        X3VwZGF0ZWQiOjE2MTM3NDc3MzIsInB1bHAyX3N0b3JhZ2VfcGF0aCI6Ii92
+        YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83OC82ODcyN2Jj
+        YzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNkNTU1NmJjZGNl
+        YTkxZGE5ODBlMCIsImRvd25sb2FkZWQiOnRydWUsInB1bHAzX2NvbnRlbnQi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzL2E2ZWUwYmMx
+        LTAzZGEtNDY1Yi05ZTk1LTg0MGMyZGUxNzc0MC8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?limit=2000&offset=0&pulp2_content_type_id=erratum&pulp2_last_updated__gt=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6aacc51e17114598b8ccbbed55435cae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '1043'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50
+        LzE4NGVmMmYzLTQyYmQtNGY4Yi05ZTMzLTQ4NDg5N2FlMjRhYy8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEzLjUxMTA3MFoiLCJwdWxw
+        Ml9pZCI6IjZiNjVlMzg1LTFkMjEtNDBjMi1hZjgzLTY3ODMyMDIwNzNhYyIs
+        InB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6ImVycmF0dW0iLCJwdWxwMl9sYXN0
+        X3VwZGF0ZWQiOjE2MTM3NTAyMjUsInB1bHAyX3N0b3JhZ2VfcGF0aCI6bnVs
+        bCwiZG93bmxvYWRlZCI6ZmFsc2UsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9hZjVlZjdiZS00YzllLTQw
+        MTUtYTU2Mi1mNzY5MmEzMzA0NGYvIiwicHVscDNfcmVwb3NpdG9yeV92ZXJz
+        aW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzE2NzVh
+        NWJiLWE2YWEtNDg1Zi04YTk4LTA1NDVlNmUyYzY5MC92ZXJzaW9ucy8xLyJ9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC9iM2Rl
+        MmU5YS1hOGYxLTRjNjItYWRkMy00NTAwNWU0MjExNDIvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMy41MTEwNDdaIiwicHVscDJfaWQi
+        OiI2YjY1ZTM4NS0xZDIxLTQwYzItYWY4My02NzgzMjAyMDczYWMiLCJwdWxw
+        Ml9jb250ZW50X3R5cGVfaWQiOiJlcnJhdHVtIiwicHVscDJfbGFzdF91cGRh
+        dGVkIjoxNjEzNzUwMjI1LCJwdWxwMl9zdG9yYWdlX3BhdGgiOm51bGwsImRv
+        d25sb2FkZWQiOmZhbHNlLCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvYWY1ZWY3YmUtNGM5ZS00MDE1LWE1
+        NjItZjc2OTJhMzMwNDRmLyIsInB1bHAzX3JlcG9zaXRvcnlfdmVyc2lvbiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMDM3NjNmYi02
+        ZjQ0LTQ5ZGQtYjViNS1kNjBiMjc4MGZiYTkvdmVyc2lvbnMvMS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvNDI1MDVmYzYt
+        MDdiMy00YTRjLWE3ZTUtNTkwZmIyYTQ3ZmYyLyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjEtMDItMTlUMTU6NTc6MTMuNTExMDI0WiIsInB1bHAyX2lkIjoiY2U3
+        ODFjMDEtNTdjZi00OWIxLTk5ODktYTA4YmY3NmU4ZTJkIiwicHVscDJfY29u
+        dGVudF90eXBlX2lkIjoiZXJyYXR1bSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6
+        MTYxMzc1MDIyNSwicHVscDJfc3RvcmFnZV9wYXRoIjpudWxsLCJkb3dubG9h
+        ZGVkIjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9hZHZpc29yaWVzLzkyN2JjNDU3LTI1YmMtNDc1YS1hYzA5LTMz
+        NWUzZmQ2MDEzYS8iLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTY3NWE1YmItYTZhYS00
+        ODVmLThhOTgtMDU0NWU2ZTJjNjkwL3ZlcnNpb25zLzEvIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50LzgxNTA5NmFhLWRmMWUt
+        NGY0Ni05MGRkLWVmNzA4NGQ1M2Q4MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
+        LTAyLTE5VDE1OjU3OjEzLjUxMTAwMFoiLCJwdWxwMl9pZCI6ImNlNzgxYzAx
+        LTU3Y2YtNDliMS05OTg5LWEwOGJmNzZlOGUyZCIsInB1bHAyX2NvbnRlbnRf
+        dHlwZV9pZCI6ImVycmF0dW0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3
+        NTAyMjUsInB1bHAyX3N0b3JhZ2VfcGF0aCI6bnVsbCwiZG93bmxvYWRlZCI6
+        ZmFsc2UsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vYWR2aXNvcmllcy82ZDY4MWM1Yi1hZWI4LTQ5MmEtYWMyYi0xMDBjYjU1
+        ZjIxM2YvIiwicHVscDNfcmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IwMzc2M2ZiLTZmNDQtNDlkZC1i
+        NWI1LWQ2MGIyNzgwZmJhOS92ZXJzaW9ucy8xLyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC80YWEzNjFhYi03NzQzLTRhNzQt
+        Yjk4Yi1lMTNkYzhjYTgwZDQvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0x
+        OVQxNTo1NzoxMy41MTA5NzhaIiwicHVscDJfaWQiOiI5ODkzYzVkYi1kNzhk
+        LTRhZmMtYjkzYy1jODU1NWE2MzRmYmUiLCJwdWxwMl9jb250ZW50X3R5cGVf
+        aWQiOiJlcnJhdHVtIiwicHVscDJfbGFzdF91cGRhdGVkIjoxNjEzNzUwMjI1
+        LCJwdWxwMl9zdG9yYWdlX3BhdGgiOm51bGwsImRvd25sb2FkZWQiOmZhbHNl
+        LCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fk
+        dmlzb3JpZXMvZGNjMmVkNWEtMThiMS00Y2EzLWI5OTEtZTU4ODQ5ZDk4OGJk
+        LyIsInB1bHAzX3JlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS8xNjc1YTViYi1hNmFhLTQ4NWYtOGE5OC0w
+        NTQ1ZTZlMmM2OTAvdmVyc2lvbnMvMS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9wdWxwMmNvbnRlbnQvMjBlZjNjNDUtNTdjOS00MDlmLTk0YzQt
+        MWYyOTQyMTBjYmZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6
+        NTc6MTMuNTEwOTU0WiIsInB1bHAyX2lkIjoiOTg5M2M1ZGItZDc4ZC00YWZj
+        LWI5M2MtYzg1NTVhNjM0ZmJlIiwicHVscDJfY29udGVudF90eXBlX2lkIjoi
+        ZXJyYXR1bSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6MTYxMzc1MDIyNSwicHVs
+        cDJfc3RvcmFnZV9wYXRoIjpudWxsLCJkb3dubG9hZGVkIjpmYWxzZSwicHVs
+        cDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
+        aWVzLzQyMDAwZWNlLTI4MzYtNGZjNC04ZTI3LWM5OTRkZWNkMmI0Mi8iLCJw
+        dWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vYjAzNzYzZmItNmY0NC00OWRkLWI1YjUtZDYwYjI3
+        ODBmYmE5L3ZlcnNpb25zLzEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvcHVscDJjb250ZW50L2UxYzFjNGVhLWE3MzctNGYzNi1hMDA5LWZkYmYz
+        MTNlNTY3NS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEz
+        LjUxMDkzMFoiLCJwdWxwMl9pZCI6IjIzYjAyNzk1LTI5YmEtNDQ1MC04NTNi
+        LWJiMTNmYjI5YjM3YiIsInB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6ImVycmF0
+        dW0iLCJwdWxwMl9sYXN0X3VwZGF0ZWQiOjE2MTM3NTAyMjUsInB1bHAyX3N0
+        b3JhZ2VfcGF0aCI6bnVsbCwiZG93bmxvYWRlZCI6ZmFsc2UsInB1bHAzX2Nv
+        bnRlbnQiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy9i
+        ZDY4NjRhYi01NjIzLTQ0ZjktYjYzYS04OGQxYzIwOTJmYjMvIiwicHVscDNf
+        cmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9ycG0vcnBtLzE2NzVhNWJiLWE2YWEtNDg1Zi04YTk4LTA1NDVlNmUyYzY5
+        MC92ZXJzaW9ucy8xLyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1
+        bHAyY29udGVudC9lYmIyNmJkMi1lN2U0LTQ2NDAtOGVhYS02OWUyZGU0MDlk
+        NmIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMy41MTA5
+        MDdaIiwicHVscDJfaWQiOiIyM2IwMjc5NS0yOWJhLTQ0NTAtODUzYi1iYjEz
+        ZmIyOWIzN2IiLCJwdWxwMl9jb250ZW50X3R5cGVfaWQiOiJlcnJhdHVtIiwi
+        cHVscDJfbGFzdF91cGRhdGVkIjoxNjEzNzUwMjI1LCJwdWxwMl9zdG9yYWdl
+        X3BhdGgiOm51bGwsImRvd25sb2FkZWQiOmZhbHNlLCJwdWxwM19jb250ZW50
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNTk1NWJm
+        N2UtOTc0Mi00YzgxLWE4YzUtYmIwYTI4ZWVmNjg3LyIsInB1bHAzX3JlcG9z
+        aXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS9iMDM3NjNmYi02ZjQ0LTQ5ZGQtYjViNS1kNjBiMjc4MGZiYTkvdmVy
+        c2lvbnMvMS8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNv
+        bnRlbnQvYjk0ZjI3ZGEtOGY2NS00NGUyLWFkOWMtOThiOTdlN2MyNWE4LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNTEwODgzWiIs
+        InB1bHAyX2lkIjoiZmMzNmFkYmEtNzUzMi00MGJkLWFlYmItN2I3NjZmMGYy
+        MGM2IiwicHVscDJfY29udGVudF90eXBlX2lkIjoiZXJyYXR1bSIsInB1bHAy
+        X2xhc3RfdXBkYXRlZCI6MTYxMzc1MDIyNSwicHVscDJfc3RvcmFnZV9wYXRo
+        IjpudWxsLCJkb3dubG9hZGVkIjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLzRhMTg5MWNhLWRj
+        YzctNDFiMi1hNTEzLWI1OTEzMTE0MjJhMy8iLCJwdWxwM19yZXBvc2l0b3J5
+        X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
+        MTY3NWE1YmItYTZhYS00ODVmLThhOTgtMDU0NWU2ZTJjNjkwL3ZlcnNpb25z
+        LzEvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVscDJjb250ZW50
+        L2RiNjVkZDJkLTMxMDYtNGIxNC04ZTAzLTg1YWRmYmNkNTViOC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjEzLjUxMDg1OVoiLCJwdWxw
+        Ml9pZCI6ImZjMzZhZGJhLTc1MzItNDBiZC1hZWJiLTdiNzY2ZjBmMjBjNiIs
+        InB1bHAyX2NvbnRlbnRfdHlwZV9pZCI6ImVycmF0dW0iLCJwdWxwMl9sYXN0
+        X3VwZGF0ZWQiOjE2MTM3NTAyMjUsInB1bHAyX3N0b3JhZ2VfcGF0aCI6bnVs
+        bCwiZG93bmxvYWRlZCI6ZmFsc2UsInB1bHAzX2NvbnRlbnQiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy80YTE4OTFjYS1kY2M3LTQx
+        YjItYTUxMy1iNTkxMzExNDIyYTMvIiwicHVscDNfcmVwb3NpdG9yeV92ZXJz
+        aW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2IwMzc2
+        M2ZiLTZmNDQtNDlkZC1iNWI1LWQ2MGIyNzgwZmJhOS92ZXJzaW9ucy8xLyJ9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3B1bHAyY29udGVudC80YTU4
+        NjliYy05ZTI3LTQ5OTQtOGU5NC0zNjJiYjkwMTRiNTIvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0wMi0xOVQxNTo1NzoxMy41MTA4MzNaIiwicHVscDJfaWQi
+        OiI3Zjg0ZGFjMC0wMjYzLTQwZjYtYTAyMS03OWM1NmU3MGEzYTgiLCJwdWxw
+        Ml9jb250ZW50X3R5cGVfaWQiOiJlcnJhdHVtIiwicHVscDJfbGFzdF91cGRh
+        dGVkIjoxNjEzNzUwMjI1LCJwdWxwMl9zdG9yYWdlX3BhdGgiOm51bGwsImRv
+        d25sb2FkZWQiOmZhbHNlLCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvNDI4ZjRmNmEtNWFmOC00ZmIzLTg4
+        ZDUtMzU4ZDYxODFiNzVmLyIsInB1bHAzX3JlcG9zaXRvcnlfdmVyc2lvbiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xNjc1YTViYi1h
+        NmFhLTQ4NWYtOGE5OC0wNTQ1ZTZlMmM2OTAvdmVyc2lvbnMvMS8ifSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvYzIzMTMwYWYt
+        NjFhNS00NTA4LWFiYmEtNjZlZTRjMGEwOTE0LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjEtMDItMTlUMTU6NTc6MTMuNTEwNzgwWiIsInB1bHAyX2lkIjoiN2Y4
+        NGRhYzAtMDI2My00MGY2LWEwMjEtNzljNTZlNzBhM2E4IiwicHVscDJfY29u
+        dGVudF90eXBlX2lkIjoiZXJyYXR1bSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6
+        MTYxMzc1MDIyNSwicHVscDJfc3RvcmFnZV9wYXRoIjpudWxsLCJkb3dubG9h
+        ZGVkIjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9hZHZpc29yaWVzLzQyOGY0ZjZhLTVhZjgtNGZiMy04OGQ1LTM1
+        OGQ2MTgxYjc1Zi8iLCJwdWxwM19yZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjAzNzYzZmItNmY0NC00
+        OWRkLWI1YjUtZDYwYjI3ODBmYmE5L3ZlcnNpb25zLzEvIn1dfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=4f9eea2a-a124-497e-8492-828b64444abc,4f9eea2a-a124-497e-8492-828b6d938aaa,17dd6206-9d24-49f5-bc52-c4a4c6c266cd,17f10a1a-9fef-41fc-aee0-c54298f721a1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6138544f1fda48efad16082c92ed3df6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        ZjQzYmY5YzQtYzZlMy00Yzc2LWE3NDUtMDdlZTEyNTIzOGZjLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNzQ0Mjc1WiIsInB1bHAy
+        X2lkIjoiMTdmMTBhMWEtOWZlZi00MWZjLWFlZTAtYzU0Mjk4ZjcyMWExIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoicGFja2FnZV9ncm91cCIsInB1bHAy
+        X2xhc3RfdXBkYXRlZCI6MTYxMzc0NzczMywicHVscDJfc3RvcmFnZV9wYXRo
+        IjpudWxsLCJkb3dubG9hZGVkIjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzL2M4Y2NjYjcx
+        LWQ5NTQtNDJiMS1iYzRkLTcxNjljNGIzZWQyZC8ifSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQvOTE0MjAyY2MtNmI4Yy00ZmE2
+        LTkwY2YtM2ExY2RjMTRmMzVkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDIt
+        MTlUMTU6NTc6MTMuNzQ0MTI4WiIsInB1bHAyX2lkIjoiMTdkZDYyMDYtOWQy
+        NC00OWY1LWJjNTItYzRhNGM2YzI2NmNkIiwicHVscDJfY29udGVudF90eXBl
+        X2lkIjoicGFja2FnZV9ncm91cCIsInB1bHAyX2xhc3RfdXBkYXRlZCI6MTYx
+        Mzc0NzczMywicHVscDJfc3RvcmFnZV9wYXRoIjpudWxsLCJkb3dubG9hZGVk
+        IjpmYWxzZSwicHVscDNfY29udGVudCI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L3JwbS9wYWNrYWdlZ3JvdXBzLzEzZGNkZjVjLTEyMmYtNDA2Ni1iN2U2LTJl
+        M2YzMjQ0ZDk0Yy8ifV19
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=c1ad6f92-ea30-41cc-8fa8-217bb9cbf19d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f02eba7e97ca46fc8c883c452775d2ad
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+      Content-Length:
+      - '406'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9wdWxwMmNvbnRlbnQv
+        MGE0YWMwMDctMjE2My00MmZiLWI5ZmUtYjA4ZTM3NmJkN2RkLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDItMTlUMTU6NTc6MTMuNjczNzk0WiIsInB1bHAy
+        X2lkIjoiYzFhZDZmOTItZWEzMC00MWNjLThmYTgtMjE3YmI5Y2JmMTlkIiwi
+        cHVscDJfY29udGVudF90eXBlX2lkIjoieXVtX3JlcG9fbWV0YWRhdGFfZmls
+        ZSIsInB1bHAyX2xhc3RfdXBkYXRlZCI6MTYxMzc1MDIyNSwicHVscDJfc3Rv
+        cmFnZV9wYXRoIjoiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL3l1bV9y
+        ZXBvX21ldGFkYXRhX2ZpbGUvM2YvYmIxMTZhN2EwNTRiYTlhMmViYjU1YmNk
+        NWRkN2E3OTg0MzFjNWIyMTY4MjEyMTE3Yzc3MjdjYWJhYzJjODgvYmE4MmQ0
+        YzdhN2MwYjBhNmE1NzUwNmUyNzc1YWEwZGUwMzYyY2E2YWNmZTVhNWZhZGVk
+        OGU4NzU5OWI5NTIzMi1wcm9kdWN0aWQuZ3oiLCJkb3dubG9hZGVkIjp0cnVl
+        LCJwdWxwM19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3Jl
+        cG9fbWV0YWRhdGFfZmlsZXMvY2Y1YWFlOTMtNDQ4YS00NzkyLWI2ZGQtMGZl
+        Nzk0ZjQ2MGVlLyJ9XX0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=three-uuid,two-uuid,one-uuid,one-uuid-two
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - b357ef0f1b86464ab87ff11958319f8d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJycG0ifV19fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/a3eea583-ee28-4005-a3c0-1feb77e44110/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '163'
+      Correlation-Id:
+      - 5636bb89e98d4ad495cd75e01a5e9d5c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zL2Ez
+        ZWVhNTgzLWVlMjgtNDAwNS1hM2MwLTFmZWI3N2U0NDExMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTAyLTE5VDE1OjU3OjE5LjQ3NTIwOVoiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJycG0ifV19fQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v3/migration-plans/a3eea583-ee28-4005-a3c0-1feb77e44110/reset/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbHVnaW5zIjpbeyJ0eXBlIjoicnBtIn1dfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - gunicorn/20.0.4
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - '0810f0e91345426ab9fac2f1dc0472b8'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlODkzZjZhLTgzZjMtNDU5
+        ZS05MzljLWUxMzRhYTE4N2ViZS8ifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg1MjFjMjdhLWY2NGItNDc1OC04OTEwLTIzYzU2YzhjMjkyZC8iLCAi
+        dGFza19pZCI6ICI4NTIxYzI3YS1mNjRiLTQ3NTgtODkxMC0yM2M1NmM4YzI5
+        MmQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/8521c27a-f64b-4758-8910-23c56c8c292d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fcd70459419fbdc192afeaf456a20b44-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '382'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NTIxYzI3YS1mNjRiLTQ3NTgtODkxMC0yM2M1NmM4YzI5
+        MmQvIiwgInRhc2tfaWQiOiAiODUyMWMyN2EtZjY0Yi00NzU4LTg5MTAtMjNj
+        NTZjOGMyOTJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6MTlaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6
+        MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2
+        MDJmZGZkZmY3M2I2OWE4MzY2NTEyODIifSwgImlkIjogIjYwMmZkZmRmZjcz
+        YjY5YTgzNjY1MTI4MiJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1_archive/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:19 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdmZGZjY2I3LWIwNmMtNDZiOC1iZWE4LWU0OTVlZTZiOWYxYi8iLCAi
+        dGFza19pZCI6ICI3ZmRmY2NiNy1iMDZjLTQ2YjgtYmVhOC1lNDk1ZWU2Yjlm
+        MWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/7fdfccb7-b06c-46b8-bea8-e495ee6b9f1b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ea5a93c2d8152b17828b5432323c7358-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '376'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83ZmRmY2NiNy1iMDZjLTQ2YjgtYmVhOC1lNDk1ZWU2Yjlm
+        MWIvIiwgInRhc2tfaWQiOiAiN2ZkZmNjYjctYjA2Yy00NmI4LWJlYTgtZTQ5
+        NWVlNmI5ZjFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4X3ZpZXcx
+        X2FyY2hpdmUiLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjIwWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDIxLTAyLTE5VDE1OjU3OjIwWiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1w
+        bGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVs
+        bG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNjAyZmRmZGZm
+        NzNiNjlhODM2NjUxMmNjIn0sICJpZCI6ICI2MDJmZGZkZmY3M2I2OWE4MzY2
+        NTEyY2MifQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_view1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzYyZDQ5ZWFhLTNlNjYtNDhjZS04MDEwLWVkZGUxMTM0YmQ3Yy8iLCAi
+        dGFza19pZCI6ICI2MmQ0OWVhYS0zZTY2LTQ4Y2UtODAxMC1lZGRlMTEzNGJk
+        N2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/62d49eaa-3e66-48ce-8010-edde1134bd7c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"47dde9177722c1250820219ffea87b4b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '369'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MmQ0OWVhYS0zZTY2LTQ4Y2UtODAxMC1lZGRlMTEzNGJk
+        N2MvIiwgInRhc2tfaWQiOiAiNjJkNDllYWEtM2U2Ni00OGNlLTgwMTAtZWRk
+        ZTExMzRiZDdjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4X3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAy
+        MS0wMi0xOVQxNTo1NzoyMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAyMS0wMi0xOVQxNTo1NzoyMFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVs
+        LTIuY2Fubm9sby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjYwMmZkZmUwZjczYjY5YTgz
+        NjY1MTMxNSJ9LCAiaWQiOiAiNjAyZmRmZTBmNzNiNjlhODM2NjUxMzE1In0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1_archive/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzM1YmQwNzQzLWI4MTUtNDFkNi1iOWE2LWIyOTE4MzJhZGUyYS8iLCAi
+        dGFza19pZCI6ICIzNWJkMDc0My1iODE1LTQxZDYtYjlhNi1iMjkxODMyYWRl
+        MmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/35bd0743-b815-41d6-b9a6-b291832ade2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"332ec8b53579ea39797d5e5453c2eb07-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '383'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNWJkMDc0My1iODE1LTQxZDYtYjlhNi1iMjkxODMyYWRl
+        MmEvIiwgInRhc2tfaWQiOiAiMzViZDA3NDMtYjgxNS00MWQ2LWI5YTYtYjI5
+        MTgzMmFkZTJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4X2NvbXBv
+        c2l0ZV92ZXJzaW9uMV9hcmNoaXZlIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJd
+        LCAiZmluaXNoX3RpbWUiOiAiMjAyMS0wMi0xOVQxNTo1NzoyMFoiLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAyMS0wMi0xOVQx
+        NTo1NzoyMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIu
+        Y2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQi
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjYwMmZkZmUwZjczYjY5YTgzNjY1MTM1ZiJ9LCAiaWQiOiAiNjAyZmRm
+        ZTBmNzNiNjlhODM2NjUxMzVmIn0=
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/8_composite_version1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI5ZDYxM2QzLTYyNjEtNDYzOS1iZjVjLWNlZTAzZWM5MjIwNS8iLCAi
+        dGFza19pZCI6ICIyOWQ2MTNkMy02MjYxLTQ2MzktYmY1Yy1jZWUwM2VjOTIy
+        MDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/29d613d3-6261-4639-bf5c-cee03ec92205/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Feb 2021 15:57:20 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d261f2069c3a9fd8f32cd8d8e044d371-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yOWQ2MTNkMy02MjYxLTQ2MzktYmY1Yy1jZWUwM2VjOTIy
+        MDUvIiwgInRhc2tfaWQiOiAiMjlkNjEzZDMtNjI2MS00NjM5LWJmNWMtY2Vl
+        MDNlYzkyMjA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo4X2NvbXBv
+        c2l0ZV92ZXJzaW9uMSIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6MjBaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMjEtMDItMTlUMTU6NTc6MjBa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczct
+        a2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI2MDJm
+        ZGZlMGY3M2I2OWE4MzY2NTEzYTkifSwgImlkIjogIjYwMmZkZmUwZjczYjY5
+        YTgzNjY1MTNhOSJ9
+    http_version: 
+  recorded_at: Fri, 19 Feb 2021 15:57:20 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/docker_migration_test.rb
+++ b/test/services/katello/pulp3/docker_migration_test.rb
@@ -47,6 +47,26 @@ module Katello
           refute_nil distribution_reference(@repo)
         end
 
+        def test_docker_migration_reset
+          migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_primary, repository_types: ['docker'])
+
+          task = migration_service.create_and_run_migrations
+          wait_on_task(@primary, task)
+
+          migration_service.import_pulp3_content
+
+          task = migration_service.reset
+          wait_on_task(@primary, task)
+
+          [@repo].each { |repo| repo.reload }
+
+          assert_nil @repo.version_href
+          assert_nil @repo.publication_href
+          assert_nil @repo.remote_href
+          assert_nil repository_reference(@repo)
+          assert_nil distribution_reference(@repo)
+        end
+
         def repository_reference(repo)
           Katello::Pulp3::RepositoryReference.find_by(:content_view => repo.content_view, :root_repository_id => repo.root_id)
         end

--- a/test/services/katello/pulp3/yum_migration_test.rb
+++ b/test/services/katello/pulp3/yum_migration_test.rb
@@ -116,6 +116,64 @@ module Katello
           assert_empty @composite_archive.repository_errata.where(:erratum_pulp3_href => nil)
         end
 
+        def test_yum_migration_reset
+          migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_primary, repository_types: ['yum'])
+
+          task = migration_service.create_and_run_migrations
+          wait_on_task(@master, task)
+          migration_service.import_pulp3_content
+
+          task = migration_service.reset
+          wait_on_task(@master, task)
+          @repos.each(&:reload)
+
+          assert_nil @library_repo.version_href
+          assert_nil @library_repo.publication_href
+          assert_nil @library_repo.remote_href
+          assert_nil repository_reference(@library_repo)
+          assert_nil distribution_reference(@library_repo)
+
+          assert_nil @component_archive_repo.version_href
+          assert_nil @component_archive_repo.publication_href
+          assert_nil @component_archive_repo.remote_href
+          assert_nil repository_reference(@component_archive_repo)
+          assert_nil distribution_reference(@component_archive_repo)
+
+          assert_nil @component_env_repo.version_href
+          assert_nil @component_env_repo.publication_href
+          assert_nil @component_env_repo.remote_href
+
+          assert_nil repository_reference(@component_env_repo)
+          assert_nil distribution_reference(@component_env_repo)
+
+          assert_nil @composite_archive.version_href
+          assert_nil @composite_archive.publication_href
+          assert_nil @composite_archive.remote_href
+          assert_nil repository_reference(@composite_archive)
+          assert_nil distribution_reference(@composite_archive)
+
+          assert_nil @composite_env.version_href
+          assert_nil @composite_env.publication_href
+          assert_nil @composite_env.remote_href
+          assert_nil repository_reference(@composite_env)
+          assert_nil distribution_reference(@composite_env)
+
+          refute_empty @library_repo.repository_errata
+          refute_empty @library_repo.repository_errata.where(:erratum_pulp3_href => nil)
+
+          refute_empty @component_archive_repo.repository_errata
+          refute_empty @component_archive_repo.repository_errata.where(:erratum_pulp3_href => nil)
+
+          refute_empty @component_env_repo.repository_errata
+          refute_empty @component_env_repo.repository_errata.where(:erratum_pulp3_href => nil)
+
+          refute_empty @composite_env.repository_errata
+          refute_empty @composite_env.repository_errata.where(:erratum_pulp3_href => nil)
+
+          refute_empty @composite_archive.repository_errata
+          refute_empty @composite_archive.repository_errata.where(:erratum_pulp3_href => nil)
+        end
+
         def repository_reference(repo)
           Katello::Pulp3::RepositoryReference.find_by(:content_view => repo.content_view, :root_repository_id => repo.root_id)
         end


### PR DESCRIPTION
To test:

1) Switch over to Pulp 2 for yum, docker, and file
2) Sync content for each repo type
3) Run `bundle exec rake katello:pulp3_migration`
4) Check in the console for Pulp 3 DB entries such as:
  - Repo entries (version_href, remote_href, publication_href)
  - ::Katello::Pulp3::DistributionReference
  - ::Katello::Pulp3::RepositoryReference
  - Content unit entries (migrated_pulp3_href)
5) Run `bundle exec rake katello:pulp3_migration_reset
6) Check that the entries mentioned before are all `nil` or nonexistent