### PR TITLE
Fixes #31506 - support disk space check/widget for pulpcore

### DIFF
--- a/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
@@ -26,8 +26,7 @@ module Katello
         before_action :find_resource_and_status, :only => [:pulp_storage, :pulp_status]
 
         def pulp_storage
-          pulp_connection = @proxy_status[:pulp] || @proxy_status[:pulpnode]
-          @storage = pulp_connection.storage
+          @storage = @smart_proxy.pulp_disk_usage
           respond_to do |format|
             format.html { render :layout => false }
             format.json { render :json => {:success => true, :message => @storage} }

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -153,6 +153,34 @@ module Katello
         end
       end
 
+      def pulp_disk_usage
+        if has_feature?(PULP_FEATURE) || has_feature?(PULP_NODE_FEATURE)
+          status = self.statuses[:pulp] || self.statuses[:pulpnode]
+          status&.storage&.map do |label, results|
+            {
+              description: results['path'],
+              total: results['1k-blocks'] * 1024,
+              used: results['used'] * 1024,
+              free: results['available'] * 1024,
+              percentage: (results['used'] / results['1k-blocks'].to_f * 100).to_i,
+              label: label
+            }.with_indifferent_access
+          end
+        elsif pulp3_enabled?
+          storage = ping_pulp3['storage']
+          [
+            {
+              description: 'Pulp Storage (/var/lib/pulp by default)',
+              total: storage['total'],
+              used: storage['used'],
+              free: storage['free'],
+              percentage: (storage['used'] / storage['total'].to_f * 100).to_i,
+              label: 'pulp_dir'
+            }.with_indifferent_access
+          ]
+        end
+      end
+
       def backend_service_type(repository)
         if pulp3_support?(repository)
           Actions::Pulp3::Abstract::BACKEND_SERVICE_TYPE

--- a/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
+++ b/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
@@ -5,12 +5,9 @@ module Katello
         class << self
           def deliver!
             SmartProxy.unscoped.with_content.each do |proxy|
-              status = proxy.statuses[:pulp] || proxy.statuses[:pulpnode]
-              next unless (percentage = status&.storage&.dig('pulp_dir', 'percent'))
-
-              if percentage[0..2].to_i < 90 && notification_already_exists?(proxy)
+              if percentage < 90 && notification_already_exists?(proxy)
                 blueprint.notifications.where(subject: proxy).destroy_all
-              elsif update_notifications(proxy).empty? && percentage[0..2].to_i > 90
+              elsif update_notifications(proxy).empty? && percentage > 90
                 ::Notification.create!(
                   :subject => proxy,
                   :initiator => User.anonymous_admin,

--- a/app/views/smart_proxies/_disk_usage.html.erb
+++ b/app/views/smart_proxies/_disk_usage.html.erb
@@ -3,12 +3,14 @@
     <div class="progress-description" title="<%= disk['header'] %>">
       <%= disk['header'] %>
     </div>
+
     <div class="progress progress-label-top-right">
-      <div class="progress-bar progress-bar-<%= disk['size_status'] %>" role="progressbar" aria-valuenow="<%= disk['percent'].delete('%') %>" aria-valuemin="0" aria-valuemax="100" style="width: <%= disk['percent'] %>;" data-toggle="tooltip" title="<%= _('%s Used') % disk['used'] %>">
-        <span><strong><%= _('%{used} of %{total}') % {:used => disk['used'],:total => disk['total']} %></strong> Used</span>
+      <div class="progress-bar progress-bar-<%= disk['size_status'] %>" role="progressbar" aria-valuenow="<%= disk['percentage'] %>" aria-valuemin="0" aria-valuemax="100" style="width: <%= disk['percentage'] %>%;" data-toggle="tooltip" title="<%= _('%s Used') % humanize_bytes(disk['used']) %>">
+        <span><strong><%= _('%{used} of %{total}') % {:used => humanize_bytes(disk['used']),:total => humanize_bytes(disk['total'])} %></strong> Used</span>
       </div>
-      <div class="progress-bar progress-bar-remaining" role="progressbar" aria-valuenow="<%= disk['available_percent'].delete('%') %>" aria-valuemin="0" aria-valuemax="100" style="width: <%= disk['available_percent'] %>;" data-toggle="tooltip" title="<%= _('%s Available') % disk['available'] %>">
-        <span class="sr-only"><%= _('%s Available') % disk['available'] %></span>
+
+      <div class="progress-bar progress-bar-remaining" role="progressbar" aria-valuenow="<%= disk['available_percent'] %>" aria-valuemin="0" aria-valuemax="100" style="width: <%= disk['available_percent'] %>%;" data-toggle="tooltip" title="<%= _('%s Available') % humanize_bytes(disk['free']) %>">
+        <span class="sr-only"><%= _('%s Available') % humanize_bytes(disk['free']) %></span>
       </div>
     </div>
   </div>

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -293,7 +293,7 @@ Foreman::Plugin.register :katello do
     cx.add_pagelet :details_content,
                    :name => _('Storage'),
                    :partial => 'smart_proxies/show/storage',
-                   :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_FEATURE) || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) }
+                   :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_FEATURE) || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) || proxy.has_feature?(SmartProxy::PULP3_FEATURE) }
   end
 
   register_facet Katello::Host::ContentFacet, :content_facet do


### PR DESCRIPTION
this does a few things:
* Fixes the disk space notification to work with pulp3 (in addition to pulp2)
* Supports the disk space widget for pulp 3 (but prefers pulp2 if a SP has it)
* Changes the output of the disk space widget to only contain information that
  is supported by pulp3, for consistency