### PR TITLE
fixes #32515 - Parse Rocky Linux distribution properly

### DIFF
--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -157,6 +157,8 @@ module Katello
           'OracleLinux'
         elsif name =~ /almalinux/
           'AlmaLinux'
+        elsif name =~ /rocky/
+          'Rocky'
         else
           'Unknown'
         end

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -90,6 +90,15 @@ module Katello
       assert_nil os.release_name
     end
 
+    def test_operatingsystem_rockylinux
+      @facts['distribution.name'] = 'Rocky Linux'
+      @facts['distribution.version'] = '8.3'
+
+      assert_equal parser.operatingsystem.name, 'Rocky'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, '3'
+    end
+
     def test_operatingsystem_debian
       @facts['distribution.name'] = 'Debian GNU/Linux'
       @facts['distribution.version'] = '9'

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -64,6 +64,8 @@ module Katello
 
         assert_equal 'AlmaLinux', Candlepin::Consumer.distribution_to_puppet_os('AlmaLinux')
 
+        assert_equal 'Rocky', Candlepin::Consumer.distribution_to_puppet_os('Rocky Linux')
+
         assert_equal 'Unknown', Candlepin::Consumer.distribution_to_puppet_os('RedHot')
       end
 


### PR DESCRIPTION
This PR will add the correct parsing of [Rocky Linux](https://rockylinux.org/) to Katello.
Here also the reference about the [discussion](https://community.theforeman.org/t/client-recognition-for-rocky-linux-in-foreman-katello/23437).

This is the second try, as I broke the first PR #9342 
Thank you @jlsherrill for helping!

I also corrected the rocky parsing now as you mentioned, didn't understand before where this is exactly used, but it should be now!

If I can still improve something I will really gladly do so! :)
Thank you!