### PR TITLE
Fixes #31918 - Host Registration - Activation key field improvements

### DIFF
--- a/app/views/foreman/hosts/_registration_commands.html.erb
+++ b/app/views/foreman/hosts/_registration_commands.html.erb
@@ -1,12 +1,12 @@
 <div class='form-group'>
   <label class='col-md-2 control-label'>
-    <%= _('Activation Key(s)') %>
-    <% help = _('Activation key(s) for Subscription Manager. Required for CentOS and Red Hat Enterprise Linux. Multiple keys add separated by comma, example: key1,key2,key3.') %>
+    <%= _('Activation Key(s) *') %>
+    <% help = _('Activation key(s) for Subscription Manager. Multiple keys should be comma-separated, for example: key1,key2,key3.') %>
     <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
       <span class="pficon pficon-info "></span>
     </a>
   </label>
   <div class='col-md-4'>
-    <%= text_field_tag 'activation_key', params[:activation_key], class: 'form-control' %>
+    <%= text_field_tag 'activation_key', params[:activation_key], class: 'form-control', required: true %>
   </div>
 </div>


### PR DESCRIPTION
6.9 BZs:
* Remove CentOS from label - https://bugzilla.redhat.com/show_bug.cgi?id=1921491
* Required field - https://bugzilla.redhat.com/show_bug.cgi?id=1919566 & https://bugzilla.redhat.com/show_bug.cgi?id=1919960