### PR TITLE
Fixes #32591 - use correct ping mechanism for katello-agent events

### DIFF
--- a/app/lib/katello/event_daemon/monitor.rb
+++ b/app/lib/katello/event_daemon/monitor.rb
@@ -38,6 +38,7 @@ module Katello
             begin
               service_class.close
               service_class.run
+              sleep 0.1
               @service_statuses[service_name] = service_class.status
             rescue => error
               Rails.logger.error("Error occurred while starting #{service_class}")

--- a/app/lib/katello/event_daemon/services/agent_event_receiver.rb
+++ b/app/lib/katello/event_daemon/services/agent_event_receiver.rb
@@ -2,8 +2,6 @@ module Katello
   module EventDaemon
     module Services
       class AgentEventReceiver
-        STATUS_CACHE_KEY = 'katello_agent_events'.freeze
-
         class Handler
           attr_accessor :processed, :failed
 
@@ -48,14 +46,12 @@ module Katello
           @agent_connection&.open? && @thread&.status.present?
         end
 
-        def self.status(refresh: true)
-          Rails.cache.fetch(STATUS_CACHE_KEY, force: refresh) do
-            {
-              running: running?,
-              processed_count: @handler&.processed || 0,
-              failed_count: @handler&.failed || 0
-            }
-          end
+        def self.status
+          {
+            running: running?,
+            processed_count: @handler&.processed || 0,
+            failed_count: @handler&.failed || 0
+          }
         end
       end
     end

--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -73,7 +73,7 @@ module Katello
 
       def ping_katello_agent(result)
         exception_watch(result) do
-          status = Katello::EventDaemon::Services::AgentEventReceiver.status(refresh: false)
+          status = Katello::EventDaemon::Runner.service_status(:katello_agent_events)
           event_daemon_status(status, result)
         end
       end

--- a/test/models/ping_test.rb
+++ b/test/models/ping_test.rb
@@ -156,8 +156,8 @@ module Katello
     end
 
     def test_ping_katello_agent_enabled
-      Katello::EventDaemon::Services::AgentEventReceiver
-        .expects(:status)
+      Katello::EventDaemon::Runner
+        .expects(:service_status).with(:katello_agent_events)
         .returns(processed_count: 0, failed_count: 0, running: true)
 
       result = Katello::Ping.ping_katello_agent({})


### PR DESCRIPTION
While the katello-based agent infra was in development the Event Daemon ping code was rewritten - removing the need for caching the individual service status since the Daemon caches them now. This PR addresses that and also adds a small sleep after each service is started to give its thread some time to start.

Testing: The ping api should return 'ok' for katello_agent at app startup