### PR TITLE
Fixes #31921 - fix cancel on sync status page

### DIFF
--- a/app/assets/stylesheets/katello/contents.scss
+++ b/app/assets/stylesheets/katello/contents.scss
@@ -322,7 +322,7 @@ $container_width: ($static_width/2) - 36;
         position: relative;
         text-align: left;
         bottom: 18px;
-        left: 30px;
+        left: 10px;
       }
       .progress {
         display: inline-block;


### PR DESCRIPTION
this adjusts the position of the cancel link such that
long repo names no longer push it out of the table