### PR TITLE
Refs #31788 - Can migrate CVV Export History correctly

### DIFF
--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -8,13 +8,14 @@ module Katello
 
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :inverse_of => :export_histories
     validates_lengths_from_database
+
     validates :content_view_version_id, :presence => true
     validates :destination_server, :uniqueness => { :scope => [:content_view_version_id, :destination_server, :path] }
-    validates :export_type, :inclusion => { :in => EXPORT_TYPES,
-                                            :allow_blank => false,
-                                            :message => _("Invalid export_type from one of the following: %s" % EXPORT_TYPES.join(', '))
-                                          }
-
+    validates :export_type, :presence => true,
+              :inclusion => { :in => EXPORT_TYPES,
+                              :allow_blank => false,
+                              :message => _("must be one of the following: %s" % EXPORT_TYPES.join(', '))
+                            }
     validates :metadata, :presence => true
     serialize :metadata, Hash
 
@@ -39,7 +40,7 @@ module Katello
     end
 
     def export_type_from_metadata
-      cvve.metadata[:incremental] ? INCREMENTAL : COMPLETE
+      metadata[:incremental] ? INCREMENTAL : COMPLETE
     end
 
     def set_export_type

--- a/db/migrate/20210218214048_change_default_content_view_version_export_history.rb
+++ b/db/migrate/20210218214048_change_default_content_view_version_export_history.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultContentViewVersionExportHistory < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:katello_content_view_version_export_histories, :export_type, nil)
+  end
+end

--- a/test/fixtures/models/katello_content_view_version_export_histories.yml
+++ b/test/fixtures/models/katello_content_view_version_export_histories.yml
@@ -2,6 +2,7 @@ library_view_version_1_export_history:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
   destination_server:   perfect.example.com
   path:  /tmp/perfect
+  export_type: complete
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
@@ -10,5 +11,6 @@ library_view_version_1_server2:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
   destination_server:   lovely.example.com
   path:  /tmp/lovely
+  export_type: incremental
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>

--- a/test/models/content_view_version_export_history_test.rb
+++ b/test/models/content_view_version_export_history_test.rb
@@ -59,14 +59,23 @@ module Katello
     end
 
     def test_valid_on_blank_export_type
-      destination = "greatest"
       path = "/tmp"
       assert_nothing_raised do
-        ::Katello::ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
-                                                              destination_server: destination,
-                                                              metadata: {foo: :bar},
-                                                              path: path)
+        ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                  metadata: {foo: :bar},
+                                                  path: path)
       end
+      assert_equal ContentViewVersionExportHistory.latest(@cvv.content_view).export_type, "complete"
+    end
+
+    def test_valid_on_export_type_from_metadata
+      path = "/tmp"
+      assert_nothing_raised do
+        ContentViewVersionExportHistory.create!(content_view_version_id: @cvv.id,
+                                                  metadata: { incremental: true },
+                                                  path: path)
+      end
+      assert_equal ContentViewVersionExportHistory.latest(@cvv.content_view).export_type, "incremental"
     end
 
     def test_scoped_search_export_type


### PR DESCRIPTION
Due to a botched previous commit to this issue if one tried to migrate
with existing export histories you'd hit the following issue
`undefined local variable or method `cvve' for

This commit fixes that