### PR TITLE
Fixes #32590 - always remove puppet and ostree repos

### DIFF
--- a/db/migrate/20210119162528_delete_puppet_and_ostree_repos.rb
+++ b/db/migrate/20210119162528_delete_puppet_and_ostree_repos.rb
@@ -32,28 +32,24 @@ class DeletePuppetAndOstreeRepos < ActiveRecord::Migration[6.0]
   end
 
   def up
-    if Katello::Repository.ostree_type.any? || puppet_repositories.any?
-      User.as_anonymous_admin do
-        FakeContentViewPuppetModule.delete_all
-        FakeContentViewPuppetEnvironmentPuppetModule.delete_all
-        FakeRepositoryPuppetModule.delete_all
+    FakeContentViewPuppetModule.delete_all
+    FakeContentViewPuppetEnvironmentPuppetModule.delete_all
+    FakeRepositoryPuppetModule.delete_all
 
-        FakeContentViewPuppetEnvironment.delete_all
-        FakePuppetModule.delete_all
+    FakeContentViewPuppetEnvironment.delete_all
+    FakePuppetModule.delete_all
 
-        ::Katello::Repository.delete(puppet_repositories)
+    ::Katello::Repository.delete(puppet_repositories) if puppet_repositories.any?
 
-        FakeRepositoryOstreeBranch.delete_all
-        FakeOstreeBranch.delete_all
-        Katello::Repository.ostree_type.where.not(:library_instance_id => nil, :environment_id => nil).destroy_all #CV LCE repos
-        Katello::Repository.ostree_type.where.not(:library_instance_id => nil).destroy_all # archive repos
-        Katello::Repository.ostree_type.destroy_all #all the rest (should just be library repos)
+    FakeRepositoryOstreeBranch.delete_all
+    FakeOstreeBranch.delete_all
+    Katello::Repository.ostree_type.where.not(:library_instance_id => nil, :environment_id => nil).destroy_all #CV LCE repos
+    Katello::Repository.ostree_type.where.not(:library_instance_id => nil).destroy_all # archive repos
+    Katello::Repository.ostree_type.destroy_all #all the rest (should just be library repos)
 
-        Katello::ContentViewVersion.where.not(:content_counts => nil).each do |version|
-          version.content_counts.except!('ostree', 'puppet_module')
-          version.save
-        end
-      end
+    Katello::ContentViewVersion.where.not(:content_counts => nil).each do |version|
+      version.content_counts.except!('ostree', 'puppet_module')
+      version.save
     end
   end
 


### PR DESCRIPTION
the previous detection of puppet repos did not account
for the situation where the user had a content view puppet
environment, but no longer had any puppet repos. This now
will run the cleanup code regardless