### PR TITLE
Fixes #31894 - apply errata with REX from content->errata page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -15,6 +15,15 @@
 <section class="details details-full" ng-show="selectedContentHosts && errataIds">
   <h3 ng-show="errata" translate>Apply {{ errata.errata_id }}</h3>
 
+  <form id="errataActionForm" method="post" action="/katello/remote_execution">
+    <input type="hidden" name="remote_action" value="errata_install"/>
+    <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
+    <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+    <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+    <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
+    <input type="hidden" name="install_all" ng-value="table.allResultsSelected" />
+  </form>
+
   <section ng-hide="updates.length > 0">
     <div ng-show="errata">
       <p translate ng-show="contentHostIds.length === 0">


### PR DESCRIPTION
To test:

1) Install remote execution on your machine
2) Set the option Content > "Use remote execution by default" to true
3) Go to the WebUI > Content > Errata > select errata > apply errata > select hosts > Next > Apply Errata > Confirm
4) Notice that katello-agent is still trying to be used
5) Apply this PR
6) Try step 3 again

I wasn't able to get remote execution working properly on my development environment, but I did see the job run with the proper parameters for hosts and errata.

I don't fix bugs in the JavaScript often, so let me know if I'm doing anything weird. 