### PR TITLE
Fixes #32225 - store akey original environment on the right scope

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
@@ -25,10 +25,6 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsInfoCo
 
         $scope.environments = Organization.readableEnvironments({id: CurrentOrganization});
 
-        $scope.$on('activationKey.loaded', function () {
-            $scope.originalEnvironment = $scope.activationKey.environment;
-        });
-
         $scope.$watch('activationKey.environment', function (environment) {
             if ($scope.originalEnvironment) {
                 if (environment) {
@@ -63,7 +59,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsInfoCo
             $scope.editContentView = false;
             $scope.editEnvironment = false;
             $scope.save(activationKey).then(function (actKey) {
-                $scope.originalEnvironment = actKey.environment;
+                $scope.setOriginalEnvironment(actKey.environment);
                 $scope.resetEnvironmentPathSelector(activationKey);
             });
             $scope.disableEnvironmentSelection = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details-info.controller.js
@@ -59,8 +59,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsInfoCo
             $scope.editContentView = false;
             $scope.editEnvironment = false;
             $scope.save(activationKey).then(function (actKey) {
-                $scope.setOriginalEnvironment(actKey.environment);
-                $scope.resetEnvironmentPathSelector(activationKey);
+                $scope.resetEnvironmentPathSelector(actKey);
             });
             $scope.disableEnvironmentSelection = false;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -51,9 +51,13 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
             ];
         };
 
+        $scope.setOriginalEnvironment = function(newEnvironment) {
+            $scope.originalEnvironment = newEnvironment;
+        };
+
         $scope.activationKey = ActivationKey.get({id: $scope.$stateParams.activationKeyId}, function (activationKey) {
-            $scope.$broadcast('activationKey.loaded', activationKey);
             $scope.panel.loading = false;
+            $scope.setOriginalEnvironment(activationKey.environment);
         }, function (response) {
             $scope.panel.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -51,13 +51,9 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
             ];
         };
 
-        $scope.setOriginalEnvironment = function(newEnvironment) {
-            $scope.originalEnvironment = newEnvironment;
-        };
-
         $scope.activationKey = ActivationKey.get({id: $scope.$stateParams.activationKeyId}, function (activationKey) {
             $scope.panel.loading = false;
-            $scope.setOriginalEnvironment(activationKey.environment);
+            $scope.originalEnvironment = activationKey.environment;
         }, function (response) {
             $scope.panel.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);
@@ -68,6 +64,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
 
             activationKey.$update(function (response) {
                 deferred.resolve(response);
+                $scope.originalEnvironment = activationKey.environment;
                 Notification.setSuccessMessage(translate('Activation Key updated'));
             }, function (response) {
                 deferred.reject(response);

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
@@ -4,18 +4,20 @@ describe('Controller: ActivationKeyDetailsController', function() {
         ActivationKey,
         CurrentOrganization,
         Organization,
+        Notification,
+        mockEnvironment,
         mockOrg,
         mockActivationKey;
 
     beforeEach(module(
         'Bastion.activation-keys',
-        'Bastion.organizations',
-        'activation-keys/views/activation-keys.html'));
+        'Bastion.organizations'));
 
     beforeEach(inject(function(_$controller_, $rootScope, $state, $injector) {
         $controller = _$controller_;
         $scope = $rootScope.$new();
         $httpBackend = $injector.get('$httpBackend');
+        Notification = $injector.get('Notification');
 
         mockOrg = {
             id: '1',
@@ -26,6 +28,10 @@ describe('Controller: ActivationKeyDetailsController', function() {
             }
         }
 
+        mockEnvironment = {
+          id: 1000
+        }
+
         Organization = $injector.get('Organization');
         spyOn(Organization, 'get').and.callThrough();
         $httpBackend.expectGET('/katello/api/v2/organizations/1').respond(mockOrg);
@@ -34,6 +40,7 @@ describe('Controller: ActivationKeyDetailsController', function() {
 
         mockActivationKey = {
             id: 1,
+            environment: mockEnvironment,
             purpose_usage: 'current-usage',
             purpose_role: 'current-role',
             purpose_addons: ['current-addon'],
@@ -70,10 +77,24 @@ describe('Controller: ActivationKeyDetailsController', function() {
             $state: $state,
             ActivationKey: ActivationKey,
             CurrentOrganization: CurrentOrganization,
+            Notification: Notification,
             Organization: Organization,
             simpleContentAccessEnabled: 'simpleContentAccessEnabled'
         });
     }));
+
+    it("stores activation key original environment on the scope", function() {
+        expect($scope.originalEnvironment).toEqual(mockEnvironment);
+    });
+
+    it("stores activation key original environment on the scope after saving", function() {
+        var newEnvironment = { id: 25 };
+        mockActivationKey.environment = newEnvironment;
+        spyOn(Notification, "setSuccessMessage");
+        $scope.save(mockActivationKey);
+
+        expect($scope.originalEnvironment).toEqual(newEnvironment);
+    });
 
     it("provides a list of system purpose roles", function() {
         $scope.purposeRoles().then(function(roles) {


### PR DESCRIPTION
Check the BZ for the basic repro steps. For a slightly more clever test:

- change the env + cv of the activation key
- change to a different tab
- change back to Details tab
- everything should look good (cv+env are accurate, no info messages shown for the CV field)