### PR TITLE
Fixes #32407 - Trim the Metadata json

### DIFF
--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -65,14 +65,18 @@ module Katello
     def metadata_params
       params.require(:metadata).permit(
         :organization,
-        :repository_mapping,
+        :repositories,
+        :products,
+        :gpg_keys,
         :toc,
         :incremental,
         content_view: [:name, :label, :description],
-        content_view_version: [:major, :minor],
+        content_view_version: [:major, :minor, :description],
         from_content_view_version: [:major, :minor]
       ).tap do |nested|
-        nested[:repository_mapping] = params[:metadata].require(:repository_mapping).permit!
+        nested[:repositories] = params[:metadata].require(:repositories).permit!
+        nested[:products] = params[:metadata].require(:products).permit!
+        nested[:gpg_keys] = params[:metadata].require(:gpg_keys).permit!
       end
     end
   end

--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -67,16 +67,15 @@ module Katello
         :organization,
         :repositories,
         :products,
-        :gpg_keys,
         :toc,
         :incremental,
+        gpg_keys: {},
         content_view: [:name, :label, :description],
         content_view_version: [:major, :minor, :description],
         from_content_view_version: [:major, :minor]
       ).tap do |nested|
         nested[:repositories] = params[:metadata].require(:repositories).permit!
         nested[:products] = params[:metadata].require(:products).permit!
-        nested[:gpg_keys] = params[:metadata].require(:gpg_keys).permit!
       end
     end
   end

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -16,12 +16,18 @@ module Actions
 
           major = metadata[:content_view_version][:major]
           minor = metadata[:content_view_version][:minor]
+          description = metadata[:content_view_version][:description]
+
+          gpg_helper = ::Katello::Pulp3::ContentViewVersion::ImportGpgKeys.
+                          new(organization: organization,
+                              metadata: metadata)
+          gpg_helper.import!
 
           sequence do
             plan_action(AutoCreateProducts, organization: content_view.organization, metadata: metadata)
             plan_action(AutoCreateRepositories, organization: content_view.organization, metadata: metadata)
             plan_action(ResetContentViewRepositoriesFromMetadata, content_view: content_view, metadata: metadata)
-            plan_action(::Actions::Katello::ContentView::Publish, content_view, '',
+            plan_action(::Actions::Katello::ContentView::Publish, content_view, description,
                           path: path,
                           metadata: metadata,
                           importing: true,

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -13,7 +13,7 @@ module Katello
 
         def repository_mapping
           mapping = {}
-          @metadata[:repository_mapping].each do |key, value|
+          @metadata[:repositories].each do |key, value|
             repo = @content_view_version.importable_repositories.joins(:root, :product).
                         where("#{::Katello::Product.table_name}" => {:label => value[:product][:label]},
                                                   "#{::Katello::RootRepository.table_name}" => {:label => value[:label]}).first
@@ -65,7 +65,7 @@ module Katello
           # Create a map that looks like -> {[product, repo]: {name: 'Foo Repo', label:.....}}
           # these values should be curated from the metadata.
           metadata_map = {}
-          metadata[:repository_mapping].values.each do |repo|
+          metadata[:repositories].values.each do |repo|
             next if custom_only && repo[:redhat]
             if product_only
               metadata_map[repo[:product][:label]] = repo[:product]

--- a/app/services/katello/pulp3/content_view_version/import_gpg_keys.rb
+++ b/app/services/katello/pulp3/content_view_version/import_gpg_keys.rb
@@ -1,0 +1,32 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class ImportGpgKeys
+        attr_accessor :organization, :metadata
+
+        def initialize(organization:, metadata:)
+          self.organization = organization
+          self.metadata = metadata
+        end
+
+        def create_or_update_gpg!(params)
+          return if params.blank?
+          gpg = organization.gpg_keys.find_by(:name => params[:name])
+          if gpg
+            gpg.update!(params.except(:name))
+          else
+            gpg = organization.gpg_keys.create!(params)
+          end
+          gpg
+        end
+
+        def import!
+          return if metadata[:gpg_keys].blank?
+          metadata[:gpg_keys].values.each do |gpg|
+            create_or_update_gpg!(gpg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/content_view_version/import_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/import_validator.rb
@@ -90,7 +90,7 @@ module Katello
           # repos_in_library look like [["prod1", "repo1", "Anonymous"], ["prod2", "repo2", "Red Hat"]]
           rh_repos_in_library = repos_in_library.redhat
           product_repos_in_library = rh_repos_in_library.map { |repo| [repo.product.label, repo.label] }
-          product_repos_in_metadata = metadata[:repository_mapping].values.map { |repo| [repo[:product][:label], repo[:label]] if repo[:redhat] }
+          product_repos_in_metadata = metadata[:repositories].values.map { |repo| [repo[:product][:label], repo[:label]] if repo[:redhat] }
           product_repos_in_metadata.compact!
 
           # product_repos_in_library & product_repos_in_metadata look like [["prod1", "repo1", false], ["prod2", "repo2", false]]

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -23,11 +23,14 @@ module Katello
           #            They are ready to be created
           # updatable: products that are both in the metadata and library.
           #            These may contain updates to the product and hence ready to be updated.
-          metadata_map = Import.metadata_map(metadata, product_only: true, custom_only: true)
-          metadata_map.each do |product_label, params|
-            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                               params: params[:gpg_key])&.id
-            params = params.except(:gpg_key)
+          metadata[:products].each do |product_label, params|
+            next if params[:redhat]
+            if params[:gpg_key].blank?
+              params[:gpg_key_id] = nil
+            else
+              params[:gpg_key_id] = organization.gpg_keys.find_by(name: params[:gpg_key][:name]).id
+            end
+            params = params.except(:gpg_key, :redhat)
             if products_in_library.include? product_label
               # add to the update list if product is already available
               product = ::Katello::Product.in_org(organization).find_by(label: product_label)

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -32,8 +32,11 @@ module Katello
             product = Katello::Product.in_org(organization).find_by(label: product_label)
             fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
             params = metadata_map[[product_label, repo_label]]
-            params[:gpg_key_id] = Import.create_or_update_gpg!(organization: organization,
-                                                               params: params[:gpg_key])&.id
+            if params[:gpg_key].blank?
+              params[:gpg_key_id] = nil
+            else
+              params[:gpg_key_id] = organization.gpg_keys.find_by(name: params[:gpg_key][:name]).id
+            end
             params = params.except(:redhat, :product, :gpg_key)
             if repositories_in_library.include? [product_label, repo_label]
               repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)

--- a/app/services/katello/pulp3/content_view_version/metadata_generator.rb
+++ b/app/services/katello/pulp3/content_view_version/metadata_generator.rb
@@ -1,0 +1,99 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class MetadataGenerator
+        attr_accessor :export_service, :gpg_keys, :products
+
+        delegate :repositories, :content_view_version, :from_content_view_version, :to => :export_service
+        delegate :content_view, :to => :content_view_version
+        delegate :organization, :to => :content_view
+
+        def initialize(export_service:)
+          self.export_service = export_service
+          self.gpg_keys = {}
+          self.products = {}
+        end
+
+        def generate!
+          ret = { organization: organization.name,
+                  repositories: {},
+                  content_view: content_view.slice(:name, :label, :description),
+                  content_view_version: content_view_version.slice(:major, :minor, :description),
+                  incremental: from_content_view_version.present?
+          }
+
+          unless from_content_view_version.blank?
+            ret[:from_content_view_version] = from_content_view_version.slice(:major, :minor)
+          end
+          repositories.each do |repo|
+            next if repo.version_href.blank?
+            pulp3_repo = export_service.fetch_repository_info(repo.version_href).name
+            ret[:repositories][pulp3_repo] = generate_repository_metadata(repo)
+          end
+
+          zip_products(ret[:repositories].values)
+
+          zip_gpg_keys(ret[:repositories].values)
+          zip_gpg_keys(products.values)
+
+          ret[:products] = products
+          ret[:gpg_keys] = gpg_keys
+          ret
+        end
+
+        def generate_repository_metadata(repo)
+          repo.slice(:name, :label, :description, :arch, :content_type, :unprotected,
+                     :checksum_type, :os_versions, :major, :minor).
+            merge(product: generate_product_metadata(repo.product),
+                  gpg_key: generate_gpg_metadata(repo.gpg_key),
+                  redhat: repo.redhat?)
+        end
+
+        def generate_product_metadata(product)
+          product.slice(:name, :label, :description).
+            merge(gpg_key: generate_gpg_metadata(product.gpg_key),
+                  redhat: product.redhat?)
+        end
+
+        def generate_gpg_metadata(gpg)
+          return {} if gpg.blank?
+          gpg.slice(:name, :content_type, :content)
+        end
+
+        def zip_gpg_keys(entities)
+          # this goes through each repo/product
+          # identifies gpg keys
+          # updates the gpg_keys map if necessary
+          # replaces the value of gpg_key by just the name
+          # For example:
+          # Input: {label: 'repo', gpg_key: {name: 'who', content: 'great'}}
+          # Output: {label: 'repo', gpg_key: {name: 'who'}}
+          entities.each do |entity|
+            gpg = entity[:gpg_key]
+            unless gpg.blank? || gpg_keys.key?(gpg[:name])
+              gpg_keys[gpg[:name]] = gpg
+            end
+            entity[:gpg_key] = gpg.slice(:name)
+          end
+        end
+
+        def zip_products(repos)
+          # this goes through each repo
+          # identifies product
+          # updates the products map if necessary
+          # replaces the value of product by just the label
+          # For example:
+          # Input: {label: 'repo', product: {name: 'prod', label: 'foo', description: 'great'}}
+          # Output: {label: 'repo', product: {label: 'foo'}}
+          repos.each do |repo|
+            product = repo[:product]
+            unless products.key?(product[:label])
+              products[product[:label]] = product
+            end
+            repo[:product] = product.slice(:label)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/actions/katello/content_view_version/import_library_test.rb
+++ b/test/actions/katello/content_view_version/import_library_test.rb
@@ -26,9 +26,13 @@ module ::Actions::Katello::ContentViewVersion
       prod = katello_products(:redhat)
 
       {
-        repository_mapping: {
+        products: {
+          prod.label => prod.slice(:name, :label).merge(redhat: prod.redhat?)
+        },
+        gpg_keys: {},
+        repositories: {
           "misc-24037" => { label: prod.repositories.first.label,
-                            product: prod.slice(:name, :label),
+                            product: prod.slice(:label),
                             redhat: prod.redhat?
           }
         },

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -31,18 +31,27 @@ module ::Actions::Katello::ContentViewVersion
       prod = katello_products(:redhat)
 
       {
-        repository_mapping: {
+        products: {
+          prod.label => prod.slice(:label, :name).merge(redhat: prod.redhat?)
+        },
+        repositories: {
           "misc-24037" => { label: prod.repositories.first.label,
-                            product: prod.slice(:label, :name),
+                            product: prod.slice(:label),
                             redhat: prod.redhat?
           }
         },
+        gpg_keys: {},
         content_view_version: {
           major: content_view_version.major,
-          minor: content_view_version.minor
+          minor: content_view_version.minor,
+          description: description
         },
         content_view: content_view.slice(:label, :name, :description)
       }.with_indifferent_access
+    end
+
+    let(:description) do
+      "cool cvv"
     end
 
     let(:path) do
@@ -90,7 +99,7 @@ module ::Actions::Katello::ContentViewVersion
         plan_action(action, organization: organization, path: path, metadata: metadata)
         assert_action_planned_with(action,
                                     ::Actions::Katello::ContentView::Publish,
-                                    content_view, '',
+                                    content_view, description,
                                     path: path,
                                     metadata: metadata,
                                     importing: true,
@@ -109,7 +118,7 @@ module ::Actions::Katello::ContentViewVersion
         assert content_view.import_only?
         assert_action_planned_with(action,
                                     ::Actions::Katello::ContentView::Publish,
-                                    content_view, '',
+                                    content_view, description,
                                     path: path,
                                     metadata: metadata,
                                     importing: true,
@@ -128,7 +137,7 @@ module ::Actions::Katello::ContentViewVersion
         assert content_view.import_only?
         assert_action_planned_with(action,
                                     ::Actions::Katello::ContentView::Publish,
-                                    content_view, '',
+                                    content_view, description,
                                     path: path,
                                     metadata: metadata,
                                     importing: true,

--- a/test/controllers/api/v2/content_imports_controller_test.rb
+++ b/test/controllers/api/v2/content_imports_controller_test.rb
@@ -5,11 +5,15 @@ module Katello
     include Support::ForemanTasks::Task
     METADATA = {
       organization: "org name",
-      repository_mapping: {
+      products: {
+        'label' => { name: 'product name', label: 'label' }
+      },
+      gpg_keys: {'foo' => {label: 'lol'} },
+      repositories: {
         'repo name' => {
           name: 'root repo name',
           label: 'root_label',
-          product: { name: 'product name', label: 'label' },
+          product: { label: 'label' },
           redhat: true
         }
       },

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -23,7 +23,7 @@ module Katello
             assert_equal data[:content_view], version.content_view.slice(:name, :label, :description)
 
             version_repositories = version.archived_repos.yum_type
-            data[:repository_mapping].each do |name, repo_info|
+            data[:repositories].each do |name, repo_info|
               repo = version_repositories[name.to_i]
               assert_equal repo_info[:repository][:name], repo.root.name
               assert_equal repo_info[:product].slice(:name, :label), repo.root.product.slice(:name, :label)

--- a/test/services/katello/pulp3/content_view_version/import_validator_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_validator_test.rb
@@ -70,13 +70,16 @@ module Katello
               exception = assert_raises(RuntimeError) do
                 metadata = { content_view: cvv.content_view.slice(:name, :label, :description),
                              content_view_version: { major: cvv.major + 10, minor: cvv.minor },
-                             repository_mapping: {
+                             products: {
+                               repo.product.label => repo.product.slice(:name, :label).merge(redhat: !repo.redhat?)
+                             },
+                             repositories: {
                                "misc-24037": { label: repo.label,
                                                product: { name: repo.product.name, label: repo.product.label},
                                                redhat: !repo.redhat?
                                              }
-                             }
-
+                             },
+                             gpg_keys: {}
                 }
                 validator(content_view: cvv.content_view, metadata: metadata).check!
               end
@@ -91,9 +94,13 @@ module Katello
               exception = assert_raises(RuntimeError) do
                 metadata = { content_view: cv.slice(:name, :label, :description),
                              content_view_version: { major: cvv.major + 10, minor: cvv.minor },
-                             repository_mapping: {
+                             products: {
+                               "prod" => { name: "prod", label: 'prod'}
+                             },
+                             gpg_keys: {},
+                             repositories: {
                                "misc-24037": { label: "misc",
-                                               product: { name: "prod", label: 'prod'},
+                                               product: {label: 'prod'},
                                                "redhat": true
                                              }
                              }

--- a/test/services/katello/pulp3/content_view_version/importable_products_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_products_test.rb
@@ -10,23 +10,25 @@ module Katello
             repo = katello_repositories(:fedora_17_x86_64)
             new_prod_1 = "New-Prod-1"
             new_prod_2 = "New-Prod-2"
-            gpg_key = "MyCoolKey10000"
-
+            gpg_key = katello_gpg_keys(:fedora_gpg_key)
             metadata = {
-              repository_mapping: {
+              products: {
+                new_prod_1 => { label: new_prod_1, name: new_prod_1, gpg_key: { name: gpg_key.name }},
+                new_prod_2 => { label: new_prod_2, name: new_prod_2, gpg_key: { name: gpg_key.name }},
+                repo.product.label => repo.product.slice(:name, :label)
+              },
+              gpg_keys: { gpg_key => gpg_key.slice(:name, :content) },
+              repositories: {
                 "misc-24037": { "label": repo.label,
                                 "product": { label: repo.product.label },
                                 "redhat": repo.redhat?
                               },
                 "hoo-24037": { "label": repo.label,
-                               "product": { label: new_prod_1, name: new_prod_1 },
+                               "product": { label: new_prod_1 },
                                "redhat": false
                              },
                 "hah-24037": { "label": repo.label,
-                               "product": { label: new_prod_2,
-                                            name: new_prod_1,
-                                            gpg_key: { name: gpg_key, content: "wow" }
-                                           },
+                               "product": { label: new_prod_2 },
                                "redhat": false
                              }
               }
@@ -39,8 +41,7 @@ module Katello
             refute_includes helper.creatable.map { |prod| prod[:product].label }, repo.product.label
             assert_includes helper.updatable.map { |prod| prod[:product].label }, repo.product.label
             refute_includes helper.updatable.map { |prod| prod[:product].label }, new_prod_1
-
-            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key)
+            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key.name)
           end
         end
       end

--- a/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
@@ -10,22 +10,29 @@ module Katello
             repo = katello_repositories(:fedora_17_x86_64)
             new_repo_1 = "New-Repo-1"
             new_repo_2 = "New-Repo-2"
-            gpg_key = "MyCoolKey10000"
+            gpg_key = katello_gpg_keys(:fedora_gpg_key)
+            product_label = repo.product.label
             metadata = {
-              repository_mapping: {
+              products: {
+                product_label => { label: product_label }
+              },
+              repositories: {
                 "misc-24037": { "label": repo.label,
-                                "product": { label: repo.product.label },
+                                "product": { label: product_label },
                                 "redhat": repo.redhat?
                               },
                 "hoo-24037": { "label": new_repo_1,
-                               "product": { label: repo.product.label },
+                               "product": { label: product_label },
                                "redhat": false
                               },
                 "hah-24037": { "label": new_repo_2,
-                               "product": { label: repo.product.label },
+                               "product": { label: product_label },
                                "redhat": false,
-                               "gpg_key": { name: gpg_key, content: "wow" }
+                               "gpg_key": { name: gpg_key.name }
                               }
+              },
+              gpg_keys: {
+                gpg_key => gpg_key.slice(:name, :content)
               }
             }.with_indifferent_access
             helper = Katello::Pulp3::ContentViewVersion::ImportableRepositories.
@@ -38,7 +45,7 @@ module Katello
             assert_includes helper.updatable.map { |r| r[:repository].label }, repo.label
             refute_includes helper.updatable.map { |r| r[:repository].label }, new_repo_1
 
-            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key)
+            refute_nil repo.organization.gpg_keys.find_by(name: gpg_key.name)
           end
         end
       end


### PR DESCRIPTION
Trimmed the json to have the products and gpg_keys in separate lists.
Also moved some of the metadata generation to a Metadata Generator
class.