### PR TITLE
Fixes #32351 - Race condition in katello-agent dynflow actions

### DIFF
--- a/app/lib/actions/katello/bulk_agent_action.rb
+++ b/app/lib/actions/katello/bulk_agent_action.rb
@@ -3,18 +3,31 @@ module Actions
     class BulkAgentAction < Actions::BulkAction
       def plan(agent_action, hosts, args)
         host_ids = hosts.map(&:id)
-        dispatch_args = {
-          content: args[:content]
-        }
-        histories = ::Katello::Agent::Dispatcher.dispatch(agent_action.agent_message, host_ids, dispatch_args)
+
+        histories = ::Katello::Agent::Dispatcher.create_histories(
+          host_ids: host_ids
+        )
 
         grouped_histories = {}
         histories.each { |h| grouped_histories[h.host_id] = h.id }
         options = {
           dispatch_histories: grouped_histories,
-          content: args[:content]
+          type: agent_action.agent_message,
+          content: args[:content],
+          bulk: true
         }
         super(agent_action, hosts, options)
+      end
+
+      def spawn_plans
+        args = input[:args].first
+        histories = ::Katello::Agent::DispatchHistory.where(id: args[:dispatch_histories].slice(*current_batch.map(&:to_s)).values)
+        ::Katello::Agent::Dispatcher.dispatch(
+          args[:type].to_sym,
+          histories,
+          content: args[:content]
+        )
+        super
       end
     end
   end

--- a/app/lib/katello/agent/client_message_handler.rb
+++ b/app/lib/katello/agent/client_message_handler.rb
@@ -8,6 +8,7 @@ module Katello
         @dispatch_history = Katello::Agent::DispatchHistory.find_by_id(dispatch_history_id)
 
         unless @dispatch_history
+          logger.error("Invalid client message: #{@json}")
           fail("No valid dispatch history in client message")
         end
       end

--- a/app/models/katello/agent/dispatch_history.rb
+++ b/app/models/katello/agent/dispatch_history.rb
@@ -3,6 +3,8 @@ module Katello
     class DispatchHistory < Katello::Model
       self.table_name = 'katello_agent_dispatch_histories'
 
+      belongs_to :host, :class_name => "::Host::Managed"
+
       serialize :result, Hash
 
       def accepted?

--- a/app/services/katello/agent/dispatcher.rb
+++ b/app/services/katello/agent/dispatcher.rb
@@ -14,36 +14,30 @@ module Katello
       register_message(:install_package_group, Katello::Agent::InstallPackageGroupMessage)
       register_message(:remove_package_group, Katello::Agent::RemovePackageGroupMessage)
 
-      def self.dispatch(message_type, host_ids, args)
+      def self.dispatch(message_type, histories, args)
         message_class = @supported_messages[message_type]
+        fail("Unsupported message type: #{message_type}") unless message_class
 
-        fail("Unsupported message type") unless message_class
-
-        uuid_data = ::Katello::Host::ContentFacet.where(host_id: host_ids).pluck(:host_id, :uuid)
-        fail("Couldn't find all hosts specified") unless host_ids.size == uuid_data.size
-
-        host_data = uuid_data.map do |host_id, consumer_id|
-          {
-            host_id: host_id,
-            consumer_id: consumer_id,
-            history: Katello::Agent::DispatchHistory.new(host_id: host_id),
-            message: message_class.new(**args.merge(consumer_id: consumer_id))
-          }
+        messages = histories.map do |history|
+          message = message_class.new(**args.merge(consumer_id: history.host.subscription_facet.uuid))
+          message.dispatch_history_id = history.id
+          message.recipient_address = settings[:client_queue_format] % history.host.subscription_facet.uuid
+          message.reply_to = settings[:event_queue_name]
+          message
         end
 
-        histories = host_data.map { |attrs| attrs[:history] }
-        ActiveRecord::Base.transaction do
-          Katello::Agent::DispatchHistory.import(histories)
+        connection = Connection.new
+        connection.send_messages(messages)
 
-          host_data.each do |d|
-            d[:message].dispatch_history_id = d[:history].id
-            d[:message].recipient_address = settings[:client_queue_format] % [d[:consumer_id]]
-            d[:message].reply_to = settings[:event_queue_name]
-          end
+        histories
+      end
 
-          connection = Connection.new
-          connection.send_messages(host_data.map { |d| d[:message] })
+      def self.create_histories(host_ids:)
+        histories = host_ids.map do |id|
+          Katello::Agent::DispatchHistory.new(host_id: id)
         end
+
+        Katello::Agent::DispatchHistory.import(histories)
 
         histories
       end

--- a/test/services/katello/agent/dispatcher_test.rb
+++ b/test/services/katello/agent/dispatcher_test.rb
@@ -4,26 +4,38 @@ module Katello
   module Agent
     class DispatcherTest < ActiveSupport::TestCase
       let(:host) { hosts(:one) }
-      let(:consumer_id) { "pulp.agent.#{host.content_facet.uuid}" }
+      let(:consumer_id) { "pulp.agent.#{host.subscription_facet.uuid}" }
       let(:dispatch_params) { { content: ['vim'] } }
-      let(:message_params) { { content: ['vim'], consumer_id: host.content_facet.uuid } }
+      let(:message_params) { { content: ['vim'], consumer_id: host.subscription_facet.uuid } }
       let(:agent_message) { stub('dispatch_history_id=' => 100, 'recipient_address=' => consumer_id, 'reply_to=' => 'pulp.task') }
+      let(:history) { Katello::Agent::DispatchHistory.create!(host_id: host.id) }
 
       class TestMessage
       end
 
       def test_dispatch
         Katello::Agent::Dispatcher.register_message(:test, TestMessage)
-        Katello::Agent::Connection.any_instance.expects(:send_messages)
+        Katello::Agent::Connection.any_instance.expects(:send_messages).with([agent_message])
         TestMessage.expects(:new).with(message_params).returns(agent_message)
 
-        Katello::Agent::Dispatcher.dispatch(:test, [host.id], dispatch_params)
+        Katello::Agent::Dispatcher.dispatch(:test, [history], dispatch_params)
       end
 
       def test_dispatch_unregistered
         assert_raises(StandardError) do
           Katello::Agent::Dispatcher.dispatch(:test, [host.id], dispatch_params)
         end
+      end
+
+      def test_create_histories
+        assert_equal 0, host.dispatch_histories.length
+
+        histories = ::Katello::Agent::Dispatcher.create_histories(host_ids: [host.id])
+
+        assert_equal 1, histories.length
+
+        host.reload
+        assert_equal 1, host.dispatch_histories.length
       end
 
       def test_delete_client_queue


### PR DESCRIPTION
This PR fixes a race condition where the agent message (ex: install package) is handled by the client *before* the plan phase of the respective AgentAction is finished. Because the transaction of `plan` hasn't completed, the ClientMessageHandler is not able to find the DispatchHistory to update.

The fix is two-fold:
- Refactor `Katello::Agent::Dispatcher.dispatch` so that it no longer creates the `DispatchHistory` objects. That is handled by the new method `create_histories` on the same class. The result is that `dispatch` is much more succinct
- This refactor allows the `DispatchHistory` objects to be created in `plan`, while the `.dispatch` call has been moved to the `run` phase. This means the DispatchHistory will always be found by the ClientMessageHandler.

A bonus of this PR is that the `BulkAgentAction` now uses the batching capability provided by Dynflow (default batch size is 1000). `spawn_plans` is called for each batch. Reference: https://github.com/Dynflow/dynflow/blob/master/lib/dynflow/action/with_bulk_sub_plans.rb

**To test:**

- Register a client
- Fire up the rails server and curl some URL so that the event handlers start up
- From the rails console invoke some package actions on the client:

`User.as_anonymous_admin { ForemanTasks.sync_task(::Actions::Katello::Host::Package::Remove, ::Host.where(id: 1).first, content: ['screen']) }`

`User.as_anonymous_admin { ForemanTasks.sync_task(::Actions::Katello::BulkAgentAction, ::Actions::Katello::Host::Package::Install, ::Host.where(id: 1), content: ['screen']) }`
- Do this enough times and you'll likely see the error shown in the redmine description
- Check out this PR, repeat the testing steps and all should be well
-  Think critically about this change and if it introduces any new problems / try to break it
