### PR TITLE
Fixes #29898,#31411 - applicability improvements

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -43,7 +43,6 @@ module Katello
       task = async_task(::Actions::BulkAction,
                         ::Actions::Katello::Repository::Sync,
                         syncable_repositories,
-                        nil,
                         :skip_metadata_check => skip_metadata_check,
                         :validate_contents => validate_contents)
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -286,7 +286,7 @@ module Katello
         fail HttpErrors::BadRequest, _("attempted to sync without a feed URL")
       end
 
-      task = async_task(::Actions::Katello::Repository::Sync, @repository, nil, sync_options)
+      task = async_task(::Actions::Katello::Repository::Sync, @repository, sync_options)
       respond_for_async :resource => task
     rescue Errors::InvalidActionOptionError => e
       raise HttpErrors::BadRequest, e.message

--- a/app/lib/actions/katello/repository/verify_checksum.rb
+++ b/app/lib/actions/katello/repository/verify_checksum.rb
@@ -13,7 +13,7 @@ module Actions
           else
             options = {}
             options[:validate_contents] = true
-            plan_action(Actions::Katello::Repository::Sync, repo, nil, options)
+            plan_action(Actions::Katello::Repository::Sync, repo, options)
           end
         end
 

--- a/app/lib/actions/pulp3/repository/save_version.rb
+++ b/app/lib/actions/pulp3/repository/save_version.rb
@@ -23,6 +23,7 @@ module Actions
           if version_href
             if repo.version_href != version_href || input[:force_fetch_version]
               output[:contents_changed] = true
+              repo.update(:last_contents_changed => DateTime.now)
               repo.update(:version_href => version_href)
             end
           else

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -84,10 +84,7 @@ module Katello
 
       def self.trigger_applicability_generation(host_ids)
         host_ids = [host_ids] unless host_ids.is_a?(Array)
-
-        host_ids.each do |host_id|
-          ::Katello::ApplicableHostQueue.push_host(host_id)
-        end
+        ::Katello::ApplicableHostQueue.push_hosts(host_ids)
         ::Katello::EventQueue.push_event(::Katello::Events::GenerateHostApplicability::EVENT_TYPE, 0)
       end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -740,10 +740,6 @@ module Katello
       throw :abort unless destroyable?
     end
 
-    def hosts_with_applicability
-      ::Host.joins(:content_facet => :bound_repositories).where("#{Katello::Repository.table_name}.id" => (self.clones.pluck(:id) + [self.id]))
-    end
-
     def docker_meta_tag_count
       DockerMetaTag.in_repositories(self.id).count
     end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -156,6 +156,10 @@ module Katello
       end
     end
 
+    def self.hosts_with_applicability
+      ::Host.joins(:content_facet => :bound_repositories).where("#{Katello::Repository.table_name}.root_id" => self.select(:id))
+    end
+
     def ensure_no_download_policy
       if !yum? && download_policy.present?
         errors.add(:download_policy, _("cannot be set for non-yum repositories."))

--- a/app/services/katello/applicable_host_queue.rb
+++ b/app/services/katello/applicable_host_queue.rb
@@ -8,8 +8,8 @@ module Katello
       ::Katello::HostQueueElement.all.size
     end
 
-    def self.push_host(host_id)
-      HostQueueElement.create!({ host_id: host_id })
+    def self.push_hosts(ids)
+      HostQueueElement.import ids.map { |host_id| { host_id: host_id } }, validate: false
     end
 
     def self.pop_hosts(amount = self.batch_size)

--- a/db/migrate/20210512170039_add_repo_timestamps.rb
+++ b/db/migrate/20210512170039_add_repo_timestamps.rb
@@ -1,0 +1,6 @@
+class AddRepoTimestamps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_repositories, :last_contents_changed, :datetime, :default => Time.at(0).to_datetime
+    add_column :katello_repositories, :last_applicability_regen, :datetime, :default => Time.at(0).to_datetime
+  end
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -385,7 +385,7 @@ module ::Actions::Katello::Repository
     it 'passes the source URL to pulp sync action when provided' do
       action = create_action action_class
       action.stubs(:action_subject).with(repository)
-      plan_action action, repository, nil, :source_url => 'file:///tmp/'
+      plan_action action, repository, :source_url => 'file:///tmp/'
 
       assert_action_planed_with(action, pulp2_action_class, repository, proxy,
                                 source_url: 'file:///tmp/')
@@ -394,7 +394,7 @@ module ::Actions::Katello::Repository
     it 'passes force_full when skip_metadata_check is nil' do
       action = create_action action_class
       action.stubs(:action_subject).with(repository)
-      plan_action action, repository, nil, :skip_metadata_check => true
+      plan_action action, repository, :skip_metadata_check => true
 
       assert_action_planed_with(action, pulp2_action_class, repository, proxy,
                                 source_url: nil, force_full: true, optimize: false)
@@ -404,7 +404,7 @@ module ::Actions::Katello::Repository
     it 'calls download action when validate_contents is passed' do
       action = create_action action_class
       action.stubs(:action_subject).with(repository)
-      plan_action action, repository, nil, :validate_contents => true
+      plan_action action, repository, :validate_contents => true
 
       assert_action_planed_with(action, pulp2_action_class, repository, proxy,
                                 source_url: nil, download_policy: 'on_demand', force_full: true, :optimize => false)

--- a/test/actions/katello/sync_plan/run_test.rb
+++ b/test/actions/katello/sync_plan/run_test.rb
@@ -27,7 +27,8 @@ describe ::Actions::Katello::SyncPlan::Run do
     plan_action(action, @sync_plan)
     syncable_products = @sync_plan.products.syncable
     syncable_repositories = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
-    assert_action_planed_with(action, ::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_repositories.map(&:library_instance))
+    assert_action_planed_with(action, ::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_repositories.map(&:library_instance),
+                              generate_applicability: false)
   end
 
   it 'does not plan without products' do

--- a/test/actions/pulp3/orchestration/yum_sync_test.rb
+++ b/test/actions/pulp3/orchestration/yum_sync_test.rb
@@ -53,7 +53,7 @@ module ::Actions::Pulp3
       @repo.index_content #should clear out the repo
       assert_empty @repo.rpms
 
-      ForemanTasks.sync_task(::Actions::Katello::Repository::Sync, @repo, nil, skip_metadata_check: true)
+      ForemanTasks.sync_task(::Actions::Katello::Repository::Sync, @repo, skip_metadata_check: true)
 
       @repo.reload
       assert_equal old_url, @repo.version_href

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -753,9 +753,8 @@ module Katello
     end
 
     def test_sync_with_url_override
-      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
+      assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        assert_nil pulp_task_id
         options[:source_url].must_equal('file:///tmp/')
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/' }
@@ -763,9 +762,8 @@ module Katello
     end
 
     def test_sync_with_incremental_flag
-      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
+      assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        assert_nil pulp_task_id
         options[:source_url].must_equal('file:///tmp/')
         options[:incremental].must_equal true
       end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -740,27 +740,4 @@ module Katello
       refute rhel7.in_content_view?(view)
     end
   end
-
-  class RepositoryApplicabilityTest < RepositoryTestBase
-    def setup
-      super
-      @lib_host = FactoryBot.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
-                                     :lifecycle_environment =>  @fedora_17_x86_64.environment)
-
-      @lib_host.content_facet.bound_repositories << @fedora_17_x86_64
-      @lib_host.content_facet.save!
-
-      @view_repo = Repository.find(katello_repositories(:fedora_17_x86_64_library_view_1).id)
-
-      @view_host = FactoryBot.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
-                                     :lifecycle_environment =>  @fedora_17_x86_64.environment)
-      @view_host.content_facet.bound_repositories = [@view_repo]
-      @view_host.content_facet.save!
-    end
-
-    def test_host_with_applicability
-      assert_includes @fedora_17_x86_64.hosts_with_applicability, @lib_host
-      assert_includes @fedora_17_x86_64.hosts_with_applicability, @view_host
-    end
-  end
 end

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -749,6 +749,29 @@ module Katello
     end
   end
 
+  class RootRepositoryApplicabilityTest < RepositoryTestBase
+    def setup
+      super
+      @lib_host = FactoryBot.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
+                                    :lifecycle_environment =>  @fedora_17_x86_64.environment)
+
+      @lib_host.content_facet.bound_repositories << @fedora_17_x86_64
+      @lib_host.content_facet.save!
+
+      @view_repo = Repository.find(katello_repositories(:fedora_17_x86_64_library_view_1).id)
+
+      @view_host = FactoryBot.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
+                                     :lifecycle_environment =>  @fedora_17_x86_64.environment)
+      @view_host.content_facet.bound_repositories = [@view_repo]
+      @view_host.content_facet.save!
+    end
+
+    def test_host_with_applicability
+      assert_includes Katello::RootRepository.where(:id => @fedora_17_x86_64.root).hosts_with_applicability, @lib_host
+      assert_includes Katello::RootRepository.where(:id => @fedora_17_x86_64.root).hosts_with_applicability, @view_host
+    end
+  end
+
   class RootRepositoryAuditTest < RepositoryTestBase
     def setup
       super

--- a/test/services/katello/applicable_host_queue_test.rb
+++ b/test/services/katello/applicable_host_queue_test.rb
@@ -11,14 +11,14 @@ module Katello
     end
 
     def test_pop_1_host
-      ApplicableHostQueue.push_host(999)
+      ApplicableHostQueue.push_hosts([999])
       popped_hosts = ApplicableHostQueue.pop_hosts
 
       assert_equal [999], popped_hosts.map(&:host_id).sort
     end
 
     def test_pop_5_hosts
-      5.times { |i| ApplicableHostQueue.push_host(i) }
+      5.times { |i| ApplicableHostQueue.push_hosts([i]) }
       popped_hosts = ApplicableHostQueue.pop_hosts
 
       assert_equal [0, 1, 2, 3, 4], popped_hosts.map(&:host_id).sort
@@ -26,22 +26,22 @@ module Katello
 
     def test_pop_batch_size_only
       Setting['applicability_batch_size'] = 3
-      5.times { |i| ApplicableHostQueue.push_host(i) }
+      5.times { |i| ApplicableHostQueue.push_hosts([i]) }
       popped_hosts = ApplicableHostQueue.pop_hosts
 
       assert_equal 3, popped_hosts.to_a.size
     end
 
     def test_pop_duplicate_hosts
-      5.times { |i| ApplicableHostQueue.push_host(i) }
-      5.times { |i| ApplicableHostQueue.push_host(i) }
+      5.times { |i| ApplicableHostQueue.push_hosts([i]) }
+      5.times { |i| ApplicableHostQueue.push_hosts([i]) }
       popped_hosts = ApplicableHostQueue.pop_hosts
 
       assert_equal [0, 1, 2, 3, 4], popped_hosts.map(&:host_id).sort
     end
 
     def test_queue_depth
-      3.times { |i| ApplicableHostQueue.push_host(i) }
+      3.times { |i| ApplicableHostQueue.push_hosts([i]) }
 
       assert_equal 3, ApplicableHostQueue.queue_depth
     end


### PR DESCRIPTION
This pr resolves a couple issues:

1) Inserting hosts into the applicable host queue can cause a race condition where the 
    thread consuming the queue items are consuming at the same rate as the thread pushing host ids onto it.
    In that case you end up with applicability generation tasks that are only servicing a single host (or two)
2) run applicability once after a sync plan run.  This also refactors repo applicability generation to use db columns
    to determine if it needs to be run instead of the 'contents_changed' mechanism