### PR TITLE
Fixes #32221 - use eslint react-hooks rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^24.9.0",
     "nock": "^12.0.3",
     "react-test-renderer": "^16.0.0"

--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -19,13 +19,14 @@ module.exports = {
   plugins: [
     'jest',
     'react',
-    'babel',
-    'promise'
+    'react-hooks',
+    'promise',
   ],
   parser: 'babel-eslint',
   rules: {
-    'babel/semi': 1,
     'react/jsx-filename-extension': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     // Import rules off for now due to HoundCI issue
     'import/no-unresolved': 'off',
     'import/extensions': 'off',

--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -26,7 +26,9 @@ module.exports = {
   rules: {
     'react/jsx-filename-extension': 'off',
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': ["warn", {
+      "additionalHooks": "(useDeepCompareEffect)"
+    }],
     // Import rules off for now due to HoundCI issue
     'import/no-unresolved': 'off',
     'import/extensions': 'off',

--- a/webpack/components/EditableTextInput/EditableTextInput.js
+++ b/webpack/components/EditableTextInput/EditableTextInput.js
@@ -14,13 +14,13 @@ const EditableTextInput = ({
   const [editing, setEditing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  // Setting didCancel to avoid actions from happening after component has been unmounted
+  // Setting didCancel to prevent actions from happening after component has been unmounted
   // see https://overreacted.io/a-complete-guide-to-useeffect/#speaking-of-race-conditions
   useEffect(() => {
     let didCancel = false;
 
     const onSubmit = async () => {
-      if (submitting) {
+      if (submitting) { // no dependency array because this check takes care of it
         await onEdit(inputValue, attribute);
         if (!didCancel) {
           setSubmitting(false);
@@ -33,7 +33,7 @@ const EditableTextInput = ({
     return () => {
       didCancel = true;
     };
-  }, [submitting]);
+  });
 
   // Listen for enter and trigger submit workflow on enter
   useEffect(() => {

--- a/webpack/components/RoutedTabs/RoutedTabs.js
+++ b/webpack/components/RoutedTabs/RoutedTabs.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { shape, string, number, element, arrayOf } from 'prop-types';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -17,30 +17,29 @@ const RoutedTabs = ({
   const { hash } = useLocation();
   const { hash: tabFromUrl, params: { subContentId } } = paramsFromHash(hash);
 
-  const buildLink = tabKey => `${baseUrl}#${tabKey}`;
-
-  const changeTab = (eventKey) => {
+  const changeTab = useCallback((eventKey) => {
+    const buildLink = tabKey => `${baseUrl}#${tabKey}`;
     const matchedTab = tabs.find(tab => tab.key === eventKey);
     if (matchedTab) {
       history.push(buildLink(matchedTab.key));
     } else {
       history.replace(buildLink(tabs[defaultTabIndex].key)); // go to first tab if no tab selected
     }
-  };
+  }, [tabs, defaultTabIndex, history, baseUrl]);
 
   const handleTabSelect = (_event, eventKey) => changeTab(eventKey);
 
-  const getActiveTab = () => {
+  const getActiveTab = useCallback(() => {
     const matchedTab = tabs.find(tab => tab.key === tabFromUrl);
     if (matchedTab) return matchedTab.key;
 
     return tabs[defaultTabIndex].key; // Default to first tab
-  };
+  }, [tabs, tabFromUrl, defaultTabIndex]);
 
   // Useful when first navigating to the page, switches to default tab in url
   useEffect(() => {
     if (tabFromUrl !== getActiveTab()) changeTab(tabFromUrl);
-  }, [tabFromUrl]);
+  }, [tabFromUrl, getActiveTab, changeTab]);
 
   // Handle subroutes to show item's detail content while staying on a tab
   const showContent = (tab) => {

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -30,31 +30,37 @@ const TableWrapper = ({
   const [total, setTotal] = useState(0);
 
   const updatePagination = (data) => {
+    console.log('updatePagination')
     const { subtotal: newTotal, page: newPage, per_page: newPerPage } = data;
     if (newTotal !== undefined) setTotal(parseInt(newTotal, 10));
     if (newPage !== undefined) setPage(parseInt(newPage, 10));
     if (newPerPage !== undefined) setPerPage(parseInt(newPerPage, 10));
   };
   // eslint-disable-next-line no-underscore-dangle
-  const _paginationParams = () => ({ per_page: perPage, page });
-  const paginationParams = useCallback(_paginationParams, [page, perPage]);
-
-  useEffect(() => updatePagination(metadata), [metadata]);
+  const paginationParams = () => ({ per_page: perPage, page });
+  // const paginationParams = useCallback(_paginationParams, [page, perPage]);
+let counter = React.useRef(1);
+  // useEffect(() => updatePagination(metadata), [metadata]);
 
   // The search component will update the search query when a search is performed, listen for that
   // and perform the search so we can be sure the searchQuery is updated when search is performed.
   useEffect(() => {
     const fetchWithParams = (allParams = {}) => {
-      dispatch(fetchItems({ ...paginationParams(), ...allParams }));
+      dispatch(fetchItems({ per_page: perPage, page, ...allParams }));
     };
     if (searchQuery || activeFilters) {
       // Reset page back to 1 when filter or search changes
+      console.log('fetchWithParams with searchQuery')
       fetchWithParams({ search: searchQuery, page: 1 });
     } else {
-      fetchWithParams();
+      console.log('fetchWithParams')
+      counter.current += 1;
+      // if (counter.current > 10) debugger;
+      // fetchWithParams();
+      if (counter.current < 10) fetchWithParams();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, ...additionalListeners, activeFilters, dispatch, fetchItems, paginationParams]);
+  }, [searchQuery, ...additionalListeners, activeFilters, dispatch, fetchItems, page, perPage]);
 
   const getAutoCompleteParams = search => ({
     endpoint: autocompleteEndpoint,

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pagination, Flex, FlexItem } from '@patternfly/react-core';
 
 import PropTypes from 'prop-types';
@@ -30,7 +30,6 @@ const TableWrapper = ({
   const [total, setTotal] = useState(0);
 
   const updatePagination = (data) => {
-    console.log('updatePagination')
     const { subtotal: newTotal, page: newPage, per_page: newPerPage } = data;
     if (newTotal !== undefined) setTotal(parseInt(newTotal, 10));
     if (newPage !== undefined) setPage(parseInt(newPage, 10));
@@ -39,7 +38,7 @@ const TableWrapper = ({
   // eslint-disable-next-line no-underscore-dangle
   const paginationParams = () => ({ per_page: perPage, page });
   // const paginationParams = useCallback(_paginationParams, [page, perPage]);
-let counter = React.useRef(1);
+  const counter = React.useRef(1);
   // useEffect(() => updatePagination(metadata), [metadata]);
 
   // The search component will update the search query when a search is performed, listen for that
@@ -50,10 +49,8 @@ let counter = React.useRef(1);
     };
     if (searchQuery || activeFilters) {
       // Reset page back to 1 when filter or search changes
-      console.log('fetchWithParams with searchQuery')
       fetchWithParams({ search: searchQuery, page: 1 });
     } else {
-      console.log('fetchWithParams')
       counter.current += 1;
       // if (counter.current > 10) debugger;
       // fetchWithParams();

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -55,7 +55,7 @@ const TableWrapper = ({
   }, [
     activeFilters,
     dispatch,
-    // fetchItems,
+    fetchItems,
     paginationParams,
     searchQuery,
     additionalListeners,

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Pagination, Flex, FlexItem } from '@patternfly/react-core';
 
 import PropTypes from 'prop-types';
@@ -35,23 +35,26 @@ const TableWrapper = ({
     if (newPage !== undefined) setPage(parseInt(newPage, 10));
     if (newPerPage !== undefined) setPerPage(parseInt(newPerPage, 10));
   };
-  const paginationParams = () => ({ per_page: perPage, page });
-  const fetchWithParams = (allParams = {}) => {
-    dispatch(fetchItems({ ...paginationParams(), ...allParams }));
-  };
+  // eslint-disable-next-line no-underscore-dangle
+  const _paginationParams = () => ({ per_page: perPage, page });
+  const paginationParams = useCallback(_paginationParams, [page, perPage]);
 
   useEffect(() => updatePagination(metadata), [metadata]);
 
   // The search component will update the search query when a search is performed, listen for that
   // and perform the search so we can be sure the searchQuery is updated when search is performed.
   useEffect(() => {
+    const fetchWithParams = (allParams = {}) => {
+      dispatch(fetchItems({ ...paginationParams(), ...allParams }));
+    };
     if (searchQuery || activeFilters) {
       // Reset page back to 1 when filter or search changes
       fetchWithParams({ search: searchQuery, page: 1 });
     } else {
       fetchWithParams();
     }
-  }, [searchQuery, ...additionalListeners]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, ...additionalListeners, activeFilters, dispatch, fetchItems, paginationParams]);
 
   const getAutoCompleteParams = search => ({
     endpoint: autocompleteEndpoint,

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -52,7 +52,14 @@ const TableWrapper = ({
     } else {
       fetchWithParams();
     }
-  }, [activeFilters, dispatch, fetchItems, paginationParams, searchQuery, additionalListeners]);
+  }, [
+    activeFilters,
+    dispatch,
+    // fetchItems,
+    paginationParams,
+    searchQuery,
+    additionalListeners,
+  ]);
 
   const getAutoCompleteParams = search => ({
     endpoint: autocompleteEndpoint,
@@ -64,7 +71,6 @@ const TableWrapper = ({
 
   const onPaginationUpdate = (updatedPagination) => {
     updatePagination(updatedPagination);
-    dispatch(fetchItems({ ...paginationParams(), ...updatedPagination, search: searchQuery }));
   };
 
   return (

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -40,7 +40,7 @@ const ActivationKeys = ({
   // Validate field when hostgroup is changed (host group may have some keys)
   useEffect(() => {
     handleInvalidField('Activation Keys', akHasValidValue(hostGroupId, pluginValues?.activationKeys, hostGroupActivationKeys));
-  }, [handleInvalidField, hostGroupId, hostGroupActivationKeys, pluginValues]);
+  }, [hostGroupId, hostGroupActivationKeys, pluginValues]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <FormGroup

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -40,7 +40,7 @@ const ActivationKeys = ({
   // Validate field when hostgroup is changed (host group may have some keys)
   useEffect(() => {
     handleInvalidField('Activation Keys', akHasValidValue(hostGroupId, pluginValues?.activationKeys, hostGroupActivationKeys));
-  }, [hostGroupId, hostGroupActivationKeys, pluginValues]);
+  }, [handleInvalidField, hostGroupId, hostGroupActivationKeys, pluginValues]);
 
   return (
     <FormGroup

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -18,7 +18,7 @@ const RegistrationCommands = ({
 }) => {
   useEffect(() => {
     onChange({ activationKeys: [], lifecycleEnvironmentId: '' });
-  }, [onChange, organizationId, hostGroupId]);
+  }, [organizationId, hostGroupId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -18,7 +18,7 @@ const RegistrationCommands = ({
 }) => {
   useEffect(() => {
     onChange({ activationKeys: [], lifecycleEnvironmentId: '' });
-  }, [organizationId, hostGroupId]);
+  }, [onChange, organizationId, hostGroupId]);
 
   return (
     <>
@@ -78,4 +78,3 @@ RegistrationCommands.defaultProps = {
 };
 
 export default RegistrationCommands;
-

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useDispatch, useSelector } from 'react-redux';
 import { Bullseye, Split, SplitItem, Button } from '@patternfly/react-core';
@@ -211,7 +211,7 @@ const ContentViewComponents = ({ cvId, details }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/content_views/auto_complete_search"
-      fetchItems={params => getContentViewComponents(cvId, params, statusSelected)}
+      fetchItems={useCallback(params => getContentViewComponents(cvId, params, statusSelected), [cvId, statusSelected])}
       additionalListeners={[statusSelected, addComponentsResolved, removeComponentsResolved]}
     >
       <Split hasGutter>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -66,7 +66,7 @@ const ContentViewComponents = ({ cvId, details }) => {
 
   const bulkRemoveEnabled = () => rows.some(row => row.selected && row.added);
 
-  const onAdd = ({
+  const onAdd = useCallback(({
     componentCvId, published, added, latest,
   }) => {
     if (published) {
@@ -82,7 +82,7 @@ const ContentViewComponents = ({ cvId, details }) => {
         components: [{ latest: true, content_view_id: componentCvId }],
       }));
     }
-  };
+  }, [cvId, dispatch]);
 
   const removeBulk = () => {
     const componentIds = [];
@@ -100,7 +100,7 @@ const ContentViewComponents = ({ cvId, details }) => {
     }));
   };
 
-  const buildRows = (results) => {
+  const buildRows = useCallback((results) => {
     const newRows = [];
     results.forEach((componentCV) => {
       const {
@@ -151,7 +151,7 @@ const ContentViewComponents = ({ cvId, details }) => {
       });
     });
     return newRows;
-  };
+  }, [onAdd]);
 
   const actionResolver = (rowData, { _rowIndex }) => [
     {
@@ -189,7 +189,7 @@ const ContentViewComponents = ({ cvId, details }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response]);
+  }, [response, buildRows, loading]);
 
   return (
     <TableWrapper
@@ -211,7 +211,8 @@ const ContentViewComponents = ({ cvId, details }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/content_views/auto_complete_search"
-      fetchItems={useCallback(params => getContentViewComponents(cvId, params, statusSelected), [cvId, statusSelected])}
+      fetchItems={useCallback(params =>
+        getContentViewComponents(cvId, params, statusSelected), [cvId, statusSelected])}
       additionalListeners={[statusSelected, addComponentsResolved, removeComponentsResolved]}
     >
       <Split hasGutter>

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
@@ -102,7 +102,7 @@ const CVPackageGroupFilterContent = ({ cvId, filterId }) => {
             cells={columnHeaders}
             variant={TableVariant.compact}
             autocompleteEndpoint={`/package_groups/auto_complete_search?filterid=${filterId}`}
-            fetchItems={params => getCVFilterPackageGroups(cvId, filterId, params)}
+            fetchItems={useCallback(params => getCVFilterPackageGroups(cvId, filterId, params), [cvId, filterId])}
           />
         </div>
       </Tab>

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -39,7 +39,7 @@ const CVPackageGroupFilterContent = ({ cvId, filterId }) => {
     __('Status'),
   ];
 
-  const buildRows = (results) => {
+  const buildRows = useCallback((results) => {
     const newRows = [];
     results.forEach((packageGroups) => {
       const {
@@ -63,7 +63,7 @@ const CVPackageGroupFilterContent = ({ cvId, filterId }) => {
     });
 
     return newRows;
-  };
+  }, [filterId]);
 
   useDeepCompareEffect(() => {
     const { results, ...meta } = response;
@@ -73,7 +73,7 @@ const CVPackageGroupFilterContent = ({ cvId, filterId }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response]);
+  }, [response, loading, buildRows]);
 
   const emptyContentTitle = __('No package groups have been added to this filter.');
   const emptyContentBody = __("Add to this filter using the 'Add package group' button.");
@@ -102,7 +102,8 @@ const CVPackageGroupFilterContent = ({ cvId, filterId }) => {
             cells={columnHeaders}
             variant={TableVariant.compact}
             autocompleteEndpoint={`/package_groups/auto_complete_search?filterid=${filterId}`}
-            fetchItems={useCallback(params => getCVFilterPackageGroups(cvId, filterId, params), [cvId, filterId])}
+            fetchItems={useCallback(params =>
+              getCVFilterPackageGroups(cvId, filterId, params), [cvId, filterId])}
           />
         </div>
       </Tab>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
@@ -96,7 +96,7 @@ const CVRpmFilterContent = ({ filterId, inclusion }) => {
             cells={columnHeaders}
             variant={TableVariant.compact}
             autocompleteEndpoint={`/content_view_filters/${filterId}/rules/auto_complete_search`}
-            fetchItems={params => getCVFilterRules(filterId, params)}
+            fetchItems={useCallback(params => getCVFilterRules(filterId, params), [filterId])}
           />
         </div>
       </Tab>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -43,7 +43,7 @@ const CVRpmFilterContent = ({ filterId, inclusion }) => {
     return 'All versions';
   };
 
-  const buildRows = (results) => {
+  const buildRows = useCallback((results) => {
     const newRows = [];
     results.forEach((rule) => {
       const { name, architecture } = rule;
@@ -57,7 +57,7 @@ const CVRpmFilterContent = ({ filterId, inclusion }) => {
     });
 
     return newRows;
-  };
+  }, []);
 
   useDeepCompareEffect(() => {
     const { results, ...meta } = response;
@@ -67,7 +67,7 @@ const CVRpmFilterContent = ({ filterId, inclusion }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response]);
+  }, [response, loading, buildRows]);
 
   const emptyContentTitle = __('No rules have been added to this filter.');
   const emptyContentBody = __("Add to this filter using the 'Add RPM' button.");

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
@@ -26,7 +26,7 @@ const ContentViewFilterDetails = () => {
 
   useEffect(() => {
     dispatch(getCVFilterDetails(cvId, filterId));
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useDeepCompareEffect(() => {
     if (loaded) setDetails(response);

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
@@ -26,7 +26,7 @@ const ContentViewFilterDetails = () => {
 
   useEffect(() => {
     dispatch(getCVFilterDetails(cvId, filterId));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch, cvId, filterId]);
 
   useDeepCompareEffect(() => {
     if (loaded) setDetails(response);

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -90,33 +90,6 @@ const ContentViewFilters = ({ cvId }) => {
     const { results, ...meta } = response;
     setMetadata(meta);
 
-    const buildRows = () => {
-      const newRows = [];
-      results.forEach((filter) => {
-        let errataByDate = false;
-        const {
-          id, name, type, description, updated_at: updatedAt, inclusion,
-        } = filter;
-        if (filter.type === 'erratum' && filter.rules[0].types) errataByDate = true;
-
-        const cells = [
-          { title: <Link to={cvFilterUrl(cvId, id)}>{name}</Link> },
-          truncate(description || ''),
-          { title: <LongDateTime date={updatedAt} showRelativeTimeTooltip /> },
-          { title: <ContentType type={type} errataByDate={errataByDate} /> },
-          {
-            title: (
-              <Label color={inclusion && 'blue'}>
-                {inclusion ? 'Include' : 'Exclude'}
-              </Label>),
-          },
-        ];
-
-        newRows.push({ cells });
-      });
-      return newRows;
-    };
-
     if (!loading && results) {
       const newRows = buildRows();
       setRows(newRows);

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -91,7 +91,7 @@ const ContentViewFilters = ({ cvId }) => {
     setMetadata(meta);
 
     if (!loading && results) {
-      const newRows = buildRows();
+      const newRows = buildRows(results);
       setRows(newRows);
     }
   }, [response]);

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -47,7 +47,7 @@ const ContentViewFilters = ({ cvId }) => {
     __('Inclusion type'),
   ];
 
-  const buildRows = (results) => {
+  const buildRows = useCallback((results) => {
     const newRows = [];
     results.forEach((filter) => {
       let errataByDate = false;
@@ -72,7 +72,7 @@ const ContentViewFilters = ({ cvId }) => {
       newRows.push({ cells, id });
     });
     return newRows;
-  };
+  }, [cvId]);
 
   const bulkRemove = () => {
     setBulkActionOpen(false);
@@ -94,7 +94,7 @@ const ContentViewFilters = ({ cvId }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response]);
+  }, [response, loading, buildRows]);
 
   const actionResolver = () => [
     {

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -90,8 +90,35 @@ const ContentViewFilters = ({ cvId }) => {
     const { results, ...meta } = response;
     setMetadata(meta);
 
+    const buildRows = () => {
+      const newRows = [];
+      results.forEach((filter) => {
+        let errataByDate = false;
+        const {
+          id, name, type, description, updated_at: updatedAt, inclusion,
+        } = filter;
+        if (filter.type === 'erratum' && filter.rules[0].types) errataByDate = true;
+
+        const cells = [
+          { title: <Link to={cvFilterUrl(cvId, id)}>{name}</Link> },
+          truncate(description || ''),
+          { title: <LongDateTime date={updatedAt} showRelativeTimeTooltip /> },
+          { title: <ContentType type={type} errataByDate={errataByDate} /> },
+          {
+            title: (
+              <Label color={inclusion && 'blue'}>
+                {inclusion ? 'Include' : 'Exclude'}
+              </Label>),
+          },
+        ];
+
+        newRows.push({ cells });
+      });
+      return newRows;
+    };
+
     if (!loading && results) {
-      const newRows = buildRows(results);
+      const newRows = buildRows();
       setRows(newRows);
     }
   }, [response]);

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { Label, Split, SplitItem, Button, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
@@ -110,7 +110,6 @@ const ContentViewFilters = ({ cvId }) => {
   const emptyContentBody = __("Add filters using the 'Add filter' button above."); // needs link
   const emptySearchTitle = __('No matching filters found');
   const emptySearchBody = __('Try changing your search settings.');
-
   return (
     <TableWrapper
       {...{
@@ -130,7 +129,7 @@ const ContentViewFilters = ({ cvId }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/content_view_filters/auto_complete_search"
-      fetchItems={params => getContentViewFilters(cvId, params)}
+      fetchItems={useCallback(params => getContentViewFilters(cvId, params), [cvId])}
     >
       <Split hasGutter>
         <SplitItem>

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -27,14 +27,6 @@ const ContentViewHistories = ({ cvId }) => {
   const [metadata, setMetadata] = useState({});
   const [searchQuery, updateSearchQuery] = useState('');
 
-  const taskTypes = {
-    publish: 'Actions::Katello::ContentView::Publish',
-    promotion: 'Actions::Katello::ContentView::Promote',
-    removal: 'Actions::Katello::ContentView::Remove',
-    incrementalUpdate: 'Actions::Katello::ContentView::IncrementalUpdates',
-    export: 'Actions::Katello::ContentViewVersion::Export',
-  };
-
   const columnHeaders = [
     __('Date'),
     __('Version'),
@@ -46,6 +38,14 @@ const ContentViewHistories = ({ cvId }) => {
 
 
   useDeepCompareEffect(() => {
+    const taskTypes = {
+      publish: 'Actions::Katello::ContentView::Publish',
+      promotion: 'Actions::Katello::ContentView::Promote',
+      removal: 'Actions::Katello::ContentView::Remove',
+      incrementalUpdate: 'Actions::Katello::ContentView::IncrementalUpdates',
+      export: 'Actions::Katello::ContentViewVersion::Export',
+    };
+
     const actionText = (history) => {
       const {
         action,
@@ -103,7 +103,7 @@ const ContentViewHistories = ({ cvId }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response, setMetadata, loading, setRows]);
+  }, [response, setMetadata, loading, setRows, cvId]);
 
   const emptyContentTitle = __("You currently don't have any history for this content view.");
   const emptyContentBody = __('History will appear here when the content view is published or promoted.'); // needs link

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector } from 'react-redux';
 import { TableVariant, TableText } from '@patternfly/react-table';
@@ -127,7 +127,7 @@ const ContentViewHistories = ({ cvId }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_views/${cvId}/history/auto_complete_search`}
-      fetchItems={params => getContentViewHistories(cvId, params)}
+      fetchItems={useCallback(params => getContentViewHistories(cvId, params), [cvId])}
     />);
 };
 

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -108,35 +108,6 @@ const ContentViewRepositories = ({ cvId }) => {
     const { results, ...meta } = response;
     setMetadata(meta);
 
-    const buildRows = () => {
-      const newRows = [];
-      results.forEach((repo) => {
-        const {
-          id,
-          content_type: contentType,
-          name,
-          added_to_content_view: addedToCV,
-          product: { id: productId, name: productName },
-          content_counts: counts,
-          last_sync_words: lastSyncWords,
-          last_sync: lastSync,
-        } = repo;
-
-        const cells = [
-          { title: <Bullseye><RepoIcon type={contentType} /></Bullseye> },
-          { title: <a href={urlBuilder(`products/${productId}/repositories`, '', id)}>{name}</a> },
-          productName,
-          { title: <LastSync {...{ lastSyncWords, lastSync }} /> },
-          { title: <ContentCounts {...{ counts, productId }} repoId={id} /> },
-          {
-            title: <AddedStatusLabel added={addedToCV || statusSelected === ADDED} />,
-          },
-        ];
-        newRows.push({ repoId: id, cells });
-      });
-      return newRows;
-    };
-
     if (!loading && results) {
       const newRows = buildRows();
       setRows(newRows);

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -75,7 +75,7 @@ const ContentViewRepositories = ({ cvId }) => {
   ];
   const loading = status === STATUS.PENDING;
 
-  const buildRows = (results) => {
+  const buildRows = useCallback((results) => {
     const newRows = [];
     results.forEach((repo) => {
       const {
@@ -102,7 +102,7 @@ const ContentViewRepositories = ({ cvId }) => {
       newRows.push({ repoId: id, cells });
     });
     return newRows;
-  };
+  }, [statusSelected]);
 
   useDeepCompareEffect(() => {
     const { results, ...meta } = response;
@@ -112,7 +112,7 @@ const ContentViewRepositories = ({ cvId }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response]);
+  }, [response, loading, buildRows]);
 
   useEffect(() => {
     dispatch(getRepositoryTypes());

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -108,15 +108,44 @@ const ContentViewRepositories = ({ cvId }) => {
     const { results, ...meta } = response;
     setMetadata(meta);
 
+    const buildRows = () => {
+      const newRows = [];
+      results.forEach((repo) => {
+        const {
+          id,
+          content_type: contentType,
+          name,
+          added_to_content_view: addedToCV,
+          product: { id: productId, name: productName },
+          content_counts: counts,
+          last_sync_words: lastSyncWords,
+          last_sync: lastSync,
+        } = repo;
+
+        const cells = [
+          { title: <Bullseye><RepoIcon type={contentType} /></Bullseye> },
+          { title: <a href={urlBuilder(`products/${productId}/repositories`, '', id)}>{name}</a> },
+          productName,
+          { title: <LastSync {...{ lastSyncWords, lastSync }} /> },
+          { title: <ContentCounts {...{ counts, productId }} repoId={id} /> },
+          {
+            title: <AddedStatusLabel added={addedToCV || statusSelected === ADDED} />,
+          },
+        ];
+        newRows.push({ repoId: id, cells });
+      });
+      return newRows;
+    };
+
     if (!loading && results) {
-      const newRows = buildRows(results);
+      const newRows = buildRows();
       setRows(newRows);
     }
   }, [response]);
 
   useEffect(() => {
     dispatch(getRepositoryTypes());
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useDeepCompareEffect(() => {
     const rowsAreSelected = rows.some(row => row.selected);

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import {
@@ -189,12 +189,12 @@ const ContentViewRepositories = ({ cvId }) => {
     ];
   };
 
-  const getCVReposWithOptions = (params = {}) => {
+  const getCVReposWithOptions = useCallback((params = {}) => {
     const allParams = { ...params };
     if (typeSelected !== 'All repositories') allParams.content_type = repoTypes[typeSelected];
 
     return getContentViewRepositories(cvId, allParams, statusSelected);
-  };
+  }, [cvId, repoTypes, statusSelected, typeSelected]);
 
   const emptyContentTitle = __("You currently don't have any repositories to add to this content view.");
   const emptyContentBody = __('Please add some repositories.'); // needs link
@@ -231,7 +231,7 @@ const ContentViewRepositories = ({ cvId }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/repositories/auto_complete_search"
-      fetchItems={params => getCVReposWithOptions(params)}
+      fetchItems={useCallback(params => getCVReposWithOptions(params), [getCVReposWithOptions])}
       additionalListeners={[typeSelected, statusSelected]}
     >
       <Split hasGutter>

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -109,7 +109,7 @@ const ContentViewRepositories = ({ cvId }) => {
     setMetadata(meta);
 
     if (!loading && results) {
-      const newRows = buildRows();
+      const newRows = buildRows(results);
       setRows(newRows);
     }
   }, [response]);

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector } from 'react-redux';
 import { TableVariant, TableText } from '@patternfly/react-table';
@@ -96,7 +96,7 @@ const ContentViewVersions = ({ cvId }) => {
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_view_versions/auto_complete_search?content_view_id=${cvId}`}
-      fetchItems={params => getContentViewVersions(cvId, params)}
+      fetchItems={useCallback(params => getContentViewVersions(cvId, params), [cvId])}
     />);
 };
 

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -72,7 +72,7 @@ const ContentViewVersions = ({ cvId }) => {
       const newRows = buildRows(results);
       setRows(newRows);
     }
-  }, [response, setMetadata, loading, setRows]);
+  }, [response, setMetadata, loading, setRows, cvId]);
 
   const emptyContentTitle = __("You currently don't have any versions for this content view.");
   const emptyContentBody = __('Versions will appear here when the content view is published.'); // needs link

--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -1,5 +1,6 @@
 import { STATUS } from 'foremanReact/constants';
 import React, { useState, useEffect } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Bullseye, Button, Grid, GridItem } from '@patternfly/react-core';
@@ -77,7 +78,7 @@ const CVPublishFinish = ({
     setDescription, setUserCheckedItems, currentStep, setCurrentStep,
     cvId, versionCount, description, forcePromote, userCheckedItems]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (!response) return;
     setSaving(true);
     const { id } = response;
@@ -88,11 +89,11 @@ const CVPublishFinish = ({
     } else if (status === STATUS.ERROR) {
       setSaving(false);
     }
-  }, [JSON.stringify(response), status, error, cvId, versionCount,
+  }, [response, status, error, cvId, versionCount,
     pollPublishTask, setPolling, setSaving]);
 
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     const { state, result } = pollResponse;
     if (state === 'paused' || result === 'error') {
       setTaskErrored(true);
@@ -105,7 +106,7 @@ const CVPublishFinish = ({
         handleEndTask({ taskComplete: true });
       }, 500);
     }
-  }, [JSON.stringify(pollResponse), dispatch, setTaskErrored,
+  }, [pollResponse, dispatch, setTaskErrored,
     setPolling, setIsOpen, pollResponseStatus, handleEndTask]);
 
   if (saving) {

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -45,20 +45,20 @@ const ContentViewTable = () => {
     setIsPublishModalOpen(true);
   };
 
-  // Prevents flash of "No Content" before rows are loaded
-  const tableStatus = () => {
-    if (typeof cvResults === 'undefined' || status === STATUS.ERROR) return status; // will handle errored state
-    const resultsIds = Array.from(cvResults.map(result => result.id));
-    // All results are accounted for in row mapping, the page is ready to load
-    if (resultsIds.length === rowMappingIds.length &&
-      resultsIds.every(id => rowMappingIds.includes(id))) {
-      return status;
-    }
-    return STATUS.PENDING; // Fallback to pending
-  };
-
   useDeepCompareEffect(
     () => {
+      // Prevents flash of "No Content" before rows are loaded
+      const tableStatus = () => {
+        if (typeof cvResults === 'undefined' || status === STATUS.ERROR) return status; // will handle errored state
+        const resultsIds = Array.from(cvResults.map(result => result.id));
+        // All results are accounted for in row mapping, the page is ready to load
+        if (resultsIds.length === rowMappingIds.length &&
+          resultsIds.every(id => rowMappingIds.includes(id))) {
+          return status;
+        }
+        return STATUS.PENDING; // Fallback to pending
+      };
+
       const { results, ...meta } = response;
       if (status === STATUS.ERROR) {
         setCvTableStatus(tableStatus());
@@ -74,7 +74,7 @@ const ContentViewTable = () => {
       }
     },
     [response, status, loadingResponse, setTable, setRowMappingIds,
-      setCvResults, setCvTableStatus, setCurrentStep, setMetadata],
+      setCvResults, setCvTableStatus, setCurrentStep, setMetadata, cvResults, rowMappingIds],
   );
 
   const onSelect = (_event, isSelected, rowId) => {

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -161,7 +161,7 @@ const ContentViewTable = () => {
       }}
       variant={TableVariant.compact}
       status={cvTableStatus}
-      fetchItems={getContentViews}
+      fetchItems={useCallback(getContentViews, [])}
       onCollapse={onCollapse}
       canSelectAll={false}
       cells={columns}

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -231,18 +231,16 @@ test('Can handle pagination', async (done) => {
   const firstPageScope = nockInstance
     .get(cvIndexPath)
     // Using a custom query params matcher because parameters can be strings
-    .query(actualQueryObject => parseInt(actualQueryObject.page, 10) === 1)
+    .query(actualQueryObject => (parseInt(actualQueryObject.page, 10) === 1))
     .reply(200, cvIndexFirstPage);
 
   // Match second page API request
   const secondPageScope = nockInstance
     .get(cvIndexPath)
     // Using a custom query params matcher because parameters can be strings
-    .query(actualQueryObject => parseInt(actualQueryObject.page, 10) === 2)
+    .query(actualQueryObject => (parseInt(actualQueryObject.page, 10) === 2))
     .reply(200, cvIndexSecondPage);
-
   const { queryByText, getByLabelText } = renderWithRedux(<ContentViewsPage />, renderOptions);
-
   // Wait for first paginated page to load and assert only the first page of results are present
   await patientlyWaitFor(() => {
     expect(queryByText(results[0].name)).toBeInTheDocument();
@@ -253,14 +251,12 @@ test('Can handle pagination', async (done) => {
   // Label comes from patternfly, if this test fails, check if patternfly updated the label.
   expect(getByLabelText('Go to next page')).toBeTruthy();
   getByLabelText('Go to next page').click();
-
   // Wait for second paginated page to load and assert only the second page of results are present
   await patientlyWaitFor(() => {
     expect(queryByText(results[20].name)).toBeInTheDocument();
     expect(queryByText(results[39].name)).toBeInTheDocument();
     expect(queryByText(results[41].name)).not.toBeInTheDocument();
   });
-
   assertNockRequest(autocompleteScope);
   assertNockRequest(firstPageScope);
   assertNockRequest(secondPageScope, done); // Only pass jest callback to the last API request

--- a/webpack/scenes/SmartProxy/SmartProxyContentTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentTable.js
@@ -50,10 +50,6 @@ const SmartProxyContentTable = ({ smartProxyId }) => {
     },
   ];
 
-  const fetchWithParams = () => {
-    dispatch(getSmartProxyContent({ smartProxyId }));
-  };
-
   const buildrows = (results) => {
     const newRows = [];
     let envCount = 0;
@@ -126,8 +122,12 @@ const SmartProxyContentTable = ({ smartProxyId }) => {
     setRow(newRows);
   };
 
-
-  useEffect(() => fetchWithParams(), []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(
+    () => {
+      dispatch(getSmartProxyContent({ smartProxyId }));
+    }
+    , [dispatch, smartProxyId],
+  );
 
   useDeepCompareEffect(() => {
     if (status !== STATUS.PENDING && response) {

--- a/webpack/scenes/SmartProxy/SmartProxyContentTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentTable.js
@@ -127,7 +127,7 @@ const SmartProxyContentTable = ({ smartProxyId }) => {
   };
 
 
-  useEffect(() => fetchWithParams(), []);
+  useEffect(() => fetchWithParams(), []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useDeepCompareEffect(() => {
     if (status !== STATUS.PENDING && response) {


### PR DESCRIPTION
Foreman was enforcing [react-hooks rules](https://reactjs.org/docs/hooks-faq.html#what-exactly-do-the-lint-rules-enforce) (rules-of-hooks and exhaustive-deps) but Katello currently is not.

This change adds those rules to Katello's eslint configuration, and makes the necessary changes to follow them.

Lint warnings generated (and fixed) here include ones like:
```
/home/vagrant/katello/webpack/components/EditableTextInput/EditableTextInput.js
  36:6  warning  React Hook useEffect has missing dependencies: 'attribute', 'inputValue', and 'onEdit'. Either include them or remove the dependency array. If 'onEdit' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps

/home/vagrant/katello/webpack/components/Table/TableWrapper.js
  54:20  warning  React Hook useEffect has a spread element in its dependency array. This means we can't statically verify whether you've passed the correct dependencies  react-hooks/exhaustive-deps

/home/vagrant/katello/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
  30:7  warning  React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked  react-hooks/exhaustive-deps

/home/vagrant/katello/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
  42:9  warning  The 'pollPublishTask' function makes the dependencies of useDeepCompareEffect Hook (at line 92) change on every render. Move it inside the useDeepCompareEffect callback. Alternatively, wrap the definition of 'pollPublishTask' in its own useCallback() Hook  react-hooks/exhaustive-deps

  48:9  warning  The 'handleEndTask' function makes the dependencies of useDeepCompareEffect Hook (at line 109) change on every render. To fix this, wrap the definition of 'handleEndTask' in its own useCallback() Hook                                                         react-hooks/exhaustive-deps


```