### PR TITLE
Fixes #32224 - Expose Katello events for Webhooks

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -2,6 +2,9 @@ module Actions
   module Katello
     module ContentView
       class Promote < Actions::EntryAction
+        extend ApipieDSL::Class
+        include ::Actions::ObservableAction
+
         def plan(version, environments, is_force = false, description = nil, incremental_update = false)
           action_subject(version.content_view)
           version.check_ready_to_promote!(environments)
@@ -17,6 +20,28 @@ module Actions
               plan_action(Katello::ContentViewVersion::AfterPromoteHook, :id => version.id)
             end
           end
+        end
+
+        def environments
+          input['environments']
+        end
+
+        apipie :class, "A class representing #{self} object" do
+          desc 'This object is available as **@object** variable in
+                webhook templates when a corresponding event occures.
+                The following properties can be used to retrieve the needed information.'
+          name "#{class_scope}"
+          refs "#{class_scope}"
+          sections only: %w[all webhooks]
+          property :task, object_of: 'Task', desc: 'Returns the task to which this action belongs'
+          property :environments, array_of: String, desc: 'Returns the list of environments the content view was promoted to'
+        end
+        include Actions::Katello::JailConcern::Organization
+        include Actions::Katello::JailConcern::ContentView
+        class Jail < ::Actions::ObservableAction::Jail
+          allow :organization_id, :organization_name, :organization_label,
+                :content_view_id, :content_view_name, :content_view_label,
+                :environments
         end
       end
     end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -3,7 +3,9 @@ module Actions
   module Katello
     module ContentView
       class Publish < Actions::EntryAction
+        extend ApipieDSL::Class
         include ::Katello::ContentViewHelper
+        include ::Actions::ObservableAction
         attr_accessor :version
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
         def plan(content_view, description = "", options = {importing: false}) # rubocop:disable Metrics/PerceivedComplexity
@@ -188,6 +190,33 @@ module Actions
               plan_action(Katello::Repository::IndexContent, id: id)
             end
           end
+        end
+
+        def content_view_version_id
+          input['content_view_version_id']
+        end
+
+        def content_view_version_name
+          input['content_view_version_name']
+        end
+
+        apipie :class, "A class representing #{self} object" do
+          desc 'This object is available as **@object** variable in
+                webhook templates when a corresponding event occures.
+                The following properties can be used to retrieve the needed information.'
+          name "#{class_scope}"
+          refs "#{class_scope}"
+          sections only: %w[all webhooks]
+          property :task, object_of: 'Task', desc: 'Returns the task to which this action belongs'
+          property :content_view_version_id, Integer, desc: 'Returns published content view version id'
+          property :content_view_version_name, String, desc: 'Returns published content view version name'
+        end
+        include Actions::Katello::JailConcern::Organization
+        include Actions::Katello::JailConcern::ContentView
+        class Jail < ::Actions::ObservableAction::Jail
+          allow :organization_id, :organization_name, :organization_label,
+                :content_view_id, :content_view_name, :content_view_label,
+                :content_view_version_id, :content_view_version_name
         end
       end
     end

--- a/app/lib/actions/katello/jail_concern/content_view.rb
+++ b/app/lib/actions/katello/jail_concern/content_view.rb
@@ -1,0 +1,30 @@
+module Actions
+  module Katello
+    module JailConcern
+      module ContentView
+        def content_view_id
+          input['content_view']['id']
+        end
+
+        def content_view_name
+          input['content_view']['name']
+        end
+
+        def content_view_label
+          input['content_view']['label']
+        end
+
+        def self.included(base)
+          super
+          base.instance_eval do
+            apipie :class do
+              property :content_view_id, Integer, desc: 'Returns the id of the content view'
+              property :content_view_name, String, desc: 'Returns the name of the content view'
+              property :content_view_label, String, desc: 'Returns the label of the content view'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/jail_concern/organization.rb
+++ b/app/lib/actions/katello/jail_concern/organization.rb
@@ -1,0 +1,30 @@
+module Actions
+  module Katello
+    module JailConcern
+      module Organization
+        def organization_id
+          input['organization']['id']
+        end
+
+        def organization_name
+          input['organization']['name']
+        end
+
+        def organization_label
+          input['organization']['label']
+        end
+
+        def self.included(base)
+          super
+          base.instance_eval do
+            apipie :class do
+              property :organization_id, Integer, desc: 'Returns the id of the organization'
+              property :organization_name, String, desc: 'Returns the name of the organization'
+              property :organization_label, String, desc: 'Returns the label of the organization'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -3,8 +3,10 @@ module Actions
   module Katello
     module Repository
       class Sync < Actions::EntryAction
+        extend ApipieDSL::Class
         include Helpers::Presenter
         include Actions::Katello::PulpSelector
+        include ::Actions::ObservableAction
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
         input_format do
@@ -123,6 +125,63 @@ module Actions
 
         def rescue_strategy
           Dynflow::Action::Rescue::Skip
+        end
+
+        def repository_id
+          input['repository']['id']
+        end
+
+        def repository_name
+          input['repository']['name']
+        end
+
+        def repository_label
+          input['repository']['label']
+        end
+
+        def product_id
+          input['product']['id']
+        end
+
+        def product_name
+          input['product']['name']
+        end
+
+        def product_label
+          input['product']['label']
+        end
+
+        def contents_changed
+          input['contents_changed']
+        end
+
+        def sync_result
+          input['sync_result']
+        end
+
+        apipie :class, "A class representing #{self} object" do
+          desc 'This object is available as **@object** variable in
+                webhook templates when a corresponding event occures.
+                The following properties can be used to retrieve the needed information.'
+          name "#{class_scope}"
+          refs "#{class_scope}"
+          sections only: %w[all webhooks]
+          property :task, object_of: 'Task', desc: 'Returns the task to which this action belongs'
+          property :repository_id, Integer, desc: 'Returns synced repository id'
+          property :repository_name, String, desc: 'Returns synced repository name'
+          property :repository_label, String, desc: 'Returns synced repository label'
+          property :product_id, Integer, desc: 'Returns product id the synced repository belongs to'
+          property :product_name, String, desc: 'Returns product name the synced repository belongs to'
+          property :product_label, String, desc: 'Returns product label the synced repository belongs to'
+          property :sync_result, Hash, desc: 'Returns Hash object with sync result'
+          property :contents_changed, one_of: [true, false], desc: 'Returns true if repository content was changed due to sync, false otherwise'
+        end
+        include Actions::Katello::JailConcern::Organization
+        class Jail < ::Actions::ObservableAction::Jail
+          allow :organization_id, :organization_name, :organization_label,
+                :repository_id, :repository_name, :repository_label,
+                :product_id, :product_name, :product_label,
+                :sync_result, :contents_changed
         end
       end
     end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -6,6 +6,7 @@ module Katello
     include Ext::LabelFromName
     include Katello::Authorization::ContentView
     include ForemanTasks::Concerns::ActionSubject
+    include Foreman::ObservableModel
 
     CONTENT_DIR = "content_views".freeze
     IMPORT_LIBRARY = "Import-Library".freeze
@@ -85,6 +86,17 @@ module Katello
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :label, :complete_value => true
     scoped_search :on => :composite, :complete_value => true
+
+    set_crud_hooks :content_view
+
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Content View'
+      refs 'ContentView'
+      sections only: %w[all additional]
+      prop_group :katello_idname_props, Katello::Model, meta: { friendly_name: 'Content View' }
+      property :label, String, desc: 'Returns label of the Content View'
+      property :organization, 'Organization', desc: 'Returns organization object'
+    end
 
     def self.in_environment(env)
       joins(:content_view_environments).
@@ -649,14 +661,8 @@ module Katello
       self.organization
     end
 
-    apipie :class, desc: "A class representing #{model_name.human} object" do
-      name 'Content View'
-      refs 'ContentView'
-      sections only: %w[all additional]
-      prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Content View' }
-    end
     class Jail < ::Safemode::Jail
-      allow :name, :label, :version
+      allow :id, :name, :label, :version, :organization
     end
   end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -79,16 +79,6 @@ module Katello
       require 'katello/apipie/validators'
     end
 
-    # make sure the Katello plugin is initialized before `after_initialize`
-    # hook so that the resumed Dynflow tasks can rely on everything ready.
-    initializer 'katello.register_plugin', :before => :finisher_hook, :after => 'foreman_remote_execution.register_plugin' do
-      ::Foreman::AccessControl::Permission.prepend ::Katello::Concerns::PermissionExtensions
-      require 'katello/plugin'
-
-      # extend builtin permissions from core with new actions
-      require 'katello/permissions'
-    end
-
     initializer "katello.register_actions", :before => :finisher_hook do |_app|
       ForemanTasks.dynflow.require!
       if (Setting.table_exists? rescue(false)) && Setting['host_tasks_workers_pool_size'].to_i > 0
@@ -99,6 +89,17 @@ module Katello
                         #{Katello::Engine.root}/app/lib/headpin/actions
                         #{Katello::Engine.root}/app/lib/katello/actions)
       ForemanTasks.dynflow.config.eager_load_paths.concat(action_paths)
+      ForemanTasks.dynflow.eager_load_actions!
+    end
+
+    # make sure the Katello plugin is initialized before `after_initialize`
+    # hook so that the resumed Dynflow tasks can rely on everything ready.
+    initializer 'katello.register_plugin', :before => :finisher_hook, :after => 'foreman_remote_execution.register_plugin' do
+      ::Foreman::AccessControl::Permission.prepend ::Katello::Concerns::PermissionExtensions
+      require 'katello/plugin'
+
+      # extend builtin permissions from core with new actions
+      require 'katello/permissions'
     end
 
     initializer "katello.set_dynflow_middlewares", :before => :finisher_hook do |_app|

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -3,7 +3,7 @@ require 'katello/repository_types.rb'
 require 'katello/host_status_manager.rb'
 # rubocop:disable Metrics/BlockLength
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 2.3'
+  requires_foreman '>= 2.4'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'),
            :icon => 'fa fa-book', :after => :monitor_menu do
@@ -218,7 +218,8 @@ Foreman::Plugin.register :katello do
   apipie_documented_controllers ["#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"]
   apipie_ignored_controllers %w(::Api::V2::OrganizationsController)
   ApipieDSL.configuration.dsl_classes_matchers.concat [
-    "#{Katello::Engine.root}/app/models/katello/**/*.rb"
+    "#{Katello::Engine.root}/app/models/katello/**/*.rb",
+    "#{Katello::Engine.root}/app/lib/actions/**/*.rb"
   ]
 
   parameter_filter ::Host::Managed, :host_collection_ids => [],
@@ -403,4 +404,6 @@ Foreman::Plugin.register :katello do
   precompile.concat(bastion_locale_files)
 
   precompile_assets(precompile)
+
+  extend_observable_events(::Dynflow::Action.descendants.select { |klass| klass <= ::Actions::ObservableAction }.map(&:namespaced_event_names))
 end


### PR DESCRIPTION
This PR exposes new events for subscriprions within Foreman Webhooks plugin, to test this you might want to have it installed.

@lzap, you might want to test it and probably tell what is missing.

TODO:
 - [x] Add DSL docs
 
 NOTE: I've changed the order of initializers because currently the actions are being loaded after all plugin registration methods are called, which leads to addition of new observable events being impossible. Also `extend_observable_events` is available from `2.4`, so I've updated the required version as well.