### PR TITLE
Fixes #32262 - Avoid leaking file descriptors

### DIFF
--- a/app/controllers/katello/api/v2/content_credentials_controller.rb
+++ b/app/controllers/katello/api/v2/content_credentials_controller.rb
@@ -49,7 +49,7 @@ module Katello
 
       content = nil
       if filepath
-        content = File.open(filepath, 'rb') { |file| file.read }
+        content = File.read(filepath, mode: 'rb')
       else
         content = params[:content]
       end

--- a/app/lib/katello/event_daemon/runner.rb
+++ b/app/lib/katello/event_daemon/runner.rb
@@ -17,7 +17,7 @@ module Katello
         def pid
           return unless pid_file && File.exist?(pid_file)
 
-          File.open(pid_file) { |f| f.read.to_i }
+          File.read(pid_file).to_i
         end
 
         def pid_file
@@ -36,7 +36,7 @@ module Katello
           return unless pid_file
 
           FileUtils.mkdir_p(pid_dir)
-          File.open(pid_file, 'w') { |f| f.puts Process.pid }
+          File.write(pid_file, Process.pid)
         end
 
         def stop

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -97,10 +97,7 @@ module Katello
         data = Resources::Candlepin::UpstreamConsumer.export("#{url}#{upstream['uuid']}/export", upstream['idCert']['cert'],
                                                              upstream['idCert']['key'], ca_file)
 
-        File.open(zip_file_path, 'w') do |f|
-          f.binmode
-          f.write data
-        end
+        File.write(zip_file_path, data, mode: 'wb')
 
         return true
       end

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -5,11 +5,11 @@ module Cert
     end
 
     def self.ca_cert
-      File.open(Setting[:ssl_ca_file], 'r').read
+      File.read(Setting[:ssl_ca_file])
     end
 
     def self.ssl_client_cert
-      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.open(ssl_client_cert_filename, 'r').read)
+      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.read(ssl_client_cert_filename))
     end
 
     def self.ssl_client_cert_filename
@@ -17,7 +17,7 @@ module Cert
     end
 
     def self.ssl_client_key
-      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.open(ssl_client_key_filename, 'r').read)
+      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename))
     end
 
     def self.ssl_client_key_filename

--- a/lib/katello/tasks/receptor/extract_orgs.rake
+++ b/lib/katello/tasks/receptor/extract_orgs.rake
@@ -17,9 +17,7 @@ namespace :katello do
         }
       end
 
-      File.open(output_file, 'w') do |f|
-        f.write(JSON.pretty_generate(data))
-      end
+      File.write(output_file, JSON.pretty_generate(data))
 
       puts "Wrote results to #{output_file}. Please delete it when finished."
     end

--- a/lib/katello/tasks/update_subscription_facet_backend_data.rake
+++ b/lib/katello/tasks/update_subscription_facet_backend_data.rake
@@ -12,9 +12,9 @@ namespace :katello do
         filename = "subscription_facet_upgrade-#{Time.now.to_i}.log"
         path = File.join(path, filename)
 
-        file = File.open(path, 'w')
-        @errors.each { |error| file.write(error) }
-        file.close
+        File.open(path, 'w') do |file|
+          @errors.each { |error| file.write(error) }
+        end
         $stderr.print "***********************************\n"
         $stderr.print "*************WARNING***************\n"
         $stderr.print "Errors detected during upgrade step.\n"

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -12,7 +12,7 @@ module Katello
     describe "create gpg key" do
       before(:each) do
         @organization = get_organization
-        @test_gpg_content = File.open("#{Katello::Engine.root}/spec/assets/gpg_test_key").read
+        @test_gpg_content = File.read("#{Katello::Engine.root}/spec/assets/gpg_test_key")
       end
 
       it "should be successful with valid parameters" do

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -95,7 +95,7 @@ module FixtureTestCase
       next unless taxonomy['type'] == 'Organization'
       taxonomy['label'] = taxonomy['name'].tr(' ', '_')
     end
-    File.open(taxonomies_file, 'w') { |file| file.write(taxonomies.to_yaml) }
+    File.write(taxonomies_file, taxonomies.to_yaml)
 
     fixtures(:all)
 

--- a/test/lib/tasks/receptor/extract_orgs_test.rb
+++ b/test/lib/tasks/receptor/extract_orgs_test.rb
@@ -39,7 +39,7 @@ module Katello
 
       Rake.application.invoke_task('katello:receptor:extract_orgs')
 
-      data = JSON.parse(File.read(File.open(ENV['OUTPUT_FILE'])))
+      data = JSON.parse(File.read(ENV['OUTPUT_FILE']))
 
       assert_equal orgs.size, data.size
 


### PR DESCRIPTION
Using File.open without closing it can leak file descriptors. File.read ensures the file is closed and as a nice bonus actually shorter.

This also shortens a lot of cases where the file was closed to make it shorter.

I'm not 100% sure everything is exactly the same, I'll note them inline.