### PR TITLE
Fixes #32100 - Unable to set HostGroup content source to capsule that isn't synced

### DIFF
--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -2,12 +2,6 @@ module Katello
   module Validators
     class HostgroupKickstartRepositoryValidator < ActiveModel::Validator
       def validate(facet)
-        # check content source first, otherwise it's meaningless to proceed
-        if facet.content_source && facet.lifecycle_environment
-          valid = facet.content_source.lifecycle_environments.include?(facet.lifecycle_environment)
-          facet.errors.add(:base, _("The selected content source and lifecycle environment do not match")) && return unless valid
-        end
-
         return unless facet.kickstart_repository_id
 
         msg = if facet.content_source.blank?

--- a/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
+++ b/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
@@ -13,7 +13,6 @@ module Katello
 
       @repos = [{:name => "foo", :id => 4}]
       @error_messages = {
-        :mismatched_cs_lce => 'The selected content source and lifecycle environment do not match',
         :missing_os => 'Please select an operating system before assigning a kickstart repository',
         :missing_arch => 'Please select an architecture before assigning a kickstart repository',
         :invalid_os => 'Kickstart repositories can only be assigned to hosts in the Red Hat family',
@@ -37,14 +36,6 @@ module Katello
       @validator.validate(@content_facet)
 
       assert_empty @content_facet.errors[:base]
-    end
-
-    test 'it invalidates on content source and environment mismatch' do
-      @content_facet.expects(:content_source).twice.returns(FactoryBot.create(:smart_proxy))
-
-      @validator.validate(@content_facet)
-
-      assert_equal @error_messages[:mismatched_cs_lce], @content_facet.errors[:base].first
     end
 
     test 'it invalidates on missing OS' do


### PR DESCRIPTION
Hosts don't validate that the content source and lifecycle environment match, so host groups shouldn't need to either.

To see the validation in action:

1) Load up the foreman console
2) Create a lifecycle environment and a pulp node smart proxy
3) Make a hostgroup (note that if you try to make a mismatched LCE and content source, the hostgroup creation will silently fail.  This might be due to a `create` vs `create!` situation.)
4) Create a new hostgroup content facet like so:
```ruby
::Katello::Hostgroup::ContentFacet.create!(hostgroup_id: <hostgroup_id>, kickstart_repository_id: nil, content_source_id: <mismatched_content_source_id>, content_view_id: nil, lifecycle_environment_id: <mismatched_LCE_id>)
```
5) See the error "The selected content source and lifecycle environment do not match".