### PR TITLE
Fixes #32623 - delete_orphaned_content fails if no Pulp 3

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -8,7 +8,7 @@ module Actions
         def plan(proxy)
           sequence do
             plan_action(Actions::Pulp::Orchestration::OrphanCleanup::RemoveOrphans, proxy)
-            if proxy.pulp3_enabled?
+            if proxy.pulp3_enabled? && ::Katello::Ping.pulpcore_enabled
               plan_action(
                 Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans,
                 proxy)


### PR DESCRIPTION
On 3.18, it's not enough to check that Pulp 3 is enabled on the smart proxy. We also need to check if Pulp 3 is enabled.

To test:
1) Spin up a 3.18 box
2) Ensure Pulp 2 is being used everywhere and disable the pulpcore-api service
3) Try running `bundle exec rake katello:delete_orphaned_content`
4) Patch in this PR
5) Try again