### PR TITLE
Fixes #32515 - Parse Rocky Linux distribution properly

### DIFF
--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -155,6 +155,8 @@ module Katello
           'Ubuntu'
         elsif name =~ /oracle/
           'OracleLinux'
+        elsif name =~ /rocky\s*linux/
+          'RockyLinux'
         else
           'Unknown'
         end

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -90,6 +90,15 @@ module Katello
       assert_nil os.release_name
     end
 
+    def test_operatingsystem_rockylinux
+      @facts['distribution.name'] = 'Rocky Linux'
+      @facts['distribution.version'] = '8.3'
+
+      assert_equal parser.operatingsystem.name, 'RockyLinux'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, '3'
+    end
+
     def test_operatingsystem_debian
       @facts['distribution.name'] = 'Debian GNU/Linux'
       @facts['distribution.version'] = '9'

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -62,6 +62,8 @@ module Katello
 
         assert_equal 'OracleLinux', Candlepin::Consumer.distribution_to_puppet_os('Oracle Linux Server')
 
+        assert_equal 'RockyLinux', Candlepin::Consumer.distribution_to_puppet_os('Rocky Linux')
+
         assert_equal 'Unknown', Candlepin::Consumer.distribution_to_puppet_os('RedHot')
       end
 


### PR DESCRIPTION
This PR will add the correct parsing of [Rocky Linux](https://rockylinux.org) to Katello.
Here also the reference about the [discussion](https://community.theforeman.org/t/client-recognition-for-rocky-linux-in-foreman-katello/23437).

If I can improve something I'm really open for recommendations, as I'm not really familiar with the code of Foreman/Katello.
Thank you!