### PR TITLE
Fixes #32447 - Have task goto warn state instead of paused on error

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -49,6 +49,8 @@ module Actions
 
             schedule_timeout(timeout)
           end
+        when Dynflow::Action::Skip
+          # Do not fail and goto a paused state, instead skip and send the state to warning so we do not block other host actions
         when Dynflow::Action::Timeouts::Timeout
           process_timeout
         when 'accepted'


### PR DESCRIPTION
With patch showing no regression on installing packages:

https://nimb.ws/M8blXr

Task now fails and does not goto a paused state:

https://nimb.ws/HlrxY7

@adamruzicka here is the pr, thanks for the pointer. 