### PR TITLE
Fixes #32380 - Set correct variable for pulp disk space check

### DIFF
--- a/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
+++ b/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
@@ -5,6 +5,7 @@ module Katello
         class << self
           def deliver!
             SmartProxy.unscoped.with_content.each do |proxy|
+              percentage = proxy.pulp_disk_usage[0]['percentage']
               if percentage < 90 && notification_already_exists?(proxy)
                 blueprint.notifications.where(subject: proxy).destroy_all
               elsif update_notifications(proxy).empty? && percentage > 90


### PR DESCRIPTION
## To test:

* Spin up a new devel machine and apply the patch (don't start foreman up before, because it will create the task and you have to wait for a new one 12 hours later or you can change the interval but easier to just do it this way.)
* Try to create a product so the UI task gets created and notice it work correctly without a traceback.
* Notice in the dev log we see the task get created:
```ruby
19:04:02 rails.1   | 2021-05-25T19:04:02 [I|app|103b8682] Enqueued CreatePulpDiskSpaceNotifications (Job ID: 30e5c10b-dcf2-4dc5-a9c0-340cfbb4364c) to Dynflow(default)
19:04:02 rails.1   | 2021-05-25T19:04:02 [D|kat|103b8682] Candlepin request 7aaa97c2-b49d-462c-a200-e172c6bdca22 returned with code 200
19:04:02 rails.1   | 2021-05-25T19:04:02 [D|kat|103b8682] Processing response: 200

```