### PR TITLE
Refs #32334 - ensure import_all creates Pools with a subscription_id

### DIFF
--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -24,8 +24,8 @@ module Katello
     scope :upstream, -> { where.not(upstream_pool_id: nil) }
     scope :redhat, -> { joins(:products).merge(Katello::Product.redhat).distinct }
 
-    include Glue::Candlepin::Pool
     include Glue::Candlepin::CandlepinObject
+    include Glue::Candlepin::Pool
 
     scoped_search :on => :cp_id, :complete_value => true, :rename => :id, :only_explicit => true
     scoped_search :on => :upstream_pool_id, :complete_value => true, :only_explicit => true

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -7,6 +7,32 @@ module Katello
       @other = katello_subscriptions(:other_subscription)
     end
 
+    def test_import_all
+      org = FactoryBot.create(:organization)
+      provider = FactoryBot.create(:katello_provider, organization: org)
+      product = FactoryBot.create(:katello_product, organization: org, provider: provider, cp_id: '12345')
+      Katello::Resources::Candlepin::Product.expects(:get).returns(
+        [
+          {
+            'id' => product.cp_id,
+            'attributes' => {}
+          }
+        ]
+      )
+
+      product_data = [
+        {
+          'id' => product.cp_id
+        }
+      ]
+
+      Katello::Resources::Candlepin::Product.expects(:all).returns(product_data)
+
+      Subscription.import_all(org)
+
+      refute_empty org.subscriptions
+    end
+
     def test_subscription_returns_pools
       assert @other.pools.count > 0
     end


### PR DESCRIPTION
My recent PR https://github.com/Katello/katello/pull/9295 added non-null constraints+validations for subscription_id and organization_id on `Katello::Pool`. I missed updating one area of the code => `import_all` which would silently fail and not create any pools because it calls `first_or_create` without `!` (due to the missing subscription_id). This PR adjusts the `CandlepinObject` module to add a new method `import_candlepin_record` which the Pool model now overrides in order to ensure the subscription_id is provided.

If you run into issues I may need your development.log output. Since it logs tons of HTTP requests I ask that you please change to INFO logging in ~/foreman/config/logging.yaml under 'development' to suppress those. Restart the rails server after changing that!

Two ways I recommend to test this. The first is the Rails console:

```
Katello::Subscription.destroy_all
Katello::Pool.import_all
Katello::Pool.count => 0
```
The result will be zero here because of the issue mentioned above. Notice that there was no error raised. Assuming you have a manifest imported or a custom product created that number should be > 1. Repeating the steps with this PR checked out should show the correct # of Pool objects.

To test the actual workflow: delete any imported manifest and then import it again. Notice that the Subscriptions list may be missing some or all of the expected Subscriptions. That's because import_all didn't create them, and the CandlepinEventListener may have some luck in doing so. The results should be deterministic with this PR checked out! Repeat the test a few times or various permutations (SCA toggle, add or remove subscriptions, anything that re-imports the manifest) to make sure the fix sticks.