### PR TITLE
Fixes #31836 - Unclear error message for cvv promotion with bad perrms

### DIFF
--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -196,7 +196,7 @@ module Katello
 
       results = JSON.parse(response.body)
 
-      error_message = "Could not find product resource with id #{fake_product_id}"
+      error_message = "Could not find product resource with id #{fake_product_id}. Potential missing permissions: edit_products"
 
       assert_response :not_found
       assert_includes results["errors"], error_message


### PR DESCRIPTION
This PR brings back the error message that reports which permissions could be missing that went away with https://github.com/Katello/katello/pull/8956

The root of the issue here is that `promote_or_remove_content_views_to_environments` has a special relationship to `promote_or_remove_content_views`.  The whole permissions model seems to expect permissions to be separate and not have relationships, which isn't always the case.  The PR here does seem like a bit of a workaround, but it also seems to be the least complicated fix at least.

A better long-term solution may be to formally declare these special relationships somehow.  I'm not sure if it's worth the time to do that here.

I'm curious to hear if there are ideas about better ways to solve the issue.  I'm not sure how this change will interact with other permissions so I'm marking it a draft for now.

To test:
1) Go through the scenario in the redmine
2) Test accessing other things with the UI and Hammer to make sure that my new messages doesn't break anything.