### PR TITLE
Fixes #31864 - Add cell formatter for entitlements column

### DIFF
--- a/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
+++ b/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
@@ -11,22 +11,26 @@ const renderValue = (rawValue, additionalData, onActivate) => {
   const value = getEntitlementsDisplayValue({
     rawValue, available, collapsible, upstreamPoolId,
   });
+  const editable = (value === rawValue);
 
   return (
-    <td className="editable">
-      <div
-        onClick={() => onActivate(additionalData)}
-        onKeyPress={(e) => {
-          if (e.keyCode === KEYCODES.ENTER) {
-            onActivate(additionalData);
-          }
-        }}
-        className="input"
-        role="textbox"
-        tabIndex={0}
-      >
-        {value}
-      </div>
+    <td className={editable ? 'editable' : ''}>
+      {editable &&
+        <div
+          onClick={() => onActivate(additionalData)}
+          onKeyPress={(e) => {
+            if (e.keyCode === KEYCODES.ENTER) {
+              onActivate(additionalData);
+            }
+          }}
+          className="input"
+          role="textbox"
+          tabIndex={0}
+        >
+          {value}
+        </div>
+      }
+      {!editable && value}
     </td>
   );
 };

--- a/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
+++ b/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
@@ -3,19 +3,14 @@ import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { KEYCODES } from 'foremanReact/common/keyCodes';
 import { Table, FormControl, FormGroup, HelpBlock, Spinner } from 'patternfly-react';
 import { validateQuantity } from '../../../scenes/Subscriptions/SubscriptionValidations';
+import { getEntitlementsDisplayValue } from '../../../scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers';
 
-const renderValue = (value, additionalData, onActivate) => {
+const renderValue = (rawValue, additionalData, onActivate) => {
   const { available, upstream_pool_id: upstreamPoolId, collapsible } = additionalData.rowData;
 
-  if (collapsible) {
-    return (
-      <td>{__('NA')}</td>
-    );
-  } else if (available < 0 || !upstreamPoolId) {
-    return (
-      <td>{available < 0 ? __('Unlimited') : available}</td>
-    );
-  }
+  const value = getEntitlementsDisplayValue({
+    rawValue, available, collapsible, upstreamPoolId,
+  });
 
   return (
     <td className="editable">

--- a/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
+++ b/webpack/components/pf3Table/formatters/EntitlementsInlineEditFormatter.js
@@ -11,7 +11,7 @@ const renderValue = (rawValue, additionalData, onActivate) => {
   const value = getEntitlementsDisplayValue({
     rawValue, available, collapsible, upstreamPoolId,
   });
-  const editable = (value === rawValue);
+  const editable = (typeof value === 'number');
 
   return (
     <td className={editable ? 'editable' : ''}>

--- a/webpack/components/pf3Table/formatters/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
+++ b/webpack/components/pf3Table/formatters/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
@@ -222,7 +222,17 @@ exports[`EntitlementsInlineEditFormatter value mode renders the value 1`] = `
 `;
 
 exports[`EntitlementsInlineEditFormatter value mode renders unlimited for -1 1`] = `
-<td>
-  Unlimited
+<td
+  className="editable"
+>
+  <div
+    className="input"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="textbox"
+    tabIndex={0}
+  >
+    Unlimited
+  </div>
 </td>
 `;

--- a/webpack/components/pf3Table/formatters/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
+++ b/webpack/components/pf3Table/formatters/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
@@ -223,16 +223,8 @@ exports[`EntitlementsInlineEditFormatter value mode renders the value 1`] = `
 
 exports[`EntitlementsInlineEditFormatter value mode renders unlimited for -1 1`] = `
 <td
-  className="editable"
+  className=""
 >
-  <div
-    className="input"
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    role="textbox"
-    tabIndex={0}
-  >
-    Unlimited
-  </div>
+  Unlimited
 </td>
 `;

--- a/webpack/components/pf3Table/formatters/entitlementsValueFormatter.js
+++ b/webpack/components/pf3Table/formatters/entitlementsValueFormatter.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Table as PfTable } from 'patternfly-react';
+import { getEntitlementsDisplayValue } from '../../../scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js';
+
+export default (rawValue, additionalData) => {
+  const { available, upstream_pool_id: upstreamPoolId, collapsible } = additionalData.rowData;
+  const value = getEntitlementsDisplayValue({
+    rawValue, available, collapsible, upstreamPoolId,
+  });
+
+  return (
+    <PfTable.Cell>
+      {value}
+    </PfTable.Cell>
+  );
+};

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
@@ -1,3 +1,6 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
+
 const getMaxQuantity = (subscription, upstreamAvailable) => {
   if (upstreamAvailable === -1) {
     return upstreamAvailable;
@@ -102,3 +105,17 @@ export const buildPools = updatedQuantity =>
     id,
     quantity,
   }));
+
+export const getEntitlementsDisplayValue = ({
+  rawValue, available, collapsible, upstreamPoolId,
+}) => {
+  if (collapsible) {
+    return __('NA');
+  }
+  if ((available && available < 0) || !upstreamPoolId) {
+    return (
+      available < 0 ? __('Unlimited') : available
+    );
+  }
+  return rawValue;
+};

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Icon } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
+import entitlementsValueFormatter from '../../../../components/pf3Table/formatters/entitlementsValueFormatter.js';
 import { entitlementsInlineEditFormatter } from '../../../../components/pf3Table/formatters/EntitlementsInlineEditFormatter';
 import { subscriptionTypeFormatter } from './SubscriptionTypeFormatter';
 import { subscriptionNameFormatter } from './SubscriptionNameFormatter';
@@ -16,7 +17,7 @@ function getEntitlementsFormatter(inlineEditController, canManageSubscriptionAll
   if (canManageSubscriptionAllocations) {
     return entitlementsInlineEditFormatter(inlineEditController);
   }
-  return cellFormatter;
+  return entitlementsValueFormatter;
 }
 
 export const createSubscriptionsTableSchema = (


### PR DESCRIPTION
### Issue
While a manifest task is in progress (refresh, add subscription, delete, etc), the subscription entitlements count is showing as -1 for custom products.

### Cause
The `canManageSubscriptionAllocations` permission is set to a falsey value during this time.  (See `getEntitlementsFormatter` in `webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js`) This causes the formatter for the table cell to fall back to the `cellFormatter` instead of `entitlementsInlineEditFormatter`, and thus the raw value is passed directly to the table with no formatting.

### To recreate
On the Subscriptions page, make sure you have at least one custom product (the Entitlement column for that product should show quantity as 'Unlimited').
Now you can see the issue one of 3 ways:
1. Refresh the browser, and notice 'Unlimited' changes to '-1' only while the page is loading.
2. Log in as or impersonate a user with only Viewer role.  You will see '-1' even after the page is finished loading.
3. Start a manifest task (add subscriptions, delete subscriptions, refresh manifest, etc.)  You will see '-1' behind the task progress dialog.

### Solution
The formatting logic should be applied regardless of whether or not the user has edit permissions.  I added a new Patternfly cell formatter for the Entitlements cells, and made sure the formatting logic runs from both formatters.