### PR TITLE
Fixes #32233 - Katello should send user-repo info to container gateway

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -97,6 +97,7 @@ module Katello
           :required => false
     param :with_content, RepositoryTypeManager.enabled_content_types, :desc => N_("only repositories having at least one of the specified content type ex: rpm , erratum")
     param :download_policy, ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES, :desc => N_("limit to only repositories with this download policy")
+    param :username, String, :desc => N_("only show the repositories readable by this user with this username")
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Repository)
     def index

--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -35,15 +35,53 @@ module Actions
               end
             end
           end
-          update_unauthenticated_repo_list(smart_proxy) if smart_proxy.has_feature?("Container_Gateway")
+          sync_container_gateway(smart_proxy)
         end
 
-        def update_unauthenticated_repo_list(smart_proxy)
-          unauthenticated_repo_list =
-            ::Katello::SmartProxyHelper.new(smart_proxy).combined_repos_available_to_capsule.select do |repo|
-              repo.docker? && repo.environment.registry_unauthenticated_pull
+        def sync_container_gateway(smart_proxy)
+          if smart_proxy.has_feature?(::SmartProxy::CONTAINER_GATEWAY_FEATURE)
+            update_container_repo_list(smart_proxy)
+            users = smart_proxy.container_gateway_users
+            update_user_container_repo_mapping(smart_proxy, users) if users.any?
+          end
+        end
+
+        def unauthenticated_container_repositories
+          ::Katello::Repository.joins(:environment).where("#{::Katello::KTEnvironment.table_name}.registry_unauthenticated_pull" => true).select(:id).pluck(:id)
+        end
+
+        def update_container_repo_list(smart_proxy)
+          # [{ repository: "repoA", auth_required: false }]
+          repo_list = []
+          ::Katello::SmartProxyHelper.new(smart_proxy).combined_repos_available_to_capsule.each do |repo|
+            if repo.docker? && !repo.container_repository_name.nil?
+              repo_list << { repository: repo.container_repository_name,
+                             auth_required: !unauthenticated_container_repositories.include?(repo.id) }
             end
-          smart_proxy.update_unauthenticated_repo_list(unauthenticated_repo_list.map(&:container_repository_name))
+          end
+          smart_proxy.update_container_repo_list(repo_list)
+        end
+
+        def update_user_container_repo_mapping(smart_proxy, users)
+          # Example user-repo mapping:
+          # { users:
+          #   [
+          #     'user a' => [{ repository: 'repo 1', auth_required: true }]
+          #   ]
+          # }
+
+          user_repo_map = { users: [] }
+          users.each do |user|
+            inner_repo_list = []
+            repositories = ::Katello::Repository.readable_docker_catalog_as(user)
+            repositories.each do |repo|
+              next if repo.container_repository_name.nil?
+              inner_repo_list << { repository: repo.container_repository_name,
+                                   auth_required: !unauthenticated_container_repositories.include?(repo.id) }
+            end
+            user_repo_map[:users] << { user.login => inner_repo_list }
+          end
+          smart_proxy.update_user_container_repo_mapping(user_repo_map)
         end
 
         def repos_to_sync(smart_proxy, environment, content_view, repository, skip_metatadata_check = false)

--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -41,6 +41,10 @@ module Katello
         creatable? && publishable?
       end
 
+      def readable_as(user)
+        authorized_as(user, :view_content_views)
+      end
+
       def readable?
         ::User.current.can?(:view_content_views)
       end

--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -27,6 +27,24 @@ module Katello
         joins(:root).where("#{Repository.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?)", in_products, in_content_views, in_versions, in_environments)
       end
 
+      def readable_as(user)
+        in_products = Repository.in_product(Katello::Product.authorized_as(user, :view_products)).select(:id)
+        in_environments = Repository.where(:environment_id => Katello::KTEnvironment.authorized_as(user, :view_lifecycle_environments)).select(:id)
+        in_content_views = Repository.joins(:content_view_repositories).where("#{ContentViewRepository.table_name}.content_view_id" => Katello::ContentView.readable_as(user)).select(:id)
+        in_versions = Repository.joins(:content_view_version).where("#{Katello::ContentViewVersion.table_name}.content_view_id" => Katello::ContentView.readable_as(user)).select(:id)
+        joins(:root).where("#{Repository.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?)", in_products, in_content_views, in_versions, in_environments)
+      end
+
+      def readable_docker_catalog
+        readable_docker_catalog_as(User.current)
+      end
+
+      def readable_docker_catalog_as(user)
+        table_name = Repository.table_name
+        in_unauth_environments = Repository.joins(:environment).where("#{Katello::KTEnvironment.table_name}.registry_unauthenticated_pull" => true).select(:id)
+        Repository.readable_as(user).or(Repository.joins(:root).where("#{table_name}.id in (?)", in_unauth_environments)).non_archived.docker_type
+      end
+
       def exportable
         in_product(Katello::Product.exportable)
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -17,6 +17,7 @@ module Katello
       PULP3_FEATURE = "Pulpcore".freeze
       PULP_FEATURE = "Pulp".freeze
       PULP_NODE_FEATURE = "Pulp Node".freeze
+      CONTAINER_GATEWAY_FEATURE = "Container_Gateway".freeze
 
       DOWNLOAD_INHERIT = 'inherit'.freeze
       DOWNLOAD_POLICIES = ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES + [DOWNLOAD_INHERIT]
@@ -102,6 +103,19 @@ module Katello
 
       def update_unauthenticated_repo_list(repo_names)
         ProxyAPI::ContainerGateway.new(url: self.url).unauthenticated_repository_list("repositories": repo_names)
+      end
+
+      def update_container_repo_list(repo_list)
+        ProxyAPI::ContainerGateway.new(url: self.url).repository_list({ repositories: repo_list })
+      end
+
+      def update_user_container_repo_mapping(user_repo_map)
+        ProxyAPI::ContainerGateway.new(url: self.url).user_repository_mapping(user_repo_map)
+      end
+
+      def container_gateway_users
+        usernames = ProxyAPI::ContainerGateway.new(url: self.url).users
+        ::User.where(login: usernames['users'])
       end
 
       def pulp_url

--- a/lib/proxy_api/container_gateway.rb
+++ b/lib/proxy_api/container_gateway.rb
@@ -1,21 +1,32 @@
 module ProxyAPI
   class ContainerGateway < ::ProxyAPI::Resource
     def initialize(args)
-      @url = args[:url] + "/container_gateway/v2"
+      @url = args[:url] + "/container_gateway"
       super args
     end
 
-    def unauthenticated_repository_list(args = {})
-      # get '/v2/unauthenticated_repository_list/?'
-      # put '/v2/unauthenticated_repository_list/?'
-      @url += "/unauthenticated_repository_list"
-      if args.empty?
-        @unauthenticated_repo_list = parse get
-      else
-        parse put(args)
-      end
+    def repository_list(args)
+      # put '/v2/repository_list/?'
+      @url += "/repository_list"
+      parse put(args)
     rescue => e
-      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to perform unauthenticated repository list operation"))
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to update the repository list"))
+    end
+
+    def user_repository_mapping(args)
+      # put '/v2/user_repository_mapping/?'
+      @url += "/user_repository_mapping"
+      parse put(args)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to update the user-repository mapping"))
+    end
+
+    def users
+      # get '/v2/users/?'
+      @url += "/users"
+      @users = parse get
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to get users"))
     end
   end
 end

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -3,7 +3,8 @@ module Support
     def pulp_features
       @pulp_node_feature ||= Feature.where(name: SmartProxy::PULP_NODE_FEATURE).first_or_create
       @pulp3_feature ||= Feature.where(name: SmartProxy::PULP3_FEATURE).first_or_create
-      [@pulp_node_feature, @pulp3_feature]
+      @container_gateway_feature ||= Feature.where(name: SmartProxy::CONTAINER_GATEWAY_FEATURE).first_or_create
+      [@pulp_node_feature, @pulp3_feature, @container_gateway_feature]
     end
 
     def proxy_with_pulp(proxy_resource = nil)


### PR DESCRIPTION
Causes Katello to send user and repo info to the container gateway during proxy sync time.  Katello will only send the user-repo mapping for users who exist in the Container Gateway's database.

Related Container Gateway PR: https://github.com/Katello/smart_proxy_container_gateway/pull/13

TODO:

- [x] Write tests