### PR TITLE
Fixes #31862 - eslint error in Tasks/helpers.js

### DIFF
--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -11,8 +11,8 @@ const link = id => ({
 });
 const getErrors = task => (
   <ul>
-    {task.humanized.errors.map(error => (
-      <li key={error}> {error} </li>
+    {task.humanized.errors.map(e => (
+      <li key={e}> {e} </li>
     ))}
   </ul>
 );


### PR DESCRIPTION
Looks like the recent release of eslint-plugin-promise broke us due to this change https://github.com/xjamundx/eslint-plugin-promise/pull/202

While I think it could be a bug there, we can easily fix it to keep our builds passing and PRs merging, so that's what this PR does :)