### PR TITLE
Fixes #31955 - Pulp3 check for import path

### DIFF
--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -10,8 +10,10 @@ module Actions
                                                                                                    name: metadata[:content_view])
           end
           content_view.check_ready_to_import!
-
-          ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: content_view, metadata: metadata, path: path)
+          ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: content_view,
+                                                              metadata: metadata,
+                                                              path: path,
+                                                              smart_proxy: SmartProxy.pulp_primary!)
           ::Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: content_view, metadata: metadata)
 
           major = metadata[:content_view_version][:major]

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -66,6 +66,10 @@ module Katello
           PulpcoreClient::ImportersPulpApi.new(core_api_client)
         end
 
+        def importer_check_api
+          PulpcoreClient::ImportersCoreImportCheckApi.new(core_api_client)
+        end
+
         def export_api
           PulpcoreClient::ExportersCoreExportsApi.new(core_api_client)
         end

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -43,8 +43,11 @@ module Katello
           api.importer_api.delete(importer_href)
         end
 
-        def self.check!(content_view:, metadata:, path:)
-          ImportValidator.new(content_view: content_view, metadata: metadata, path: path).check!
+        def self.check!(content_view:, metadata:, path:, smart_proxy:)
+          ImportValidator.new(smart_proxy: smart_proxy,
+                               content_view: content_view,
+                               metadata: metadata,
+                               path: path).check!
         end
 
         def self.reset_content_view_repositories_from_metadata!(content_view:, metadata:)

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -68,6 +68,7 @@ module ::Actions::Katello::ContentViewVersion
     before do
       setup_proxy
       content_view.import_only = true
+      ::Katello::Pulp3::ContentViewVersion::ImportValidator.any_instance.stubs(:ensure_pulp_importable!).returns
     end
 
     describe 'Import' do
@@ -80,7 +81,10 @@ module ::Actions::Katello::ContentViewVersion
 
       it 'should plan properly' do
         metadata[:content_view_version][:major] += 10
-        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view, metadata: metadata, path: path).returns
+        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view,
+                                                                           metadata: metadata,
+                                                                           path: path,
+                                                                          smart_proxy: SmartProxy.pulp_primary).returns
 
         plan_action(action, content_view: content_view, path: path, metadata: metadata)
         assert_action_planned_with(action,
@@ -112,7 +116,10 @@ module ::Actions::Katello::ContentViewVersion
       end
 
       it 'should plan the full tree appropriately' do
-        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view, metadata: metadata, path: path).returns
+        ::Katello::Pulp3::ContentViewVersion::Import.expects(:check!).with(content_view: content_view,
+                                                                           metadata: metadata,
+                                                                           path: path,
+                                                                          smart_proxy: SmartProxy.pulp_primary).returns
 
         metadata[:content_view_version][:major] += 10
         generated_cvv = nil


### PR DESCRIPTION
This commit adds code to check if the path provided in the hammer
content-import command is valid and useful  by making use of the pulp
dry run api.