### PR TITLE
Fixes #31880 - correctly use SSL for qpid connections

### DIFF
--- a/app/lib/katello/agent/connection.rb
+++ b/app/lib/katello/agent/connection.rb
@@ -1,23 +1,37 @@
 module Katello
   module Agent
     class Connection
+      def initialize
+        @connection = ::Katello::Qpid::Connection.new(
+          url: settings[:broker_url],
+          ssl_cert_file: settings[:broker_ssl_cert_file],
+          ssl_key_file: settings[:broker_ssl_key_file],
+          ssl_ca_file: settings[:broker_ssl_ca_file]
+        )
+      end
+
       def send_messages(messages)
-        connection = ::Katello::Qpid::Connection.new(settings[:broker_url])
-        connection.send_messages(messages)
+        @connection.send_messages(messages)
       end
 
       def fetch_agent_messages(handler = ClientMessageHandler)
-        connection = ::Katello::Qpid::Connection.new(settings[:broker_url])
-        connection.receive_messages(address: settings[:event_queue_name], handler: handler)
+        @connection.receive_messages(address: settings[:event_queue_name], handler: handler)
       end
 
       def delete_client_queue(queue_name)
-        connection = ::Katello::Qpid::Connection.new(settings[:broker_url])
-        connection.delete_queue(queue_name)
+        @connection.delete_queue(queue_name)
       end
 
       def settings
         SETTINGS[:katello][:agent]
+      end
+
+      def open?
+        @connection.open?
+      end
+
+      def close
+        @connection.close
       end
     end
   end

--- a/app/lib/katello/event_daemon/services/agent_event_receiver.rb
+++ b/app/lib/katello/event_daemon/services/agent_event_receiver.rb
@@ -34,17 +34,18 @@ module Katello
 
           @thread = Thread.new do
             @handler = Handler.new
-            agent_connection = ::Katello::Agent::Connection.new
-            agent_connection.fetch_agent_messages(@handler)
+            @agent_connection = ::Katello::Agent::Connection.new
+            @agent_connection.fetch_agent_messages(@handler)
           end
         end
 
         def self.close
-          @thread&.kill
+          @agent_connection&.close
+          @thread&.join
         end
 
         def self.running?
-          @thread&.status.present?
+          @agent_connection&.open? && @thread&.status.present?
         end
 
         def self.status(refresh: true)

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -60,10 +60,9 @@ module Katello
           :client_queue_format => 'pulp.agent.%s',
           :event_queue_name => 'katello.agent',
           :broker_url => 'amqps://localhost:5671',
-          # puppetize these
-          :broker_ssl_cert_file => '/etc/pki/katello/qpid_router_client.crt',
-          :broker_ssl_key_file => '/etc/pki/katello/qpid_router_client.key',
-          :broker_ssl_ca_file => '/etc/pki/katello/certs/katello-default-ca.crt'
+          :broker_ssl_cert_file => SETTINGS[:ssl_certificate],
+          :broker_ssl_key_file => SETTINGS[:ssl_priv_key],
+          :broker_ssl_ca_file => SETTINGS[:ssl_ca_file]
         }
       }
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -58,8 +58,12 @@ module Katello
         },
         :agent => {
           :client_queue_format => 'pulp.agent.%s',
-          :broker_url => 'amqp:ssl:localhost:5671',
-          :event_queue_name => 'katello.agent'
+          :event_queue_name => 'katello.agent',
+          :broker_url => 'amqps://localhost:5671',
+          # puppetize these
+          :broker_ssl_cert_file => '/etc/pki/katello/qpid_router_client.crt',
+          :broker_ssl_key_file => '/etc/pki/katello/qpid_router_client.key',
+          :broker_ssl_ca_file => '/etc/pki/katello/certs/katello-default-ca.crt'
         }
       }
 


### PR DESCRIPTION
Correctly sets up the SSL connection and handles closing qpid connections a little better. I need to give this a more thorough test but my dev env is in an odd state..

To be tested in conjunction with https://github.com/theforeman/puppet-katello/pull/384 and https://github.com/theforeman/puppet-foreman_proxy_content/pull/327/files
