### PR TITLE
Fixes #32528 - Auto create RH repos/Products upon import

### DIFF
--- a/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class AutoCreateRedhatRepositories < Actions::Base
+        def plan(organization:, metadata:)
+          helper = ::Katello::Pulp3::ContentViewVersion::ImportableRepositories.
+                      new(organization: organization,
+                      metadata: metadata, redhat: true)
+          helper.generate!
+          sequence do
+            helper.creatable.each do |root|
+              plan_action(::Actions::Katello::RepositorySet::EnableRepository, root[:product], root[:content], root[:substitutions])
+            end
+            helper.updatable.each do |root|
+              plan_action(::Actions::Katello::Repository::Update, root[:repository], root[:options])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -26,6 +26,7 @@ module Actions
           sequence do
             plan_action(AutoCreateProducts, organization: content_view.organization, metadata: metadata)
             plan_action(AutoCreateRepositories, organization: content_view.organization, metadata: metadata)
+            plan_action(AutoCreateRedhatRepositories, organization: content_view.organization, metadata: metadata)
             plan_action(ResetContentViewRepositoriesFromMetadata, content_view: content_view, metadata: metadata)
             plan_action(::Actions::Katello::ContentView::Publish, content_view, description,
                           path: path,

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -61,12 +61,12 @@ module Katello
           gpg
         end
 
-        def self.metadata_map(metadata, product_only: false, custom_only: false)
+        def self.metadata_map(metadata, product_only: false, custom_only: false, redhat_only: false)
           # Create a map that looks like -> {[product, repo]: {name: 'Foo Repo', label:.....}}
           # these values should be curated from the metadata.
           metadata_map = {}
           metadata[:repositories].values.each do |repo|
-            next if custom_only && repo[:redhat]
+            next if (custom_only && repo[:redhat]) || (redhat_only && !repo[:redhat])
             if product_only
               metadata_map[repo[:product][:label]] = repo[:product]
             else

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -2,20 +2,25 @@ module Katello
   module Pulp3
     module ContentViewVersion
       class ImportableRepositories
-        attr_accessor :creatable, :updatable, :organization, :metadata
+        attr_reader :creatable, :updatable, :organization, :metadata, :redhat
 
-        def initialize(organization:, metadata:)
-          self.organization = organization
-          self.metadata = metadata
-          self.creatable = []
-          self.updatable = []
+        def initialize(organization:, metadata:, redhat: false)
+          @organization = organization
+          @metadata = metadata
+          @creatable = []
+          @updatable = []
+          @redhat = redhat
+        end
+
+        def product_content_by_label(content_label)
+          ::Katello::Content.find_by_label(content_label)
         end
 
         def repositories_in_library
           return @repositories_in_library unless @repositories_in_library.blank?
-
+          repo_type = redhat ? :redhat : :custom
           # fetch a list of [product, repo] pairs for every non-redhat library repo
-          product_repos_in_library = Import.repositories_in_library(organization).custom.
+          product_repos_in_library = Import.repositories_in_library(organization).send(repo_type).
                                       pluck("#{Katello::Product.table_name}.label",
                                             "#{Katello::RootRepository.table_name}.label")
           @repositories_in_library = Set.new(product_repos_in_library.compact)
@@ -27,7 +32,7 @@ module Katello
           #         They are ready to be created
           # updatable: repo that are both in the metadata and library.
           #         These may contain updates to the repo and hence ready to be updated.
-          metadata_map = Import.metadata_map(metadata, custom_only: true)
+          metadata_map = Import.metadata_map(metadata, custom_only: !redhat, redhat_only: redhat)
           metadata_map.keys.each do |product_label, repo_label|
             product = Katello::Product.in_org(organization).find_by(label: product_label)
             fail _("Unable to find product '%s' in organization '%s'" % [product_label, organization.name]) if product.blank?
@@ -37,10 +42,18 @@ module Katello
             else
               params[:gpg_key_id] = organization.gpg_keys.find_by(name: params[:gpg_key][:name]).id
             end
-            params = params.except(:redhat, :product, :gpg_key)
+            content = params[:content]
+            params = params.except(:redhat, :product, :gpg_key, :content)
             if repositories_in_library.include? [product_label, repo_label]
               repo = ::Katello::RootRepository.find_by(product: product, label: repo_label)
               updatable << { repository: repo, options: params.except(:label, :name, :content_type) }
+            elsif redhat
+              product_content = product_content_by_label(content[:label])
+              substitutions = {
+                basearch: params[:arch],
+                releasever: params[:minor]
+              }
+              creatable << { product: product, content: product_content, substitutions: substitutions }
             else
               creatable << { repository: product.add_repo(params) }
             end

--- a/app/services/katello/pulp3/content_view_version/metadata_generator.rb
+++ b/app/services/katello/pulp3/content_view_version/metadata_generator.rb
@@ -46,6 +46,7 @@ module Katello
                      :checksum_type, :os_versions, :major, :minor).
             merge(product: generate_product_metadata(repo.product),
                   gpg_key: generate_gpg_metadata(repo.gpg_key),
+                  content: generate_content_metadata(repo.content),
                   redhat: repo.redhat?)
         end
 
@@ -58,6 +59,11 @@ module Katello
         def generate_gpg_metadata(gpg)
           return {} if gpg.blank?
           gpg.slice(:name, :content_type, :content)
+        end
+
+        def generate_content_metadata(content)
+          return {} if content.blank?
+          { id: content.cp_content_id, label: content.label }
         end
 
         def zip_gpg_keys(entities)


### PR DESCRIPTION
To test this:

Have this PR and Katello/hammer-cli-katello master checked out.

* In your main org upload a Red Hat Manifest
* Enable a Red Hat Repo, I used the Red Hat Ansible one (top one in recommended repos since it's small)
* Change the repo from `on_demand` to `immediate`
* Sync the Repo
* Now export the library using `hammer content-export complete library --organization=<...>..`

* Create a new org for the export
* Try to import the library without importing a manifest in the export org to test that the manifest validator works
* Import a different manifest, since we can't have the same one in multiple orgs
* Try to import the library export `hammer content-import library --organization=xxxx --path=/var/lib/pulp/exports/export-3439/Export-Library/9.0/2021-04-21T01-59-57-00-00 --metadata-file=metadata.json`
* Verify the RH Product got created, the repo got enabled and synchronized.
