### PR TITLE
Fixes #31939 - Can search errata by title

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -19,7 +19,7 @@ module Katello
 
     scoped_search :on => :errata_id, :only_explicit => true
     scoped_search :on => :errata_id, :rename => :id, :complete_value => true, :only_explicit => true
-    scoped_search :on => :title, :only_explicit => true
+    scoped_search :on => :title
     scoped_search :on => :severity, :complete_value => true
     scoped_search :on => :errata_type, :only_explicit => true
     scoped_search :on => :errata_type, :rename => :type, :complete_value => true

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -33,6 +33,10 @@ module Katello
       assert_includes Katello::Erratum.search_for("modular = true"), katello_errata(:modular)
     end
 
+    def test_freeform_search_looks_for_title
+      assert_includes Katello::Erratum.search_for(@security.title[0..3]), @security
+    end
+
     def test_create_truncates_long_title
       attrs = {:pulp_id => 'foo', :title => "This life, which had been the tomb of " \
         "his virtue and of his honour is but a walking shadow; a poor player, " \


### PR DESCRIPTION
This commit enables the `freeform` errata search to search on title by
default