### PR TITLE
Fixes #32241 - Auto create CV on import

### DIFF
--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -2,7 +2,13 @@ module Actions
   module Katello
     module ContentViewVersion
       class Import < Actions::EntryAction
-        def plan(content_view, path:, metadata:)
+        def plan(content_view: nil, organization: nil, path:, metadata:)
+          fail _("Atleast one of ContentView or Organization must be provided") if content_view.nil? && organization.nil?
+          if organization
+            fail _("Content view not provided in the metadata") if metadata[:content_view].blank?
+            content_view = ::Katello::Pulp3::ContentViewVersion::Import.find_or_create_import_view(organization: organization,
+                                                                                                   name: metadata[:content_view])
+          end
           content_view.check_ready_to_import!
 
           ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: content_view, metadata: metadata, path: path)

--- a/app/lib/actions/katello/content_view_version/import_library.rb
+++ b/app/lib/actions/katello/content_view_version/import_library.rb
@@ -5,7 +5,7 @@ module Actions
         def plan(organization, path:, metadata:)
           action_subject(organization)
           library_view = ::Katello::Pulp3::ContentViewVersion::Import.find_or_create_library_import_view(organization)
-          plan_action(::Actions::Katello::ContentViewVersion::Import, library_view, path: path, metadata: metadata)
+          plan_action(::Actions::Katello::ContentViewVersion::Import, content_view: library_view, path: path, metadata: metadata)
         end
 
         def humanized_name

--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -33,8 +33,24 @@ module Katello
         authorized(:view_content_views)
       end
 
+      def creatable
+        authorized(:view_content_views)
+      end
+
+      def importable?
+        creatable? && publishable?
+      end
+
       def readable?
         ::User.current.can?(:view_content_views)
+      end
+
+      def creatable?
+        ::User.current.can?(:create_content_views)
+      end
+
+      def publishable?
+        ::User.current.can?(:publish_content_views)
       end
 
       def editable

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -81,7 +81,10 @@ module Katello
         end
 
         def self.find_or_create_library_import_view(organization)
-          name = ::Katello::ContentView::IMPORT_LIBRARY
+          find_or_create_import_view(organization: organization, name: ::Katello::ContentView::IMPORT_LIBRARY)
+        end
+
+        def self.find_or_create_import_view(organization:, name:)
           ::Katello::ContentView.where(name: name,
                                        organization: organization,
                                        import_only: true).first_or_create

--- a/test/actions/katello/content_view_version/import_library_test.rb
+++ b/test/actions/katello/content_view_version/import_library_test.rb
@@ -66,9 +66,10 @@ module ::Actions::Katello::ContentViewVersion
                                                 name: ::Katello::ContentView::IMPORT_LIBRARY).first
         action_class.any_instance.expects(:action_subject).with(organization)
         plan_action(action, organization, path: path, metadata: metadata)
-        assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Import) do |view, options|
-          assert view.library_import?
-          assert view.import_only?
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Import) do |options|
+          options = options.first if options.is_a? Array
+          assert options[:content_view].library_import?
+          assert options[:content_view].import_only?
           assert_equal options[:metadata], metadata
           assert_equal options[:path], path
         end


### PR DESCRIPTION
Automatically create a content view if one with the same name does not
exist in this organization. The name of the content view is provided in
the import metadata.