### PR TITLE
Fixes #32256 - aborts a migration task if the Katello config is invalid

### DIFF
--- a/lib/katello/tasks/check_config.rake
+++ b/lib/katello/tasks/check_config.rake
@@ -1,0 +1,17 @@
+namespace :katello do
+  task :check_config => ['environment'] do
+    desc "Task that can be run before a content migration to check that the configuration valid"
+
+    puts "Checking for valid Katello configuraton."
+    if SETTINGS[:katello][:use_pulp_2_for_content_type].nil?
+      fail _("Invalid Katello configuration: 'use_pulp_2_for_content_type' is missing. ")
+    end
+
+    if !SETTINGS[:katello][:use_pulp_2_for_content_type][:docker] &&
+      !SETTINGS[:katello][:use_pulp_2_for_content_type][:file] &&
+      !SETTINGS[:katello][:use_pulp_2_for_content_type][:yum] &&
+      !SETTINGS[:katello][:use_pulp_2_for_content_type][:deb]
+      fail _("Invalid Katello configuration: no content types in 'use_pulp_2_for_content_type' section are set to 'true'. ")
+    end
+  end
+end

--- a/lib/katello/tasks/check_config.rake
+++ b/lib/katello/tasks/check_config.rake
@@ -1,17 +1,18 @@
 namespace :katello do
   task :check_config => ['environment'] do
     desc "Task that can be run before a content migration to check that the configuration valid"
+    fail_msg = _("The system appears to already be using pulp3 with all content migrated.")
 
     puts "Checking for valid Katello configuraton."
     if SETTINGS[:katello][:use_pulp_2_for_content_type].nil?
-      fail _("Invalid Katello configuration: 'use_pulp_2_for_content_type' is missing. ")
+      fail fail_msg
     end
 
     if !SETTINGS[:katello][:use_pulp_2_for_content_type][:docker] &&
       !SETTINGS[:katello][:use_pulp_2_for_content_type][:file] &&
       !SETTINGS[:katello][:use_pulp_2_for_content_type][:yum] &&
       !SETTINGS[:katello][:use_pulp_2_for_content_type][:deb]
-      fail _("Invalid Katello configuration: no content types in 'use_pulp_2_for_content_type' section are set to 'true'. ")
+      fail fail_msg
     end
   end
 end

--- a/lib/katello/tasks/pulp3_content_switchover.rake
+++ b/lib/katello/tasks/pulp3_content_switchover.rake
@@ -3,8 +3,9 @@ require "#{Katello::Engine.root}/app/services/katello/pulp3/migration_switchover
 
 namespace :katello do
   desc "Runs a Pulp 3 migration of pulp3 hrefs to pulp ids for supported content types."
-  task :pulp3_content_switchover => ["dynflow:client"] do
+  task :pulp3_content_switchover => ["dynflow:client", "check_config"] do
     dryrun = ENV['DRYRUN']
+
     begin
       User.current = User.anonymous_admin
 

--- a/lib/katello/tasks/pulp3_migration.rake
+++ b/lib/katello/tasks/pulp3_migration.rake
@@ -1,6 +1,6 @@
 namespace :katello do
   desc "Runs a Pulp 2 to 3 Content Migration for supported types.  May be run multiple times.  Use wait=false to immediately return with a task url."
-  task :pulp3_migration => ["dynflow:client"] do
+  task :pulp3_migration => ["dynflow:client", 'check_config'] do
     services = [:candlepin, :foreman_tasks, :pulp3, :pulp, :pulp_auth]
     Katello::Ping.ping!(services: services)
 

--- a/test/lib/tasks/pulp3_content_switchover_test.rb
+++ b/test/lib/tasks/pulp3_content_switchover_test.rb
@@ -8,6 +8,7 @@ module Katello
         Rake::Task['katello:pulp3_content_switchover'].reenable
         Rake::Task.define_task(:environment)
         Rake::Task.define_task('dynflow:client')
+        Rake::Task.define_task('check_config')
 
         @primary = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
         SETTINGS[:katello][:use_pulp_2_for_content_type] = {:file => true, :docker => true}


### PR DESCRIPTION
Adds a check for Katello configuration - the `use_pulp_2_for_content_type` section must exist and at least 1 of the content types must be set to `true`. If not, the migration task fails.