### PR TITLE
Fixes #32464 - Inherited hostgroup values are not passed to host

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -121,7 +121,7 @@ module Katello
           facet_model = Facets.registered_facets[facet].hostgroup_configuration.model
           value = facet_model.where.not(attribute => nil).joins(:hostgroup).merge(
             ::Hostgroup.where(id: self.ancestor_ids).reorder(ancestry: :desc)
-          ).limit(1).pluck(attribute)
+          ).limit(1).pluck(attribute).first
         end
         value
       end


### PR DESCRIPTION
User is unable to create a host using a nested hostgroup because all values that inherited from the parent host group are not set, such has content_view_id, content_source_id, lifecycle_environment_id and kickstart_repository_id. This commit fixes the issue.