### PR TITLE
Fixes #32425 - Add 'view_smart_proxies' permission to 'Register hosts' role

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -356,7 +356,7 @@ Foreman::Plugin.register :katello do
     :attach_subscriptions, :view_host_collections,
     :view_organizations, :view_lifecycle_environments, :view_products,
     :view_locations, :view_domains, :view_architectures,
-    :view_operatingsystems
+    :view_operatingsystems, :view_smart_proxies
   ]
 
   def find_katello_assets(args = {})


### PR DESCRIPTION
**Issue**
Non-Admin users cannot generate the curl command for automated registration while having "Register hosts" role associated with them.

**Steps to Reproduce:**
1. Create a user called testuser in the Satellite server and assign the "Register hosts" role to the same.
2. Login to Satellite UI using that testuser.
3. Go to Hosts --> All Hosts --> Register Host
4. Select All Parameters as applicable related to registration
5. Click on "Generate Command"

**Actual results:**
```
echo "ERROR: not_found";
exit 1
```

**Expected results:**
It should be able to generate the curl command with token as expected [ or it can for an admin user ]