### PR TITLE
Fixes #32582 - old rh repo root arch stops disabling

### DIFF
--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -38,16 +38,20 @@ child @resource.repositories => :repositories do
 end
 
 node :override do |pc|
-  pc.override
+  pc.override if pc.respond_to? :override
 end
 
 node :overrides do |pc|
-  pc.content_overrides.map do |override|
-    {:name => override.name, :value => override.computed_value}
+  if pc.respond_to? :content_overrides
+    pc.content_overrides.map do |override|
+      {:name => override.name, :value => override.computed_value}
+    end
   end
 end
 
 node :enabled_content_override do |pc|
-  override = pc.enabled_content_override
-  override&.computed_value
+  if pc.respond_to? :enabled_content_override
+    override = pc.enabled_content_override
+    override&.computed_value
+  end
 end

--- a/db/migrate/20210512192745_fix_red_hat_root_repository_arch.rb
+++ b/db/migrate/20210512192745_fix_red_hat_root_repository_arch.rb
@@ -1,0 +1,11 @@
+class FixRedHatRootRepositoryArch < ActiveRecord::Migration[6.0]
+  def up
+    ::Katello::RootRepository.
+      joins("INNER JOIN katello_contents ON katello_contents.cp_content_id = katello_root_repositories.content_id").
+      where.not(arch: 'noarch').where.not("katello_contents.content_url ILIKE '%$basearch%'").update(arch: 'noarch')
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The addition of https://github.com/Katello/katello/blob/master/app/models/katello/candlepin/repository_mapper.rb#L73 caused issues with disabling RH repos whose roots had an arch other than 'noarch' and a `root.content.content_url` that didn't have `$basearch`.

My PR adds a migration that changes these root repos to have 'noarch' as their architectures.

To test:
1) Enable a Red Hat repo whose repo-set (`::Katello::Content`) has a `content_url` that doesn't say `$basearch`.  One example I found was any RHEL 8 AppStream repo.
2) Find that repository's root and change the `arch` to something other than 'noarch'.
3) Try to disable the repo and see the error: `Repository not found`
4) Apply this PR and migrate
5) Try disabling the repo again