### PR TITLE
Fixes #32232 - Package matching query issue w/ TimeScale DB (upgrade to pulp-rpm 3.10)

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_ansible_client", ">= 0.7", "< 0.8"
   gem.add_dependency "pulp_container_client", ">= 2.4.0", "< 2.5.0"
   gem.add_dependency "pulp_deb_client", ">= 2.10.0", "< 2.11.0"
-  gem.add_dependency "pulp_rpm_client", ">=3.9.0", "< 3.10.0"
+  gem.add_dependency "pulp_rpm_client", ">=3.10.0", "< 3.11.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
 
   # UI


### PR DESCRIPTION
This PR updates our pulp-rpm client bindings version to 3.10 to address the issue in the redmine.