### PR TITLE
Fixes #32362 - Change default pulp url to primary pulp smart proxy url

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -73,11 +73,6 @@ module Katello
         pulp_repo_facts['content_unit_counts']['srpm']
       end
 
-      def uri
-        uri = URI.parse(SETTINGS[:katello][:pulp][:url])
-        "https://#{uri.host}/pulp/content/#{relative_path}"
-      end
-
       def to_hash
         pulp_repo_facts.merge(as_json).merge(:sync_state => sync_state)
       end
@@ -353,20 +348,6 @@ module Katello
           history = sort_sync_status(history)
           return PulpSyncStatus.pulp_task(history.first.with_indifferent_access)
         end
-      end
-    end
-
-    def full_path(smart_proxy = nil, force_http = false)
-      pulp_uri = URI.parse(smart_proxy ? smart_proxy.url : SETTINGS[:katello][:pulp][:url])
-      scheme = force_http ? 'http' : 'https'
-      if docker?
-        "#{pulp_uri.host.downcase}/#{container_repository_name}"
-      elsif ostree?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/web/#{relative_path}"
-      elsif ansible_collection?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp_ansible/galaxy/#{relative_path}/api"
-      else
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/#{relative_path}/"
       end
     end
   end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -399,6 +399,20 @@ module Katello
       all_instances
     end
 
+    def full_path(smart_proxy = nil, force_http = false)
+      pulp_uri = URI.parse(smart_proxy ? smart_proxy.url : ::SmartProxy.pulp_primary.url)
+      scheme = force_http ? 'http' : 'https'
+      if docker?
+        "#{pulp_uri.host.downcase}/#{container_repository_name}"
+      elsif ostree?
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/web/#{relative_path}"
+      elsif ansible_collection?
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp_ansible/galaxy/#{relative_path}/api"
+      else
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/#{relative_path}/"
+      end
+    end
+
     def to_hash(content_source = nil, force_http = false)
       {id: id, name: label, url: full_path(content_source, force_http)}
     end

--- a/lib/katello.rb
+++ b/lib/katello.rb
@@ -28,6 +28,6 @@ module Katello
   require "katello/engine"
 
   def self.pulp_server
-    Katello::Pulp::Server.config(SETTINGS[:katello][:pulp][:url], User.remote_user)
+    Katello::Pulp::Server.config(::SmartProxy.pulp_primary.url + '/pulp/api/v2/', User.remote_user)
   end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -37,7 +37,6 @@ module Katello
         },
         :pulp => {
           :default_login => 'admin',
-          :url => 'https://localhost/pulp/api/v2/',
           :skip_checksum_validation => false,
           :upload_chunk_size => 1_048_575, # upload size in bytes to pulp. see SSLRenegBufferSize in apache
           :sync_threads => 4,

--- a/spec/helpers/sync_management_helper_spec.rb
+++ b/spec/helpers/sync_management_helper_spec.rb
@@ -15,7 +15,6 @@ module Katello
 
     before do
       @routes = Katello::Engine.routes
-      disable_product_orchestration
       disable_org_orchestration
       Katello.stubs(:pulp_server).returns(stub(:extensions => stub(:repository => stub(:search_by_repository_ids => []))))
       ProductTestData::PRODUCT_WITH_ATTRS.merge!(:provider => provider, :organization => provider.organization)

--- a/spec/models/activation_key_spec.rb
+++ b/spec/models/activation_key_spec.rb
@@ -9,8 +9,6 @@ module Katello
 
     before(:each) do
       disable_org_orchestration
-      disable_consumer_group_orchestration
-      disable_product_orchestration
       disable_activation_key_orchestration
 
       @organization = get_organization

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -7,8 +7,6 @@ module Katello
 
     describe "main" do
       before(:each) do
-        disable_product_orchestration
-        disable_repo_orchestration
         disable_org_orchestration
 
         Repository.any_instance.stubs(:save_content_orchestration).returns(true)

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -22,7 +22,6 @@ module Katello
 
       it 'should be destroyable' do
         gpg_key = GpgKey.create!(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
-        disable_product_orchestration
         product = katello_products(:fedora)
         product.gpg_key = gpg_key
         product.save!

--- a/spec/models/model_spec_helper.rb
+++ b/spec/models/model_spec_helper.rb
@@ -134,14 +134,6 @@ module Katello
       model.any_instance.stubs(execute_planned_action: nil)
     end
 
-    def disable_consumer_group_orchestration
-      Katello.pulp_server.extensions.consumer_group.stubs(:create).returns({})
-      Katello.pulp_server.extensions.consumer_group.stubs(:delete).returns(200)
-      Katello.pulp_server.extensions.consumer_group.stubs(:retrieve).returns({})
-      Katello.pulp_server.extensions.consumer_group.stubs(:add_consumers_by_id).returns(200)
-      Katello.pulp_server.extensions.consumer_group.stubs(:remove_consumers_by_id).returns(200)
-    end
-
     def disable_repo_orchestration
       Katello.pulp_server.extensions.repository.stubs(:create).returns({})
       Katello.pulp_server.extensions.repository.stubs(:sync_history).returns([])

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -9,7 +9,6 @@ module Katello
     before(:each) do
       load "#{Katello::Engine.root}/spec/helpers/product_test_data.rb"
       disable_org_orchestration
-      disable_product_orchestration
 
       as_admin do
         @organization = get_organization
@@ -84,10 +83,6 @@ module Katello
     end
 
     describe "validation" do
-      before(:each) do
-        disable_product_orchestration
-      end
-
       specify { Product.new(:label => "goo", :name => 'contains /', :provider => @provider).must_be :valid? }
       specify { Product.new(:label => "boo", :name => 'contains #', :provider => @provider).must_be :valid? }
       specify { Product.new(:label => "shoo", :name => 'contains space', :provider => @provider).must_be :valid? }
@@ -104,7 +99,6 @@ module Katello
 
     describe "#environments" do
       it "should contain a unique list of environments" do
-        disable_repo_orchestration
         product = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id))
         2.times do
           root = create(:katello_root_repository, product: product, url: "http://something")
@@ -119,7 +113,6 @@ module Katello
     end
 
     it 'should be destroyable' do
-      disable_repo_orchestration
       product = create(:katello_product, :fedora, provider: create(:katello_provider), organization: @organization)
       assert product.destroy
     end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -27,7 +27,6 @@ module Katello
 
     before(:each) do
       disable_org_orchestration
-      disable_product_orchestration
       @organization = get_organization(:organization2)
       @organization.redhat_provider.delete
     end
@@ -255,7 +254,6 @@ module Katello
     end
 
     it 'should be destroyable' do
-      disable_product_orchestration
       provider = create(:katello_provider, organization: @organization)
       create(:katello_product, :fedora, provider: provider, organization: @organization)
       assert_raise ActiveRecord::DeleteRestrictionError do

--- a/spec/models/pulp_task_status_spec.rb
+++ b/spec/models/pulp_task_status_spec.rb
@@ -35,48 +35,6 @@ module Katello
           :traceback => "traceback"
         }.with_indifferent_access
       end
-
-      describe "TaskStatus should have correct attributes for a completed task" do
-        before do
-          Runcible::Resources::Task.any_instance.stubs(:poll).returns(pulp_task_without_error)
-          @t = PulpTaskStatus.using_pulp_task(pulp_task_with_error)
-        end
-        specify { @t.uuid.must_equal(pulp_task_without_error[:task_id]) }
-        specify { @t.state.must_equal(pulp_task_without_error[:state]) }
-        specify { @t.start_time.must_equal(pulp_task_without_error[:start_time]) }
-        specify { @t.finish_time.must_equal(pulp_task_without_error[:finish_time]) }
-        specify { @t.result.must_equal(pulp_task_without_error[:result]) }
-      end
-
-      describe "TaskStatus should have correct attributes for a failed task" do
-        before do
-          Runcible::Resources::Task.any_instance.stubs(:poll).returns(pulp_task_with_error)
-          @t = PulpTaskStatus.using_pulp_task(pulp_task_with_error)
-        end
-        specify { @t.result.must_equal(:errors => [pulp_task_with_error[:exception], pulp_task_with_error[:traceback]]) }
-      end
-
-      describe "refreshing TaskStatus with latest from pulp" do
-        before(:each) do
-          disable_org_orchestration
-          @organization = Organization.create!(:name => 'test_org', :label => 'test_org')
-          Runcible::Resources::Task.any_instance.stubs(:poll).returns(pulp_task_without_error)
-          @t = PulpTaskStatus.using_pulp_task(pulp_task_without_error) do |t|
-            t.organization = @organization
-            t.user = users(:one)
-          end
-          @t.save!
-          Runcible::Resources::Task.any_instance.stubs(:poll).returns(updated_pulp_task)
-        end
-
-        it "should update attributes with values from pulp" do
-          @t.refresh
-
-          assert_equal @t.state, updated_pulp_task[:state]
-          assert_equal @t.finish_time, updated_pulp_task[:finish_time]
-          assert_equal @t.result, updated_pulp_task[:result]
-        end
-      end
     end
   end
 end

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -17,6 +17,7 @@ module Katello
     end
 
     def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       setup_controller_defaults_api
       Repository.any_instance.stubs(:last_sync).returns(Time.now.asctime)
       ::Katello::Erratum.any_instance.stubs(:repositories).returns([])

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -3,6 +3,7 @@ require "katello_test_helper"
 module Katello
   class Api::V2::ContentViewRepositoriesControllerTest < ActionController::TestCase
     def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       setup_controller_defaults_api
       @organization = get_organization
       @view = katello_content_views(:library_view)

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -10,6 +10,7 @@ module Katello
     end
 
     def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       setup_controller_defaults_api
       models
     end

--- a/test/glue/pulp/content_type_test.rb
+++ b/test/glue/pulp/content_type_test.rb
@@ -3,6 +3,7 @@ require 'katello_test_helper'
 module Katello
   class ContentTypeTest < ActiveSupport::TestCase
     def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       set_user
     end
 

--- a/test/services/katello/pulp/erratum_test.rb
+++ b/test/services/katello/pulp/erratum_test.rb
@@ -9,6 +9,8 @@ module Katello
       ERRATA_ID = 'KATELLO-RHSA-2010:0858'.freeze
 
       def setup
+        FactoryBot.create(:smart_proxy, :default_smart_proxy)
+
         User.current = users(:admin)
 
         @repo = katello_repositories(:fedora_17_x86_64)

--- a/test/services/katello/pulp/package_group_test.rb
+++ b/test/services/katello/pulp/package_group_test.rb
@@ -7,6 +7,7 @@ module Katello
       include RepositorySupport
 
       def setup
+        FactoryBot.create(:smart_proxy, :default_smart_proxy)
         User.current = users(:admin)
 
         @repo = katello_repositories(:fedora_17_x86_64)

--- a/test/services/katello/pulp/srpm_test.rb
+++ b/test/services/katello/pulp/srpm_test.rb
@@ -3,6 +3,10 @@ require 'support/pulp/repository_support'
 
 module Katello
   module Services
+    def setup
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
+    end
+
     class SrpmNonVcrTest < ActiveSupport::TestCase
       def test_update_model
         pulp_id = 'foo'

--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -82,11 +82,6 @@ def configure_vcr
       end
     end
 
-    if ENV['record'] == "false" && mode != :none
-      uri = URI.parse(SETTINGS[:katello][:pulp][:url])
-      c.ignore_hosts uri.host
-    end
-
     c.default_cassette_options = {
       :record => mode,
       :decode_compressed_response => true,


### PR DESCRIPTION
Also moved full_path method from repo.rb to repository.rb.