### PR TITLE
Fixes #32261 - Manifest delete should only index subscriptions for current org

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -144,7 +144,7 @@ module Katello
           prod_content_importer.import
         end
 
-        self.index_subscriptions(self.organization)
+        self.index_subscriptions
         prod_content_importer
       end
 
@@ -158,7 +158,7 @@ module Katello
         product
       end
 
-      def index_subscriptions(organization = nil)
+      def index_subscriptions
         Katello::Subscription.import_all(organization)
         Katello::Pool.import_all(organization, false)
       end


### PR DESCRIPTION
This is bad because it needlessly re-imports all Subscriptions and Pools for all orgs and not just the org which had its manifest deleted.

**to test**

- create a few organizations
- tail candlepin.log
- import a manifest into one of them
- ensure no regression for subscriptions index by verifying there are no candlepin API requests at this time for any other org except the importing org such as `uri=/candlepin/owners/SOME_OTHER_ORG/products/?`
- delete the org's manifest
- verify the same - no candlepin API requests are made for any other org but the deleting org
- verify that the katello:import_subscriptions rake task queries *all* orgs which is the intended behavior (no regression)