### PR TITLE
Fixes #32119 - adjust task group error check

### DIFF
--- a/app/services/katello/pulp3/task_group.rb
+++ b/app/services/katello/pulp3/task_group.rb
@@ -71,8 +71,11 @@ module Katello
       end
 
       def error
+        return if task_group_data[WAITING] > 0 || task_group_data[RUNNING] > 0
         if task_group_data[FAILED] > 0
           "#{task_group_data[FAILED]} subtask(s) failed for task group #{@href}."
+        elsif task_group_data[CANCELLED] > 0
+          "#{task_group_data[CANCELLED]} subtask(s) cancelled for task group #{@href}."
         end
       end
 

--- a/test/services/katello/pulp3/task_group_test.rb
+++ b/test/services/katello/pulp3/task_group_test.rb
@@ -1,0 +1,73 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    module Pulp3
+      class TaskGroupTest < ActiveSupport::TestCase
+        include Katello::Pulp3Support
+
+        def setup
+          @primary = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+        end
+
+        def test_error_no_errors
+          group_data = {
+            "pulp_href": "/pulp/api/v3/task-groups/d9841aaa-8a47-4e31-9018-10e4430766bf/",
+            "description": "Migration Sub-tasks",
+            "waiting": 0,
+            "skipped": 0,
+            "running": 1,
+            "completed": 0,
+            "canceled": 0,
+            "failed": 0
+          }
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          refute group.error
+        end
+
+        def test_error_with_errors
+          group_data = {
+            "pulp_href": "/pulp/api/v3/task-groups/d9841aaa-8a47-4e31-9018-10e4430766bf/",
+            "description": "Migration Sub-tasks",
+            "waiting": 0,
+            "skipped": 0,
+            "running": 0,
+            "completed": 0,
+            "canceled": 0,
+            "failed": 1
+          }
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          assert group.error
+
+          group_data['running'] = 1
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          refute group.error
+        end
+
+        def test_error_with_cancelled
+          group_data = {
+            "pulp_href": "/pulp/api/v3/task-groups/d9841aaa-8a47-4e31-9018-10e4430766bf/",
+            "description": "Migration Sub-tasks",
+            "waiting": 0,
+            "skipped": 0,
+            "running": 0,
+            "completed": 0,
+            "canceled": 1,
+            "failed": 0
+          }
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          assert group.error
+
+          group_data['completed'] = 1
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          assert group.error
+
+          group_data['running'] = 1
+          group = Katello::Pulp3::TaskGroup.new(@primary, group_data)
+          refute group.error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this adjusts the error check to handle 2 conditions
1) do not report an error while there are tasks still left to execute
2) if a task is cancelled and there are no tasks left to execute, report an error