### PR TITLE
Fixes #32471 - Use pulp_deb 2.9 for Katello 4.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.2.0", "< 1.6.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.2", "< 0.7"
   gem.add_dependency "pulp_container_client", ">= 2.0.0", "< 2.3.0"
-  gem.add_dependency "pulp_deb_client", ">= 2.6.0", "< 2.9.0"
+  gem.add_dependency "pulp_deb_client", ">= 2.9.0", "< 2.10.0"
   gem.add_dependency "pulp_rpm_client", ">=3.10.0", "< 3.11.0"
   gem.add_dependency "pulp_2to3_migration_client", ">= 0.7.0", "< 1.0.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"


### PR DESCRIPTION
https://projects.theforeman.org/issues/32471

As I understand it, the merge of this PR, needs to be coordinated with:

- https://github.com/theforeman/pulpcore-packaging/pull/145
- https://github.com/theforeman/foreman-packaging/pull/6587
- The Katello 4.0.1 release