### PR TITLE
Fixes #32429 - Permit use of version 2.11 of the pulp_deb_client

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.6.0", "< 1.7.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.7", "< 0.8"
   gem.add_dependency "pulp_container_client", ">= 2.4.0", "< 2.5.0"
-  gem.add_dependency "pulp_deb_client", ">= 2.10.0", "< 2.11.0"
+  gem.add_dependency "pulp_deb_client", ">= 2.10.0", "< 2.12.0"
   gem.add_dependency "pulp_rpm_client", ">=3.10.0", "< 3.11.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
 


### PR DESCRIPTION
https://projects.theforeman.org/issues/32429

See also: https://github.com/theforeman/foreman-packaging/pull/6566

This merely raises the dependency ceiling.