### PR TITLE
Fixes #31801 - Katello not handling multiple kickstart variants

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -51,17 +51,14 @@ module Katello
         end
       end
 
-      def variant_repo(host, variant)
+      def variant_repos(host, variant)
         if variant && host.content_source
           product_id = host.try(:content_facet).try(:kickstart_repository).try(:product_id) || host.try(:kickstart_repository).try(:product_id)
-          distro = distribution_repositories(host)
+          distros = distribution_repositories(host)
             .joins(:product)
-            .where(
-              distribution_variant: variant,
-              "#{Katello::Product.table_name}.id": product_id
-            ).first
-
-          distro&.to_hash(host.content_source)
+            .where("#{Katello::Repository.table_name}.distribution_variant LIKE :variant", { variant: "%#{variant}%" })
+            .where("#{Katello::Product.table_name}.id": product_id).collect { |repo| repo.to_hash(host.content_source, true) }
+          distros
         end
       end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -399,8 +399,8 @@ module Katello
       all_instances
     end
 
-    def to_hash(content_source = nil)
-      {id: id, name: label, url: full_path(content_source)}
+    def to_hash(content_source = nil, force_http = false)
+      {id: id, name: label, url: full_path(content_source, force_http)}
     end
 
     #is the repo cloned in the specified environment

--- a/app/services/katello/managed_content_medium_provider.rb
+++ b/app/services/katello/managed_content_medium_provider.rb
@@ -14,11 +14,11 @@ module Katello
       URI.parse(url)
     end
 
-    # If there is an 'AppStream' variant, we need to make it
+    # If there are any 'AppStream' variants, we need to make them
     # available to Anaconda
     def additional_media
-      appstream = entity.operatingsystem.variant_repo(entity, 'AppStream')
-      super + (appstream ? [appstream] : [])
+      appstream_repos = entity.operatingsystem.variant_repos(entity, 'AppStream')
+      super + (appstream_repos.present? ? appstream_repos : [])
     end
 
     def unique_id

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -61,7 +61,7 @@ module Katello
             )
             unless distribution.results.first.variants.empty?
               unless distribution.results.first.variants.first.name.nil?
-                repo.update!(:distribution_variant => distribution.results.first.variants.first.name)
+                repo.update!(:distribution_variant => distribution.results.first.variants.map(&:name).join(','))
               end
             end
           end


### PR DESCRIPTION
This PR stops a synced kickstart repo from randomly choosing a single variant. Instead, it stores the variants as a comma-delimited string, just like it is in the `.treeinfo` file.  This way, the `variant_repo` method will return all AppStream-related repositories instead of (potentially) the wrong one.

To test:
1) Bring up a `centos7-provision-nightly` box.  I hit a couple of installer issues, so ping me if you're stuck.
2) Sync the CentOS 8 BaseOS repo.  Check the repo's Distribution Variant after syncing. It will likely be "AppStream".
3) Apply this PR
4) Re-sync the repo. Note that the Variant is now "AppStream,BaseOS"
5) Sync the CentOS 8 AppStream repo.
6) Create a libvirt host using the synced CentOS 8 content. Let me know if you need any help setting this up.
7) Check the provisioning template (Kickstart file) preview.  At the top should be something like:
```
url --url http://centos7-provision-nightly.cannolo.example.com/pulp/content/Default_Organization/Library/custom/CentOS/centos_8_baseos/
# renamed from "http://centos7-provision-nightly.cannolo.example.com/pulp/content/Default_Organization/Library/custom/CentOS/AppStream/" for CentOS Anaconda to work
repo --name AppStream --baseurl http://centos7-provision-nightly.cannolo.example.com/pulp/content/Default_Organization/Library/custom/CentOS/AppStream/
repo --name centos_8_baseos --baseurl http://centos7-provision-nightly.cannolo.example.com/pulp/content/Default_Organization/Library/custom/CentOS/centos_8_baseos/ 
```

Without this PR, since the BaseOS variant is AppStream, only the BaseOS repository would appear in the Kickstart file. We want to make sure that both AppStream and BaseOS are in there.

Note that, as of some newer pulp-rpm version, this issue no longer causes an error during provisioning with Pulp 3.  Pulp 3 is now including AppStream into BaseOS themselves so it takes care of the situation. I say we still need this code in case Pulp 3 doesn't keep doing that in the future.

As a part of this PR, I'm also re-forcing HTTP instead of HTTPS for the `to_hash` method.  This HTTPS was preferred as of [this PR](https://github.com/Katello/katello/pull/9261/files#diff-a944b4d48b5bf6f08e51d32ab6526e455b6a7c7672d7051560891146d39c2d75R359), but that causes provisioning to fail.