### PR TITLE
Refs #31954 - use uncached for applicable_differences

### DIFF
--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -122,20 +122,22 @@ module Katello
       end
 
       def applicable_differences
-        consumer_ids = content_facet.send(applicable_units).pluck("#{content_unit_class.table_name}.id")
-        content_ids = fetch_content_ids
+        ActiveRecord::Base.connection.uncached do
+          consumer_ids = content_facet.send(applicable_units).pluck("#{content_unit_class.table_name}.id")
+          content_ids = fetch_content_ids
 
-        to_remove = consumer_ids - content_ids
-        to_add = content_ids - consumer_ids
+          to_remove = consumer_ids - content_ids
+          to_add = content_ids - consumer_ids
 
-        [to_add, to_remove]
+          [to_add, to_remove]
+        end
       end
 
       def insert(applicable_ids)
         unless applicable_ids.empty?
           inserts = applicable_ids.map { |applicable_id| "(#{applicable_id.to_i}, #{content_facet.id.to_i})" }
           sql = "INSERT INTO #{content_facet_association_class.table_name} (#{content_unit_association_id}, content_facet_id) VALUES #{inserts.join(', ')}"
-          ActiveRecord::Base.connection.execute(sql)
+          ActiveRecord::Base.connection.exec_insert(sql)
         end
       end
 


### PR DESCRIPTION
Sometimes the applicable_differences method seems to use the Active Record cache, and sometimes it doesn't as we'd ordinarily expect:

```
[2021-03-11T17:11:32.241Z] Katello::Service::Applicability::ApplicableContentHelperTest#test_applicable_differences_adds_and_removes_no_rpm_ids D, [2021-03-11T17:11:28.382516 #5501] DEBUG -- :   Katello::Repository Load (0.2ms)  SELECT "katello_repositories".* FROM "katello_repositories" INNER JOIN "katello_content_facet_repositories" ON "katello_repositories"."id" = "katello_content_facet_repositories"."repository_id" WHERE "katello_content_facet_repositories"."content_facet_id" = $1  [["content_facet_id", 906413887]]
[2021-03-11T17:11:32.241Z] D, [2021-03-11T17:11:28.384739 #5501] DEBUG -- :    (0.5ms)  SELECT katello_rpms.id FROM "katello_rpms" INNER JOIN "katello_content_facet_applicable_rpms" ON "katello_rpms"."id" = "katello_content_facet_applicable_rpms"."rpm_id" WHERE "katello_content_facet_applicable_rpms"."content_facet_id" = $1  [["content_facet_id", 906413887]]
[2021-03-11T17:11:32.241Z] applicable_differences consumer_ids sql: []
[2021-03-11T17:11:32.241Z] D, [2021-03-11T17:11:28.386743 #5501] DEBUG -- :   Katello::Rpm Load (1.0ms)  SELECT "katello_rpms"."nvra", "katello_rpms"."epoch" FROM "katello_rpms" INNER JOIN katello_module_stream_rpms ON katello_rpms.id = katello_module_stream_rpms.rpm_id WHERE (katello_module_stream_rpms.module_stream_id IN (SELECT "katello_module_streams"."id" FROM "katello_module_streams" inner join katello_available_module_streams on
[2021-03-11T17:11:32.241Z]             katello_module_streams.name = katello_available_module_streams.name and
[2021-03-11T17:11:32.241Z]             katello_module_streams.stream = katello_available_module_streams.stream inner join katello_host_available_module_streams on
[2021-03-11T17:11:32.241Z]             katello_available_module_streams.id = katello_host_available_module_streams.available_module_stream_id WHERE (katello_host_available_module_streams.host_id = 980191148 and
[2021-03-11T17:11:32.241Z]             katello_host_available_module_streams.status = 'enabled')))
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.389679 #5501] DEBUG -- :    (2.1ms)  SELECT "katello_rpms"."id" FROM "katello_rpms" INNER JOIN katello_repository_rpms ON
[2021-03-11T17:11:44.206Z]             katello_rpms.id = katello_repository_rpms.rpm_id INNER JOIN katello_installed_packages ON
[2021-03-11T17:11:44.206Z]             katello_rpms.name = katello_installed_packages.name AND
[2021-03-11T17:11:44.206Z]             katello_rpms.arch = katello_installed_packages.arch AND
[2021-03-11T17:11:44.206Z]             katello_rpms.evr > katello_installed_packages.evr AND
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id in (SELECT DISTINCT ON (katello_installed_packages.name) katello_installed_packages.id FROM katello_installed_packages INNER JOIN katello_host_installed_packages ON katello_installed_packages.id = katello_host_installed_packages.installed_package_id WHERE katello_host_installed_packages.host_id = 980191148 ORDER BY katello_installed_packages.name, katello_installed_packages.evr DESC) LEFT JOIN katello_module_stream_rpms ON
[2021-03-11T17:11:44.206Z]             katello_rpms.id = katello_module_stream_rpms.rpm_id INNER JOIN katello_host_installed_packages ON
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id = katello_host_installed_packages.installed_package_id WHERE (katello_repository_rpms.repository_id in (367202338)) AND (katello_host_installed_packages.host_id = 980191148) AND ((katello_module_stream_rpms.module_stream_id IS NULL AND
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id NOT IN (SELECT "katello_installed_packages"."id" FROM "katello_installed_packages" WHERE 1=0 AND 1=0)) OR
[2021-03-11T17:11:44.206Z]             (katello_module_stream_rpms.module_stream_id IN (SELECT "katello_module_streams"."id" FROM "katello_module_streams" inner join katello_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_module_streams.name = katello_available_module_streams.name and
[2021-03-11T17:11:44.206Z]             katello_module_streams.stream = katello_available_module_streams.stream inner join katello_host_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_available_module_streams.id = katello_host_available_module_streams.available_module_stream_id WHERE (katello_host_available_module_streams.host_id = 980191148 and
[2021-03-11T17:11:44.206Z]             katello_host_available_module_streams.status = 'enabled'))
[2021-03-11T17:11:44.206Z]             AND katello_installed_packages.id IN (SELECT "katello_installed_packages"."id" FROM "katello_installed_packages" WHERE 1=0 AND 1=0)))
[2021-03-11T17:11:44.206Z] applicable_differences content_ids: [1046165992]
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.390187 #5501] DEBUG -- :    (0.2ms)  SAVEPOINT active_record_1
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.390554 #5501] DEBUG -- :    (0.3ms)  INSERT INTO katello_content_facet_applicable_rpms (rpm_id, content_facet_id) VALUES (1046165992, 906413887)
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.390778 #5501] DEBUG -- :    (0.1ms)  RELEASE SAVEPOINT active_record_1
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.391715 #5501] DEBUG -- :   CACHE  (0.0ms)  SELECT katello_rpms.id FROM "katello_rpms" INNER JOIN "katello_content_facet_applicable_rpms" ON "katello_rpms"."id" = "katello_content_facet_applicable_rpms"."rpm_id" WHERE "katello_content_facet_applicable_rpms"."content_facet_id" = $1  [["content_facet_id", 906413887]]
[2021-03-11T17:11:44.206Z] applicable_differences consumer_ids sql: []
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.392509 #5501] DEBUG -- :   CACHE Katello::Rpm Load (0.0ms)  SELECT "katello_rpms"."nvra", "katello_rpms"."epoch" FROM "katello_rpms" INNER JOIN katello_module_stream_rpms ON katello_rpms.id = katello_module_stream_rpms.rpm_id WHERE (katello_module_stream_rpms.module_stream_id IN (SELECT "katello_module_streams"."id" FROM "katello_module_streams" inner join katello_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_module_streams.name = katello_available_module_streams.name and
[2021-03-11T17:11:44.206Z]             katello_module_streams.stream = katello_available_module_streams.stream inner join katello_host_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_available_module_streams.id = katello_host_available_module_streams.available_module_stream_id WHERE (katello_host_available_module_streams.host_id = 980191148 and
[2021-03-11T17:11:44.206Z]             katello_host_available_module_streams.status = 'enabled')))
[2021-03-11T17:11:44.206Z] D, [2021-03-11T17:11:28.393094 #5501] DEBUG -- :   CACHE  (0.0ms)  SELECT "katello_rpms"."id" FROM "katello_rpms" INNER JOIN katello_repository_rpms ON
[2021-03-11T17:11:44.206Z]             katello_rpms.id = katello_repository_rpms.rpm_id INNER JOIN katello_installed_packages ON
[2021-03-11T17:11:44.206Z]             katello_rpms.name = katello_installed_packages.name AND
[2021-03-11T17:11:44.206Z]             katello_rpms.arch = katello_installed_packages.arch AND
[2021-03-11T17:11:44.206Z]             katello_rpms.evr > katello_installed_packages.evr AND
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id in (SELECT DISTINCT ON (katello_installed_packages.name) katello_installed_packages.id FROM katello_installed_packages INNER JOIN katello_host_installed_packages ON katello_installed_packages.id = katello_host_installed_packages.installed_package_id WHERE katello_host_installed_packages.host_id = 980191148 ORDER BY katello_installed_packages.name, katello_installed_packages.evr DESC) LEFT JOIN katello_module_stream_rpms ON
[2021-03-11T17:11:44.206Z]             katello_rpms.id = katello_module_stream_rpms.rpm_id INNER JOIN katello_host_installed_packages ON
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id = katello_host_installed_packages.installed_package_id WHERE (katello_repository_rpms.repository_id in (367202338)) AND (katello_host_installed_packages.host_id = 980191148) AND ((katello_module_stream_rpms.module_stream_id IS NULL AND
[2021-03-11T17:11:44.206Z]             katello_installed_packages.id NOT IN (SELECT "katello_installed_packages"."id" FROM "katello_installed_packages" WHERE 1=0 AND 1=0)) OR
[2021-03-11T17:11:44.206Z]             (katello_module_stream_rpms.module_stream_id IN (SELECT "katello_module_streams"."id" FROM "katello_module_streams" inner join katello_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_module_streams.name = katello_available_module_streams.name and
[2021-03-11T17:11:44.206Z]             katello_module_streams.stream = katello_available_module_streams.stream inner join katello_host_available_module_streams on
[2021-03-11T17:11:44.206Z]             katello_available_module_streams.id = katello_host_available_module_streams.available_module_stream_id WHERE (katello_host_available_module_streams.host_id = 980191148 and
[2021-03-11T17:11:44.206Z]             katello_host_available_module_streams.status = 'enabled'))
[2021-03-11T17:11:44.206Z]             AND katello_installed_packages.id IN (SELECT "katello_installed_packages"."id" FROM "katello_installed_packages" WHERE 1=0 AND 1=0)))
[2021-03-11T17:11:44.206Z] applicable_differences content_ids: [1046165992]
[2021-03-11T17:11:44.206Z] 0.46 = F
```