### PR TITLE
Refs #32604 - remove psych dep

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -71,8 +71,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
-  # https://github.com/Katello/katello/pull/9365
-  gem.add_development_dependency "psych", "< 4.0.0"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "rubocop-checkstyle_formatter"
   gem.add_development_dependency "simplecov"


### PR DESCRIPTION
katello can use the built in psych and it seems
to cause issues running tests locally