### PR TITLE
Fixes #32156 - update katello-agent deprecation warnings

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -39,7 +39,15 @@ module Katello
     end
 
     def deprecate_katello_agent
-      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in a future release.")
+      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{katello_agent_removal_release}.")
+    end
+
+    def self.katello_agent_deprecation_text
+      N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % katello_agent_removal_release
+    end
+
+    def self.katello_agent_removal_release
+      N_("a future release")
     end
 
     def full_result_response(collection)

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -39,7 +39,7 @@ module Katello
     end
 
     def deprecate_katello_agent
-      ::Foreman::Deprecation.api_deprecation_warning("Katello-agent is deprecated and will be removed in a future release.")
+      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in a future release.")
     end
 
     def full_result_response(collection)

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -39,15 +39,11 @@ module Katello
     end
 
     def deprecate_katello_agent
-      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{self.katello_agent_removal_release}.")
+      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{katello_agent_removal_release}.")
     end
 
-    def self.katello_agent_deprecation_text
-      N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % self.katello_agent_removal_release
-    end
-
-    def self.katello_agent_removal_release
-      N_("a future release")
+    def katello_agent_removal_release
+      self.class.katello_agent_removal_release
     end
 
     def full_result_response(collection)

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -45,7 +45,7 @@ module Katello
 
     def check_katello_agent_not_disabled
       unless ::Katello.with_katello_agent?
-        fail HttpErrors::BadRequest, _("This action uses katello-agent, which is currently disabled in Settings.")
+        fail HttpErrors::BadRequest, _("This action uses katello-agent, which is currently disabled. Use remote execution instead.")
       end
     end
 

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -39,7 +39,14 @@ module Katello
     end
 
     def deprecate_katello_agent
+      check_katello_agent_not_disabled
       ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{katello_agent_removal_release}.")
+    end
+
+    def check_katello_agent_not_disabled
+      unless ::Katello.with_katello_agent?
+        fail HttpErrors::BadRequest, _("This action uses katello-agent, which is currently disabled in Settings.")
+      end
     end
 
     def katello_agent_removal_release

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -39,11 +39,11 @@ module Katello
     end
 
     def deprecate_katello_agent
-      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{katello_agent_removal_release}.")
+      ::Foreman::Deprecation.api_deprecation_warning("This action uses katello-agent, which is deprecated and will be removed in #{self.katello_agent_removal_release}.")
     end
 
     def self.katello_agent_deprecation_text
-      N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % katello_agent_removal_release
+      N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % self.katello_agent_removal_release
     end
 
     def self.katello_agent_removal_release

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -50,7 +50,7 @@ module Katello
       respond_for_index :collection => collection
     end
 
-    api :PUT, "/hosts/:host_id/errata/apply", N_("Schedule errata for installation")
+    api :PUT, "/hosts/:host_id/errata/apply", N_("Schedule errata for installation using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param :host_id, :number, :desc => N_("Host ID"), :required => true
     param :errata_ids, Array, :desc => N_("List of Errata ids to install. Will be removed in Katello 4.1."), :required => false, :deprecated => true
 

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -2,11 +2,12 @@ module Katello
   class Api::V2::HostErrataController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_action :find_host, :only => :index
-    before_action :find_host_editable, :except => :index
-    before_action :find_errata_ids, :only => :apply
-    before_action :find_environment, :only => :index
-    before_action :find_content_view, :only => :index
+    before_action :find_host, only: :index
+    before_action :find_host_editable, except: :index
+    before_action :find_errata_ids, only: :apply
+    before_action :find_environment, only: :index
+    before_action :find_content_view, only: :index
+    before_action :deprecate_katello_agent, only: :apply
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -27,7 +27,7 @@ module Katello
       respond_for_index(:collection => collection)
     end
 
-    api :PUT, "/hosts/:host_id/packages/install", N_("Install packages remotely")
+    api :PUT, "/hosts/:host_id/packages/install", N_("Install packages remotely using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param :host_id, :number, :required => true, :desc => N_("ID of the host")
     param_group :packages_or_groups
     def install
@@ -45,7 +45,7 @@ module Katello
       end
     end
 
-    api :PUT, "/hosts/:host_id/packages/upgrade", N_("Update packages remotely")
+    api :PUT, "/hosts/:host_id/packages/upgrade", N_("Update packages remotely using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param :host_id, :number, :required => true, :desc => N_("ID of the host")
     param :packages, Array, :desc => N_("list of packages names"), :required => true
     def upgrade
@@ -56,14 +56,14 @@ module Katello
       end
     end
 
-    api :PUT, "/hosts/:host_id/packages/upgrade_all", N_("Update packages remotely")
+    api :PUT, "/hosts/:host_id/packages/upgrade_all", N_("Update packages remotely using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param :host_id, :number, :required => true, :desc => N_("ID of the host")
     def upgrade_all
       task = async_task(::Actions::Katello::Host::Package::Update, @host, content: [])
       respond_for_async :resource => task
     end
 
-    api :PUT, "/hosts/:host_id/packages/remove", N_("Uninstall packages remotely")
+    api :PUT, "/hosts/:host_id/packages/remove", N_("Uninstall packages remotely using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param :host_id, :number, :required => true, :desc => N_("ID of the host")
     param_group :packages_or_groups
     def remove

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -115,7 +115,7 @@ module Katello
                                                      :resource_class => Erratum))
     end
 
-    api :PUT, "/hosts/bulk/install_content", N_("Install content on one or more hosts")
+    api :PUT, "/hosts/bulk/install_content", N_("Install content on one or more hosts using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param_group :bulk_params
     param :content_type, String,
           :desc => N_("The type of content.  The following types are supported: 'package', 'package_group' and 'errata'."),
@@ -125,7 +125,7 @@ module Katello
       content_action
     end
 
-    api :PUT, "/hosts/bulk/update_content", N_("Update content on one or more hosts")
+    api :PUT, "/hosts/bulk/update_content", N_("Update content on one or more hosts using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param_group :bulk_params
     param :content_type, String,
           :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
@@ -136,7 +136,7 @@ module Katello
       content_action
     end
 
-    api :PUT, "/hosts/bulk/remove_content", N_("Remove content on one or more hosts")
+    api :PUT, "/hosts/bulk/remove_content", N_("Remove content on one or more hosts using katello-agent. %s") % katello_agent_deprecation_text, deprecated: true
     param_group :bulk_params
     param :content_type, String,
           :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -4,19 +4,19 @@ module Katello
     include Concerns::Api::V2::BulkHostsExtensions
     include Katello::Concerns::Api::V2::ContentOverridesController
 
-    before_action :find_host_collections, :only => [:bulk_add_host_collections, :bulk_remove_host_collections]
-    before_action :find_environment, :only => [:environment_content_view]
-    before_action :find_content_view, :only => [:environment_content_view]
-    before_action :find_editable_hosts, :except => [:destroy_hosts, :resolve_traces]
-    before_action :find_deletable_hosts, :only => [:destroy_hosts]
-    before_action :find_readable_hosts, :only => [:applicable_errata, :installable_errata, :available_incremental_updates]
-    before_action :find_errata, :only => [:available_incremental_updates]
-    before_action :find_organization, :only => [:add_subscriptions]
-    before_action :find_traces, :only => [:resolve_traces]
-    before_action :deprecate_katello_agent, :only => [:install_content, :update_content, :remove_content]
+    before_action :find_host_collections, only: [:bulk_add_host_collections, :bulk_remove_host_collections]
+    before_action :find_environment, only: [:environment_content_view]
+    before_action :find_content_view, only: [:environment_content_view]
+    before_action :find_editable_hosts, except: [:destroy_hosts, :resolve_traces]
+    before_action :find_deletable_hosts, only: [:destroy_hosts]
+    before_action :find_readable_hosts, only: [:applicable_errata, :installable_errata, :available_incremental_updates]
+    before_action :find_errata, only: [:available_incremental_updates]
+    before_action :find_organization, only: [:add_subscriptions]
+    before_action :find_traces, only: [:resolve_traces]
+    before_action :deprecate_katello_agent, only: [:install_content, :update_content, :remove_content]
 
-    before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
-    before_action :validate_organization, :only => [:add_subscriptions]
+    before_action :validate_content_action, only: [:install_content, :update_content, :remove_content]
+    before_action :validate_organization, only: [:add_subscriptions]
 
     # disable *_count fields on erratum rabl, since they perform N+1 queries
     before_action :disable_erratum_hosts_count

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -17,6 +17,16 @@ module Katello
         User.current
       end
 
+      class_methods do
+        def katello_agent_deprecation_text
+          N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % katello_agent_removal_release
+        end
+
+        def katello_agent_removal_release
+          N_("a future release")
+        end
+      end
+
       protected
 
       def request_from_katello_cli?

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -112,7 +112,7 @@ class Setting::Content < Setting
                "/etc/pki/katello/certs/pulp-client.crt", N_('Pulp client cert')),
       self.set('sync_connect_timeout', N_("Total timeout in seconds for connections when syncing"),
                300, N_('Sync Connection Timeout')),
-      self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"),
+      self.set('remote_execution_by_default', N_("If set to true, use remote execution instead of katello-agent for remote actions"),
                false, N_('Use remote execution by default')),
       self.set('unregister_delete_host', N_("When unregistering a host via subscription-manager, also delete the host record. Managed resources linked to host " \
                                             "such as virtual machines and DNS records may also be deleted."),

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -21,6 +21,20 @@ module Katello
       @options = nil
     end
 
+    def test_check_katello_agent_not_disabled
+      ::Katello.expects(:with_katello_agent?).returns(true)
+      @controller.expects(:fail).never
+
+      @controller.check_katello_agent_not_disabled
+    end
+
+    def test_check_katello_agent_not_disabled_fail
+      ::Katello.expects(:with_katello_agent?).returns(false)
+      @controller.expects(:fail).with(HttpErrors::BadRequest, "This action uses katello-agent, which is currently disabled in Settings.")
+
+      @controller.check_katello_agent_not_disabled
+    end
+
     def test_scoped_search
       params = {}
       @controller.stubs(:params).returns(params)

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -30,7 +30,7 @@ module Katello
 
     def test_check_katello_agent_not_disabled_fail
       ::Katello.expects(:with_katello_agent?).returns(false)
-      @controller.expects(:fail).with(HttpErrors::BadRequest, "This action uses katello-agent, which is currently disabled in Settings.")
+      @controller.expects(:fail).with(HttpErrors::BadRequest, "This action uses katello-agent, which is currently disabled. Use remote execution instead.")
 
       @controller.check_katello_agent_not_disabled
     end

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -130,6 +130,7 @@ module Katello
     end
 
     def test_apply
+      ::Katello.stubs(:with_katello_agent?).returns(true)
       assert_async_task ::Actions::Katello::Host::Erratum::Install do |host, options|
         host.id == @host.id && options[:content] == %w(RHSA-1999-1231)
       end
@@ -156,6 +157,7 @@ module Katello
 
     def test_apply_protected
       ::Host.any_instance.stubs(:check_host_registration).returns(true)
+      ::Katello.stubs(:with_katello_agent?).returns(true)
 
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @create_permission, @destroy_permission]

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -34,6 +34,8 @@ module Katello
     end
 
     def test_install_package
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::Package::Install do |host, options|
         host.id == @host.id && options[:content] == %w(foo)
       end
@@ -50,6 +52,8 @@ module Katello
     end
 
     def test_install_group
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::PackageGroup::Install do |host, options|
         host.id == @host.id && options[:content] == %w(blah)
       end
@@ -60,6 +64,8 @@ module Katello
     end
 
     def test_upgrade
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::Package::Update do |host, options|
         host.id == @host.id && options[:content] == %w(foo bar)
       end
@@ -76,6 +82,8 @@ module Katello
     end
 
     def test_upgrade_all
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::Package::Update do |host, options|
         host.id == @host.id && options[:content] == []
       end
@@ -86,6 +94,8 @@ module Katello
     end
 
     def test_remove
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::Package::Remove do |host, options|
         host.id == @host.id && options[:content] == %w(foo)
       end
@@ -108,6 +118,8 @@ module Katello
     end
 
     def test_remove_group
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task ::Actions::Katello::Host::PackageGroup::Remove do |host, options|
         host.id == @host.id && options[:content] == %w(blah)
       end
@@ -138,6 +150,7 @@ module Katello
 
     def test_permissions
       ::Host.any_instance.stubs(:check_host_registration).returns(true)
+      ::Katello.stubs(:with_katello_agent?).returns(true)
 
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @create_permission, @destroy_permission]

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -65,6 +65,8 @@ module Katello
     end
 
     def test_install_package
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::Package::Install
         assert_equal ['foo'], options[:content]
@@ -78,6 +80,8 @@ module Katello
     end
 
     def test_update_package
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::Package::Update
         assert_equal ['foo'], options[:content]
@@ -91,6 +95,8 @@ module Katello
     end
 
     def test_remove_package
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::Package::Remove
         assert_equal ['foo'], options[:content]
@@ -104,6 +110,8 @@ module Katello
     end
 
     def test_install_package_group
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::PackageGroup::Install
         assert_equal ['foo group'], options[:content]
@@ -117,6 +125,8 @@ module Katello
     end
 
     def test_update_package_group
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::PackageGroup::Install
         assert_equal ['foo group'], options[:content]
@@ -130,6 +140,8 @@ module Katello
     end
 
     def test_remove_package_group
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       assert_async_task(::Actions::Katello::BulkAgentAction) do |action_class, hosts, options|
         assert_equal action_class, ::Actions::Katello::Host::PackageGroup::Remove
         assert_equal ['foo group'], options[:content]
@@ -145,6 +157,7 @@ module Katello
     def test_install_errata
       errata = katello_errata("bugfix")
       @host1.content_facet.applicable_errata << errata
+      ::Katello.stubs(:with_katello_agent?).returns(true)
       @controller.expects(:async_task).with(::Actions::BulkAction, ::Actions::Katello::Host::Erratum::ApplicableErrataInstall,
                                             [@host1], :errata_ids => [errata.errata_id]).returns({})
 
@@ -265,6 +278,8 @@ module Katello
     end
 
     def test_install_content_permissions
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
       allow_restricted_user_to_see_host
@@ -274,6 +289,8 @@ module Katello
     end
 
     def test_update_content_permissions
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
       allow_restricted_user_to_see_host
@@ -283,6 +300,8 @@ module Katello
     end
 
     def test_remove_content_permissions
+      ::Katello.stubs(:with_katello_agent?).returns(true)
+
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
       allow_restricted_user_to_see_host


### PR DESCRIPTION
Introduce / update API deprecation warnings as per _Option 1_ discussed [here](https://community.theforeman.org/t/katello-package-actions-in-an-agent-less-world/22777?u=jeremylenz)

This change covers only the Katello API.  The `hammer` changes including the [feature Justin mentions here](https://community.theforeman.org/t/katello-package-actions-in-an-agent-less-world/22777/5?u=jeremylenz) will be in a future `hammer-cli-katello` update.

### Katello API endpoints affected
```
/api/v2/hosts/:host_id/packages/{install,upgrade,upgrade_all,remove}
/api/v2/hosts/:host_id/errata/apply
/api/v2/hosts/bulk/{install_content, update_content, remove_content}
```

I found API deprecation warnings already in place for all of the above, except `/api/v2/hosts/:host_id/errata/apply`.  Am I missing something?
