### PR TITLE
Fixes #32159 - hides archived container repos from search/catalog 

### DIFF
--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -14,7 +14,7 @@ module Support
             proxy.features << pulp_feature
           end
         end
-        proxy.smart_proxy_features.where(:feature_id => @pulp3_feature.id).update(:capabilities => [:pulpcore])
+        proxy.smart_proxy_features.where(:feature_id => @pulp3_feature.id).update(:capabilities => [:core])
       end
     end
 


### PR DESCRIPTION
Before:
```
[root@centos7-katello-devel-stable ~]# podman search --tls-verify=false centos7-katello-devel-stable.example.com/
INDEX         NAME                                                                                                       DESCRIPTION   STARS   OFFICIAL   AUTOMATED
example.com   centos7-katello-devel-stable.example.com/default_organization-docker1-1_0-test-docker-hello-world                        0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-hello-world                                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker1-test-docker-hello-world                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world                     0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker-ccv-test-docker-hello-world                 0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-ccv-test-docker-hello-world                    0 
```
After:
```                 
[root@centos7-katello-devel-stable ~]# podman search --tls-verify=false centos7-katello-devel-stable.example.com/
INDEX         NAME                                                                                                       DESCRIPTION   STARS   OFFICIAL   AUTOMATED
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-hello-world                                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker1-test-docker-hello-world                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker-ccv-test-docker-hello-world                 0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-ccv-test-docker-hello-world                    0 
```

When trying to pull an unlisted, archived version (perhaps the end user deduced the container name):
```
podman search --tls-verify=false centos7-katello-devel-stable.example.com/
INDEX         NAME                                                                                                       DESCRIPTION   STARS   OFFICIAL   AUTOMATED
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-hello-world                                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker1-test-docker-hello-world                    0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-library-docker-ccv-test-docker-hello-world                 0                  
example.com   centos7-katello-devel-stable.example.com/default_organization-test-docker-ccv-test-docker-hello-world                    0                  
[root@centos7-katello-devel-stable ~]# podman pull --tls-verify centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world
Trying to pull centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world...
  name unknown: Repository not found.
Error: error pulling image "centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world": unable to pull centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world: unable to pull image: Error initializing source docker://centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world:latest: Error reading manifest latest in centos7-katello-devel-stable.example.com/default_organization-docker-ccv-1_0-test-docker-hello-world: name unknown: Repository not found.
```