### PR TITLE
Fixes #32487: Use Foreman client certificates to communicate with Pulp

### DIFF
--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -31,9 +31,9 @@ module Katello
             uri = URI.parse(content_app_url)
             self.prefix = "/pulpcore_registry/"
             self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
-            self.ssl_client_cert = ::Cert::Certs.ssl_client_cert
-            self.ssl_client_key = ::Cert::Certs.ssl_client_key
             self.ca_cert_file = Setting[:ssl_ca_file]
+            pulp_primary.pulp3_ssl_configuration(self)
+
             self
           end
 

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -141,12 +141,14 @@ module Katello
       end
 
       def pulp3_ssl_configuration(config)
+        legacy_pulp_cert = !self.setting(PULP3_FEATURE, 'client_authentication')&.include?('client_certificates')
+
         if Faraday.default_adapter == :excon
-          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename
-          config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename
+          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename(use_admin_as_cn_cert: legacy_pulp_cert)
+          config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename(use_admin_as_cn_cert: legacy_pulp_cert)
         elsif Faraday.default_adapter == :net_http
-          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert
-          config.ssl_client_key = ::Cert::Certs.ssl_client_key
+          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert(use_admin_as_cn_cert: legacy_pulp_cert)
+          config.ssl_client_key = ::Cert::Certs.ssl_client_key(use_admin_as_cn_cert: legacy_pulp_cert)
         else
           fail "Unexpected faraday default_adapter #{Faraday.default_adapter}!  Cannot continue, this is likely a bug."
         end

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -12,20 +12,28 @@ module Cert
       File.read(SETTINGS[:katello][:candlepin][:ca_cert_file])
     end
 
-    def self.ssl_client_cert
-      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.read(ssl_client_cert_filename))
+    def self.ssl_client_cert(use_admin_as_cn_cert: false)
+      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.read(ssl_client_cert_filename(use_admin_as_cn_cert: use_admin_as_cn_cert)))
     end
 
-    def self.ssl_client_cert_filename
-      Setting['pulp_client_cert']
+    def self.ssl_client_cert_filename(use_admin_as_cn_cert: false)
+      if use_admin_as_cn_cert
+        Setting[:pulp_client_cert]
+      else
+        Setting[:ssl_certificate]
+      end
     end
 
-    def self.ssl_client_key
-      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename))
+    def self.ssl_client_key(use_admin_as_cn_cert: false)
+      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename(use_admin_as_cn_cert: use_admin_as_cn_cert)))
     end
 
-    def self.ssl_client_key_filename
-      Setting['pulp_client_key']
+    def self.ssl_client_key_filename(use_admin_as_cn_cert: false)
+      if use_admin_as_cn_cert
+        Setting[:pulp_client_key]
+      else
+        Setting[:ssl_priv_key]
+      end
     end
 
     def self.verify_ueber_cert(organization)

--- a/app/services/katello/pulp/server.rb
+++ b/app/services/katello/pulp/server.rb
@@ -17,8 +17,8 @@ module Katello
             :debug => true
           },
           :cert_auth => {
-            :ssl_client_cert => ::Cert::Certs.ssl_client_cert,
-            :ssl_client_key => ::Cert::Certs.ssl_client_key
+            :ssl_client_cert => ::Cert::Certs.ssl_client_cert(use_admin_as_cn_pulp_cert: true),
+            :ssl_client_key => ::Cert::Certs.ssl_client_key(use_admin_as_cn_pulp_cert: true)
           }
         }
 


### PR DESCRIPTION
See https://community.theforeman.org/t/rfc-using-foreman-client-certificates-for-all-backend-service-communication/23391 for some reference

Requires:
  * https://github.com/theforeman/puppet-pulpcore/pull/186 -- MERGED
  * https://github.com/theforeman/puppet-foreman_proxy_content/pull/350