### PR TITLE
Fixes #32333 - Auto Create custom repositories + products + gpg

### DIFF
--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -65,10 +65,10 @@ module Katello
     def metadata_params
       params.require(:metadata).permit(
         :organization,
-        :content_view,
         :repository_mapping,
         :toc,
         :incremental,
+        content_view: [:name, :label, :description],
         content_view_version: [:major, :minor],
         from_content_view_version: [:major, :minor]
       ).tap do |nested|

--- a/app/lib/actions/katello/content_view_version/auto_create_products.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_products.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class AutoCreateProducts < Actions::Base
+        def plan(organization:, metadata:)
+          helper = ::Katello::Pulp3::ContentViewVersion::ImportableProducts.
+                      new(organization: organization,
+                          metadata: metadata)
+          helper.generate!
+          concurrence do
+            helper.creatable.each do |product|
+              plan_action(::Actions::Katello::Product::Create, product[:product], organization)
+            end
+            helper.updatable.each do |product|
+              plan_action(::Actions::Katello::Product::Update, product[:product], product[:options])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view_version/auto_create_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_repositories.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class AutoCreateRepositories < Actions::Base
+        def plan(organization:, metadata:)
+          helper = ::Katello::Pulp3::ContentViewVersion::ImportableRepositories.
+                      new(organization: organization,
+                          metadata: metadata)
+          helper.generate!
+          sequence do
+            helper.creatable.each do |root|
+              plan_action(::Actions::Katello::Repository::CreateRoot, root[:repository])
+            end
+            helper.updatable.each do |root|
+              plan_action(::Actions::Katello::Repository::Update, root[:repository], root[:options])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -2,29 +2,32 @@ module Actions
   module Katello
     module ContentViewVersion
       class Import < Actions::EntryAction
-        def plan(content_view: nil, organization: nil, path:, metadata:)
-          fail _("Atleast one of ContentView or Organization must be provided") if content_view.nil? && organization.nil?
-          if organization
-            fail _("Content view not provided in the metadata") if metadata[:content_view].blank?
-            content_view = ::Katello::Pulp3::ContentViewVersion::Import.find_or_create_import_view(organization: organization,
-                                                                                                   name: metadata[:content_view])
-          end
+        def plan(organization:, path:, metadata:, library: false)
+          fail _("Content view not provided in the metadata") if metadata[:content_view].blank?
+          content_view = ::Katello::Pulp3::ContentViewVersion::Import.
+                                find_or_create_import_view(organization: organization,
+                                                           metadata: metadata[:content_view],
+                                                           library: library)
           content_view.check_ready_to_import!
           ::Katello::Pulp3::ContentViewVersion::Import.check!(content_view: content_view,
                                                               metadata: metadata,
                                                               path: path,
                                                               smart_proxy: SmartProxy.pulp_primary!)
-          ::Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: content_view, metadata: metadata)
 
           major = metadata[:content_view_version][:major]
           minor = metadata[:content_view_version][:minor]
 
-          plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
-                        path: path,
-                        metadata: metadata,
-                        importing: true,
-                        major: major,
-                        minor: minor)
+          sequence do
+            plan_action(AutoCreateProducts, organization: content_view.organization, metadata: metadata)
+            plan_action(AutoCreateRepositories, organization: content_view.organization, metadata: metadata)
+            plan_action(ResetContentViewRepositoriesFromMetadata, content_view: content_view, metadata: metadata)
+            plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
+                          path: path,
+                          metadata: metadata,
+                          importing: true,
+                          major: major,
+                          minor: minor)
+          end
         end
 
         def humanized_name

--- a/app/lib/actions/katello/content_view_version/import_library.rb
+++ b/app/lib/actions/katello/content_view_version/import_library.rb
@@ -4,8 +4,10 @@ module Actions
       class ImportLibrary < Actions::EntryAction
         def plan(organization, path:, metadata:)
           action_subject(organization)
-          library_view = ::Katello::Pulp3::ContentViewVersion::Import.find_or_create_library_import_view(organization)
-          plan_action(::Actions::Katello::ContentViewVersion::Import, content_view: library_view, path: path, metadata: metadata)
+          plan_action(::Actions::Katello::ContentViewVersion::Import, organization: organization,
+                                                                      library: true,
+                                                                      path: path,
+                                                                      metadata: metadata)
         end
 
         def humanized_name

--- a/app/lib/actions/katello/content_view_version/reset_content_view_repositories_from_metadata.rb
+++ b/app/lib/actions/katello/content_view_version/reset_content_view_repositories_from_metadata.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class ResetContentViewRepositoriesFromMetadata < Actions::Base
+        def plan(content_view:, metadata:)
+          ::Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: content_view, metadata: metadata)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -9,7 +9,6 @@ module Actions
             product.setup_label_from_name
             product.cp_id = ::Katello::Product.unused_product_id
             product.save!
-
             plan_action(::Actions::Candlepin::Product::Create,
                         :owner => product.organization.label,
                         :name => product.name,

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -141,6 +141,9 @@ module Katello
       immediate.or(where("#{RootRepository.table_name}.download_policy" => nil)).
         or(where("#{RootRepository.table_name}.download_policy" => ""))
     end
+    scope :redhat, -> { joins(:product => :provider).where("#{Provider.table_name}.provider_type": Provider::REDHAT) }
+    scope :custom, -> { joins(:product => :provider).where.not("#{Provider.table_name}.provider_type": Provider::REDHAT) }
+
     scoped_search :on => :name, :relation => :root, :complete_value => true
     scoped_search :rename => :product, :on => :name, :relation => :product, :complete_value => true
     scoped_search :rename => :product_id, :on => :id, :relation => :product
@@ -170,7 +173,7 @@ module Katello
              :content_type, :product_id, :checksum_type, :docker_upstream_name, :mirror_on_sync, :"mirror_on_sync?",
              :download_policy, :verify_ssl_on_sync, :"verify_ssl_on_sync?", :upstream_username, :upstream_password,
              :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases, :deb_components, :deb_architectures,
-             :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id,
+             :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id, :os_versions,
              :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :ansible_collection_requirements,
              :ansible_collection_auth_url, :ansible_collection_auth_token, :http_proxy_policy, :http_proxy_id, :to => :root
 

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -25,10 +25,8 @@ module Katello
           #            These may contain updates to the product and hence ready to be updated.
           metadata_map = Import.metadata_map(metadata, product_only: true, custom_only: true)
           metadata_map.each do |product_label, params|
-            unless params[:gpg_key].blank?
-              params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                                 params: params[:gpg_key]).id
-            end
+            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                               params: params[:gpg_key])&.id
             params = params.except(:gpg_key)
             if products_in_library.include? product_label
               # add to the update list if product is already available

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -1,0 +1,43 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class ImportableProducts
+        attr_accessor :creatable, :updatable, :organization, :metadata
+
+        def initialize(organization:, metadata:)
+          self.organization = organization
+          self.metadata = metadata
+          self.creatable = []
+          self.updatable = []
+        end
+
+        def products_in_library
+          # Get the product labels in library
+          return @products_in_library unless @products_in_library.blank?
+          @products_in_library = Set.new(::Katello::Product.in_org(organization).custom.pluck(:label))
+        end
+
+        def generate!
+          # This returns a 2 different list of importable products
+          # creatable: products that are part of the metadata but not in the library.
+          #            They are ready to be created
+          # updatable: products that are both in the metadata and library.
+          #            These may contain updates to the product and hence ready to be updated.
+          metadata_map = Import.metadata_map(metadata, product_only: true, custom_only: true)
+          metadata_map.each do |product_label, params|
+            params[:gpg_key] = Import.create_or_update_gpg!(organization: organization,
+                                                            params: params[:gpg_key])
+            if products_in_library.include? product_label
+              # add to the update list if product is already available
+              product = ::Katello::Product.in_org(organization).find_by(label: product_label)
+              updatable << { product: product, options: params.except(:name, :label) }
+            else
+              # add to the create list if its  a new product
+              creatable << { product: ::Katello::Product.new(params) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -25,8 +25,10 @@ module Katello
           #            These may contain updates to the product and hence ready to be updated.
           metadata_map = Import.metadata_map(metadata, product_only: true, custom_only: true)
           metadata_map.each do |product_label, params|
-            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                            params: params[:gpg_key]).id
+            unless params[:gpg_key].blank?
+              params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                                 params: params[:gpg_key]).id
+            end
             params = params.except(:gpg_key)
             if products_in_library.include? product_label
               # add to the update list if product is already available

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -25,8 +25,9 @@ module Katello
           #            These may contain updates to the product and hence ready to be updated.
           metadata_map = Import.metadata_map(metadata, product_only: true, custom_only: true)
           metadata_map.each do |product_label, params|
-            params[:gpg_key] = Import.create_or_update_gpg!(organization: organization,
-                                                            params: params[:gpg_key])
+            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                            params: params[:gpg_key]).id
+            params = params.except(:gpg_key)
             if products_in_library.include? product_label
               # add to the update list if product is already available
               product = ::Katello::Product.in_org(organization).find_by(label: product_label)

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -1,0 +1,49 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class ImportableRepositories
+        attr_accessor :creatable, :updatable, :organization, :metadata
+
+        def initialize(organization:, metadata:)
+          self.organization = organization
+          self.metadata = metadata
+          self.creatable = []
+          self.updatable = []
+        end
+
+        def repositories_in_library
+          return @repositories_in_library unless @repositories_in_library.blank?
+
+          # fetch a list of [product, repo] pairs for every non-redhat library repo
+          product_repos_in_library = Import.repositories_in_library(organization).custom.
+                                      pluck("#{Katello::Product.table_name}.label",
+                                            "#{Katello::RootRepository.table_name}.label")
+          @repositories_in_library = Set.new(product_repos_in_library.compact)
+        end
+
+        def generate!
+          # This set's up a 2 different list of importable root repositories
+          # creatable: repos that are part of the metadata but not in the library.
+          #         They are ready to be created
+          # updatable: repo that are both in the metadata and library.
+          #         These may contain updates to the repo and hence ready to be updated.
+          metadata_map = Import.metadata_map(metadata, custom_only: true)
+          metadata_map.keys.each do |product_label, repo_label|
+            product = Katello::Product.in_org(organization).find_by(label: product_label)
+            fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
+            params = metadata_map[[product_label, repo_label]].except(:redhat, :product)
+            params[:gpg_key] = Import.create_or_update_gpg!(organization: organization,
+                                                            params: params[:gpg_key])
+
+            if repositories_in_library.include? [product_label, repo_label]
+              repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)
+              updatable << { repository: repo, options: params.except(:label, :name, :content_type) }
+            else
+              creatable << { repository: product.add_repo(params) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -32,10 +32,8 @@ module Katello
             product = Katello::Product.in_org(organization).find_by(label: product_label)
             fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
             params = metadata_map[[product_label, repo_label]]
-            unless params[:gpg_key].blank?
-              params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                                 params: params[:gpg_key]).id
-            end
+            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                               params: params[:gpg_key])&.id
             params = params.except(:redhat, :product, :gpg_key)
             if repositories_in_library.include? [product_label, repo_label]
               repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -31,10 +31,10 @@ module Katello
           metadata_map.keys.each do |product_label, repo_label|
             product = Katello::Product.in_org(organization).find_by(label: product_label)
             fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
-            params = metadata_map[[product_label, repo_label]].except(:redhat, :product)
-            params[:gpg_key] = Import.create_or_update_gpg!(organization: organization,
-                                                            params: params[:gpg_key])
-
+            params = metadata_map[[product_label, repo_label]]
+            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                            params: params[:gpg_key]).id
+            params = params.except(:redhat, :product, :gpg_key)
             if repositories_in_library.include? [product_label, repo_label]
               repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)
               updatable << { repository: repo, options: params.except(:label, :name, :content_type) }

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -32,8 +32,10 @@ module Katello
             product = Katello::Product.in_org(organization).find_by(label: product_label)
             fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
             params = metadata_map[[product_label, repo_label]]
-            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                            params: params[:gpg_key]).id
+            unless params[:gpg_key].blank?
+              params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
+                                                                 params: params[:gpg_key]).id
+            end
             params = params.except(:redhat, :product, :gpg_key)
             if repositories_in_library.include? [product_label, repo_label]
               repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)

--- a/test/controllers/api/v2/content_imports_controller_test.rb
+++ b/test/controllers/api/v2/content_imports_controller_test.rb
@@ -7,13 +7,14 @@ module Katello
       organization: "org name",
       repository_mapping: {
         'repo name' => {
-          repository: 'root repo name',
-          product: 'product name',
+          name: 'root repo name',
+          label: 'root_label',
+          product: { name: 'product name', label: 'label' },
           redhat: true
         }
       },
       toc: "toc file name",
-      content_view: "cv name",
+      content_view: { name: "cv name", label: 'cv label' },
       content_view_version: {
         major: "4",
         minor: "5"

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -53,9 +53,13 @@ module Katello
     end
 
     def test_sync
+      expected_repo_size = Katello::Repository.in_default_view.
+                            where(root: Katello::RootRepository.has_url.
+                                        where(product: @products.syncable)).count
+
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
-        assert_equal 9, repos.size
+        assert_equal expected_repo_size, repos.size
       end
 
       put :sync_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -20,13 +20,13 @@ module Katello
             data = export.generate_metadata
             assert_equal data[:content_view_version][:major], version.major
             assert_equal data[:content_view_version][:minor], version.minor
-            assert_equal data[:content_view], version.content_view.name
+            assert_equal data[:content_view], version.content_view.slice(:name, :label, :description)
 
             version_repositories = version.archived_repos.yum_type
             data[:repository_mapping].each do |name, repo_info|
               repo = version_repositories[name.to_i]
-              assert_equal repo_info[:repository], repo.root.name
-              assert_equal repo_info[:product], repo.root.product.name
+              assert_equal repo_info[:repository][:name], repo.root.name
+              assert_equal repo_info[:product].slice(:name, :label), repo.root.product.slice(:name, :label)
               assert_equal repo_info[:redhat], repo.redhat?
             end
           end

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -12,8 +12,8 @@ module Katello
             repo = katello_repositories(:rhel_7_x86_64)
             metadata = { content_view: cv.name,
                          repository_mapping: {
-                           "misc-24037": { "repository": repo.name,
-                                           "product": repo.product.name,
+                           "misc-24037": { "label": repo.label,
+                                           "product": { label: repo.product.label },
                                            "redhat": repo.redhat?
                                          }
                          }
@@ -22,6 +22,69 @@ module Katello
             Katello::Pulp3::ContentViewVersion::Import.reset_content_view_repositories_from_metadata!(content_view: cv, metadata: metadata)
             refute_equal prior_repository_ids, cv.repository_ids
             assert_equal cv.repository_ids, [repo.id]
+          end
+
+          it "Fetches the and updates gpgkeys correctly" do
+            org = get_organization
+            gpg_key = "MyCoolKey10000"
+            existing_gpgkey = katello_gpg_keys(:fedora_gpg_key)
+            updated_content = "#{existing_gpgkey.content} additional content!"
+
+            Katello::Pulp3::ContentViewVersion::Import.create_or_update_gpg!(
+                organization: org,
+                params: { name: existing_gpgkey.name, content: updated_content }
+            )
+
+            assert_equal updated_content, org.gpg_keys.find_by(name: existing_gpgkey.name).content
+
+            Katello::Pulp3::ContentViewVersion::Import.create_or_update_gpg!(
+                organization: org,
+                params: { name: gpg_key, content: "wow" }
+            )
+            refute_nil org.gpg_keys.find_by(name: gpg_key)
+          end
+
+          it "Fetches the intersecting repos correctly" do
+            org = get_organization
+            repo = katello_repositories(:feedless_fedora_17_x86_64)
+            repos = Katello::Pulp3::ContentViewVersion::Import.intersecting_repos_library_and_metadata(
+                  organization: org,
+                  metadata: {
+                    repository_mapping: {
+                      foo: { label: repo.label,
+                             product: repo.product.slice(:name, :label)
+                      },
+                      unknown: { label: "#{repo.label}-unknown-007",
+                                 product: repo.product.slice(:name, :label)
+                      }
+                    }
+                  }.with_indifferent_access
+              )
+
+            assert_equal [repo.id], repos.pluck(:id)
+          end
+
+          it "Fetches the metadata map correctly" do
+            repo = katello_repositories(:fedora_17_x86_64)
+            unknown = "#{repo.label}-unknown-007"
+            metadata_map = Katello::Pulp3::ContentViewVersion::Import.metadata_map(
+                      repository_mapping: {
+                        foo: { label: repo.label,
+                               product: repo.product.slice(:name, :label),
+                               redhat: true
+                        },
+                        unknown: { label: unknown,
+                                   product: repo.product.slice(:name, :label),
+                                   redhat: false
+                        }
+                      }.with_indifferent_access
+              )
+
+            refute_empty metadata_map[[repo.product.label, repo.label]]
+            assert metadata_map[[repo.product.label, repo.label]][:redhat]
+
+            refute_empty metadata_map[[repo.product.label, unknown]]
+            refute metadata_map[[repo.product.label, unknown]][:redhat]
           end
         end
       end

--- a/test/services/katello/pulp3/content_view_version/importable_products_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_products_test.rb
@@ -1,0 +1,49 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      module ContentViewVersion
+        class ImportCustomProductsTest < ActiveSupport::TestCase
+          include Support::Actions::Fixtures
+
+          it "Fetches the right products to auto create" do
+            repo = katello_repositories(:fedora_17_x86_64)
+            new_prod_1 = "New-Prod-1"
+            new_prod_2 = "New-Prod-2"
+            gpg_key = "MyCoolKey10000"
+
+            metadata = {
+              repository_mapping: {
+                "misc-24037": { "label": repo.label,
+                                "product": { label: repo.product.label },
+                                "redhat": repo.redhat?
+                              },
+                "hoo-24037": { "label": repo.label,
+                               "product": { label: new_prod_1, name: new_prod_1 },
+                               "redhat": false
+                             },
+                "hah-24037": { "label": repo.label,
+                               "product": { label: new_prod_2,
+                                            name: new_prod_1,
+                                            gpg_key: { name: gpg_key, content: "wow" }
+                                           },
+                               "redhat": false
+                             }
+              }
+            }.with_indifferent_access
+            helper = Katello::Pulp3::ContentViewVersion::ImportableProducts.
+                      new(organization: repo.organization, metadata: metadata)
+            helper.generate!
+            assert_includes helper.creatable.map { |prod| prod[:product].label }, new_prod_1
+            assert_includes helper.creatable.map { |prod| prod[:product].label }, new_prod_2
+            refute_includes helper.creatable.map { |prod| prod[:product].label }, repo.product.label
+            assert_includes helper.updatable.map { |prod| prod[:product].label }, repo.product.label
+            refute_includes helper.updatable.map { |prod| prod[:product].label }, new_prod_1
+
+            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/content_view_version/importable_products_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_products_test.rb
@@ -3,7 +3,7 @@ module Katello
   module Service
     module Pulp3
       module ContentViewVersion
-        class ImportCustomProductsTest < ActiveSupport::TestCase
+        class ImportableProductsTest < ActiveSupport::TestCase
           include Support::Actions::Fixtures
 
           it "Fetches the right products to auto create" do

--- a/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
@@ -3,7 +3,7 @@ module Katello
   module Service
     module Pulp3
       module ContentViewVersion
-        class ImportCustomRepositoriesTest < ActiveSupport::TestCase
+        class ImportableRepositoriesTest < ActiveSupport::TestCase
           include Support::Actions::Fixtures
 
           it "Fetches the right repos to auto create" do

--- a/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
@@ -1,0 +1,47 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      module ContentViewVersion
+        class ImportCustomRepositoriesTest < ActiveSupport::TestCase
+          include Support::Actions::Fixtures
+
+          it "Fetches the right repos to auto create" do
+            repo = katello_repositories(:fedora_17_x86_64)
+            new_repo_1 = "New-Repo-1"
+            new_repo_2 = "New-Repo-2"
+            gpg_key = "MyCoolKey10000"
+            metadata = {
+              repository_mapping: {
+                "misc-24037": { "label": repo.label,
+                                "product": { label: repo.product.label },
+                                "redhat": repo.redhat?
+                              },
+                "hoo-24037": { "label": new_repo_1,
+                               "product": { label: repo.product.label },
+                               "redhat": false
+                              },
+                "hah-24037": { "label": new_repo_2,
+                               "product": { label: repo.product.label },
+                               "redhat": false,
+                               "gpg_key": { name: gpg_key, content: "wow" }
+                              }
+              }
+            }.with_indifferent_access
+            helper = Katello::Pulp3::ContentViewVersion::ImportableRepositories.
+                      new(organization: repo.organization, metadata: metadata)
+            helper.generate!
+
+            assert_includes helper.creatable.map { |r| r[:repository].label }, new_repo_1
+            assert_includes helper.creatable.map { |r| r[:repository].label }, new_repo_2
+            refute_includes helper.creatable.map { |r| r[:repository].label }, repo.label
+            assert_includes helper.updatable.map { |r| r[:repository].label }, repo.label
+            refute_includes helper.updatable.map { |r| r[:repository].label }, new_repo_1
+
+            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit exports many more attributes belonging to the repository and
product in the metadata.json

On import it looks at the metadata json and automatically creates custom
repositories in the importing org under the same product.

In addition it also auto creates the product and associated gpg keys.
