### PR TITLE
Fixes #32510 - Parse AlmaLinux facts properly

### DIFF
--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -155,6 +155,8 @@ module Katello
           'Ubuntu'
         elsif name =~ /oracle/
           'OracleLinux'
+        elsif name =~ /almalinux/
+          'AlmaLinux'
         else
           'Unknown'
         end

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -142,6 +142,17 @@ module Katello
       assert_equal parser.operatingsystem.minor, '7'
     end
 
+    def test_operatingsystem_almalinux
+      @facts['distribution.name'] = 'AlmaLinux'
+      @facts['distribution.version'] = '8.3'
+      @facts['distribution.id'] = 'Purple Manul'
+
+      assert_equal parser.operatingsystem.name, 'AlmaLinux'
+      assert_equal parser.operatingsystem.type, 'Redhat'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, '3'
+    end
+
     def test_uname_architecture
       @facts['uname.machine'] = 'i686'
 

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -62,6 +62,8 @@ module Katello
 
         assert_equal 'OracleLinux', Candlepin::Consumer.distribution_to_puppet_os('Oracle Linux Server')
 
+        assert_equal 'AlmaLinux', Candlepin::Consumer.distribution_to_puppet_os('AlmaLinux')
+
         assert_equal 'Unknown', Candlepin::Consumer.distribution_to_puppet_os('RedHot')
       end
 


### PR DESCRIPTION
This PR adds support for AlmaLinux OS (https://almalinux.org)
It's already supported in Puppet: https://github.com/puppetlabs/facter/pull/2292