### PR TITLE
Fixes #32406 - Prevent re-register unless host is in build mode

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -146,6 +146,8 @@ class Setting::Content < Setting
       self.set('host_profile_assume_build_can_change', N_("Allow Host registrations to bypass 'Host Profile Assume' " \
                   "as long as the host is in build mode."),
                false, N_('Host Profile Can Change In Build')),
+      self.set('host_re_register_build_only', N_("Allow hosts to re-register themselves only when they are in build mode"),
+               false, N_('Host Can Re-Register Only In Build')),
       self.set('host_tasks_workers_pool_size', N_("Amount of workers in the pool to handle the execution of host-related tasks. When set to 0, the default queue will be used instead. Restart of the dynflowd/foreman-tasks service is required."),
                5, N_('Host Tasks Workers Pool Size')),
       self.set('applicability_batch_size', N_("Number of host applicability calculations to process per task."),

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -87,6 +87,10 @@ module Katello
           host = hosts.first
 
           if host.name == host_name
+            if !host.build && Setting[:host_re_register_build_only]
+              registration_error("Host with name %{host_name} is currently registered but not in build mode (host_re_register_build_only==True). Unregister the host manually or put it into build mode to continue.", host_name: host_name)
+            end
+
             current_dmi_uuid = host.subscription_facet&.dmi_uuid
             dmi_uuid_changed = current_dmi_uuid && current_dmi_uuid != host_uuid
             if dmi_uuid_changed && !dmi_uuid_change_allowed?(host, host_uuid_overridden)


### PR DESCRIPTION
This should help keep hosts from registering under a name that is already in use unless that host is in build mode.