### PR TITLE
Fixes #31854 - Fix blank screen after editing entitlements

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -51,8 +51,11 @@ class ManageManifestModal extends Component {
   showDeleteManifestModal = () =>
     this.props.setModalOpen({ id: DELETE_MANIFEST_MODAL_ID });
 
-  hideDeleteManifestModal = () =>
-    this.props.setModalClosed({ id: DELETE_MANIFEST_MODAL_ID });
+  hideDeleteManifestModal = () => {
+    if (this.props.deleteManifestModalExists) {
+      this.props.setModalClosed({ id: DELETE_MANIFEST_MODAL_ID });
+    }
+  };
 
   updateRepositoryUrl = (event) => {
     this.setState({ redhat_repository_url: event.target.value });
@@ -326,6 +329,7 @@ ManageManifestModal.propTypes = {
   canImportManifest: PropTypes.bool,
   canDeleteManifest: PropTypes.bool,
   isManifestImported: PropTypes.bool,
+  deleteManifestModalExists: PropTypes.bool,
   canEditOrganizations: PropTypes.bool,
   disableManifestActions: PropTypes.bool,
   disabledReason: PropTypes.string,
@@ -351,6 +355,7 @@ ManageManifestModal.defaultProps = {
   canImportManifest: false,
   canDeleteManifest: false,
   isManifestImported: false,
+  deleteManifestModalExists: false,
   canEditOrganizations: false,
   simpleContentAccess: false,
   simpleContentAccessEligible: undefined,

--- a/webpack/scenes/Subscriptions/Manifest/index.js
+++ b/webpack/scenes/Subscriptions/Manifest/index.js
@@ -20,6 +20,7 @@ const mapStateToProps = state => ({
   simpleContentAccess: selectSimpleContentAccessEnabled(state),
   isManifestImported: selectIsManifestImported(state),
   modalOpenState: state.foremanModals.ManageManifestModal,
+  deleteManifestModalExists: !!state.foremanModals.deleteManifestModal,
   manifestActionStarted: selectManifestActionStarted(state),
   simpleContentAccessEligible: selectSimpleContentAccessEligible(state),
 });


### PR DESCRIPTION
### The issue

Confirming a change to entitlements on the subscriptions table causes `componentDidUpdate` to run on `ManageManifestModal` even though it is not displayed on the screen.  `componentDidUpdate` then tries to close the Delete Manifest confirmation dialog, which doesn't exist yet.

### To recreate

Go to Content > Subscriptions
Refresh the page in the browser (this will clear the Redux store.  In order to get the error, the `deleteManifestModal` must not already be in the store.)
Edit the number of entitlements for a subscription
Click the checkmark and also confirm on the next confirmation dialog
At this point, the page will turn blank and you'll see a console error `SET_MODAL_CLOSED error: deleteManifestModal does not exist`

~~side note: Now that it's causing bugs, this is probably a good time to look at completing https://projects.theforeman.org/issues/30724.~~
_update_: See https://github.com/theforeman/foreman/pull/8322  (if that is merged, this PR will merely prevent a console warning rather than a blank page.)