### PR TITLE
Fixes #32137 - Deprecate package groups UI for content hosts

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -15,7 +15,7 @@ module Katello
 
     def_param_group :packages_or_groups do
       param :packages, Array, :desc => N_("List of package names"), :required => false
-      param :groups, Array, :desc => N_("List of package group names"), :required => false
+      param :groups, Array, :desc => N_("List of package group names (Deprecated)"), :required => false
     end
 
     api :GET, "/hosts/:host_id/packages", N_("List packages installed on the host")

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -120,7 +120,7 @@ module Katello
     param :content_type, String,
           :desc => N_("The type of content.  The following types are supported: 'package', 'package_group' and 'errata'."),
           :required => true
-    param :content, Array, :desc => N_("List of content (e.g. package names, package group names or errata ids)")
+    param :content, Array, :desc => N_("List of content (e.g. package names, package group names (Deprecated) or errata ids)")
     def install_content
       content_action
     end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -15,6 +15,11 @@
           Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
           </span>
       </p>
+      <p bst-alert="warning">
+        <span translate>
+          Group package actions are being deprecated, and will be removed in a future version.
+          </span>
+      </p>
     </div>
 
     <span uib-dropdown class="input-group-btn">
@@ -64,7 +69,7 @@
                  ng-change="updatePlaceholder(content.contentType)"
                  ng-disabled="content.confirm"
                  value="package_group"/>
-          <span translate>Package Group</span>
+          <span translate>Package Group (Deprecated)</span>
         </label>
       </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -8,6 +8,11 @@
       Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
       </span>
   </p>
+  <p bst-alert="warning">
+    <span translate>
+      Group package actions are being deprecated, and will be removed in a future version.
+      </span>
+  </p>
   <section>
     <div class="row">
       <form ng-submit="performPackageAction(packageAction.actionType, packageAction.term)" role="form">
@@ -17,8 +22,8 @@
             <option value="packageInstall" translate>Package Install</option>
             <option value="packageUpdate" translate>Package Update</option>
             <option value="packageRemove" translate>Package Remove</option>
-            <option value="groupInstall" translate>Group Install</option>
-            <option value="groupRemove" translate>Group Remove</option>
+            <option value="groupInstall" translate>Group Install (Deprecated)</option>
+            <option value="groupRemove" translate>Group Remove (Deprecated)</option>
           </select>
         </div>
 


### PR DESCRIPTION
To test:

* Register a client to your Katello
* Check to see if there is a warning on package actions page
* Check for (Deprecated) in the dropdown in package actions