### PR TITLE
Fixes #31887 - Discard systemctl output

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -9,7 +9,7 @@ module Katello
         SETTINGS[:katello][:use_pulp_2_for_content_type].nil? || (!SETTINGS[:katello][:use_pulp_2_for_content_type][:yum] &&
         !SETTINGS[:katello][:use_pulp_2_for_content_type][:docker] &&
         !SETTINGS[:katello][:use_pulp_2_for_content_type][:file]) ||
-        system('systemctl is-enabled pulpcore-api.service')
+        system('systemctl is-enabled pulpcore-api.service &>/dev/null')
       end
 
       def services(capsule_id = nil)


### PR DESCRIPTION
The command prints enabled/disabled to stdout which ends up in the terminal when
running any rake task which depends on katello:check_ping. Since we do not need
the output, let's redirect it to /dev/null.