### PR TITLE
Fixes #32396 - Permissions for Import/Export

### DIFF
--- a/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
+++ b/app/controllers/katello/api/v2/content_export_incrementals_controller.rb
@@ -83,7 +83,7 @@ module Katello
 
     def find_exportable_organization
       find_organization
-      unless @organization.can_export_library_content?
+      unless @organization.can_export_content?
         throw_resource_not_found(name: 'organization', id: params[:organization_id])
       end
     end

--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -67,7 +67,7 @@ module Katello
 
     def find_exportable_organization
       find_organization
-      unless @organization.can_export_library_content?
+      unless @organization.can_export_content?
         throw_resource_not_found(name: 'organization', id: params[:organization_id])
       end
     end

--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -49,7 +49,7 @@ module Katello
     private
 
     def check_authorized
-      fail HttpErrors::Forbidden, _("Action unauthorized to be performed in this organization.") unless ContentView.importable?
+      fail HttpErrors::Forbidden, _("Action unauthorized to be performed in this organization.") unless @organization.can_import_content?
     end
 
     def find_default_content_view
@@ -59,7 +59,7 @@ module Katello
 
     def find_importable_organization
       find_organization
-      throw_resource_not_found(name: 'organization', id: params[:organization_id]) unless @organization.can_import_library_content?
+      throw_resource_not_found(name: 'organization', id: params[:organization_id]) unless @organization.can_import_content?
     end
 
     def metadata_params

--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -24,10 +24,6 @@ module Katello
       authorized?(:promote_or_remove_content_views) && Katello::KTEnvironment.any_promotable?
     end
 
-    def exportable?
-      authorized?(:export_content_views)
-    end
-
     module ClassMethods
       def readable
         authorized(:view_content_views)
@@ -35,10 +31,6 @@ module Katello
 
       def creatable
         authorized(:view_content_views)
-      end
-
-      def importable?
-        creatable? && publishable?
       end
 
       def readable_as(user)
@@ -75,7 +67,11 @@ module Katello
       end
 
       def exportable
-        authorized(:export_content_views)
+        where(organization: Organization.authorized(:export_content))
+      end
+
+      def importable
+        where(organization: Organization.authorized(:import_content))
       end
 
       def readable_repositories(repo_ids = nil)

--- a/app/models/katello/authorization/organization.rb
+++ b/app/models/katello/authorization/organization.rb
@@ -12,12 +12,12 @@ module Katello
       authorized?(:import_manifest)
     end
 
-    def can_import_library_content?
-      authorized?(:import_library_content)
+    def can_import_content?
+      authorized?(:import_content)
     end
 
-    def can_export_library_content?
-      authorized?(:export_library_content)
+    def can_export_content?
+      authorized?(:export_content)
     end
 
     def readable_promotion_paths

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -143,14 +143,6 @@ module Katello
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :promotable_or_removable
-      @plugin.permission :export_content_views,
-                         {
-                           'katello/api/v2/content_view_versions' => [:export],
-                           'katello/api/v2/content_exports' => [:version, :index],
-                           'katello/api/v2/content_export_incrementals' => [:version]
-                         },
-                         :resource_type => 'Katello::ContentView',
-                         :finder_scope => :exportable
     end
 
     def content_credential_permissions
@@ -409,16 +401,17 @@ module Katello
     end
 
     def organization_permissions
-      @plugin.permission :import_library_content,
+      @plugin.permission :import_content,
                          {
-                           'katello/api/v2/content_imports' => [:library, :index]
+                           'katello/api/v2/content_imports' => [:library, :version, :index]
                          },
                          :resource_type => 'Organization'
 
-      @plugin.permission :export_library_content,
+      @plugin.permission :export_content,
                          {
-                           'katello/api/v2/content_exports' => [:library, :index],
-                           'katello/api/v2/content_export_incrementals' => [:library]
+                           'katello/api/v2/content_view_versions' => [:export],
+                           'katello/api/v2/content_exports' => [:library, :version, :index],
+                           'katello/api/v2/content_export_incrementals' => [:library, :version]
                          },
                          :resource_type => 'Organization'
     end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -359,6 +359,15 @@ Foreman::Plugin.register :katello do
     :view_operatingsystems, :view_smart_proxies
   ]
 
+  role 'Content Importer', [
+    :import_content, :create_products, :create_content_views,
+    :edit_products, :edit_content_views, :view_organizations
+  ], 'Role granting permission to import content views in an organization'
+
+  role 'Content Exporter', [
+    :export_content, :view_products, :view_content_views, :view_organizations
+  ], 'Role granting permission to export content views in an organization'
+
   def find_katello_assets(args = {})
     type = args.fetch(:type, nil)
     vendor = args.fetch(:vendor, false)

--- a/lib/katello/tasks/upgrades/4.1/update_content_import_export_perms.rake
+++ b/lib/katello/tasks/upgrades/4.1/update_content_import_export_perms.rake
@@ -1,0 +1,33 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.1' do
+      desc "Update for content import/export permissions."
+      task :update_content_import_export_perms => ['environment'] do
+        User.current = User.anonymous_api_admin
+
+        permission_map = {
+          Permission.find_by(name: :export_library_content) => Permission.find_by(name: :export_content),
+          Permission.find_by(name: :import_library_content) => Permission.find_by(name: :import_content)
+        }
+
+        permission_map.each do |old_perm, new_perm|
+          Filtering.where(permission_id: old_perm.id).update_all(:permission_id => new_perm.id) if old_perm
+        end
+
+        names = permission_map.keys.compact.map(&:name)
+        Permission.where(:name => names).destroy_all if names.any?
+
+        export_content_views = Permission.find_by_name(:export_content_views)
+        next if export_content_views.blank?
+
+        Filtering.where(permission_id: export_content_views.id).each do |filtering|
+          filter = filtering.filter
+          filter.role.add_permissions!(:export_content)
+          filter.destroy if filter.filterings.count == 1
+        end
+        Filtering.where(permission_id: export_content_views.id).destroy_all
+        export_content_views.destroy
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/content_export_incrementals_controller_test.rb
+++ b/test/controllers/api/v2/content_export_incrementals_controller_test.rb
@@ -9,8 +9,7 @@ module Katello
       @create_permission = :create_content_views
       @update_permission = :edit_content_views
       @destroy_permission = :destroy_content_views
-      @export_permission = :export_content_views
-      @export_library_permission = :export_library_content
+      @export_permission = :export_content
     end
 
     def setup
@@ -38,9 +37,9 @@ module Katello
       @controller.stubs(:find_library_export_view)
       @controller.stubs(:find_history)
 
-      allowed_perms = [{name: @export_library_permission, :resource_type => "Organization"}]
+      allowed_perms = [{name: @export_permission, :resource_type => "Organization"}]
       denied_perms = [@create_permission, @update_permission,
-                      @destroy_permission, @view_permission, @export_permission]
+                      @destroy_permission, @view_permission]
 
       org = get_organization
       assert_protected_action(:library, allowed_perms, denied_perms, [org]) do

--- a/test/controllers/api/v2/content_exports_controller_test.rb
+++ b/test/controllers/api/v2/content_exports_controller_test.rb
@@ -9,8 +9,7 @@ module Katello
       @create_permission = :create_content_views
       @update_permission = :edit_content_views
       @destroy_permission = :destroy_content_views
-      @export_permission = :export_content_views
-      @export_library_permission = :export_library_content
+      @export_permission = :export_content
     end
 
     def setup
@@ -41,9 +40,9 @@ module Katello
     end
 
     def test_library_protected
-      allowed_perms = [{name: @export_library_permission, :resource_type => "Organization"}]
+      allowed_perms = [{name: @export_permission, :resource_type => "Organization"}]
       denied_perms = [@create_permission, @update_permission,
-                      @destroy_permission, @view_permission, @export_permission]
+                      @destroy_permission, @view_permission]
 
       org = get_organization
       assert_protected_action(:library, allowed_perms, denied_perms, [org]) do

--- a/test/controllers/api/v2/content_imports_controller_test.rb
+++ b/test/controllers/api/v2/content_imports_controller_test.rb
@@ -35,8 +35,8 @@ module Katello
       @update_permission = :edit_content_views
       @destroy_permission = :destroy_content_views
       @publish_permission = :publish_content_views
-      @export_permission = :export_content_views
-      @org_import_permission = :import_library_content
+      @export_permission = :export_content
+      @org_import_permission = :import_content
     end
 
     def setup
@@ -46,7 +46,7 @@ module Katello
     end
 
     def test_version_protected
-      allowed_perms = [[@publish_permission, @create_permission]]
+      allowed_perms = [[@publish_permission, @create_permission, @org_import_permission]]
       denied_perms = [@create_permission, @publish_permission, @update_permission,
                       @destroy_permission, @view_permission, @export_permission]
       org = get_organization

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -24,7 +24,7 @@ module Katello
       @publish_permission = :publish_content_views
       @env_promote_permission = :promote_or_remove_content_views_to_environments
       @cv_promote_permission = :promote_or_remove_content_views
-      @export_permission = :export_content_views
+      @export_permission = :export_content
 
       @dev_env_promote_permission = {:name => @env_promote_permission, :search => "name=\"#{@dev.name}\"" }
       @library_dev_staging_view_promote_permission = {:name => @cv_promote_permission, :search => "name=\"#{@library_dev_staging_view.name}\"" }

--- a/test/controllers/api/v2/errata_controller_test.rb
+++ b/test/controllers/api/v2/errata_controller_test.rb
@@ -127,7 +127,7 @@ module Katello
       cv_auth_permissions = [:view_content_views]
       cv_unauth_permissions = [
         :create_content_views, :edit_content_views, :destroy_content_views, :publish_content_views,
-        :promote_or_remove_content_views, :export_content_views
+        :promote_or_remove_content_views, :export_content
       ]
       all_unauth_permissions = @unauth_permissions + cv_unauth_permissions
       assert_protected_action(:index, cv_auth_permissions, all_unauth_permissions) do

--- a/test/controllers/api/v2/packages_controller_test.rb
+++ b/test/controllers/api/v2/packages_controller_test.rb
@@ -96,7 +96,7 @@ module Katello
       cv_auth_permissions = [:view_content_views]
       cv_unauth_permissions = [
         :create_content_views, :edit_content_views, :destroy_content_views, :publish_content_views,
-        :promote_or_remove_content_views, :export_content_views
+        :promote_or_remove_content_views, :export_content
       ]
       all_unauth_permissions = @unauth_permissions + cv_unauth_permissions
       assert_protected_action(:index, cv_auth_permissions, all_unauth_permissions) do

--- a/test/lib/tasks/upgrades/4.1/update_content_import_export_perms_test.rb
+++ b/test/lib/tasks/upgrades/4.1/update_content_import_export_perms_test.rb
@@ -1,0 +1,50 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class UpdateContentImportExportPermsTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/4.1/update_content_import_export_perms'
+      Rake::Task['katello:upgrades:4.1:update_content_import_export_perms'].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_update_content_import_export_perms
+      old_perm_names = %w[export_content_views export_library_content import_library_content].freeze
+
+      old_perms = old_perm_names.collect do |perm_name|
+        FactoryBot.create(:permission, name: perm_name)
+      end
+
+      FactoryBot.create(:role, name: 'old content tester', permissions: old_perms)
+
+      assert_equal Permission.where(name: old_perm_names).size, 3
+      assert_equal Filtering.where(permission_id: old_perms.collect(&:id)).size, 3
+
+      Rake.application.invoke_task('katello:upgrades:4.1:update_content_import_export_perms')
+
+      assert_equal Permission.where(name: old_perm_names).size, 0
+      assert_equal Filtering.where(permission_id: old_perms.collect(&:id)).size, 0
+    end
+
+    def test_update_export_content_views
+      old_perm_names = %w[export_content_views view_content_views].freeze
+
+      old_perms = old_perm_names.collect do |perm_name|
+        Permission.find_by_name(perm_name) || FactoryBot.create(:permission, name: perm_name, resource_type: "Katello::ContentView")
+      end
+
+      role = FactoryBot.create(:role, name: 'old content tester', permissions: old_perms)
+
+      old_filtering_count = Filtering.where(permission_id: old_perms.collect(&:id)).size
+      assert_equal Permission.where(name: old_perm_names).size, 2
+      assert_equal role.filters.size, 1
+
+      Rake.application.invoke_task('katello:upgrades:4.1:update_content_import_export_perms')
+
+      assert_equal Permission.where(name: old_perm_names).size, 1
+      assert_equal Filtering.where(permission_id: old_perms.collect(&:id)).size, old_filtering_count - 1
+      assert_equal role.filters.size, 2
+    end
+  end
+end


### PR DESCRIPTION
### Changes in this PR
- Replace permission `export_content_views` with `export_content`
- Rename permission `export_library_content` to `export_content`
- Rename permission `import_library_content` to `import_content`
- Add roles `Content Importer` and `Content Exporter`
- Add rake task `katello:upgrades:4.1:update_content_import_export_perms`

### Steps to import/export contents
1. Run `rake db:seed` to sync the new roles into your DB
2. Create a user with role `Content Importer` and `Content Exporter` and assign the `Organization` where your contents will be exported from and imported to.
3. Run `bundle exec hammer -u lucy -p xxx content-export complete version --id 3 --organization=export-7316`
4. Copy the contents in `/var/lib/pulp/exports` exported from step 3 into a directory in `/var/lib/pulp/imports`
5. `bundle exec hammer -u lucy -p xxx content-import version --organization=import --path /var/lib/pulp/imports/2021-05-13T13-54-14-00-00 --metadata-file metadata-17.json` 
6. Verify the contents are imported in UI.

**For existing users with permission `export_content_views`, `export_library_content` or `import_library_content`**
1. Run `bundle exec rake katello:upgrades:4.1:update_content_import_export_perms` 
2. Verify those users should be assigned permission `export_content` for `export_content_views` or `export_library_content`, `import_content` for `import_library_content`