### PR TITLE
Fixes #32436 - content host and host collection errata, package, module installation via remote execution

### DIFF
--- a/app/controllers/katello/concerns/api/v2/host_errata_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/host_errata_extensions.rb
@@ -1,0 +1,41 @@
+module Katello
+  module Concerns
+    module Api::V2::HostErrataExtensions
+      extend ActiveSupport::Concern
+
+      def find_bulk_errata_ids(hosts, bulk_errata_ids)
+        bulk_params = ActiveSupport::JSON.decode(bulk_errata_ids).deep_symbolize_keys
+        bulk_params[:included] ||= {}
+        bulk_params[:excluded] ||= {}
+
+        if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
+          fail HttpErrors::BadRequest, _("No errata has been specified.")
+        end
+
+        #works on a structure of param_group bulk_params and transforms it into a list of errata_ids
+        errata = ::Katello::Erratum.installable_for_hosts(hosts)
+
+        if bulk_params[:included][:ids]
+          errata = errata.where(:errata_id => bulk_params[:included][:ids])
+        end
+
+        if bulk_params[:included][:search]
+          search_errata = ::Katello::Erratum.installable_for_hosts(hosts)
+          search_errata = search_errata.search_for(bulk_params[:included][:search])
+
+          if errata.any?
+            errata = errata.merge(search_errata)
+          else
+            errata = search_errata
+          end
+        end
+
+        if bulk_params[:excluded][:ids].present?
+          errata = errata.where.not(errata_id: bulk_params[:excluded][:ids])
+        end
+
+        errata.pluck(:errata_id)
+      end
+    end
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
@@ -41,9 +41,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkModuleStream
             remoteAction: 'module_stream_action'
         };
 
-        if (hostIds.included.ids) {
-            $scope.moduleStreamActionFormValues.hostIds = hostIds.included.ids.join(',');
-        }
+        $scope.moduleStreamActionFormValues.bulkHostIds = angular.toJson(hostIds);
 
         $scope.performViaRemoteExecution = function(moduleSpec, actionType) {
             $scope.working = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
@@ -137,11 +137,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
                 $scope.packageActionFormValues.remoteAction = 'package_' + action;
             }
 
-            if ($scope.allHostsSelected) {
-                $scope.packageActionFormValues.scopedSearch = selectedHosts.included.search;
-            } else if (selectedHosts.included.ids.length > 0) {
-                $scope.packageActionFormValues.hostIds = selectedHosts.included.ids.join(',');
-            }
+            $scope.packageActionFormValues.bulkHostIds = angular.toJson(selectedHosts);
 
             $timeout(function () {
                 angular.element('#packageActionForm').submit();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
@@ -9,7 +9,7 @@
       <input type="hidden" name="remote_action" ng-value="moduleStreamActionFormValues.remoteAction"/>
       <input type="hidden" name="module_stream_action" ng-value="moduleStreamActionFormValues.moduleStreamAction"/>
       <input type="hidden" name="module_spec" ng-value="moduleStreamActionFormValues.moduleSpec"/>
-      <input type="hidden" name="host_ids" ng-value="moduleStreamActionFormValues.hostIds"/>
+      <input type="hidden" name="bulk_host_ids" ng-value="moduleStreamActionFormValues.bulkHostIds"/>
       <input type="hidden" name="customize" ng-value="moduleStreamActionFormValues.customize"/>
       <input type="hidden" name="authenticity_token" ng-value="moduleStreamActionFormValues.authenticityToken"/>
     </form>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -3,9 +3,9 @@
 
   <div data-block="modal-body">
     <form id="errataActionForm" name="errataActionForm" class="form" method="post" action="/katello/remote_execution">
-      <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
       <input type="hidden" name="remote_action" ng-value="errataActionFormValues.remoteAction"/>
-      <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+      <input type="hidden" name="bulk_host_ids" ng-value="errataActionFormValues.bulkHostIds"/>
+      <input type="hidden" name="bulk_errata_ids" ng-value="errataActionFormValues.bulkErrataIds"/>
       <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
       <input type="hidden" ng-if="allHostsSelected" name="scoped_search" ng-value="errataActionFormValues.scopedSearch"/>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -42,7 +42,7 @@
     <form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
       <input type="hidden" name="name" ng-value="content.content"/>
       <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
-      <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
+      <input type="hidden" name="bulk_host_ids" ng-value="packageActionFormValues.bulkHostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
       <input type="hidden" ng-if="allHostsSelected" name="scoped_search" ng-value="packageActionFormValues.scopedSearch"/>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -135,8 +135,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
 
         $scope.performViaRemoteExecution = function(customize) {
             var errataIds = $scope.selectedErrataIds();
-            $scope.errataActionFormValues.errata = errataIds.included.ids.join(',');
-            $scope.errataActionFormValues.hostIds = $scope.host.id;
+
+            $scope.errataActionFormValues.bulkErrataIds = angular.toJson(errataIds);
+            $scope.errataActionFormValues.bulkHostIds = angular.toJson({ included: { ids: [$scope.host.id] }});
+
+            $scope.errataActionFormValues.remoteAction = 'errata_install';
             $scope.errataActionFormValues.customize = customize;
 
             $timeout(function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -49,7 +49,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsCont
             $scope.working = true;
             $scope.moduleStreamActionFormValues.moduleSpec = moduleSpec;
             $scope.moduleStreamActionFormValues.moduleStreamAction = actionType;
-            $scope.moduleStreamActionFormValues.hostIds = $scope.host.id;
+            $scope.moduleStreamActionFormValues.bulkHostIds = angular.toJson({ included: { ids: [$scope.host.id] }});
 
             $timeout(function () {
                 angular.element('#moduleStreamActionForm').submit();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -67,7 +67,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
             $scope.working = true;
             $scope.packageActionFormValues.package = terms.join(' ');
             $scope.packageActionFormValues.remoteAction = actionType;
-            $scope.packageActionFormValues.hostIds = $scope.host.id;
+            $scope.packageActionFormValues.bulkHostIds = angular.toJson({ included: { ids: [$scope.host.id] }});
             $scope.packageActionFormValues.customize = customize;
 
             $timeout(function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -34,10 +34,10 @@
   <form id="errataActionForm" method="post" action="/katello/remote_execution">
     <input type="hidden" name="remote_action" value="errata_install"/>
     <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
-    <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+    <input type="hidden" name="bulk_host_ids" ng-value="errataActionFormValues.bulkHostIds"/>
+    <input type="hidden" name="bulk_errata_ids" ng-value="errataActionFormValues.bulkErrataIds"/>
     <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
     <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
-    <input type="hidden" name="install_all" ng-value="table.allResultsSelected" />
   </form>
 
   <div data-extend-template="layouts/partials/table.html">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
@@ -13,7 +13,7 @@
     <input type="hidden" name="remote_action" ng-value="moduleStreamActionFormValues.remoteAction"/>
     <input type="hidden" name="module_stream_action" ng-value="moduleStreamActionFormValues.moduleStreamAction"/>
     <input type="hidden" name="module_spec" ng-value="moduleStreamActionFormValues.moduleSpec"/>
-    <input type="hidden" name="host_ids" ng-value="moduleStreamActionFormValues.hostIds"/>
+    <input type="hidden" name="bulk_host_ids" ng-value="moduleStreamActionFormValues.hostHostIds"/>
     <input type="hidden" name="customize" ng-value="moduleStreamActionFormValues.customize"/>
     <input type="hidden" name="authenticity_token" ng-value="moduleStreamActionFormValues.authenticityToken"/>
   </form>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
@@ -1,7 +1,7 @@
 <form role="form" id="packageActionForm" method="post" action="/katello/remote_execution">
   <input type="hidden" name="name" ng-value="packageActionFormValues.package"/>
   <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
-  <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
+  <input type="hidden" name="bulk_host_ids" ng-value="packageActionFormValues.bulkHostIds"/>
   <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
   <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
 </form>

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.test.js
@@ -58,12 +58,12 @@ describe('Controller: ContentHostsBulkModuleStreamsModalController', function() 
         expect($uibModalInstance.dismiss).toHaveBeenCalled();
     });
 
-    it("can call module stream actions on multiple content hosts", function() { 
+    it("can call module stream actions on multiple content hosts", function() {
         formValues = {
-            authenticityToken: 'secret_token', 
-            remoteAction: 'module_stream_action', 
-            hostIds: '1,2,3', 
-            moduleSpec: 'django:1.9', 
+            authenticityToken: 'secret_token',
+            remoteAction: 'module_stream_action',
+            bulkHostIds: angular.toJson({ included: { ids: [1,2,3] }}), 
+            moduleSpec: 'django:1.9',
             moduleStreamAction: 'enable'
         };
         $scope.performViaRemoteExecution("django:1.9", "enable");;

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -50,7 +50,7 @@ describe('Controller: ContentHostErrataController', function() {
             this.enableSelectAllResults = function () {};
             this.getAllSelectedResults = function() {
                 return {
-                    included: { ids: [mockErratum.errata_id] }
+                    included: { ids: [mockErratum.errata_id] , params: {} }
                 };
             };
         };
@@ -103,7 +103,7 @@ describe('Controller: ContentHostErrataController', function() {
         spyOn($scope.table, "selectAll");
         spyOn($scope, "transitionTo");
         $scope.applySelected();
-        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: {included: { ids: [mockErratum.errata_id]}}},
+        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: {included: { ids: [mockErratum.errata_id], params: {} }}},
                                                          jasmine.any(Function));
         expect($scope.transitionTo).toHaveBeenCalledWith('content-host.tasks.details', {taskId: mockTask.id});
         expect($scope.table.selectAll).toHaveBeenCalledWith(false);
@@ -114,9 +114,9 @@ describe('Controller: ContentHostErrataController', function() {
 
         $scope.applySelected();
 
-        expect($scope.errataActionFormValues.hostIds).toEqual(host.id);
+        expect($scope.errataActionFormValues.bulkHostIds).toEqual('{"included":{"ids":[' + host.id + ']}}');
         expect($scope.errataActionFormValues.customize).toEqual(false);
-        expect($scope.errataActionFormValues.errata).toEqual(mockErratum.errata_id);
+        expect($scope.errataActionFormValues.bulkErrataIds).toEqual('{"included":{"ids":["RHSA-1024"],"params":{}}}');
     });
 
     it("provide a way to regenerate applicability", function() {

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -97,7 +97,7 @@ describe('Controller: ContentHostPackagesController', function() {
         expect(HostPackage.install).not.toHaveBeenCalled();
         expect($scope.packageActionFormValues.package).toEqual('foo bar baz');
         expect($scope.packageActionFormValues.remoteAction).toEqual('packageInstall');
-        expect($scope.packageActionFormValues.hostIds).toEqual(mockHost.id);
+        expect($scope.packageActionFormValues.bulkHostIds).toEqual('{"included":{"ids":[' + mockHost.id + ']}}');
         expect($scope.working).toBe(true);
     });
 

--- a/test/controllers/api/v2/concerns/host_errata_extensions_test.rb
+++ b/test/controllers/api/v2/concerns/host_errata_extensions_test.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class TestController
+    include Concerns::Api::V2::HostErrataExtensions
+  end
+
+  module Concerns
+    class Api::V2::HostErrataExtensionsTest < ActiveSupport::TestCase
+      def setup
+        @hosts = ::Host.all
+        @controller = TestController.new
+      end
+
+      test 'sending create with included ids yields those errata ids' do
+        ::Katello::Erratum.stubs(:installable_for_hosts).returns(::Katello::Erratum.all)
+
+        bulk_params = { included: { ids: ['RHSA-1999-1231', 'RHEA-2014-111'] }}.to_json
+        result = @controller.find_bulk_errata_ids(@hosts, bulk_params)
+
+        assert_equal ["RHSA-1999-1231", "RHEA-2014-111"].sort, result.sort
+      end
+
+      test 'sending create with included search yields those errata ids' do
+        ::Katello::Erratum.stubs(:installable_for_hosts).returns(::Katello::Erratum.all)
+
+        bulk_params = { included: { search: 'type=security' }}.to_json
+        @hosts = hosts(:one)
+
+        result = @controller.find_bulk_errata_ids(@hosts, bulk_params)
+
+        assert_equal ["RHSA-1999-1231"].sort, result.sort
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -44,7 +44,7 @@ module Katello
           :search => "errata_id = #{@errata.errata_id}"
         }
       }
-      result = @controller.find_bulk_errata_ids(bulk_params)
+      result = @controller.find_bulk_errata_ids([@host], bulk_params.to_json)
 
       assert_includes result, @errata.errata_id
     end
@@ -58,7 +58,7 @@ module Katello
           :ids => [@bugfix.errata_id]
         }
       }
-      result = @controller.find_bulk_errata_ids(bulk_params)
+      result = @controller.find_bulk_errata_ids([@host], bulk_params.to_json)
 
       refute_includes result, @bugfix.errata_id
       assert_includes result, @errata.errata_id
@@ -70,7 +70,7 @@ module Katello
           :ids => [@bugfix.errata_id]
         }
       }
-      result = @controller.find_bulk_errata_ids(bulk_params)
+      result = @controller.find_bulk_errata_ids([@host], bulk_params.to_json)
 
       refute_includes result, @errata.errata_id
       assert_includes result, @bugfix.errata_id
@@ -85,7 +85,7 @@ module Katello
           :ids => [@bugfix.errata_id]
         }
       }
-      result = @controller.find_bulk_errata_ids(bulk_params)
+      result = @controller.find_bulk_errata_ids([@host], bulk_params.to_json)
 
       refute_includes result, @bugfix.errata_id
       assert_includes result, @errata.errata_id
@@ -98,7 +98,7 @@ module Katello
         }
       }
       exception = assert_raises(HttpErrors::BadRequest) do
-        @controller.find_bulk_errata_ids(bulk_params)
+        @controller.find_bulk_errata_ids([@host], bulk_params.to_json)
       end
       assert_match(/No errata has been specified/, exception.message)
     end

--- a/test/controllers/remote_execution_controller_test.rb
+++ b/test/controllers/remote_execution_controller_test.rb
@@ -1,0 +1,84 @@
+require 'katello_test_helper'
+
+module Katello
+  class RemoteExecutionControllerTest < ActionController::TestCase
+    def setup
+      skip "RemoteExecution not used" unless Katello.with_remote_execution?
+      setup_controller_defaults
+      login_user(User.find(users(:admin).id))
+      models
+      permissions
+
+      @mock_composer = mock
+      @mock_composer.stubs(:save).returns(:true)
+      @mock_composer.stubs(:trigger).returns(:true)
+      @mock_composer.stubs(:job_invocation).returns(::JobInvocation.new)
+      @mock_composer.stubs(:rerun_possible?).returns(true)
+      @mock_composer.stubs(:available_job_categories).returns([])
+      @mock_composer.stubs(:remote_execution_feature_id).returns(1)
+      @mock_composer.stubs(:displayed_provider_types).returns([])
+
+      RemoteExecutionController.any_instance.stubs(:prepare_composer).returns(@mock_composer)
+    end
+
+    def test_customized_errata_install_shows_new
+      skip "RemoteExecution not used" unless Katello.with_remote_execution?
+      bulk_host_ids =
+        {
+          included: {
+            ids: [hosts(:one).id]
+          }
+        }.to_json
+
+      @controller.expects(:render).with(:action => "new")
+      post :create, params: {
+        :remote_action => "errata_install",
+        bulk_host_ids: bulk_host_ids, customize: true }
+
+      assert_response :success
+    end
+
+    def test_customized_errata_install_with_install_all_shows_new
+      skip "RemoteExecution not used" unless Katello.with_remote_execution?
+      bulk_host_ids =
+        {
+          included: {
+            ids: [hosts(:one).id]
+          }
+        }.to_json
+
+      @controller.expects(:render).with(:action => "new")
+      post :create, params: {
+        :remote_action => "errata_install",
+        bulk_host_ids: bulk_host_ids, customize: true,
+        install_all: true }
+
+      assert_response :success
+    end
+
+    def test_customized_errata_install_with_errata_id_shows_new
+      skip "RemoteExecution not used" unless Katello.with_remote_execution?
+      bulk_host_ids =
+        {
+          included: {
+            ids: [hosts(:one).id]
+          }
+        }.to_json
+
+      bulk_errata_ids =
+        {
+          included: {
+            ids: []
+          }
+        }.to_json
+
+      @controller.expects(:render).with(:action => "new")
+      post :create, params: {
+        :remote_action => "errata_install",
+        bulk_host_ids: bulk_host_ids, bulk_errata_ids: bulk_errata_ids,
+        customize: true }
+
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes "select all" for host collection (bulk) and host errata application via remote execution modals. This also fixes modal/remote execution interactions for host errata, package, and module activities.

Currently the modal is not working - if you "select all" the controller ignores any filter and only applies the first page of selected errata. The changes here addresses both the filter issues and the limitations of "select all" when more than 1 page of selected errata are desired.