### PR TITLE
Fixes #32162 - Back button doesn't work to return to list

### DIFF
--- a/webpack/components/RoutedTabs/RoutedTabs.js
+++ b/webpack/components/RoutedTabs/RoutedTabs.js
@@ -24,7 +24,7 @@ const RoutedTabs = ({
     if (matchedTab) {
       history.push(buildLink(matchedTab.key));
     } else {
-      history.push(buildLink(tabs[defaultTabIndex].key)); // go to first tab if no tab selected
+      history.replace(buildLink(tabs[defaultTabIndex].key)); // go to first tab if no tab selected
     }
   };
 


### PR DESCRIPTION
To test this on the new UI:

1. Enable the setting Administer > Settings > General > Show Experimental Labs
2. Refresh
3. You should see Lab features in the navigation menu
4. Go to Lab Features> Content views
5. From the list page, click on any CV
6. Hit back. It should take you back to list page with this PR.
7. Also move around tabs Versions, repositories, History etc on the CV details.
8. Back and forward buttons on the browser should take you back and forward correctly.
