### PR TITLE
Fixes #31923 - allow setting no proxy too

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -2,7 +2,7 @@ class Setting::Content < Setting
   #rubocop:disable Metrics/MethodLength
   #rubocop:disable Metrics/AbcSize
 
-  validate :content_default_http_proxy, if: proc { |s| s.name == 'content_default_http_proxy' && HttpProxy.table_exists? }
+  validate :content_default_http_proxy, if: proc { |s| s.name == 'content_default_http_proxy' && HttpProxy.table_exists? && s.value.present? }
 
   after_save :add_organizations_and_locations_if_global_http_proxy
 


### PR DESCRIPTION
the blank value caused problem when user tries to reset this to the default (nil), because no proxy can be found