### PR TITLE
Fixes #31859 - Add documentation for template macros

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -2,10 +2,27 @@ require 'uri'
 
 module Katello
   module KatelloUrlsHelper
+    extend ApipieDSL::Module
+
+    apipie :class, 'Helper macros related to content to use within a template' do
+      name 'Content helpers'
+      sections only: %w[all reports provisioning jobs partition_tables]
+    end
+
+    apipie :method, 'Returns Foreman URL based on settings' do
+      optional :schema, String, desc: 'Optional URL schema'
+      returns String, desc: 'Foreman URL based on settings and schema if provided'
+    end
     def foreman_settings_url(schema = 'http')
       ::Setting[:foreman_url].sub(%r|^.*?:|, "#{schema}:")
     end
 
+    apipie :method, 'Returns subscription manager configuration URL' do
+      optional :host, 'Host::Managed', desc: "The host that will be making the request (URL will be of that host's smart proxy)", default: nil
+      optional :rpm, [true, false], desc: 'When true, the returned URL will lead to the configuration as an RPM package. When false, the URL will lead to the plain-text configuration script', default: true
+      keyword :hostname, String, desc: 'Override the hostname in the URL with the specified hostname', default: nil
+      returns String, desc: 'Subscription manager configuration URL based on provided arguments'
+    end
     def subscription_manager_configuration_url(host = nil, rpm = true, hostname: nil)
       prefix = if hostname
                  "http://#{hostname}"
@@ -20,6 +37,12 @@ module Katello
       "#{prefix}/pub/#{config}"
     end
 
+    apipie :method, 'Generates an absolute path to the file' do
+      required :content_path, String, desc: "Relative path to the file or it's name"
+      optional :content_type, String, desc: 'Content type', default: 'repos'
+      optional :schema, String, desc: 'Optional URL schema for the content source', default: 'http'
+      returns String, desc: 'Absolute path to a file'
+    end
     def repository_url(content_path, content_type = 'repos', schema = 'http')
       return content_path if content_path =~ %r|^([\w\-\+]+)://|
       url = if @host.content_source

--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -2,40 +2,83 @@ module Katello
   module Concerns
     module BaseTemplateScopeExtensions
       extend ActiveSupport::Concern
+      extend ApipieDSL::Module
 
+      apipie :class, 'Base macros related to content hosts to use within a template' do
+        name 'Base Content'
+        sections only: %w[all reports provisioning jobs partition_tables]
+      end
+
+      apipie :method, 'Returns an erratum by ID' do
+        required :id, Integer, desc: 'Errata ID'
+        returns Object, desc: 'The erratum object'
+      end
       def errata(id)
         Katello::Erratum.in_repositories(Katello::Repository.readable).with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
       end
 
+      apipie :method, 'Returns subscriptions for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get subscriptions for'
+        returns array_of: 'Subscription', desc: 'Array with subscription object'
+      end
       def host_subscriptions(host)
         host.subscriptions
       end
 
+      apipie :method, 'Returns subscription names for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get subscriptions for'
+        returns array_of: String, desc: "Array with names of host's subscriptions"
+      end
       def host_subscriptions_names(host)
         host.subscriptions.map(&:name)
       end
 
+      apipie :method, 'Returns Red Hat subscription names for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get subscriptions for'
+        returns array_of: String, desc: "Array with names of host's subscriptions"
+      end
       def host_redhat_subscription_names(host)
         host.subscriptions.redhat.pluck(:name)
       end
 
+      apipie :method, 'Returns the count of Red Hat subscriptions consumed for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get subscriptions for'
+        returns Integer, desc: "Count of consumed Red Hat subscriptions"
+      end
       def host_redhat_subscriptions_consumed(host)
         presenter = ::Katello::HostSubscriptionsPresenter.new(host)
         presenter.subscriptions.select(&:redhat?).sum(&:quantity_consumed)
       end
 
+      apipie :method, 'Returns content facet for the host' do
+        desc "Content facet is an object containing the host's content-related metadata and associations"
+        required :host, 'Host::Managed', desc: 'Host object to get content facet for'
+        returns 'ContentFacet'
+      end
       def host_content_facet(host)
         host.content_facet
       end
 
+      apipie :method, 'Returns service level for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get service level for'
+        returns String, example: 'host_sla(host) #=> "Standard"'
+      end
       def host_sla(host)
         host_subscription_facet(host)&.service_level
       end
 
+      apipie :method, 'Returns installed products for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get products for'
+        returns array_of: 'Product', desc: "Array of installed product objects on the host"
+      end
       def host_products(host)
         host_subscription_facet(host)&.installed_products
       end
 
+      apipie :method, 'Returns installed product names for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get products for'
+        returns array_of: String, desc: 'Array with names of installed products on the host'
+      end
       def host_products_names(host)
         products = host_products(host)
         if products
@@ -45,52 +88,113 @@ module Katello
         end
       end
 
+      apipie :method, 'Returns the host collections the host belongs to' do
+        required :host, 'Host::Managed', desc: 'Host object to get the host collections for'
+        returns array_of: 'HostCollection', desc: "Array of the host collection objects the host belongs to"
+      end
       def host_collections(host)
         host.host_collections
       end
 
+      apipie :method, 'Returns names of the host collections the host belongs to' do
+        required :host, 'Host::Managed', desc: 'Host object to get the host collections for'
+        returns array_of: String, desc: 'Array with names of the host collections the host belongs to'
+      end
       def host_collections_names(host)
         host.host_collections.map(&:name)
       end
 
+      apipie :method, 'Returns subscription name of the pool' do
+        required :pool, 'Katello::Pool', desc: 'Pool object to get subscription name of'
+        returns String, desc: 'Name of the subscription'
+      end
       def sub_name(pool)
         return unless pool
         pool.subscription&.name
       end
 
+      apipie :method, 'Returns subscription SKU' do
+        required :pool, 'Katello::Pool', desc: 'Pool object to get subscription SKU of'
+        returns String, desc: "SKU's ID of the subscription"
+      end
       def sub_sku(pool)
         return unless pool
         pool.subscription&.cp_id
       end
 
+      apipie :method, 'Returns the smart proxy that the host was registered through' do
+        required :host, 'Host::Managed', desc: 'Host object to get smart proxy of'
+        returns String, desc: 'Hostname of the smart proxy'
+      end
       def registered_through(host)
         host_subscription_facet(host)&.registered_through
       end
 
+      apipie :method, 'Returns time the host was registered at' do
+        required :host, 'Host::Managed', desc: 'Host object to get registration time of'
+        returns 'ActiveSupport::TimeWithZone', desc: 'Registration time of the host'
+      end
       def registered_at(host)
         host_subscription_facet(host)&.registered_at
       end
 
+      apipie :method, 'Returns IDs of the applicable errata on the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get the applicable errata for'
+        returns array_of: Integer, desc: 'Array with applicable errata IDs of the host'
+      end
       def host_applicable_errata_ids(host)
         host.applicable_errata.map(&:errata_id)
       end
 
+      apipie :method, 'Returns filtered applicable errata for the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get the applicable errata for'
+        optional :filter, String, desc: 'Filter to apply on applicable errata', default: ''
+        returns array_of: 'Erratum', desc: 'Filtered applicable errata for the host'
+      end
       def host_applicable_errata_filtered(host, filter = '')
         host.applicable_errata.includes(:cves).search_for(filter)
       end
 
+      apipie :method, 'Returns version of the latest applicable RPM package' do
+        required :host, 'Host::Managed', desc: 'Host object to get the applicable RPM package version on'
+        required :package, String, desc: 'Name of the package'
+        returns String, desc: 'Package version'
+      end
       def host_latest_applicable_rpm_version(host, package)
         host.applicable_rpms.where(name: package).order(:version_sortable).limit(1).pluck(:nvra).first
       end
 
+      apipie :method, 'Loads Pool objects' do
+        desc 'This macro returns a collection of Pools matching search criteria.
+          The collection is loaded in bulk, 1000 records at a time.'
+        keyword :search, String, desc: 'A search term to limit the resulting collection, using standard search syntax', default: ''
+        keyword :includes, Array, of: [String, Symbol], desc: 'An array of associations represented by strings or symbols, to be included in the SQL query. The list can be extended
+          from plugins and can not be fully documented here. Most used associations are :subscription, :products, :organization', default: nil
+        returns array_of: 'Pool', desc: 'The collection that can be iterated over using each_record'
+      end
       def load_pools(search: '', includes: nil)
         load_resource(klass: Pool.readable, search: search, permission: nil, includes: includes)
       end
 
+      apipie :method, 'Returns the last time the host checked in via RHSM' do
+        required :host, 'Host::Managed', desc: 'Host object to get the last time the host checked in'
+        returns 'ActiveSupport::TimeWithZone', desc: 'The last time the host checked in via RHSM'
+      end
       def last_checkin(host)
         host&.subscription_facet&.last_checkin
       end
 
+      apipie :method, 'Load errata applications' do
+        desc 'This macro returns a collection of task records relating to errata being applied.
+          The collection is loaded in bulk, 1000 records at a time.'
+        keyword :filter_errata_type, String, desc: "Errata type. One of: #{Katello::Erratum::TYPES.join(', ')}", default: nil
+        keyword :include_last_reboot, String, desc: "Set to 'yes' to include the last reboot time of each host", default: 'yes'
+        keyword :since, String, desc: 'Return errata applications after this date'
+        keyword :up_to, String, desc: 'Return errata applications before this date'
+        keyword :status, String, desc: 'Task status. One of: "pending", "success", "error", "warning"'
+        keyword :host_filter, String, desc: 'A filter term to limit the resulting collection, using standard filter syntax', default: nil
+        returns array_of: 'Erratum', desc: 'The collection that can be iterated over using each_record'
+      end
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
@@ -165,6 +269,11 @@ module Katello
       end
       # rubocop:enable Metrics/MethodLength
 
+      apipie :method, 'Converts package version to be sortable' do
+        required :version, String, desc: 'Version to convert'
+        returns String, desc: 'Sortable version of a package'
+        example 'For usage example please refer to **Host - compare content hosts packages** report template'
+      end
       def sortable_version(version)
         Util::Package.sortable_version(version)
       end

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -63,7 +63,7 @@ module Katello
           property :content_view, 'ContentView', desc: 'Returns content view associated with the host'
           property :lifecycle_environment, 'KTEnvironment', desc: 'Returns lifecycle environment object associated with the host'
           property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source for the host'
-          property :applicable_errata, array_of: 'Erratum', desc: 'Returns Smart Proxy object as the content source for the host'
+          property :applicable_errata, array_of: 'Erratum', desc: 'Returns errata applicable to the host'
         end
       end
 

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -242,6 +242,7 @@ module Katello
         name 'Content Facet'
         refs 'ContentFacet'
         sections only: %w[all additional]
+        desc "Content facet is an object containing the host's content-related metadata and associations"
         property :id, Integer, desc: 'Returns ID of the facet'
         property :uuid, String, desc: 'Returns UUID of the facet'
         property :applicable_module_stream_count, Integer, desc: 'Returns applicable Module Stream count'

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -941,6 +941,13 @@ module Katello
       DockerMetaTag.cleanup_tags
     end
 
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Repository'
+      refs 'Repository'
+      sections only: %w[all additional]
+      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Repository' }
+      property :docker_upstream_name, String, desc: 'Returns name of the upstream docker repository'
+    end
     class Jail < ::Safemode::Jail
       allow :name, :label, :docker_upstream_name
     end

--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -57,5 +57,15 @@ module Katello
     def self.humanize_class_name(_name = nil)
       _("Subscription")
     end
+
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Subscription'
+      refs 'Subscription'
+      sections only: %w[all additional]
+      prop_group :katello_idname_props, Katello::Model, meta: { friendly_name: 'Subscription' }
+    end
+    class Jail < ::Safemode::Jail
+      allow :id, :name
+    end
   end
 end


### PR DESCRIPTION
Adds new entries `Base Content` and `Content helpers` to the template documentation available on `https://<fqdn>/templates_doc`.

Please, review carefully since I'm not so good in content-related stuff and this is basically a draft for more meaningful docs.

Also some parts are missing, I've marked those as `TODO: need help` and I'd like to ask anyone to provide helpful descriptions.