### PR TITLE
Fixes #32654 - katello:correct_repositories should use dynflow client

### DIFF
--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -51,7 +51,7 @@ namespace :katello do
   end
 
   desc "Correct missing pulp repositories. Specify CONTENT_VIEW=name and LIFECYCLE_ENVIRONMENT=name to narrow repositories.  COMMIT=true to perform operation."
-  task :correct_repositories => ["environment", "check_ping"] do
+  task :correct_repositories => ["dynflow:client", "environment", "check_ping"] do
     puts "All operations will be skipped.  Re-run with COMMIT=true to perform corrections." unless commit?
 
     User.current = User.anonymous_api_admin


### PR DESCRIPTION
To avoid the uninitialized Dynflow world error.

To test, apply this PR to a production box, delete a Katello repo's Pulp 3 repo with the api or Pulp CLI, then run `rake katello:correct_repositories`.