### PR TITLE
Fixes #32661 - Properly migrate hg content facet

### DIFF
--- a/app/lib/katello/util/hostgroup_facets_helper.rb
+++ b/app/lib/katello/util/hostgroup_facets_helper.rb
@@ -1,0 +1,126 @@
+# Used exclusively by fix_hostgroup_facets.rake task
+module Katello
+  module Util
+    class HostgroupFacetsHelper
+      def initialize
+        @logger = Logger.new($stdout)
+      end
+
+      def interested_hostgroups
+        groups = ::Hostgroup.unscoped.where(
+                    id: Katello::Hostgroup::ContentFacet.
+                        where(content_source_id: nil,
+                              kickstart_repository_id: nil,
+                              content_view_id: nil,
+                              lifecycle_environment_id: nil).select(:hostgroup_id))
+        parents = groups.select { |group| group.parent.blank? }
+        children = groups.reject { |group| group.parent.blank? }
+        # we want the parents to get created before the children
+        # hence the order
+        parents + children
+      end
+
+      def pick_facet_values(hg)
+        # This call looks at the audit logs for a host group.
+        # Pries out information related to lce, ks, cv and content_source_id from the audit logs.
+        # The audit logs typically only contain updates.
+        # So if the user changed  just the content_view_id, then that is the only thing marked as audited_changes.
+        # Hence we need to go through all the audit logs until we have information on lce, ks, cv and cs.
+        # If there was only one audit log and that was during the creation of hostgroup
+        # the audited changes look like this
+        # ```ruby
+        # {
+        #  content_view_id: 10,
+        #  kickstart_repository_id: 1000
+        #  ......
+        # }
+        # ```
+        # However if you updated the hostgroup and set the kickstart_repository_id, or
+        # content_view_id then audited changes look like
+        # ```ruby
+        # {
+        #  content_view_id: [10, 11],
+        #  kickstart_repository_id: [1000, 1200]
+        #  ......
+        # }
+        # ```
+        # So the code says "if the attribute value is an array pick the last value else just keep the value as it is "
+
+        # Further along it is to be noted that `hostgroup.audits` returns the audits ordered by the version number in ascending order, so the latest audit will be `hostgroup.audits.last`
+
+        # We want to iterate though each audit from latest audit to start, and as soon as we find a  content_view_id key or kickstart_repository_id key or lifecycle environment_id key  or content_source_id key we want it to be set once.
+
+        # So if I had an audit history like
+        # ``` ruby
+        # {
+        #  content_view_id: 10,
+        #  kickstart_repository_id: 1000,
+        #  version:1
+        #  ......
+        # },
+        # {
+        #  content_view_id: [10, 11],
+        #  kickstart_repository_id: [1000, 1200],
+        #   version: 2
+        #  ......
+        # }
+        # ```
+
+        # The code would start at version 2, notice that cv_id and ks_repo were set there
+        # and keep them as the final.
+        # So when it goes to version 1 since cv_id and ks_repo are already set,
+        # it will ignore. It will finally
+        # return {content_view_id: 11, kickstart_repository_id: 1200}
+        facet_values = {}
+        hg.audits.reverse_each do |audit|
+          hg_changes = audit.audited_changes.slice("lifecycle_environment_id",
+                                                   "kickstart_repository_id",
+                                                   "content_view_id",
+                                                   "content_source_id")
+          facet_values = hg_changes.merge(facet_values)
+        end
+
+        values = facet_values.map do |k, v|
+          v = v[-1] if v.is_a? Array
+          [k, v]
+        end
+        values.to_h.with_indifferent_access
+      end
+
+      def main
+        bad_hgs = []
+        good_hgs = []
+
+        groups = interested_hostgroups.each do |hg|
+          facet = hg.content_facet
+          values = pick_facet_values(hg)
+          if !values.empty? && facet.update(values)
+            good_hgs << { hostgroup: hg, facet_values: values }
+          else
+            bad_hgs << { hostgroup: hg, facet_values: values }
+            facet.save(validate: false)
+          end
+        end
+
+        unless bad_hgs.empty?
+          @logger.warn "Some of the hostgroups reported a validation error. "\
+                        "The hostgroups have been updated. "\
+                        "Check via the Web UI."
+
+          bad_hgs.each do |bad_group|
+            @logger.warn "Hostgroup #{bad_group[:hostgroup]}"
+            @logger.warn "Facet Values #{bad_group[:facet_values]}"
+          end
+        end
+        unless good_hgs.empty?
+          @logger.info "Following hostgroups were succesfully updated."
+          good_hgs.each do |good_group|
+            @logger.info "Hostgroup #{good_group[:hostgroup]}"
+            @logger.info "Facet Values #{good_group[:facet_values]}"
+          end
+        end
+        @logger.info("#{groups.count} Hostgroup(s) were updated.")
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -102,7 +102,9 @@ module Katello
         return true unless operatingsystem
 
         if operatingsystem.respond_to? :kickstart_repos
-          return operatingsystem.kickstart_repos(self).any? { |repo| repo[:id] == (content_facet&.kickstart_repository_id || content_facet&.kickstart_repository&.id) }
+          operatingsystem.kickstart_repos(self, content_facet: content_facet).any? do |repo|
+            repo[:id] == (content_facet&.kickstart_repository_id || content_facet&.kickstart_repository&.id)
+          end
         end
       end
 

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -42,10 +42,11 @@ module Katello
         end
       end
 
-      def kickstart_repos(host)
-        distros = distribution_repositories(host).where(distribution_bootable: true)
-        if distros && host&.content_facet&.content_source
-          distros.map { |distro| distro.to_hash(host.content_facet.content_source) }
+      def kickstart_repos(host, content_facet: nil)
+        distros = distribution_repositories(host, content_facet: content_facet).where(distribution_bootable: true)
+        content_facet ||= host.content_facet
+        if distros && content_facet&.content_source
+          distros.map { |distro| distro.to_hash(content_facet.content_source) }
         else
           []
         end
@@ -62,10 +63,10 @@ module Katello
         end
       end
 
-      def distribution_repositories(host)
-        content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
-        lifecycle_environment = host.try(:content_facet).try(:lifecycle_environment) || host.try(:lifecycle_environment)
-
+      def distribution_repositories(host, content_facet: nil)
+        content_facet ||= host.content_facet
+        content_view = content_facet.try(:content_view) || host.try(:content_view)
+        lifecycle_environment = content_facet.try(:lifecycle_environment) || host.try(:lifecycle_environment)
         if content_view && lifecycle_environment && host.os && host.architecture
           Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
               where(:distribution_arch => host.architecture.name).

--- a/db/migrate/20200514092553_move_katello_fields_from_hostgroups.katello.rb
+++ b/db/migrate/20200514092553_move_katello_fields_from_hostgroups.katello.rb
@@ -60,7 +60,7 @@ class MoveKatelloFieldsFromHostgroups < ActiveRecord::Migration[6.0]
         content_facet.kickstart_repository_id = kickstart_repository_id
         content_facet.content_view_id = content_view_id
         content_facet.lifecycle_environment_id = lifecycle_environment_id
-        unless content_facet.save
+        unless content_facet.save(validate: false)
           Rails.logger.warn("Unable to save content facet hostgroup for #{content_facet.inspect} ")
           Rails.logger.warn(content_facet.errors.full_messages.join("\n"))
         end

--- a/lib/katello/tasks/fix_hostgroup_facets.rake
+++ b/lib/katello/tasks/fix_hostgroup_facets.rake
@@ -1,0 +1,8 @@
+namespace :katello do
+  desc "This task collates hostgroup content facts that were missed during the upgrade from audit.\
+        It then updates the hostgroup content_facet accordingly."
+  task :fix_hostgroup_facets => :environment do
+    User.current = User.anonymous_admin
+    ::Katello::Util::HostgroupFacetsHelper.new.main
+  end
+end

--- a/test/lib/util/hostgroup_facets_helper_test.rb
+++ b/test/lib/util/hostgroup_facets_helper_test.rb
@@ -1,0 +1,80 @@
+require 'katello_test_helper'
+
+module Katello
+  class Util::HostgroupFacetsHelperTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(users(:admin).id)
+      @helper = Katello::Util::HostgroupFacetsHelper.new
+      @distro = katello_repositories(:fedora_17_x86_64)
+      @dev_distro = katello_repositories(:fedora_17_x86_64_acme_dev)
+      @os = ::Redhat.create_operating_system("GreatOS", *@distro.distribution_version.split('.'))
+      @cv = @distro.content_view
+      @env = @distro.environment
+      @arch = architectures(:x86_64)
+      @content_source = FactoryBot.create(:smart_proxy,
+                                          name: "foobar",
+                                          url: "http://example.com/",
+                                          lifecycle_environments: [@env, @dev_distro.environment])
+      @hostgroup = ::Hostgroup.create(
+        name: 'kickstart_repo',
+        operatingsystem: @os,
+        architecture: @arch
+        )
+      @facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: @hostgroup)
+    end
+
+    def test_interested_hostgroups
+      assert_includes @helper.interested_hostgroups, @hostgroup
+      @facet.update!(content_source_id: @content_source.id)
+      refute_includes @helper.interested_hostgroups, @hostgroup
+    end
+
+    def test_interested_hostgroups_parents
+      #make sure parents come before children
+      @child = ::Hostgroup.create(parent: @hostgroup,
+                            name: 'child_repo',
+                            operatingsystem: @os,
+                            architecture: @arch)
+      @child_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: @child)
+      assert_equal([@hostgroup, @child], @helper.interested_hostgroups)
+    end
+
+    def test_pick_facet_values_simple
+      expected = {
+        content_source_id: @content_source.id,
+        lifecycle_environment_id: @env.id,
+        content_view_id: @cv.id,
+        kickstart_repository_id: @distro.id
+      }.with_indifferent_access
+
+      audits = [ mock_audit(expected.slice(:content_source_id, :lifecycle_environment_id)),
+                 mock_audit(expected.except(:content_source_id, :lifecycle_environment_id))]
+      @hostgroup.expects(:audits).returns(audits)
+
+      actual = @helper.pick_facet_values(@hostgroup)
+      assert_equal expected, actual
+    end
+
+    def test_pick_facet_values_with_conflicts
+      audits = [
+        mock_audit(content_source_id: @content_source.id,
+                   lifecycle_environment_id: @env.id,
+                   content_view_id: @cv.id),
+        mock_audit(content_view_id: nil)
+      ]
+      @hostgroup.expects(:audits).returns(audits)
+
+      #now change content_view_id to nil
+      expected = {
+        content_source_id: @content_source.id,
+        lifecycle_environment_id: @env.id,
+        content_view_id: nil
+      }.with_indifferent_access
+      assert_equal expected, @helper.pick_facet_values(@hostgroup)
+    end
+
+    def mock_audit(changes)
+      mock(audited_changes: changes.with_indifferent_access)
+    end
+  end
+end

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -171,7 +171,7 @@ module Katello
       distro_repos = mock('distribution_repos').tap do |mock|
         mock.expects(:where).returns([@repo_with_distro])
       end
-      @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
+      @os.expects(:distribution_repositories).with(@host, content_facet: nil).returns(distro_repos)
       @host.content_facet.content_source = nil
       assert_empty @os.kickstart_repos(@host)
     end
@@ -180,7 +180,7 @@ module Katello
       distro_repos = mock('distribution_repos').tap do |mock|
         mock.expects(:where).returns([@repo_with_distro])
       end
-      @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
+      @os.expects(:distribution_repositories).with(@host, content_facet: nil).returns(distro_repos)
       repos = @os.kickstart_repos(@host)
       refute_empty repos
       assert_equal @repo_with_distro.full_path(@content_source), repos.first[:url]


### PR DESCRIPTION
Relaxes the validation constraints while migrating hostgroups . This is to avoid a circular validation error.
The migration creates a hostgroup_content_facet object and adds data, but unfortunately there is a circular validation happening which checks for the old object causing this ugly error.

```
/var/log/foreman/production.log:2021-05-08T15:01:11 [W|app|] Unable to save content facet hostgroup for #<Katello::Hostgroup::ContentFacet id: 1, hostgroup_id: 1, kickstart_repository_id: 6, content_source_id: 1, content_view_id: 1, lifecycle_environment_id: 1> 
``` 
