### PR TITLE
Fixes #32267 - Remove never used finalize method from Katello::Host::AutoAttachSubscriptions

### DIFF
--- a/app/lib/actions/katello/host/auto_attach_subscriptions.rb
+++ b/app/lib/actions/katello/host/auto_attach_subscriptions.rb
@@ -13,10 +13,6 @@ module Actions
           plan_action(::Actions::Candlepin::Consumer::AutoAttachSubscriptions, :uuid => host.subscription_facet.uuid)
         end
 
-        def finalize
-          ::Katello::Pool.import_all
-        end
-
         def resource_locks
           :link
         end


### PR DESCRIPTION
Without `plan_self`, `finalize` is never executed.