### PR TITLE
Fixes #32259 - Fix apipie cache for repo sets

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -225,6 +225,15 @@ module Katello
       respond_for_show(:resource => @activation_key)
     end
 
+    api :GET, "/activation_keys/:id/product_content", N_("Show content available for an activation key")
+    param :id, String, :desc => N_("ID of the activation key"), :required => true
+    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
+    param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the activation key's content view version")
+    def product_content
+      # note this is just there as a place holder for apipie.
+      # The routing would automatically redirect it to repository_sets#index
+    end
+
     def index_relation
       activation_keys = ActivationKey.readable
       activation_keys = activation_keys.where(:name => params[:name]) if params[:name]

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -147,6 +147,15 @@ module Katello
       respond_for_index(:collection => index_response(true), :template => "index")
     end
 
+    api :GET, "/hosts/:host_id/subscriptions/product_content", N_("Get content and overrides for the host")
+    param :host_id, String, :desc => N_("Id of the host"), :required => true
+    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
+    param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's content view version")
+    def product_content
+      # note this is just there as a place holder for apipie.
+      # The routing would automatically redirect it to repository_sets#index
+    end
+
     api :PUT, "/hosts/:host_id/subscriptions/content_override", N_("Set content overrides for the host")
     param :host_id, String, :desc => N_("Id of the content host"), :required => true
     param :value, String, :desc => N_("Override to a boolean value or 'default'"), :required => false
@@ -163,7 +172,7 @@ module Katello
         validate_content_overrides_enabled(override_params)
       end
       sync_task(::Actions::Katello::Host::UpdateContentOverrides, @host, content_override_values, false)
-      product_content
+      fetch_product_content
     end
 
     api :GET, "/hosts/:host_id/subscriptions/available_release_versions", N_("Show releases available for the content host")
@@ -175,7 +184,7 @@ module Katello
 
     private
 
-    def product_content
+    def fetch_product_content
       content_finder = ProductContentFinder.new(:consumable => @host.subscription_facet)
       content = content_finder.presenter_with_overrides(@host.subscription_facet.candlepin_consumer.content_overrides)
       respond_with_template_collection("index", 'repository_sets', :collection => full_result_response(content))

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -8,6 +8,7 @@ module Katello
     before_action :set_editable_product_scope, only: [:enable, :disable]
     before_action :find_product
     before_action :custom_product?
+    before_action :setup_params
     before_action :find_authorized_activation_key, :only => [:index, :auto_complete_search]
     before_action :find_authorized_host, :only => [:index, :auto_complete_search]
     before_action :find_organization
@@ -198,6 +199,15 @@ module Katello
       return unless params[:host_id]
       find_host_with_subscriptions(params[:host_id], :view_hosts)
       @consumable = @host.subscription_facet
+    end
+
+    def setup_params
+      return unless params[:id]
+      if params[:entity] == :activation_key
+        params[:activation_key_id] ||= params[:id]
+      else
+        params[:host_id] ||= params[:id]
+      end
     end
   end
 end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -33,7 +33,7 @@ Katello::Engine.routes.draw do
         api_resources :activation_keys, :only => [:index, :create, :show, :update, :destroy] do
           get :auto_complete_search, :on => :collection
           member do
-            match '/product_content' => 'repository_sets#index', :via => :get
+            match '/product_content' => 'repository_sets#index', :via => :get, :entity => :activation_key
             match '/content_override' => 'activation_keys#content_override', :via => :put
             post :copy
             put :add_subscriptions

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -105,7 +105,7 @@ Foreman::Application.routes.draw do
           resources :subscriptions, :only => [:index], :controller => :host_subscriptions do
             collection do
               put :auto_attach
-              match '/product_content' => 'repository_sets#index', :via => :get
+              match '/product_content' => 'repository_sets#index', :via => :get, :entity => :host
               get :available_release_versions
               put :content_override
               put :remove_subscriptions


### PR DESCRIPTION
A previous PR removed the product-content end points from activation key
and host subscriptions controller. It redirected the old enpoints to
repository sets controller index. However the apipie json didnot have
these end points generated.
This commit adds dummy endpoints in the controller purely with the
purpose of documenting the apipie end points.