### PR TITLE
Fixes #32523 - Make helper methods public for webhooks context

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -135,6 +135,14 @@ module Actions
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 
+        def content_view_version_id
+          input['content_view_version_id']
+        end
+
+        def content_view_version_name
+          input['content_view_version_name']
+        end
+
         private
 
         def include_other_components(override_components, content_view)
@@ -188,14 +196,6 @@ module Actions
               end
             end
           end
-        end
-
-        def content_view_version_id
-          input['content_view_version_id']
-        end
-
-        def content_view_version_name
-          input['content_view_version_name']
         end
 
         apipie :class, "A class representing #{self} object" do


### PR DESCRIPTION
https://github.com/Katello/katello/pull/9250 introduced those methods, but during refactor/reviews I missed that those methods are under `private` modifier, which makes them unusable.