### PR TITLE
Refs #32111 - rubocop: Metrics/MethodLength: Count arrays/hashes etc. as a single line

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,10 @@ AllCops:
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'
   Max: 30 # default is 10
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 
 Style/HashSyntax:
   Enabled: false # don't force 1.9 hash syntax

--- a/app/lib/actions/katello/content_view_version/export.rb
+++ b/app/lib/actions/katello/content_view_version/export.rb
@@ -16,7 +16,6 @@ module Actions
           param :export_path, String
         end
 
-        # rubocop:disable Metrics/MethodLength
         def plan(content_view_version:, destination_server: nil,
                  chunk_size: nil, from_history: nil,
                  validate_incremental: true,

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -4,7 +4,6 @@ module Actions
     module Repository
       class ImportUpload < Actions::EntryAction
         include Actions::Katello::PulpSelector
-        # rubocop:disable Metrics/MethodLength
         def plan(repository, uploads, options = {})
           action_subject(repository)
           repository.clear_smart_proxy_sync_histories

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -4,7 +4,6 @@ module Actions
       class Update < Actions::EntryAction
         include Actions::Katello::PulpSelector
 
-        # rubocop:disable Metrics/MethodLength
         def plan(root, repo_params)
           repository = root.library_instance
           action_subject root.library_instance

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -1,7 +1,6 @@
 module Katello
   module Glue::Pulp::Repo
     # TODO: move into submodules
-    # rubocop:disable Metrics/MethodLength
     def self.included(base)
       base.send :include, LazyAccessor
       base.send :include, InstanceMethods

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -1,5 +1,4 @@
 class Setting::Content < Setting
-  #rubocop:disable Metrics/MethodLength
   #rubocop:disable Metrics/AbcSize
 
   validate :content_default_http_proxy, if: proc { |s| s.name == 'content_default_http_proxy' && HttpProxy.table_exists? }

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -65,7 +65,7 @@ module Katello
                          :resource_type => "SmartProxy"
     end
 
-    def content_view_permissions # rubocop:disable Metrics/MethodLength
+    def content_view_permissions
       @plugin.permission :view_content_views,
                  {
                    'katello/api/v2/content_views' => [:index, :show, :available_puppet_modules, :auto_complete_search,
@@ -251,7 +251,7 @@ module Katello
                          :finder_scope => :promotable
     end
 
-    def product_permissions # rubocop:disable Metrics/MethodLength
+    def product_permissions
       @plugin.permission :view_products,
                          {
                            'katello/products' => [:auto_complete, :auto_complete_search],
@@ -348,7 +348,7 @@ module Katello
                          :finder_scope => :exportable
     end
 
-    def subscription_permissions # rubocop:disable Metrics/MethodLength
+    def subscription_permissions
       @plugin.permission :view_subscriptions,
                          {
                            'katello/api/v2/subscriptions' => [:index, :show, :available, :manifest_history, :auto_complete_search]

--- a/test/actions/pulp/repository/sync_progress_presenter_test.rb
+++ b/test/actions/pulp/repository/sync_progress_presenter_test.rb
@@ -5,7 +5,6 @@ module ::Actions::Pulp::Repository
     include Dynflow::Testing
     include Support::Actions::PulpTask
 
-    # rubocop:disable Metrics/MethodLength
     def sync_task_result(pull_progress_details)
       {"state" => "running",
        "progress_report" =>

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -2,7 +2,6 @@
 
 require "katello_test_helper"
 
-# rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/ClassLength
 module Katello
   class Api::V2::ContentViewsControllerTest < ActionController::TestCase

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -263,7 +263,6 @@ module Katello
       assert_response_ids response, @rpm.repository_ids
     end
 
-    # rubocop:disable Metrics/MethodLength
     def test_create
       product = mock
       product.expects(:add_repo).with({

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -14,7 +14,6 @@ module Katello
       @puppet_module       = katello_puppet_modules(:abrt)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def test_docker_promote
       org = @organization
       product = create(:katello_product, provider: org.anonymous_provider,
@@ -60,7 +59,6 @@ module Katello
         cvv2repo1.save!
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     should_not allow_values(*invalid_name_list).for(:name)
     should_not allow_values(*invalid_name_list).for(:label)

--- a/test/services/katello/pulp3/repository/yum/copy_units_test.rb
+++ b/test/services/katello/pulp3/repository/yum/copy_units_test.rb
@@ -4,7 +4,6 @@ module Katello
   module Service
     class Repository
       class YumCopyUnitsTest < ::ActiveSupport::TestCase
-        # rubocop:disable Metrics/MethodLength
         include RepositorySupport
 
         def setup


### PR DESCRIPTION
I've always thought that Metrics/MethodLength was too literal in terms of how it counts lines of code. I discovered that you can tell it to count arrays/hashes/etc as a single line of code. Considering all the other cops we enforce around line lengths, etc., I think this is a good default for Katello going forward.