### PR TITLE
Fixes #31910 - Hide k-agent dep warnings if setting is disabled.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -57,7 +57,9 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.initialLoad = true;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.allHostsSelected = hostIds.allResultsSelected;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.errataActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
@@ -46,6 +46,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
 
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.packageActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -27,7 +27,14 @@
       </div>
     </div>
 
-    <div data-extend-template="common/views/katello-agent-notice.html"></div>
+    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
+    <div bst-feature-flag="remote_actions">
+      <p bst-alert="warning" ng-hide="hostToolingEnabled">
+        <span translate>
+          Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+          </span>
+      </p>
+    </div>
 
     <div ng-show="showTable()" data-extend-template="layouts/partials/table.html">
       <div data-block="list-actions">
@@ -39,19 +46,19 @@
 
         <span uib-dropdown class="btn-group">
           <button class="btn btn-primary" type="button"
-                  ng-disabled="table.numSelected === 0 || table.working || table.numSelected === 0"
+                  ng-disabled="table.numSelected === 0 || table.working || table.numSelected === 0 || !hostToolingEnabled"
                   ng-click="showConfirm = true;">
             <span translate>Install Selected</span>
           </button>
           <button uib-dropdown-toggle class="btn btn-primary" type="button"
-                  ng-hide="!remoteExecutionPresent"
+                  ng-show="remoteExecutionPresent"
                   ng-disabled="table.numSelected === 0 || table.working || table.numSelected === 0"
                   type="button" id="use-remote-execution">
             <span class="caret"></span>
           </button>
 
           <ul uib-dropdown-menu class="dropdown-menu-right" role="menu" aria-labelledby="use-remote-execution">
-            <li role="presentation"><a ng-click="installErrataViaKatelloAgent()" role="menuitem" translate>via Katello agent</a></li>
+            <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="installErrataViaKatelloAgent()" role="menuitem" translate>via Katello agent</a></li>
             <li role="presentation"><a ng-click="installErrataViaRemoteExecution(false)" role="menuitem" translate>via remote execution</a></li>
             <li role="presentation"><a ng-click="installErrataViaRemoteExecution(true)" role="menuitem" translate>via remote execution - customize first</a></li>
           </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -8,7 +8,14 @@
       </div>
     </div>
 
-    <div data-extend-template="common/views/katello-agent-notice.html"></div>
+    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
+    <div bst-feature-flag="remote_actions">
+      <p bst-alert="warning" ng-hide="hostToolingEnabled">
+        <span translate>
+          Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+          </span>
+      </p>
+    </div>
 
     <span uib-dropdown class="input-group-btn">
       <button class="btn btn-default"
@@ -16,17 +23,17 @@
               translate
               ng-hide="denied('edit_hosts')"
               ng-click="confirmContentAction('update all', content)"
-              ng-disabled="(table.numSelected === 0)">
+              ng-disabled="(table.numSelected === 0) || !hostToolingEnabled">
         Update All Packages
       </button>
       <button uib-dropdown-toggle class="btn btn-default"
-              ng-hide="!remoteExecutionPresent"
+              ng-show="remoteExecutionPresent"
               ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
               type="button" id="update-all-use-remote-execution">
         <span class="caret"></span>
       </button>
       <ul uib-dropdown-menu role="menu" aria-labelledby="install-use-remote-execution">
-        <li role="presentation"><a ng-click="performViaKatelloAgent('update all', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+        <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('update all', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
         <li role="presentation"><a ng-click="performViaRemoteExecution('update all', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
         <li role="presentation"><a ng-click="performViaRemoteExecution('update all', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
       </ul>
@@ -77,17 +84,17 @@
                 translate
                 ng-hide="denied('edit_hosts')"
                 ng-click="confirmContentAction('install', content)"
-                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm">
+                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm || !hostToolingEnabled">
           Install
         </button>
         <button uib-dropdown-toggle class="btn btn-default"
-                ng-hide="!remoteExecutionPresent"
+                ng-show="remoteExecutionPresent"
                 ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
                 type="button" id="install-use-remote-execution">
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="install-use-remote-execution">
-          <li role="presentation"><a ng-click="performViaKatelloAgent('install', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('install', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('install', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('install', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>
@@ -98,7 +105,7 @@
                 translate
                 ng-hide="denied('edit_hosts')"
                 ng-click="confirmContentAction('update', content)"
-                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm || !hostToolingEnabled"
                 ng-hide="content.contentType == 'errata'">
           Update
         </button>
@@ -109,7 +116,7 @@
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="update-use-remote-execution">
-          <li role="presentation"><a ng-click="performViaKatelloAgent('update', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('update', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('update', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('update', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>
@@ -120,7 +127,7 @@
                 translate
                 ng-hide="content.contentType == 'errata' || denied('edit_hosts')"
                 ng-click="confirmContentAction('remove', content)"
-                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm">
+                ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm || !hostToolingEnabled">
           Remove
         </button>
         <button uib-dropdown-toggle class="btn btn-default"
@@ -130,7 +137,7 @@
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="remove-use-remote-execution">
-          <li role="presentation"><a ng-click="performViaKatelloAgent('remove', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('remove', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('remove', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('remove', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -43,6 +43,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
 
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
         $scope.errataActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
@@ -4,13 +4,17 @@
  *
  * @requires $scope
  * @requires $location
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host package actions.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesActionsController',
-    ['$scope', '$location', function ($scope, $location) {
+    ['$scope', '$location', 'BastionConfig', function ($scope, $location, BastionConfig) {
         var packageName = $location.search().package_name;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.packageAction = {actionType: 'packageInstall'}; //default to packageInstall
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-applicable.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-applicable.controller.js
@@ -9,14 +9,19 @@
  * @requires HostPackage
  * @requires translate
  * @requires Nutupane
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host packages list and actions.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesApplicableController',
-    ['$scope', '$timeout', '$window', 'Package', 'HostPackage', 'translate', 'Nutupane',
-    function ($scope, $timeout, $window, Package, HostPackage, translate, Nutupane) {
+    ['$scope', '$timeout', '$window', 'Package', 'HostPackage', 'translate', 'Nutupane', 'BastionConfig',
+    function ($scope, $timeout, $window, Package, HostPackage, translate, Nutupane, BastionConfig) {
         var packagesNutupane, openEventInfo;
+
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.getSelectedPackages = function () {
             var selected = $scope.table.getSelected();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
@@ -8,14 +8,19 @@
  * @requires HostPackage
  * @requires translate
  * @requires Nutupane
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host packages list and actions.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesInstalledController',
-    ['$scope', '$timeout', '$window', 'HostPackage', 'translate', 'Nutupane',
-    function ($scope, $timeout, $window, HostPackage, translate, Nutupane) {
+    ['$scope', '$timeout', '$window', 'HostPackage', 'translate', 'Nutupane', 'BastionConfig',
+    function ($scope, $timeout, $window, HostPackage, translate, Nutupane, BastionConfig) {
         var packagesNutupane;
+
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+        $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.removeSelectedPackages = function () {
             var selected = _.map($scope.table.getSelected(), 'name');

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -5,7 +5,7 @@
   <h3 translate ng-show="selectedErrataOption === 'current'">Installable Errata</h3>
 </div>
 
-<div data-extend-template="common/views/katello-agent-notice.html"></div>
+<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
 
 <div ng-hide="host.hasContent()">
   <div data-extend-template="common/views/registration.html"></div>
@@ -24,10 +24,10 @@
   </div>
 
   <div bst-feature-flag="remote_actions">
-    <p bst-alert="info" ng-hide="host.content_facet_attributes.katello_agent_installed">
+    <p bst-alert="warning" ng-hide="hostToolingEnabled">
       <span translate>
-        If you are not using Remote Execution to manage content on this host, ensure that it has the katello-agent package installed.
-      </span>
+        Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+        </span>
     </p>
   </div>
 
@@ -69,7 +69,7 @@
             <button class="btn btn-default" type="button"
                     translate
                     ng-hide="denied('edit_hosts', host)"
-                    ng-disabled="table.getSelected().length == 0"
+                    ng-disabled="table.getSelected().length == 0 || !hostToolingEnabled"
                     ng-click="openModal()">
               Apply Selected
             </button>
@@ -80,7 +80,7 @@
               <span class="caret"></span>
             </button>
             <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-              <li role="presentation"><a ng-click="performViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+              <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
               <li role="presentation"><a ng-click="performViaRemoteExecution(false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
               <li role="presentation"><a ng-click="performViaRemoteExecution(true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
             </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -2,11 +2,11 @@
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <h4 translate>Package Actions</h4>
-  <div data-extend-template="common/views/katello-agent-notice.html"></div>
-  <p bst-alert="info" ng-hide="host.content_facet_attributes.katello_agent_installed">
+  <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
+  <p bst-alert="warning" ng-hide="hostToolingEnabled">
     <span translate>
-      If you are not using Remote Execution to manage content on this host, ensure that it has the katello-agent package installed.
-    </span>
+      Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+      </span>
   </p>
   <section>
     <div class="row">
@@ -33,7 +33,7 @@
               <button class="btn btn-primary" type="button"
                       ng-click="performPackageAction(packageAction.actionType, packageAction.term)"
                       ng-hide="denied('edit_hosts', host)"
-                      ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
+                      ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0 || !hostToolingEnabled"
                       translate>
                 Perform
               </button>
@@ -44,7 +44,7 @@
                 <span class="caret"></span>
               </button>
               <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-                <li role="presentation"><a ng-click="performViaKatelloAgent(packageAction.actionType, packageAction.term)" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+                <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent(packageAction.actionType, packageAction.term)" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
                 <li role="presentation"><a ng-click="performViaRemoteExecution(packageAction.actionType, packageAction.term, false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
                 <li role="presentation"><a ng-click="performViaRemoteExecution(packageAction.actionType, packageAction.term, true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
               </ul>
@@ -55,7 +55,7 @@
         <div class="form-group">
           <button class="btn btn-default" type="button"
                   translate
-                  ng-disabled="working"
+                  ng-disabled="!katelloAgentPresent || working"
                   ng-click="updateAll()">
             Update All Packages
           </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -1,8 +1,16 @@
 <span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
 
-
 <h3 translate>Applicable Packages</h3>
-<div data-extend-template="common/views/katello-agent-notice.html"></div>
+<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
+
+<section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
+  <p bst-alert="warning" ng-hide="hostToolingEnabled">
+    <span translate>
+      Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+      </span>
+  </p>
+</section>
+
 <div data-extend-template="layouts/partials/table.html">
 
   <span data-block="no-rows-message" translate>
@@ -21,18 +29,18 @@
           <button class="btn btn-primary" type="button"
                   ng-click="performDefaultUpdateAction()"
                   ng-hide="denied('edit_hosts', host)"
-                  ng-disabled="working || table.numSelected === 0"
+                  ng-disabled="working || table.numSelected === 0 || !hostToolingEnabled"
                   translate>
             Upgrade Selected
           </button>
           <button uib-dropdown-toggle class="btn btn-default"
-                  ng-hide="!remoteExecutionPresent || denied('edit_hosts', contentHost)"
+                  ng-hide="!remoteExecutionPresent || denied('edit_hosts', host)"
                   ng-disabled="working ||  table.numSelected === 0"
                   type="button" id="use-remote-execution">
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-            <li role="presentation"><a ng-click="performViaKatelloAgent('packageUpdate', getKatelloAgentCommand())" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+            <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('packageUpdate', getKatelloAgentCommand())" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
             <li role="presentation"><a ng-click="performViaRemoteExecution('packageUpdate', getRemoteExecutionCommand(), false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
             <li role="presentation"><a ng-click="performViaRemoteExecution('packageUpdate', getRemoteExecutionCommand(), true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
           </ul>
@@ -41,7 +49,7 @@
         <button class="btn btn-default"
                 type="button"
                 translate
-                ng-disabled="working"
+                ng-disabled="working || !katelloAgentPresent"
                 ng-click="updateAll()">
           Update All Packages
         </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -2,13 +2,13 @@
 
 <h3 translate>Installed Packages</h3>
 
-<div data-extend-template="common/views/katello-agent-notice.html"></div>
+<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
-  <p bst-alert="info" ng-hide="host.content_facet_attributes.katello_agent_installed">
+  <p bst-alert="warning" ng-hide="hostToolingEnabled">
     <span translate>
-      If you are not using Remote Execution to manage content on this host, ensure that it has the katello-agent package installed.
-    </span>
+      Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+      </span>
   </p>
 </section>
 
@@ -24,7 +24,7 @@
   <div data-block="list-actions" bst-feature-flag="remote_actions">
     <button class="btn btn-default" type="button"
             ng-hide="denied('edit_hosts', host)"
-            ng-disabled="working || table.numSelected === 0"
+            ng-disabled="working || table.numSelected === 0 || !hostToolingEnabled"
             ng-click="removeSelectedPackages()">
       <span translate>Remove Selected</span>
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -51,10 +51,10 @@
           </button>
         </dd>
 
-        <dt bst-feature-flag="remote_actions">
+        <dt bst-feature-flag="remote_actions" ng-show="katelloAgentPresent">
           <span translate>Katello Agent</span>
         </dt>
-        <dd bst-feature-flag="remote_actions">
+        <dd bst-feature-flag="remote_actions" ng-show="katelloAgentPresent">
           <span ng-show="host.content_facet_attributes.katello_agent_installed">
             <span class="{{ getHostStatusIcon(0) }}"></span>
             <span translate>Installed</span>

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -42,9 +42,10 @@ module BastionKatello
         :config_generator =>  lambda do
           { 'consumerCertRPM' => consumer_cert_rpm,
             'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
+            'katelloAgentPresent' => ::Katello.with_katello_agent?,
             'remoteExecutionPresent' => ::Katello.with_remote_execution?,
-            'remoteExecutionByDefault' => ::Katello.with_remote_execution? &&
-                                          db_migrated && Setting['remote_execution_by_default']
+            'hostToolingEnabled' => (::Katello.with_katello_agent? || ::Katello.with_remote_execution?) ? true : false,
+            'remoteExecutionByDefault' => ::Katello.remote_execution_by_default?
           }
         end
       )

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -253,6 +253,14 @@ module Katello
     (RemoteExecutionFeature rescue false) ? true : false
   end
 
+  def self.with_katello_agent?
+    !!SETTINGS.dig(:katello, :agent, :enabled)
+  end
+
+  def self.remote_execution_by_default?
+    self.with_katello_agent? ? Setting['remote_execution_by_default'] : true
+  end
+
   def self.with_ansible?
     (ForemanAnsible rescue false) ? true : false
   end


### PR DESCRIPTION
This PR is a draft to show/hide the deprecation warnings for katello-agent if the setting is enabled in the installer. By default, katello-agent will be disabled so we hide the warnings in the UI, if the user enabled it then we will show them.

Client with katello-agent not installed:

https://nimb.ws/0qu6iK

Client with katello-agent installed:

https://nimb.ws/BOSiEk

Bulk update packages with katello-agent status set to true:

https://nimb.ws/OvgA4k

Bulk update packages with katello-agent status set to false:

https://nimb.ws/43e51x

Right now, I am keeping the PR as a draft as Eric Helms is working on a Smart Proxy feature which will set/configure the status. When that is made, I will update this PR to pull the state from that.

I am opening this in the interim for feedback etc.

To test toggle: 

https://github.com/Katello/katello/compare/master...chris1984:hide-agentwarn?expand=1#diff-7dc78088a8bc944d190599ecf572ea01ab9b85fc91415ddcadf17dd5e9b1638eR262 

To true/false and check the following pages:

- content-hosts-bulk-errata
- content-hosts-bulk-packages
- content-host-errata
- content-host-packages-actions
- content-host-packages-applicable
- content-host-packages-installed