### PR TITLE
Fixes #32036 - provides proxy parameter to repo discovery get operations

### DIFF
--- a/app/lib/actions/katello/repository/discover.rb
+++ b/app/lib/actions/katello/repository/discover.rb
@@ -54,7 +54,7 @@ module Actions
           proxy_details = {}
           if (proxy = ::HttpProxy.default_global_content_proxy)
             uri = URI(proxy.url)
-            proxy_details[:proxy_host] = "#{uri.host}#{uri.path}"
+            proxy_details[:proxy_host] = "#{uri.scheme}://#{uri.host}#{uri.path}"
             proxy_details[:proxy_port] = uri.port
             proxy_details[:proxy_user] = proxy.username
             proxy_details[:proxy_password] = proxy.password

--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -3,7 +3,9 @@ module Katello
     attr_reader :found, :crawled, :to_follow
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(url, content_type = 'yum', upstream_username = nil, upstream_password = nil, search = '*', proxy = {}, crawled = [], found = [], to_follow = [])
+    def initialize(url, content_type = 'yum', upstream_username = nil,
+      upstream_password = nil, search = '*', proxy = {}, crawled = [],
+      found = [], to_follow = [])
       @uri = uri(url)
       @content_type = content_type
       @upstream_username = upstream_username.empty? ? nil : upstream_username
@@ -45,6 +47,18 @@ module Katello
       }
       params[:user] = @upstream_username unless @upstream_username.empty?
       params[:password] = @upstream_password unless @upstream_password.empty?
+
+      RestClient.proxy = nil
+
+      if @proxy && @proxy[:proxy_host]
+        proxy_uri = URI(@proxy[:proxy_host])
+        proxy_uri.user = @proxy[:proxy_user] if @proxy[:proxy_user]
+        proxy_uri.password = @proxy[:proxy_password] if @proxy[:proxy_password]
+        proxy_uri.port = @proxy[:proxy_port] if @proxy[:proxy_port]
+
+        RestClient.proxy = proxy_uri.to_s
+      end
+
       begin
         results = RestClient.get(@uri.to_s + "v1/search?q=#{@search}", params)
         JSON.parse(results)['results'].each do |result|

--- a/test/lib/repo_discovery_test.rb
+++ b/test/lib/repo_discovery_test.rb
@@ -15,5 +15,88 @@ module Katello
       assert_empty rd.found
       assert_equal rd.crawled.first, "#{Katello::Engine.root}/test/fixtures/"
     end
+
+    def test_docker_with_v1_search_no_proxy
+      base_url = "https://docker.io/"
+      crawled = []
+      found = []
+      to_follow = [base_url]
+      proxy = {}
+      search = 'busybox'
+
+      RestClient.expects(:get)
+        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+        .returns({results: ['busybox']}.to_json)
+
+      RestClient.expects(:proxy=).with(nil)
+
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+
+      rd.run(to_follow.shift)
+    end
+
+    def test_docker_with_v1_search_with_proxy
+      base_url = "https://docker.io/"
+      crawled = []
+      found = []
+      to_follow = [base_url]
+      proxy = {
+        proxy_host: 'https://proxy.example.com',
+        proxy_user: 'admin',
+        proxy_password: 'redhat',
+        proxy_port: 8888
+      }
+      search = 'busybox'
+
+      expected_proxy_uri = URI(proxy[:proxy_host])
+      expected_proxy_uri.user = proxy[:proxy_user]
+      expected_proxy_uri.password = proxy[:proxy_password]
+      expected_proxy_uri.port = proxy[:proxy_port]
+
+      RestClient.expects(:get)
+        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+        .returns({results: ['busybox']}.to_json)
+
+      RestClient.expects(:proxy=).with(nil)
+      RestClient.expects(:proxy=).with('https://admin:redhat@proxy.example.com:8888')
+
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+
+      rd.run(to_follow.shift)
+    end
+
+    def test_docker_with_v2_search_with_proxy
+      base_url = "https://docker.io/"
+      crawled = []
+      found = []
+      to_follow = [base_url]
+      proxy = {
+        proxy_host: 'https://proxy.example.com',
+        proxy_user: 'admin',
+        proxy_password: 'redhat',
+        proxy_port: 8888
+      }
+      search = 'busybox'
+
+      expected_proxy_uri = URI(proxy[:proxy_host])
+      expected_proxy_uri.user = proxy[:proxy_user]
+      expected_proxy_uri.password = proxy[:proxy_password]
+      expected_proxy_uri.port = proxy[:proxy_port]
+
+      RestClient.expects(:get)
+        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+        .returns({code: Net::HTTPNotFound}.to_json)
+
+      RestClient.expects(:get)
+        .with(base_url.to_s + "v2/_catalog", {:accept => :json})
+        .returns({'repositories' => ['busybox']}.to_json)
+
+      RestClient.expects(:proxy=).with(nil)
+      RestClient.expects(:proxy=).with('https://admin:redhat@proxy.example.com:8888')
+
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+
+      rd.run(to_follow.shift)
+    end
   end
 end


### PR DESCRIPTION
This PR corrects docker search queries during repo discovery.

To reproduce this error:
1. setup an proxy that accepts requests at port 80, 443, etc 
2. create an HTTP Proxy, pointing to the web proxy you setup in step 1.
3. In Settings -> Content, assign this new HTTP Proxy as the default global proxy
4. From the Prodcuts page select "Repo Discovery"
5. Select "Container Images".
6. Select "Docker Hub" for "Registry to Discover"
7. Provide a search term, for example "busybox"
8. Click "Discover"

On the access logs for the proxy, notice that the proxy was not used to access the docker registry.

After applying this change, the discovery operation will (provided the HTTP Proxy you assigned as the default global proxy is valid) use the proxy value for the search HTTP operations.

Confirm this by checking the proxy access log.  You should see entries such as
```
1615231467.786    231 192.168.121.112 TCP_TUNNEL/200 9218 CONNECT index.docker.io:443 - HIER_DIRECT/34.195.201.174 -
```
where 'docker.io' conforms to the registry you used in step 7 above.