### PR TITLE
Fixes #32187 - Import/Export for the file and ansible types

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -46,29 +46,22 @@ module Actions
           sequence do
             plan_action(ContentView::AddToEnvironment, version, library) unless options[:skip_promotion]
             repository_mapping = plan_action(ContentViewVersion::CreateRepos, version, source_repositories).repository_mapping
-
             # Split Pulp 3 Yum repos out of the repository_mapping.  Only Pulp 3 RPM plugin has multi repo copy support.
             separated_repo_map = separated_repo_mapping(repository_mapping)
-            if separated_repo_map[:pulp3_yum].keys.flatten.present? &&
-              SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
 
-              if options[:importing]
-                handle_import(version, options.slice(:path, :metadata))
-              else
-                plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)
-              end
+            if options[:importing]
+              handle_import(version, options.slice(:path, :metadata))
+            elsif separated_repo_map[:pulp3_yum].keys.flatten.present? &&
+              SmartProxy.pulp_primary.pulp3_support?(separated_repo_map[:pulp3_yum].keys.flatten.first)
+              plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum], version)
             end
 
             concurrence do
               source_repositories.each do |repositories|
                 sequence do
-                  if repositories.present? && separated_repo_map[:other].keys.include?(repositories)
-                    if options[:importing]
-                      handle_import(version, options.slice(:path, :metadata))
-                    else
-                      plan_action(Repository::CloneToVersion, repositories, version, repository_mapping[repositories],
-                                  :repos_units => options[:repos_units])
-                    end
+                  if !options[:importing] && repositories.present? && separated_repo_map[:other].keys.include?(repositories)
+                    plan_action(Repository::CloneToVersion, repositories, version, repository_mapping[repositories],
+                                :repos_units => options[:repos_units])
                   end
                   plan_action(Repository::CloneToEnvironment, repository_mapping[repositories], library) unless options[:skip_promotion]
                 end
@@ -184,8 +177,6 @@ module Actions
         end
 
         def handle_import(version, path:, metadata:)
-          return if @imported
-          @imported = true
           sequence do
             plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Import, version, path: path, metadata: metadata)
             plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::CopyVersionUnitsToLibrary, version)

--- a/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
@@ -7,12 +7,11 @@ module Actions
             concurrence do
               content_view_version.importable_repositories.each do |repo|
                 sequence do
-                  copy_action = plan_action(Actions::Pulp3::Repository::CopyContent, repo, SmartProxy.pulp_primary!,
+                  plan_action(Actions::Pulp3::Repository::CopyContent, repo, SmartProxy.pulp_primary!,
                                                     repo.library_instance,
                                                     copy_all: true,
                                                     mirror: content_view_version.content_view.library_import?)
-                  plan_action(Actions::Pulp3::Repository::SaveVersion, repo.library_instance,
-                                tasks: copy_action.output[:pulp_tasks])
+                  plan_action(Actions::Pulp3::Repository::SaveVersion, repo.library_instance)
                   plan_action(Katello::Repository::IndexContent, id: repo.library_instance_id)
                   plan_action(Katello::Repository::MetadataGenerate, repo.library_instance, :force => true)
                 end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -13,7 +13,7 @@ module Actions
             content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(destination_server: destination_server,
                                                                            organization: organization,
                                                                            create_by_default: true)
-            repo_ids_in_library = organization.default_content_view_version.repositories.yum_type.immediate.pluck(:id)
+            repo_ids_in_library = organization.default_content_view_version.repositories.exportable.immediate_or_none.pluck(:id)
             content_view.update!(repository_ids: repo_ids_in_library)
 
             sequence do

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -4,12 +4,11 @@ module Katello
                                 Repository::DOCKER_TYPE,
                                 Repository::OSTREE_TYPE,
                                 Repository::FILE_TYPE,
-                                Repository::DEB_TYPE
+                                Repository::DEB_TYPE,
+                                Repository::ANSIBLE_COLLECTION_TYPE
                                ].freeze
 
-    ALLOWED_IMPORT_REPOSITORY_TYPES = [
-      Repository::YUM_TYPE
-    ].freeze
+    ALLOWED_IMPORT_REPOSITORY_TYPES = Repository::EXPORTABLE_TYPES
 
     belongs_to :content_view, :inverse_of => :content_view_repositories,
                               :class_name => "Katello::ContentView"

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -333,9 +333,9 @@ module Katello
 
     def importable_repositories
       if default?
-        repositories.yum_type
+        repositories.exportable
       else
-        archived_repos.yum_type
+        archived_repos.exportable
       end
     end
 

--- a/app/services/katello/pulp3/api/ansible_collection.rb
+++ b/app/services/katello/pulp3/api/ansible_collection.rb
@@ -24,6 +24,14 @@ module Katello
           PulpAnsibleClient::AnsibleRepositorySyncURL
         end
 
+        def self.copy_class
+          PulpAnsibleClient::Copy
+        end
+
+        def self.add_remove_content_class
+          PulpAnsibleClient::RepositoryAddRemoveContent
+        end
+
         def api_client
           api_client_class(PulpAnsibleClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpAnsibleClient::Configuration)))
         end
@@ -42,6 +50,10 @@ module Katello
 
         def distributions_api
           PulpAnsibleClient::DistributionsAnsibleApi.new(api_client)
+        end
+
+        def copy_api
+          PulpAnsibleClient::AnsibleCopyApi.new(api_client)
         end
       end
     end

--- a/app/services/katello/pulp3/api/file.rb
+++ b/app/services/katello/pulp3/api/file.rb
@@ -28,6 +28,10 @@ module Katello
           PulpFileClient::RepositorySyncURL
         end
 
+        def self.add_remove_content_class
+          PulpFileClient::RepositoryAddRemoveContent
+        end
+
         def api_client
           api_client_class(PulpFileClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpFileClient::Configuration)))
         end

--- a/app/services/katello/pulp3/api/yum.rb
+++ b/app/services/katello/pulp3/api/yum.rb
@@ -32,6 +32,14 @@ module Katello
           PulpRpmClient::RpmPackageGroup
         end
 
+        def self.copy_class
+          PulpRpmClient::Copy
+        end
+
+        def self.add_remove_content_class
+          PulpRpmClient::RepositoryAddRemoveContent
+        end
+
         def api_client
           api_client_class(PulpRpmClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpRpmClient::Configuration)))
         end

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -24,14 +24,14 @@ module Katello
 
         def repositories(fetch_all: false)
           repos = if @content_view_version.default?
-                    @content_view_version.repositories.yum_type
+                    @content_view_version.repositories.exportable
                   else
-                    @content_view_version.archived_repos.yum_type
+                    @content_view_version.archived_repos.exportable
                   end
           if fetch_all
             repos
           else
-            repos.immediate
+            repos.immediate_or_none
           end
         end
 

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -59,7 +59,7 @@ module Katello
 
           repos_in_library = Katello::Repository.
                     in_default_view.
-                    yum_type.
+                    exportable.
                     joins(:product => :provider, :content_view_version => :content_view).
                     joins(:root).
                     where("#{::Katello::ContentView.table_name}.organization_id" => content_view.organization_id).

--- a/app/services/katello/pulp3/content_view_version/import_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/import_validator.rb
@@ -46,7 +46,7 @@ module Katello
         def ensure_repositories_metadata_are_in_the_library!
           repos_in_library = Katello::Repository.
                               in_default_view.
-                              yum_type.
+                              exportable.
                               joins(:product => :provider, :content_view_version => :content_view).
                               joins(:root).
                               where("#{::Katello::ContentView.table_name}.organization_id" => content_view.organization_id).

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -282,6 +282,24 @@ module Katello
         tasks
       end
 
+      def copy_all(source_repository, mirror: false)
+        if mirror
+          data = api.class.add_remove_content_class.new(
+                    base_version: source_repository.version_href)
+
+          [api.repositories_api.modify(repository_reference.repository_href, data)]
+        elsif api.respond_to? :copy_api
+          data = api.class.copy_class.new
+          data.config = [{
+            source_repo_version: source_repository.version_href,
+            dest_repo: repository_reference.repository_href
+          }]
+          [api.copy_api.copy_content(data)]
+        else
+          copy_content_for_source(source_repository)
+        end
+      end
+
       def copy_version(from_repository)
         create_version(:base_version => from_repository.version_href)
       end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -207,22 +207,6 @@ module Katello
           tasks
         end
 
-        def copy_all(source_repository, mirror: false)
-          if mirror
-            data = PulpRpmClient::RepositoryAddRemoveContent.new(
-                      base_version: source_repository.version_href)
-
-            [api.repositories_api.modify(repository_reference.repository_href, data)]
-          else
-            data = PulpRpmClient::Copy.new
-            data.config = [{
-              source_repo_version: source_repository.version_href,
-              dest_repo: repository_reference.repository_href
-            }]
-            [api.copy_api.copy_content(data)]
-          end
-        end
-
         def remove_all_content_from_repo(repo_href)
           data = PulpRpmClient::RepositoryAddRemoveContent.new(
             remove_content_units: ['*'])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -13,7 +13,7 @@
   </div>
 
   <nav data-block="item-actions">
-    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView) || contentView.import_only" 
+    <button type="button" class="btn btn-primary" ng-hide="denied('publish_content_views', contentView) || contentView.import_only"
             ui-sref="content-view.publish">
       <span translate>Publish New Version</span>
     </button>
@@ -61,7 +61,7 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.yum') || stateIncludes('content-view.yum.filters')}"
-          ng-hide="contentView.composite || !repositoryTypeEnabled('yum')">
+          ng-hide="contentView.composite || contentView.import_only || !repositoryTypeEnabled('yum')">
 
         <a uib-dropdown-toggle>
           <span translate>Yum Content</span>

--- a/test/actions/pulp3/content_view_version/export_library_test.rb
+++ b/test/actions/pulp3/content_view_version/export_library_test.rb
@@ -30,7 +30,7 @@ module ::Actions::Pulp3::ContentView
     it 'should plan properly' do
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:version).returns(version)
       action_class.any_instance.expects(:action_subject).with(organization)
-      immediate_repo_ids_in_library = organization.default_content_view_version.repositories.yum_type.immediate.pluck(:id)
+      immediate_repo_ids_in_library = organization.default_content_view_version.repositories.exportable.immediate_or_none.pluck(:id)
 
       plan_action(action, organization, destination_server: destination_server)
       assert_action_planned_with(action, ::Actions::Katello::ContentView::Publish) do |content_view, _|


### PR DESCRIPTION
This commit adds support for import/export of file type. With this
commit one should be able to
1) Export Version/Library  file repos
2) Import Version/Library  file repos

3) Export Library for ansible_collection
4) Import Library for ansible_collections