### PR TITLE
Fixes #32230 - fix SPC sync with pulp2 for container

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -187,8 +187,8 @@ module Katello
                          'application/vnd.docker.distribution.manifest.v1+prettyjws'
                        end
         end
-
-        render json: manifest_response, content_type: media_type
+        response.headers['Content-Type'] = media_type
+        render json: manifest_response
       end
     end
 


### PR DESCRIPTION
rails appends charset=utf-8 to the CONTENT_TYPE header of all requests
by default.  This overrides that behavior as pulp2 does not like it
when syncing.