### PR TITLE
Fixes #32449 - pulp3_migration_stats can underestimate migration timing

### DIFF
--- a/lib/katello/tasks/pulp3_migration_stats.rake
+++ b/lib/katello/tasks/pulp3_migration_stats.rake
@@ -10,7 +10,8 @@ namespace :katello do
     migratable_repo_count = ::Katello::Repository.count - ::Katello::Repository.puppet_type.count -
       ::Katello::Repository.ostree_type.count - ::Katello::Repository.deb_type.count
 
-    on_demand_rpm_count = Katello::RepositoryRpm.where(:repository_id => Katello::Repository.yum_type.on_demand).distinct.count
+    on_demand_rpm_count = Katello::RepositoryRpm.where(:repository_id => Katello::Repository.yum_type.on_demand).
+      select(:rpm_id).distinct.count
     on_demand_unmigrated_rpm_count = on_demand_rpm_count - migrated_rpm_count
     immediate_unmigrated_rpm_count = ::Katello::Rpm.count - migrated_rpm_count - on_demand_unmigrated_rpm_count
 


### PR DESCRIPTION
The lack of the select meant that the number of RepositoryRpms queried could be larger than the amount of RPMs.  This would cause on_demand_rpm_count to go negative.