### PR TITLE
refs #31809 - Registration - fix incorrect LCE variable

### DIFF
--- a/app/controllers/katello/concerns/registration_commands_controller_extensions.rb
+++ b/app/controllers/katello/concerns/registration_commands_controller_extensions.rb
@@ -13,7 +13,7 @@ module Katello
                             .where(organization_id: registration_params[:organization_id])
                             .order(:name)
 
-        data = { activationKeys: aks, lifeCycleEnvironments: lces }
+        data = { activationKeys: aks, lifecycleEnvironments: lces }
 
         if registration_params[:hostgroup_id].present?
           host_group = ::Hostgroup.authorized(:view_hostgroups).find(registration_params[:hostgroup_id])


### PR DESCRIPTION
Due to the incorrect variable [registration form component](https://github.com/Katello/katello/blob/master/webpack/components/extensions/RegistrationCommands/fields/LifecycleEnvironment.js#L14) is not loading life cycle environments.