### PR TITLE
Fixes #32405 - Permit DMI change when host is in build mode

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -143,6 +143,9 @@ class Setting::Content < Setting
       self.set('host_profile_assume', N_("Allow new Host registrations to assume registered profiles with matching hostname " \
                   "as long as the registering DMI UUID is not used by another host."),
                true, N_('Host Profile Assume')),
+      self.set('host_profile_assume_build_can_change', N_("Allow Host registrations to bypass 'Host Profile Assume' " \
+                  "as long as the host is in build mode."),
+               false, N_('Host Profile Can Change In Build')),
       self.set('host_tasks_workers_pool_size', N_("Amount of workers in the pool to handle the execution of host-related tasks. When set to 0, the default queue will be used instead. Restart of the dynflowd/foreman-tasks service is required."),
                5, N_('Host Tasks Workers Pool Size')),
       self.set('applicability_batch_size', N_("Number of host applicability calculations to process per task."),


### PR DESCRIPTION
I've got an edge condition where I'd like to allow host DMI to change if and only if a host is in build mode (ie I know I'm rebuilding it)

This patch should add an extra switch to let hosts get through, but is disabled by default so (a) the existing behavior is preserved and (b) folks who want this know they want it and can turn it on.