### PR TITLE
Fixes #32285 - use public API to update setting

### DIFF
--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -49,10 +49,8 @@ module Katello
         changes = self.previous_changes
         if changes.key?(:name)
           previous_name = changes[:name].first
-          setting = Setting.find_by(name: 'content_default_http_proxy')
-
-          if setting && setting.value == previous_name && !previous_name.blank?
-            setting.update_attribute(:value, self.name)
+          if !previous_name.blank? && Setting['content_default_http_proxy'] == previous_name
+            Setting['content_default_http_proxy'] = self.name
           end
         end
       end


### PR DESCRIPTION
We are updating setting for content proxy directly in database, but that
blocks efforts in core to migrate all settings into memory.
This would just break tests, as in production settings will be loaded
from database per request anyway, but it is still better to access
Setting through public API.

This was discovered by failing tests on #8002