### PR TITLE
Fixes #32231 - intermittent module stream clause generator test

### DIFF
--- a/test/lib/util/module_stream_clause_generator_test.rb
+++ b/test/lib/util/module_stream_clause_generator_test.rb
@@ -34,7 +34,7 @@ module Katello
 
       clause_gen = setup_whitelist_filter([foo_rule, goo_rule])
       expected = combined
-      assert_equal expected, clause_gen.copy_clause
+      assert_equal expected.sort, clause_gen.copy_clause.sort
       assert_nil clause_gen.remove_clause
 
       blacklist_expected = combined


### PR DESCRIPTION
I saw it in a recent build: https://ci.theforeman.org/blue/organizations/jenkins/katello-pr-test/detail/katello-pr-test/6600/tests