### PR TITLE
Fixes #32320 - Candlepin correctly errors out on Job Failures

### DIFF
--- a/app/lib/actions/candlepin/abstract_async_task.rb
+++ b/app/lib/actions/candlepin/abstract_async_task.rb
@@ -32,7 +32,15 @@ module Actions
       private
 
       def poll_external_task
-        ::Katello::Resources::Candlepin::Job.get(external_task[:id])
+        task = ::Katello::Resources::Candlepin::Job.get(external_task[:id])
+        check_for_errors!(task)
+        task
+      end
+
+      def check_for_errors!(task)
+        if task[:state] == 'FAILED'
+          fail ::Katello::Errors::CandlepinError, task[:resultData]
+        end
       end
     end
   end


### PR DESCRIPTION
Candlepin async task was previously not erroring out when a job failed
like manifest-import failure etc.
This commit addresses that