### PR TITLE
Fixes #32472 - Use pulp_deb 2.9 for Katello 3.18

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.2.0", "< 1.4.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.2", "< 0.5"
   gem.add_dependency "pulp_container_client", ">= 2.0.0", "< 2.2.0"
-  gem.add_dependency "pulp_deb_client", ">= 2.6.0", "< 2.8.0"
+  gem.add_dependency "pulp_deb_client", ">= 2.9.0", "< 2.10.0"
   gem.add_dependency "pulp_rpm_client", ">=3.10.0", "< 3.11.0"
   gem.add_dependency "pulp_2to3_migration_client", ">= 0.8.0", "< 1.0.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"


### PR DESCRIPTION
https://projects.theforeman.org/issues/32472

As I understand it, the merge of this PR, needs to be coordinated with:

- https://github.com/theforeman/pulpcore-packaging/pull/144
- https://github.com/theforeman/foreman-packaging/pull/6588
- The Katello 3.18.4 release