### PR TITLE
Fixes #31969 - Content View package filter page

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -1,7 +1,8 @@
 module Katello
   class Api::V2::ContentViewFilterRulesController < Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
     before_action :find_filter
-    before_action :find_rule, :except => [:index, :create]
+    before_action :find_rule, :except => [:index, :create, :auto_complete_search]
 
     api :GET, "/content_view_filters/:content_view_filter_id/rules", N_("List filter rules")
     param :content_view_filter_id, :number, :desc => N_("filter identifier"), :required => true
@@ -17,6 +18,10 @@ module Katello
       query = query.where(:name => params[:name]) if params[:name]
       query = query.where(:errata_id => params[:errata_id]) if params[:errata_id]
       query
+    end
+
+    def resource_class
+      ContentViewFilter.rule_class_for(@filter)
     end
 
     api :POST, "/content_view_filters/:content_view_filter_id/rules",

--- a/app/models/katello/concerns/content_view_filter_rule_common.rb
+++ b/app/models/katello/concerns/content_view_filter_rule_common.rb
@@ -4,8 +4,8 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        scoped_search on: :id
-        scoped_search on: :name
+        scoped_search on: :id, :complete_value => true
+        scoped_search on: :name, :complete_value => true
 
         validates_lengths_from_database
       end

--- a/app/models/katello/content_view_docker_filter_rule.rb
+++ b/app/models/katello/content_view_docker_filter_rule.rb
@@ -1,6 +1,7 @@
 module Katello
   class ContentViewDockerFilterRule < Katello::Model
     include ::Katello::Concerns::ContentViewFilterRuleCommon
+    include ScopedSearchExtensions
     belongs_to :filter,
                :class_name => "Katello::ContentViewDockerFilter",
                :inverse_of => :docker_rules,

--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -10,6 +10,10 @@ module Katello
     validates :name, :presence => true
     validate :ensure_unique_attributes
     validates_with Validators::ContentViewFilterVersionValidator
+    scoped_search :on => :version, :complete_value => true
+    scoped_search :on => :min_version, :complete_value => true
+    scoped_search :on => :max_version, :complete_value => true
+    scoped_search :on => :architecture, :complete_value => true
 
     def ensure_unique_attributes
       other = self.class.where(:name => self.name,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -99,7 +99,11 @@ Katello::Engine.routes.draw do
         api_resources :content_view_filters do
           api_resources :errata, :only => [:index]
           api_resources :package_groups, :only => [:index]
-          api_resources :rules, :controller => :content_view_filter_rules
+          api_resources :rules, :controller => :content_view_filter_rules do
+            collection do
+              get :auto_complete_search
+            end
+          end
           collection do
             get :auto_complete_search
           end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -71,7 +71,7 @@ module Katello
                  {
                    'katello/api/v2/content_views' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_filters' => [:index, :show, :auto_complete_search],
-                   'katello/api/v2/content_view_filter_rules' => [:index, :show],
+                   'katello/api/v2/content_view_filter_rules' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_histories' => [:index, :auto_complete_search],
                    'katello/api/v2/content_view_repositories' => [:show_all],
                    'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search],

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -11,6 +11,7 @@ export const cvFilterDetailsKey = (cvId, filterId) => `${CONTENT_VIEWS_KEY}_${cv
 export const cvFilterPackageGroupsKey =
   (cvId, filterId) => `${CONTENT_VIEWS_KEY}_${cvId}_FILTER_${filterId}_PACKAGE_GROUPS`;
 export const cvDetailsHistoryKey = cvId => `${CONTENT_VIEWS_KEY}_HISTORIES_${cvId}`;
+export const cvFilterRulesKey = filterId => `CONTENT_VIEW_FILTER_${filterId}_RULES`;
 
 // Repo added to content view status display and key
 export const ADDED = 'Added';

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -15,6 +15,7 @@ import {
   cvFilterDetailsKey,
   cvFilterPackageGroupsKey,
   cvDetailsHistoryKey,
+  cvFilterRulesKey,
 } from '../ContentViewsConstants';
 import api from '../../../services/api';
 
@@ -108,5 +109,12 @@ export const getContentViewHistories = (cvId, params) => {
     url: api.getApiUrl(apiUrl),
   });
 };
+
+export const getCVFilterRules = (filterId, params) => get({
+  key: cvFilterRulesKey(filterId),
+  params: { ...params },
+  errorToast: error => __(`Something went wrong while retrieving the content view filter rules! ${error}`),
+  url: api.getApiUrl(`/content_view_filters/${filterId}/rules`),
+});
 
 export default getContentViewDetails;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -11,6 +11,7 @@ import {
   cvFilterDetailsKey,
   cvFilterPackageGroupsKey,
   cvDetailsHistoryKey,
+  cvFilterRulesKey,
   REPOSITORY_TYPES,
 } from '../ContentViewsConstants';
 
@@ -73,5 +74,11 @@ export const selectCVHistoriesStatus = (state, cvId) =>
 
 export const selectCVHistoriesError = (state, cvId) =>
   selectAPIError(state, cvDetailsHistoryKey(cvId));
+
+export const selectCVFilterRules = (state, filterId) =>
+  selectAPIResponse(state, cvFilterRulesKey(filterId));
+
+export const selectCVFilterRulesStatus = (state, filterId) =>
+  selectAPIStatus(state, cvFilterRulesKey(filterId)) || STATUS.PENDING;
 
 export const selectIsCVUpdating = state => state.katello?.contentViewDetails?.updating;

--- a/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CVPackageGroupFilterContent from './CVPackageGroupFilterContent';
+import CVRpmFilterContent from './CVRpmFilterContent';
+
+const CVFilterDetailType = ({
+  cvId, filterId, inclusion, type,
+}) => {
+  switch (type) {
+    case 'package_group':
+      return <CVPackageGroupFilterContent cvId={cvId} filterId={filterId} />;
+    case 'rpm':
+      return <CVRpmFilterContent filterId={filterId} inclusion={inclusion} />;
+    default:
+      return null;
+  }
+};
+
+CVFilterDetailType.propTypes = {
+  cvId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  inclusion: PropTypes.bool,
+  type: PropTypes.string,
+};
+
+CVFilterDetailType.defaultProps = {
+  cvId: '',
+  filterId: '',
+  type: '',
+  inclusion: false,
+};
+
+export default CVFilterDetailType;

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { shallowEqual, useSelector } from 'react-redux';
+import { TableVariant } from '@patternfly/react-table';
+import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { STATUS } from 'foremanReact/constants';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+import onSelect from '../../../../components/Table/helpers';
+import TableWrapper from '../../../../components/Table/TableWrapper';
+import {
+  selectCVFilterRules,
+  selectCVFilterRulesStatus,
+} from '../ContentViewDetailSelectors';
+import { getCVFilterRules } from '../ContentViewDetailActions';
+
+const CVRpmFilterContent = ({ filterId, inclusion }) => {
+  const response = useSelector(state => selectCVFilterRules(state, filterId), shallowEqual);
+  const status = useSelector(state => selectCVFilterRulesStatus(state, filterId), shallowEqual);
+
+  const [rows, setRows] = useState([]);
+  const [metadata, setMetadata] = useState({});
+  const [searchQuery, updateSearchQuery] = useState('');
+  const [activeTabKey, setActiveTabKey] = useState(0);
+  const loading = status === STATUS.PENDING;
+
+  const columnHeaders = [
+    __('RPM name'),
+    __('Architecture'),
+    __('Versions'),
+  ];
+
+  const versionText = (rule) => {
+    const { version, min_version: minVersion, max_version: maxVersion } = rule;
+
+    if (rule.version) return `Version ${version}`;
+    if (rule.min_version && !rule.max_version) return `Greater than version ${minVersion}`;
+    if (!rule.min_version && rule.max_version) return `Less than version ${maxVersion}`;
+    if (rule.min_version && rule.max_version) {
+      return `Between versions ${rule.min_version} and ${rule.max_version}`;
+    }
+    return 'All versions';
+  };
+
+  const buildRows = (results) => {
+    const newRows = [];
+    results.forEach((rule) => {
+      const { name, architecture } = rule;
+      const cells = [
+        { title: name },
+        { title: architecture || 'All architectures' },
+        { title: versionText(rule) },
+      ];
+
+      newRows.push({ cells });
+    });
+
+    return newRows;
+  };
+
+  useEffect(() => {
+    const { results, ...meta } = response;
+    setMetadata(meta);
+
+    if (!loading && results) {
+      const newRows = buildRows(results);
+      setRows(newRows);
+    }
+  }, [JSON.stringify(response)]);
+
+  const emptyContentTitle = __('No rules have been added to this filter.');
+  const emptyContentBody = __("Add to this filter using the 'Add RPM' button.");
+  const emptySearchTitle = __('No matching rules found.');
+  const emptySearchBody = __('Try changing your search settings.');
+  const tabTitle = (inclusion ? __('Included') : __('Excluded')) + __(' RPMs');
+
+  return (
+    <Tabs activeKey={activeTabKey} onSelect={(_event, eventKey) => setActiveTabKey(eventKey)}>
+      <Tab eventKey={0} title={<TabTitleText>{tabTitle}</TabTitleText>}>
+        <div className="tab-body-with-spacing">
+          <TableWrapper
+            {...{
+              rows,
+              metadata,
+              emptyContentTitle,
+              emptyContentBody,
+              emptySearchTitle,
+              emptySearchBody,
+              searchQuery,
+              updateSearchQuery,
+              status,
+            }}
+            status={status}
+            onSelect={onSelect(rows, setRows)}
+            cells={columnHeaders}
+            variant={TableVariant.compact}
+            autocompleteEndpoint={`/content_view_filters/${filterId}/rules/auto_complete_search`}
+            fetchItems={params => getCVFilterRules(filterId, params)}
+          />
+        </div>
+      </Tab>
+    </Tabs>
+  );
+};
+
+CVRpmFilterContent.propTypes = {
+  filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  inclusion: PropTypes.bool,
+};
+
+CVRpmFilterContent.defaultProps = {
+  filterId: '',
+  inclusion: false,
+};
+export default CVRpmFilterContent;

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
@@ -10,9 +10,8 @@ import {
 } from '../ContentViewDetailSelectors';
 import { getCVFilterDetails } from '../ContentViewDetailActions';
 import useUrlParamsWithHash from '../../../../utils/useUrlParams';
-import Loading from '../../../../components/Loading';
 import ContentViewFilterDetailsHeader from './ContentViewFilterDetailsHeader';
-import CVPackageGroupFilterContent from './CVPackageGroupFilterContent';
+import CVFilterDetailType from './CVFilterDetailType';
 
 const ContentViewFilterDetails = () => {
   const { id: cvId } = useParams();
@@ -32,7 +31,7 @@ const ContentViewFilterDetails = () => {
     if (loaded) setDetails(response);
   }, [JSON.stringify(response), loaded]);
 
-  const { type } = details;
+  const { type, inclusion } = details;
 
   return (
     <Grid hasGutter>
@@ -41,11 +40,7 @@ const ContentViewFilterDetails = () => {
         <div>Loading...</div>
       }
       <GridItem span={12}>
-        {
-          {
-            package_group: <CVPackageGroupFilterContent cvId={cvId} filterId={filterId} />,
-          }[type] || <Loading />
-        }
+        <CVFilterDetailType cvId={cvId} filterId={filterId} inclusion={inclusion} type={type} />
       </GridItem>
     </Grid>
   );

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -48,7 +48,7 @@ const ContentViewFilters = ({ cvId }) => {
       if (filter.type === 'erratum' && filter.rules[0].types) errataByDate = true;
 
       const cells = [
-        { title: <Link to={cvFilterUrl(cvId, id)}>{name}</Link> },
+        { title: (type === 'package_group' || type === 'rpm') ? <Link to={cvFilterUrl(cvId, id)}>{name}</Link> : name },
         truncate(description || ''),
         { title: <LongDateTime date={updatedAt} showRelativeTimeTooltip /> },
         { title: <ContentType type={type} errataByDate={errataByDate} /> },

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { Route } from 'react-router-dom';
+
+import ContentViewFilterDetails from '../ContentViewFilterDetails';
+import { cvFilterDetailsKey } from '../../../ContentViewsConstants';
+import nock, {
+  nockInstance,
+  assertNockRequest,
+  mockAutocomplete,
+  mockSetting,
+} from '../../../../../test-utils/nockWrapper';
+import api from '../../../../../services/api';
+
+const cvFilterDetails = require('./cvPackageFilterDetail.fixtures.json');
+const cvPackageFilterRules = require('./cvPackageFilterRules.fixtures.json');
+
+const cvFilterDetailsPath = api.getApiUrl('/content_view_filters/2');
+const cvPackageFilterRulesPath = api.getApiUrl('/content_view_filters/2/rules');
+const autocompleteUrl = '/content_view_filters/2/rules/auto_complete_search';
+const renderOptions = {
+  apiNamespace: cvFilterDetailsKey(1, 2),
+  routerParams: {
+    initialEntries: [{ hash: '#filters?subContentId=2', pathname: '/labs/content_views/1' }],
+    initialIndex: 1,
+  },
+};
+
+const withCVRoute = component => <Route path="/labs/content_views/:id">{component}</Route>;
+
+let searchDelayScope;
+let autoSearchScope;
+beforeEach(() => {
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  // Autosearch can cause some asynchronous issues with the typing timeout, using basic search
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', false);
+});
+
+afterEach(() => {
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autoSearchScope);
+  nock.cleanAll();
+});
+
+test('Can show filter details and package groups on page load', async (done) => {
+  const { name: cvFilterName } = cvFilterDetails;
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+  const cvPackageFilterRulesScope = nockInstance
+    .get(cvPackageFilterRulesPath)
+    .query(true)
+    .reply(200, cvPackageFilterRules);
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getByText, queryByText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(cvFilterName)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getByText(cvFilterName)).toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvPackageFilterRulesScope, done);
+});
+
+test('Can search for package groups in package group filter', async (done) => {
+  const firstPackageRule = cvPackageFilterRules.results[0];
+  const lastPackageRule = cvPackageFilterRules.results[1];
+  const { name: cvFilterName } = cvFilterDetails;
+  const { name: firstPackageRuleName } = firstPackageRule;
+  const { name: lastPackageRuleName } = lastPackageRule;
+  const searchQueryMatcher = actualParams => actualParams?.search?.includes(lastPackageRuleName);
+
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+  const cvPackageFilterRulesScope = nockInstance
+    .get(cvPackageFilterRulesPath)
+    .query(true)
+    .reply(200, cvPackageFilterRules);
+  const packageRuleSearchScope = nockInstance
+    .get(cvPackageFilterRulesPath)
+    .query(searchQueryMatcher)
+    .reply(200, { results: [lastPackageRule] });
+
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  const withSearchScope = mockAutocomplete(nockInstance, autocompleteUrl, searchQueryMatcher);
+  const { getByText, queryByText, getByLabelText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Basic results showing
+  await patientlyWaitFor(() => {
+    expect(getByText(cvFilterName)).toBeInTheDocument();
+    expect(getByText(firstPackageRuleName)).toBeInTheDocument();
+  });
+
+  // Search and only searched result shows
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: lastPackageRuleName } });
+  getByLabelText(/search button/i).click();
+  await patientlyWaitFor(() => {
+    expect(getByText(lastPackageRuleName)).toBeInTheDocument();
+    expect(queryByText(firstPackageRuleName)).not.toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvPackageFilterRulesScope);
+  assertNockRequest(withSearchScope);
+  assertNockRequest(packageRuleSearchScope, done);
+});

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvPackageFilterDetail.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvPackageFilterDetail.fixtures.json
@@ -1,0 +1,147 @@
+{
+  "inclusion": true,
+  "original_packages": false,
+  "id": 2,
+  "name": "test_package_filter",
+  "description": null,
+  "created_at": "2021-03-30 16:00:19 -0400",
+  "updated_at": "2021-03-31 12:59:12 -0400",
+  "content_view": {
+    "composite": false,
+    "component_ids": [],
+    "default": false,
+    "version_count": 4,
+    "latest_version": "4.0",
+    "auto_publish": false,
+    "solve_dependencies": false,
+    "import_only": false,
+    "repository_ids": [
+      1,
+      2
+    ],
+    "id": 2,
+    "name": "test",
+    "label": "test",
+    "description": "",
+    "organization_id": 1,
+    "organization": {
+      "name": "Default Organization",
+      "label": "Default_Organization",
+      "id": 1
+    },
+    "created_at": "2021-03-30 11:11:07 -0400",
+    "updated_at": "2021-03-30 16:04:18 -0400",
+    "environments": [
+      {
+        "id": 1,
+        "name": "Library",
+        "label": "Library",
+        "permissions": {
+          "readable": true
+        }
+      }
+    ],
+    "repositories": [
+      {
+        "id": 1,
+        "name": "test",
+        "label": "test",
+        "content_type": "yum",
+        "product": {
+          "id": 1,
+          "name": "test"
+        },
+        "content_counts": {
+          "ostree_branch": 0,
+          "docker_manifest": 0,
+          "docker_tag": 0,
+          "rpm": 8,
+          "package": 8,
+          "package_group": 0,
+          "erratum": 2,
+          "module_stream": 0
+        }
+      },
+      {
+        "id": 2,
+        "name": "test1",
+        "label": "test1",
+        "content_type": "yum",
+        "product": {
+          "id": 1,
+          "name": "test"
+        },
+        "content_counts": {
+          "ostree_branch": 0,
+          "docker_manifest": 0,
+          "docker_tag": 0,
+          "rpm": 8,
+          "package": 8,
+          "package_group": 2,
+          "erratum": 2,
+          "module_stream": 0
+        }
+      }
+    ],
+    "versions": [
+      {
+        "id": 2,
+        "version": "1.0",
+        "published": "2021-03-30 11:11:39 -0400",
+        "environment_ids": []
+      },
+      {
+        "id": 3,
+        "version": "2.0",
+        "published": "2021-03-30 11:11:57 -0400",
+        "environment_ids": []
+      },
+      {
+        "id": 4,
+        "version": "3.0",
+        "published": "2021-03-30 16:01:42 -0400",
+        "environment_ids": []
+      },
+      {
+        "id": 5,
+        "version": "4.0",
+        "published": "2021-03-30 16:04:18 -0400",
+        "environment_ids": [
+          1
+        ]
+      }
+    ],
+    "components": [],
+    "content_view_components": [],
+    "activation_keys": [],
+    "next_version": "5.0",
+    "last_published": "2021-03-30 16:04:18 -0400",
+    "permissions": {
+      "view_content_views": true,
+      "edit_content_views": true,
+      "destroy_content_views": true,
+      "publish_content_views": true,
+      "promote_or_remove_content_views": true
+    }
+  },
+  "repositories": [],
+  "type": "rpm",
+  "rules": [
+    {
+      "content_view_filter_id": 2,
+      "max_version": "0.4",
+      "architecture": "noarch",
+      "id": 2,
+      "name": "monkey",
+      "created_at": "2021-03-30 16:14:50 -0400",
+      "updated_at": "2021-03-30 16:15:39 -0400"
+    },
+    {
+      "content_view_filter_id": 2,
+      "id": 4,
+      "name": "elephant",
+      "created_at": "2021-04-01 11:35:39 -0400",
+      "updated_at": "2021-04-01 11:35:39 -0400"
+    }
+  ]
+}

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvPackageFilterRules.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvPackageFilterRules.fixtures.json
@@ -1,0 +1,30 @@
+{
+  "total": 2,
+  "subtotal": 2,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "id",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "content_view_filter_id": 2,
+      "max_version": "0.4",
+      "architecture": "noarch",
+      "id": 2,
+      "name": "monkey",
+      "created_at": "2021-03-30 16:14:50 -0400",
+      "updated_at": "2021-03-30 16:15:39 -0400"
+    },
+    {
+      "content_view_filter_id": 2,
+      "id": 4,
+      "name": "elephant",
+      "created_at": "2021-04-01 11:35:39 -0400",
+      "updated_at": "2021-04-01 11:35:39 -0400"
+    }
+  ]
+}


### PR DESCRIPTION
Reopening from John's PR: https://github.com/Katello/katello/pull/9242 to move it forward.

Provides view-only version of the package filter details page for the new CV page.

- [x] Search and autocomplete
- [x] Tests

*********************
**To test:**

Sync a few yum repos.
Create a cv and add the repos to it.
Create a filter of type Package and add a few rules.

In the new UI > 
Go to CV > CV Details > Filters.
You should be able to see the added filters and rules.