### PR TITLE
Run react UI tests on all branches

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -1,8 +1,6 @@
 name: React Tests (non-blocking)
 
-on:
-  pull_request:
-    branches: [ master ]
+on: [pull_request]
 
 defaults:
   run:


### PR DESCRIPTION
The changes in https://github.com/theforeman/jenkins-jobs/pull/20 will drop React testing that normally would happen on release branches to ensure cherry picks introduce no regressions. This would leave a gap if we leave GH actions only testing PRs on master.