### PR TITLE
Refs #32058 - correctly select services that failed to ping

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -222,7 +222,7 @@ module Katello
       private
 
       def failed_services(result)
-        result[:services].reject do |_name, details|
+        result[:services].select do |_name, details|
           details[:status] != OK_RETURN_CODE
         end
       end


### PR DESCRIPTION
Before change, with tomcat stopped:

```
Katello::Ping.ping!(services: [:candlepin])
RuntimeError: The following services have not been started or are reporting errors: 
from /home/vagrant/katello/app/models/katello/ping.rb:35:in `ping!'
```

after:

```
RuntimeError: The following services have not been started or are reporting errors: candlepin
from /home/vagrant/katello/app/models/katello/ping.rb:35:in `ping!'
```

Now we can see the service names that are not running as was the intention of the original change