### PR TITLE
Fixes #31828 - Delete client queue on unregister

### DIFF
--- a/app/lib/katello/agent/connection.rb
+++ b/app/lib/katello/agent/connection.rb
@@ -11,6 +11,11 @@ module Katello
         connection.receive_messages(address: settings[:event_queue_name], handler: handler)
       end
 
+      def delete_client_queue(queue_name)
+        connection = ::Katello::Qpid::Connection.new(settings[:broker_url])
+        connection.delete_queue(queue_name)
+      end
+
       def settings
         SETTINGS[:katello][:agent]
       end

--- a/app/models/katello/events/delete_host_agent_queue.rb
+++ b/app/models/katello/events/delete_host_agent_queue.rb
@@ -1,0 +1,19 @@
+module Katello
+  module Events
+    class DeleteHostAgentQueue
+      EVENT_TYPE = 'delete_host_agent_queue'.freeze
+
+      attr_accessor :metadata
+
+      def initialize(_host_id)
+        yield(self) if block_given?
+      end
+
+      def run
+        if metadata[:queue_name]
+          Katello::Agent::Dispatcher.delete_client_queue(queue_name: metadata[:queue_name])
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/agent/dispatcher.rb
+++ b/app/services/katello/agent/dispatcher.rb
@@ -48,6 +48,16 @@ module Katello
         histories
       end
 
+      def self.delete_client_queue(queue_name:)
+        connection = Connection.new
+        connection.delete_client_queue(queue_name)
+      end
+
+      def self.host_queue_name(host)
+        uuid = host.content_facet.uuid
+        settings[:client_queue_format] % uuid
+      end
+
       def self.settings
         SETTINGS[:katello][:agent]
       end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -242,6 +242,7 @@ module Katello
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
       Katello::EventQueue.register_event(Katello::Events::AutoPublishCompositeView::EVENT_TYPE, Katello::Events::AutoPublishCompositeView)
       Katello::EventQueue.register_event(Katello::Events::GenerateHostApplicability::EVENT_TYPE, Katello::Events::GenerateHostApplicability)
+      Katello::EventQueue.register_event(Katello::Events::DeleteHostAgentQueue::EVENT_TYPE, Katello::Events::DeleteHostAgentQueue)
     end
 
     rake_tasks do

--- a/test/lib/agent/connection_test.rb
+++ b/test/lib/agent/connection_test.rb
@@ -15,6 +15,11 @@ module Katello
         ::Katello::Qpid::Connection.any_instance.expects(:send_messages).with([message])
         connection.send_messages([message])
       end
+
+      def test_delete_client_queue
+        ::Katello::Qpid::Connection.any_instance.expects(:delete_queue).with("foo")
+        connection.delete_client_queue("foo")
+      end
     end
   end
 end

--- a/test/models/events/delete_host_agent_queue_test.rb
+++ b/test/models/events/delete_host_agent_queue_test.rb
@@ -1,0 +1,22 @@
+require 'katello_test_helper'
+
+module Katello
+  module Events
+    class DeleteHostAgentQueueTest < ActiveSupport::TestCase
+      def setup
+        @queue_name = 'pulp.agent.foo'
+        @event = DeleteHostAgentQueue.new(1000) do |instance|
+          instance.metadata = {
+            queue_name: @queue_name
+          }
+        end
+      end
+
+      def test_run
+        Katello::Agent::Dispatcher.expects(:delete_client_queue).with(queue_name: @queue_name)
+
+        @event.run
+      end
+    end
+  end
+end

--- a/test/services/katello/agent/dispatcher_test.rb
+++ b/test/services/katello/agent/dispatcher_test.rb
@@ -25,6 +25,11 @@ module Katello
           Katello::Agent::Dispatcher.dispatch(:test, [host.id], dispatch_params)
         end
       end
+
+      def test_delete_client_queue
+        Katello::Agent::Connection.any_instance.expects(:delete_client_queue).with(consumer_id)
+        Katello::Agent::Dispatcher.delete_client_queue(queue_name: consumer_id)
+      end
     end
   end
 end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -225,6 +225,7 @@ module Katello
 
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Runcible::Extensions::Consumer.any_instance.expects(:delete)
+        ::Katello::EventQueue.expects(:push_event)
 
         ::Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
       end


### PR DESCRIPTION
This PR mirrors the Pulp2 functionality of deleting the agent queue when a host is unregistered in that it will wait for ten minutes to actually delete the queue. If the client is still connected at unregistration time, goferd will re-create the queue which is the reason for the wait => hopefully the client has been turned off or destroyed by that point. The waiting is achieved by the existing mechanism of Katello's event queue which also decouples the unregistration process from Qpid.

**To test:**

- ensure your dev environment was created on or after 2.5.2021
- check out this pr
- register a content host (ie vagrant up centos7-katello-client) with katello-agent installed
- turn goferd off on the content host
- verify existence of client's queue. $UUID is derived from `subscription-manager identity` and can be found in many ways
```
qpid-stat --ssl-certificate=/etc/pki/katello/qpid_router_client.crt --ssl-key=/etc/pki/katello/qpid_router_client.key -b amqps://localhost:5671 -q | grep $UUID
```
- unregister the host using your favorite method
- use the above command to see the queue is still there
- check again in ten minutes and see that it got removed. you'll see something in your Rails log to this effect:
`19:13:00 rails.1   | 2021-02-05T19:13:00 [D|kat|] event_queue_event: type=delete_host_agent_queue, object_id=1`
- now use your imagination and try to break it so that I can fix it                                                                                                            