### PR TITLE
Fixes #31940 - clear any registered services for EventDaemon::Runner tests

### DIFF
--- a/test/lib/event_daemon/runner_test.rb
+++ b/test/lib/event_daemon/runner_test.rb
@@ -18,6 +18,7 @@ module Katello
       end
 
       def setup
+        Katello::EventDaemon::Runner.instance_variable_set("@services", {})
         Katello::EventDaemon::Runner.register_service(:mock_service, MockService)
         Katello::EventDaemon::Runner.stubs(:runnable?).returns(true)
         Katello::EventDaemon::Runner.stubs(:pid_file).returns(Rails.root.join('tmp', 'test_katello_daemon.pid'))


### PR DESCRIPTION
I don't prefer to write tests that know about instance variables of the class under test but this is a quick fix. I've got some  future changes in mind for the EventDaemon and I can solve this in a better way then.

The tests can fail because of the real services that are registered in engine.rb => https://ci.theforeman.org/job/test_develop_pr_katello/7340/database=postgresql,ruby=2.5,slave=fast/testReport/junit/(root)/Katello__EventDaemon__RunnerTest/test_stop_close_services/

We should test only with mock services!