### PR TITLE
Fixes #32340 - SubscriptionsTable test failure

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
@@ -80,7 +80,7 @@ describe('subscriptions table', () => {
         selectionEnabled
       />
                         </MemoryRouter>);
-    expect(page.find('#select1').is('[disabled]')).toBe(true);
+    expect(toJson(page)).toMatchSnapshot();
   });
 
   it('should render an empty state', async () => {

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -1,5 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`subscriptions table should disable checkboxes for custom subscriptions 1`] = `
+<div>
+  <table
+    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed"
+  >
+    <thead>
+      <tr
+        class=""
+      >
+        <th
+          aria-label="Select all rows"
+          class="table-view-pf-select"
+        >
+          <label
+            class="control-label sr-only"
+            for="selectAll"
+          >
+            Select all rows
+          </label>
+          <input
+            id="selectAll"
+            type="checkbox"
+          />
+        </th>
+        <th
+          class=""
+        >
+          Name
+        </th>
+        <th
+          class=""
+        >
+          SKU
+        </th>
+        <th
+          class=""
+        >
+          Contract
+        </th>
+        <th
+          class=""
+        >
+          Start Date
+        </th>
+        <th
+          class=""
+        >
+          End Date
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class=""
+      >
+        <td
+          class="table-view-pf-select"
+        >
+          <label
+            class="control-label sr-only"
+            for="select0"
+          >
+            Select row
+          </label>
+          <input
+            id="select0"
+            type="checkbox"
+          />
+        </td>
+        <td>
+          <a
+            href="/subscriptions/3/"
+          >
+            zoo
+          </a>
+        </td>
+        <td
+          class=""
+        >
+          853987721546
+        </td>
+        <td
+          class=""
+        />
+        <td
+          class=""
+        >
+          2017-09-21 16:18:44 -0400
+        </td>
+        <td
+          class=""
+        >
+          2047-09-14 15:18:44 -0500
+        </td>
+      </tr>
+      <tr
+        class=""
+      >
+        <td
+          class="table-view-pf-select"
+        >
+          <label
+            class="control-label sr-only"
+            for="select1"
+          >
+            Select row
+          </label>
+          <input
+            disabled=""
+            id="select1"
+            type="checkbox"
+          />
+        </td>
+        <td>
+          <a
+            href="/subscriptions/4/"
+          >
+            hsdfhsdh
+          </a>
+        </td>
+        <td
+          class=""
+        >
+          947637693017
+        </td>
+        <td
+          class=""
+        />
+        <td
+          class=""
+        >
+          2017-09-25 17:54:36 -0400
+        </td>
+        <td
+          class=""
+        >
+          2047-09-18 16:54:36 -0500
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`subscriptions table should render a loading state 1`] = `
 <SubscriptionsTable
   emptyState={Object {}}


### PR DESCRIPTION
Dunno why this is failing - probably some dependency in the Enzyme stack. Converting it to render a snapshot is a workaround. You can see the test criteria is met - the #select1 checkbox is disabled