### PR TITLE
Fixes #31760 - Add Katello versions to unversioned warnings

### DIFF
--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -29,7 +29,7 @@ module Katello
 
     api :GET, "/content_exports/api_status", N_("true if the export api is pulp3 ready and usable. This API is intended for use by hammer-cli only.")
     def api_status
-      ::Foreman::Deprecation.api_deprecation_warning("/content_exports/api_status is being deprecated and will be removed in a future version of Katello.")
+      ::Foreman::Deprecation.api_deprecation_warning("/content_exports/api_status is being deprecated and will be removed in Katello 4.1.")
       render json: { api_usable: SmartProxy.pulp_primary.pulp3_repository_type_support?(Katello::Repository::YUM_TYPE) }, status: :ok
     end
 

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -9,7 +9,7 @@ module Katello
     param :content_view_id, :number, :desc => N_("content view identifier"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
-    param :uuid, String, :desc => N_("uuid of the puppet module"), :deprecated => true
+    param :uuid, String, :desc => N_("uuid of the puppet module.  Will be removed in Katello 4.1."), :deprecated => true
     param_group :search, ::Katello::Api::V2::ApiController
     add_scoped_search_description_for(ContentViewPuppetModule)
     def index
@@ -22,7 +22,7 @@ module Katello
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
     param :id, String, :desc => N_("the id of the puppet module to associate")
-    param :uuid, String, :desc => N_("the uuid of the puppet module to associate"), :deprecated => true
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate. Will be removed in Katello 4.1."), :deprecated => true
     def create
       params[:content_view_puppet_module][:uuid] ||= PuppetModule.find(params[:id]).try(:pulp_id) if params[:id]
       respond resource: ContentViewPuppetModule.create!(puppet_module_params.merge(content_view: @view))
@@ -41,7 +41,7 @@ module Katello
     param :id, :number, :desc => N_("puppet module ID"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
-    param :uuid, String, :desc => N_("the uuid of the puppet module to associate"), :deprecated => true
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate. Will be removed in Katello 4.1."), :deprecated => true
     def update
       @puppet_module.update!(puppet_module_params)
       respond :resource => @puppet_module

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -9,7 +9,7 @@ module Katello
     param :content_view_id, :number, :desc => N_("content view identifier"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
-    param :uuid, String, :desc => N_("uuid of the puppet module.  Will be removed in Katello 4.1."), :deprecated => true
+    param :uuid, String, :desc => N_("uuid of the puppet module")
     param_group :search, ::Katello::Api::V2::ApiController
     add_scoped_search_description_for(ContentViewPuppetModule)
     def index
@@ -22,7 +22,7 @@ module Katello
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
     param :id, String, :desc => N_("the id of the puppet module to associate")
-    param :uuid, String, :desc => N_("the uuid of the puppet module to associate. Will be removed in Katello 4.1."), :deprecated => true
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     def create
       params[:content_view_puppet_module][:uuid] ||= PuppetModule.find(params[:id]).try(:pulp_id) if params[:id]
       respond resource: ContentViewPuppetModule.create!(puppet_module_params.merge(content_view: @view))
@@ -41,7 +41,7 @@ module Katello
     param :id, :number, :desc => N_("puppet module ID"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
-    param :uuid, String, :desc => N_("the uuid of the puppet module to associate. Will be removed in Katello 4.1."), :deprecated => true
+    param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     def update
       @puppet_module.update!(puppet_module_params)
       respond :resource => @puppet_module

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -95,7 +95,7 @@ module Katello
         fail HttpErrors::BadRequest, _("Invalid usage for Pulp 3 repositories. "\
                                        "Use hammer content-export for Yum repositories")
       end
-      ::Foreman::Deprecation.api_deprecation_warning("Export is being deprecated and will be removed in a future version of Katello. Use hammer content-view version export instead.")
+      ::Foreman::Deprecation.api_deprecation_warning("Export is being deprecated and will be removed in Katello 4.1. Use hammer content-view version export instead.")
       if params[:export_to_iso].blank? && params[:iso_mb_size].present?
         fail HttpErrors::BadRequest, _("ISO export must be enabled when specifying ISO size")
       end

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -95,7 +95,7 @@ module Katello
         fail HttpErrors::BadRequest, _("Invalid usage for Pulp 3 repositories. "\
                                        "Use hammer content-export for Yum repositories")
       end
-      ::Foreman::Deprecation.api_deprecation_warning("Export is being deprecated and will be removed in Katello 4.1. Use hammer content-view version export instead.")
+      ::Foreman::Deprecation.api_deprecation_warning("Pulp 2 export is deprecated and will not work as of Katello 4.0. To export using Pulp 3, use hammer content-export version.")
       if params[:export_to_iso].blank? && params[:iso_mb_size].present?
         fail HttpErrors::BadRequest, _("ISO export must be enabled when specifying ISO size")
       end

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -62,7 +62,7 @@ module Katello
       collection
     end
 
-    api :GET, "/content_view_versions/:id/available_errata", N_("Return errata that can be added to the Content View Version via an Incremental Update"), :deprecated => true
+    api :GET, "/content_view_versions/:id/available_errata", N_("Return errata that can be added to the Content View Version via an Incremental Update. Will be removed in Katello 4.1."), :deprecated => true
     param :id, :number, :desc => N_("Content View Version identifier"), :required => true
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier")

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -51,7 +51,7 @@ module Katello
 
     api :PUT, "/hosts/:host_id/errata/apply", N_("Schedule errata for installation")
     param :host_id, :number, :desc => N_("Host ID"), :required => true
-    param :errata_ids, Array, :desc => N_("List of Errata ids to install"), :required => false, :deprecated => true
+    param :errata_ids, Array, :desc => N_("List of Errata ids to install. Will be removed in Katello 4.1."), :required => false, :deprecated => true
 
     param_group :bulk_errata_ids
     def apply

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -22,7 +22,6 @@ module Katello
         param :smart_proxy_ids, Array, N_("Smart proxy IDs"), :required => false
         param :compute_resource_ids, Array, N_("Compute resource IDs"), :required => false
         param :medium_ids, Array, N_("Medium IDs"), :required => false
-        param :config_template_ids, Array, N_("Provisioning template IDs. Will be removed in Katello 4.1."), required: false, deprecated: true
         param :ptable_ids, Array, N_("Partition template IDs"), :required => false
         param :provisioning_template_ids, Array, N_("Provisioning template IDs"), :required => false
         param :domain_ids, Array, N_("Domain IDs"), :required => false

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -22,7 +22,7 @@ module Katello
         param :smart_proxy_ids, Array, N_("Smart proxy IDs"), :required => false
         param :compute_resource_ids, Array, N_("Compute resource IDs"), :required => false
         param :medium_ids, Array, N_("Medium IDs"), :required => false
-        param :config_template_ids, Array, N_("Provisioning template IDs"), :required => false # FIXME: deprecated
+        param :config_template_ids, Array, N_("Provisioning template IDs. Will be removed in Katello 4.1."), required: false, deprecated: true
         param :ptable_ids, Array, N_("Partition template IDs"), :required => false
         param :provisioning_template_ids, Array, N_("Provisioning template IDs"), :required => false
         param :domain_ids, Array, N_("Domain IDs"), :required => false

--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -6,8 +6,6 @@ module Katello
       def host_info
         info = {}
         info['parameters'] = {
-          'kt_env' => host.lifecycle_environment.try(:label), #deprecated
-          'kt_cv' => host.content_view.try(:label), #deprecated
           'foreman_host_collections' => host.host_collections.map(&:name),
           'lifecycle_environment' => host.lifecycle_environment.try(:label),
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -94,16 +94,6 @@ module Katello
       assert_includes @foreman_host.info['parameters']['foreman_host_collections'], host_collection.name
     end
 
-    def test_info_with_katello_deprecated
-      assert_nil @foreman_host.info['parameters']['kt_cv']
-      assert_nil @foreman_host.info['parameters']['kt_env']
-
-      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
-
-      assert_equal @foreman_host.info['parameters']['kt_cv'], @foreman_host.content_view.label
-      assert_equal @foreman_host.info['parameters']['kt_env'], @foreman_host.lifecycle_environment.label
-    end
-
     def test_update_with_cv_env
       host = FactoryBot.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
       host.content_facet.content_view = @library_view


### PR DESCRIPTION
* `app/models/katello/host/info_provider.rb` had two parameters marked as deprecated with a code comment (possibly since 2015).  These values don't seem to be used anywhere in Katello, so I thought it's probably safe to remove them.
* For other unversioned deprecation warnings, added Katello 4.1 as a starting point.  Need feedback on whether any should be moved to 4.0 or later versions.
* I'm not sure if our automated deprecations tool picks up both `apipie` params and `::Foreman::Deprecation.api_deprecation_warning`s.  If it's not both, Redmine issues should be created for any deprecation that won't be called out by our tooling.