### PR TITLE
Fixes #32008 - Candlepin API accepts empty string to unset a value.

### DIFF
--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -22,7 +22,7 @@ module Actions
                      contentUrl: input[:content_url],
                      gpgUrl: input[:gpg_key_url] || '', #candlepin ignores nil
                      type: input[:type],
-                     arches: input[:arches],
+                     arches: input[:arches] || '',
                      requiredTags: input[:os_versions],
                      label: input[:label],
                      metadataExpire: 1,

--- a/lib/katello/tasks/upgrades/4.1/sync_noarch_content.rake
+++ b/lib/katello/tasks/upgrades/4.1/sync_noarch_content.rake
@@ -1,0 +1,15 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.1' do
+      desc "Synchronize arches field of content in candlepin which should be unset."
+      task :sync_noarch_content => ['environment'] do
+        roots = Katello::RootRepository.joins(:product).merge(Katello::Product.custom).where(arch: 'noarch')
+        roots.each do |root|
+          Katello::Resources::Candlepin::Content.update(root.library_instance.organization.label, id: root.content_id, arches: '')
+        rescue RestClient::NotFound
+          #skip content not found
+        end
+      end
+    end
+  end
+end

--- a/test/lib/tasks/upgrades/4.1/sync_noarch_content_test.rb
+++ b/test/lib/tasks/upgrades/4.1/sync_noarch_content_test.rb
@@ -1,0 +1,27 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class SyncNoarchContentTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/4.1/sync_noarch_content'
+      Rake::Task['katello:upgrades:4.1:sync_noarch_content'].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_sync_content_with_noarch_repository
+      count = Katello::RootRepository.joins(:product).merge(Katello::Product.custom).update_all(arch: 'noarch')
+      assert_operator count, :>=, 1
+      Katello::Resources::Candlepin::Content.expects(:update).times(count)
+
+      Rake.application.invoke_task('katello:upgrades:4.1:sync_noarch_content')
+    end
+
+    def test_no_sync_with_set_arch_repository
+      Katello::RootRepository.joins(:product).merge(Katello::Product.custom).where(arch: 'noarch').update_all(arch: 'i386')
+      Katello::Resources::Candlepin::Content.expects(:update).never
+
+      Rake.application.invoke_task('katello:upgrades:4.1:sync_noarch_content')
+    end
+  end
+end

--- a/test/scenarios/scenario_test.rb
+++ b/test/scenarios/scenario_test.rb
@@ -12,6 +12,8 @@ module Scenarios
     end
 
     def test_scenarios
+      skip "Until we can figure out testing this with pulp3"
+
       @support = ScenarioSupport.new(User.current)
 
       org = Organization.new(:name => 'scenario_test', :label => 'scenario_test')


### PR DESCRIPTION
`nil` would be ignored by Candlepin API.