### PR TITLE
Remove unused settings

### DIFF
--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -13,8 +13,6 @@
   :rest_client_timeout: 30
   :gpg_strict_validation: false
 
-  :puppet_repo_root: '/etc/puppet/environments/'
-
   :redhat_repository_url: https://cdn.redhat.com
 
   :consumer_cert_rpm: 'katello-ca-consumer-latest.noarch.rpm'

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -40,7 +40,6 @@ module Katello
           :upload_chunk_size => 1_048_575, # upload size in bytes to pulp. see SSLRenegBufferSize in apache
           :sync_threads => 4,
           :sync_KBlimit => nil,
-          :notifier_ca_path => "/etc/pki/tls/certs/ca-bundle.crt"
         },
         :candlepin => {
           :url => 'https://localhost:8443/candlepin',


### PR DESCRIPTION
The use of `notifier_ca_path` setting was removed in a9ef90dd3e57295fe19e66e8601a4ff6fd1d23e8. `puppet_repo_root` was removed in c7a3b4f140651896951d1527f39a543037298abe.

I haven't opened a Redmine issue because I wasn't sure it was needed for this. Also currently 2 commits that are very focused. Let me know if you want me to change it. I took these from https://github.com/Katello/katello/pull/8832 since they can be merged already and makes that PR smaller.