### PR TITLE
Fixes #32604 - pin to psych 3.x

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -71,6 +71,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
+  # https://github.com/Katello/katello/pull/9365
+  gem.add_development_dependency "psych", "< 4.0.0"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "rubocop-checkstyle_formatter"
   gem.add_development_dependency "simplecov"


### PR DESCRIPTION
VCR is configured to use Psych as the serializer. Psych 4.0 changed load to be safe_load. In tests we don't mind, the codebase does not appear to use any YAML loading.

More info:

https://community.theforeman.org/t/psa-rubygem-psych-4-0-is-out-and-its-a-breaking-change/23604

Edit: We need to pin psych gem.