### PR TITLE
[CP] Fixes #32569 - prevent early timeout of katello-agent actions (#9351)

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -83,7 +83,12 @@ module Actions
         end
 
         unless history.finished?
-          fail _("Host did not finish content action in %s seconds.  The task has been cancelled.") % finish_timeout
+          # we could be processing the accept_timeout here
+          # only fail for finish_timeout unless the actual duration has elapsed
+          finish_limit = history.accepted_at + finish_timeout
+          if finish_limit < DateTime.now
+            fail _("Host did not finish content action in %s seconds.  The task has been cancelled.") % finish_timeout
+          end
         end
       end
 

--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.1.0.rc1".freeze
+  VERSION = "4.1.0.rc1.1".freeze
 end

--- a/test/actions/katello/agent_action_tests.rb
+++ b/test/actions/katello/agent_action_tests.rb
@@ -65,13 +65,22 @@ module Actions
           assert_match(/did not respond/, error.message)
         end
 
-        def test_process_timeout_finish
+        def test_process_timeout_finish_elapsed
           dispatch_history.accepted_at = Time.now
           bulk_action.expects(:dispatch_history).returns(dispatch_history)
 
-          error = assert_raises(StandardError) { bulk_action.process_timeout }
+          travel_to 2.hours.from_now do
+            error = assert_raises(StandardError) { bulk_action.process_timeout }
+            assert_match(/did not finish/, error.message)
+          end
+        end
 
-          assert_match(/did not finish/, error.message)
+        def test_process_timeout_finish_not_elapsed
+          dispatch_history.accepted_at = Time.now
+          dispatch_history.result = nil
+          bulk_action.expects(:dispatch_history).returns(dispatch_history)
+
+          bulk_action.process_timeout
         end
 
         def test_process_timeout_noop

--- a/test/lib/agent/client_message_handler_test.rb
+++ b/test/lib/agent/client_message_handler_test.rb
@@ -25,7 +25,8 @@ module Katello
           dynflow_step_id: 2
         )
 
-        ForemanTasks::Task.expects(:exists?).returns(true)
+        task = mock(result: 'pending')
+        ForemanTasks::Task.expects(:find_by_external_id).with(dispatch_history.dynflow_execution_plan_id).returns(task)
         mock_world = mock('mock world', event: true)
         mock_dynflow = stub('mock dynflow', world: mock_world, 'world=' => mock_world)
         ForemanTasks.stubs(:dynflow).returns(mock_dynflow)
@@ -52,7 +53,8 @@ module Katello
           dynflow_step_id: 2
         )
 
-        ForemanTasks::Task.expects(:exists?).returns(true)
+        task = mock(result: 'pending')
+        ForemanTasks::Task.expects(:find_by_external_id).with(dispatch_history.dynflow_execution_plan_id).returns(task)
         mock_world = mock('mock world', event: true)
         mock_dynflow = stub('mock dynflow', world: mock_world, 'world=' => mock_world)
         ForemanTasks.stubs(:dynflow).returns(mock_dynflow)


### PR DESCRIPTION
(cherry picked from commit 54afc67edd3aa7e85ecea53881b2f5d9e4248784)

hopefully this will fix the pipeline failure.