### PR TITLE
Fixes #32077 - provide repository architecture

### DIFF
--- a/app/services/katello/managed_content_medium_provider.rb
+++ b/app/services/katello/managed_content_medium_provider.rb
@@ -30,5 +30,9 @@ module Katello
     def kickstart_repo
       @kickstart_repo ||= entity.try(:content_facet).try(:kickstart_repository) || entity.try(:kickstart_repository)
     end
+
+    def architecture_name
+      kickstart_repo.try(:distribution_arch)
+    end
   end
 end


### PR DESCRIPTION
For S390x provisioning we need to determine architecture of a kickstart repository in order to get the correct paths to kernel and initramdisk.

Foreman core will define the very same method is the provider (the base class):

https://github.com/theforeman/foreman/pull/8390