### PR TITLE
Fixes #32569 - prevent early timeout of katello-agent actions

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -83,7 +83,12 @@ module Actions
         end
 
         unless history.finished?
-          fail _("Host did not finish content action in %s seconds.  The task has been cancelled.") % finish_timeout
+          # we could be processing the accept_timeout here
+          # only fail for finish_timeout unless the actual duration has elapsed
+          finish_limit = history.accepted_at + finish_timeout
+          if finish_limit < DateTime.now
+            fail _("Host did not finish content action in %s seconds.  The task has been cancelled.") % finish_timeout
+          end
         end
       end
 

--- a/test/actions/katello/agent_action_tests.rb
+++ b/test/actions/katello/agent_action_tests.rb
@@ -65,13 +65,22 @@ module Actions
           assert_match(/did not respond/, error.message)
         end
 
-        def test_process_timeout_finish
+        def test_process_timeout_finish_elapsed
           dispatch_history.accepted_at = Time.now
           bulk_action.expects(:dispatch_history).returns(dispatch_history)
 
-          error = assert_raises(StandardError) { bulk_action.process_timeout }
+          travel_to 2.hours.from_now do
+            error = assert_raises(StandardError) { bulk_action.process_timeout }
+            assert_match(/did not finish/, error.message)
+          end
+        end
 
-          assert_match(/did not finish/, error.message)
+        def test_process_timeout_finish_not_elapsed
+          dispatch_history.accepted_at = Time.now
+          dispatch_history.result = nil
+          bulk_action.expects(:dispatch_history).returns(dispatch_history)
+
+          bulk_action.process_timeout
         end
 
         def test_process_timeout_noop

--- a/test/lib/agent/client_message_handler_test.rb
+++ b/test/lib/agent/client_message_handler_test.rb
@@ -25,7 +25,8 @@ module Katello
           dynflow_step_id: 2
         )
 
-        ForemanTasks::Task.expects(:exists?).returns(true)
+        task = mock(result: 'pending')
+        ForemanTasks::Task.expects(:find_by_external_id).with(dispatch_history.dynflow_execution_plan_id).returns(task)
         mock_world = mock('mock world', event: true)
         mock_dynflow = stub('mock dynflow', world: mock_world, 'world=' => mock_world)
         ForemanTasks.stubs(:dynflow).returns(mock_dynflow)
@@ -52,7 +53,8 @@ module Katello
           dynflow_step_id: 2
         )
 
-        ForemanTasks::Task.expects(:exists?).returns(true)
+        task = mock(result: 'pending')
+        ForemanTasks::Task.expects(:find_by_external_id).with(dispatch_history.dynflow_execution_plan_id).returns(task)
         mock_world = mock('mock world', event: true)
         mock_dynflow = stub('mock dynflow', world: mock_world, 'world=' => mock_world)
         ForemanTasks.stubs(:dynflow).returns(mock_dynflow)


### PR DESCRIPTION
Even after the finish timeout has been set for an AgentAction, the previous accept timeout event will be processed and call `process_timeout`. This could lead to cases of failing for the finish_timeout while still within the finish_timeout window. This PR prevents that from happening and improves a bit of the logging in the ClientMessageHandler

Consider the following logs:

```
#errata install started on server
2021-05-07T00:52:10 [I|bac|2603ea86] Task {label: Actions::Katello::Host::Erratum::Install, id: 6cd02a19-12aa-4155-aa9f-0ea091b4cc2b, execution_plan_id: d3d332b1-0e9f-4456-9a11-8302c1f8bc35} state changed: running
         
# client starts errata install
May  7 00:52:12 pipe-katello-server-nightly-centos7 goferd: [INFO][worker-0] gofer.rmi.dispatcher:577 - call: Content.install() sn=None data={u'dispatch_history_id': 2, u'consumer_id': u'f486a452-d9be-46be-8e68-9f6bb8aafbe6'}
         
# errata install finishes on client six seconds before timeout
May  7 00:52:24 pipe-katello-server-nightly-centos7 goferd: [INFO][worker-0] katello.agent.pulp.libyum:139 - Updated: walrus-5.21-1.noarch
         
# errata install task times out
2021-05-07T00:52:30 [E|bac|2603ea86] Host did not finish content action in 3600 seconds.  The task has been cancelled. (RuntimeError)
2021-05-07T00:52:30 [I|bac|2603ea86] Task {label: Actions::Katello::Host::Erratum::Install, id: 6cd02a19-12aa-4155-aa9f-0ea091b4cc2b, execution_plan_id: d3d332b1-0e9f-4456-9a11-8302c1f8bc35} state changed: stopped  result: warning
         
# agent event handler can't update the task (it's no longer pending)
2021-05-07T00:52:34 [W|kat|38cf72ab] Couldn't find pending task with external_id=d3d332b1-0e9f-4456-9a11-8302c1f8bc35 dispatch_history_id=2
```

Notice in the logs above that the error is "Host did not finish content action in 3600 seconds" which is only 20 seconds after the job was started, indicating that the task was incorrectly failed for the "finish_timeout" (one hour)

**To test**
Prereqs: devel box with katello-agent infra enabled

- spin up centos7-katello-client with forklift and install katello-agent if not already there
- clean the yum cache on centos7-katello-client so that the package action takes longer since it needs to refresh metadata
- adjust the 'Content action accept timeout' setting (Settings -> Content) to 6 seconds or something, to make this more reproducible (ie the package action has to finish beyond 6 seconds)
- install screen package on the client from the UI using katello-agent. No need to set up products, repos, subscriptions, etc
- You should see the failure outlined about
- You should not see the failure outlined above with this PR checked out!