### PR TITLE
Fixes #31920 - disassociate disabled products from sync plan

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -58,6 +58,7 @@ module Actions
         end
 
         def delete_record(repository, options = {})
+          ::Katello::SyncPlan.remove_disabled_product(repository) if repository.redhat?
           repository.destroy!
           repository.root.destroy! if repository.root.repositories.empty?
           ::Katello::DockerMetaTag.cleanup_tags if options[:docker_cleanup]

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -46,6 +46,13 @@ module Katello
       end
     end
 
+    def self.remove_disabled_product(repository)
+      if (product = repository.product) && product&.redhat? && (sync_plan = product&.sync_plan) && product&.repositories&.count == 1
+        sync_plan.product_ids = (sync_plan.product_ids - [product.id])
+        sync_plan.save!
+      end
+    end
+
     def product_enabled
       products.each do |product|
         errors.add :base, _("Can not add product %s because it is disabled.") % product.name unless product.enabled?

--- a/db/migrate/20140422000001_update_products_add_organization.rb
+++ b/db/migrate/20140422000001_update_products_add_organization.rb
@@ -1,5 +1,6 @@
 class UpdateProductsAddOrganization < ActiveRecord::Migration[4.2]
-  class Katello::Product < ApplicationRecord
+  class FakeProduct < ApplicationRecord
+    self.table_name = 'katello_products'
     belongs_to :provider
     self.inheritance_column = nil
   end
@@ -7,7 +8,7 @@ class UpdateProductsAddOrganization < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_products, :organization_id, :integer, :null => true
 
-    Katello::Product.all.each do |product|
+    FakeProduct.all.each do |product|
       product.organization_id = product.provider.organization_id
       product.save!
     end

--- a/db/migrate/20210224160921_remove_disabled_products_from_sync_plans.rb
+++ b/db/migrate/20210224160921_remove_disabled_products_from_sync_plans.rb
@@ -1,0 +1,6 @@
+class RemoveDisabledProductsFromSyncPlans < ActiveRecord::Migration[6.0]
+  def change
+    disabled = ::Katello::Product.redhat.where.not(:id => Katello::Product.enabled)
+    disabled.update_all(:sync_plan_id => nil)
+  end
+end

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -1,7 +1,7 @@
 require 'katello_test_helper'
 
 module Katello
-  class SyncPlanTest < ActiveSupport::TestCase
+  class SyncPlanTest < ActiveSupport::TestCase  # rubocop:disable Metrics/ClassLength
     def setup
       @organization = get_organization
       @plan = SyncPlan.new(:name => 'Norman Rockwell', :organization => @organization, :sync_date => Time.now, :interval => 'daily')
@@ -359,6 +359,17 @@ module Katello
       p = SyncPlan.find_by_name('Sync plan')
       p.cancel_recurring_logic
       assert_equal "cancelled", p.foreman_tasks_recurring_logic.state
+    end
+
+    def test_remove_disabled_product
+      product = katello_products(:redhat)
+      repository = product.repositories.first
+      Product.any_instance.stubs(:repositories).returns([repository])
+      @plan.products << product
+      @plan.save!
+      ::Katello::SyncPlan.remove_disabled_product(repository)
+      product.reload
+      assert_nil product.sync_plan
     end
   end
 end


### PR DESCRIPTION
**To test:**
1. Enable a redhat repository and add the Product to a sync-plan
2. Disable the repository.
3. The product should get removed from the sync plan. (If the product only contains the 1 repository)
4.  The product should not get removed from the sync plan if the product contains other enabled repositories. (Enable more than 1 repository from a repository set to test this flow)