### PR TITLE
Fixes #32658 - Remove references to Pulp 2 from new/update repository UI

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -10,7 +10,7 @@ module Katello
 
     encrypts :upstream_password
 
-    IGNORABLE_CONTENT_UNIT_TYPES = %w(rpm drpm srpm distribution erratum).freeze
+    IGNORABLE_CONTENT_UNIT_TYPES = %w(srpm).freeze
     CHECKSUM_TYPES = %w(sha1 sha256).freeze
 
     OSTREE_UPSTREAM_SYNC_POLICY_LATEST = "latest".freeze

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -211,20 +211,11 @@
       </span>
 
       <span ng-if="repository.content_type === 'yum'">
-        <dt translate>Ignorable Content</dt>
-        <dd bst-edit-custom="repository.ignorable_content"
-            readonly="denied('edit_products', product)"
+        <dt translate>Ignore SRPMs</dt>
+        <dd bst-edit-checkbox="repository.ignore_srpms"
+            formatter="booleanToYesNo"
             on-save="save(repository)"
-            formatter="yumIgnorableContentFilter"
-            formatter-options="repository"
-            >
-            <div translate>Use Ctrl-click to multi-select/deselect items.</div>
-            <select id="ignorable_content"
-                    name="ignorable_content"
-                    multiple="true"
-                    ng-model="repository.ignorable_content"
-                    ng-options="id as name for (id, name) in ignorableYumContentUnits">
-            </select>
+            readonly="denied('edit_products', product)">
         </dd>
       </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -18,15 +18,14 @@
  * @requires Architecture
  * @requires RepositoryTypesService
  * @requires OSVersions
- * @requires YumContentUnits
  * #requires HttpProxyPolicy
  *
  * @description
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', '$sce', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'YumContentUnits', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture', 'RepositoryTypesService', 'HttpProxy', 'HttpProxyPolicy', 'OSVersions',
-        function ($scope, $sce, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, YumContentUnits, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture, RepositoryTypesService, HttpProxy, HttpProxyPolicy, OSVersions) {
+    ['$scope', '$sce', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture', 'RepositoryTypesService', 'HttpProxy', 'HttpProxyPolicy', 'OSVersions',
+        function ($scope, $sce, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture, RepositoryTypesService, HttpProxy, HttpProxyPolicy, OSVersions) {
 
             function success() {
                 Notification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -80,7 +79,6 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             $scope.checksums = Checksum.checksums;
             $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
             $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
-            $scope.ignorableYumContentUnits = YumContentUnits.units;
 
             $scope.$watch('repository.name', function () {
                 if ($scope.repositoryForm && $scope.repositoryForm.name) {
@@ -125,6 +123,11 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
                 }
                 if (repository.content_type === 'yum') {
                     repository.os_versions = $scope.osVersionsParam();
+                    if ($scope.repositoryForm.ignore_srpms.$modelValue) {
+                        repository.ignorable_content = ["srpm"];
+                    } else {
+                        repository.ignorable_content = [];
+                    }
                 }
                 if (repository.content_type !== 'yum') {
                     repository['download_policy'] = '';

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -175,17 +175,14 @@
 
       </div>
 
-      <div bst-form-group label="{{ 'Ignorable Content' | translate }}"  ng-if="repository.content_type === 'yum'">
-        <select id="ignorable_content"
-                name="ignorable_content"
-                multiple="true"
-                ng-model="repository.ignorable_content"
-                ng-options="id as name for (id, name) in ignorableYumContentUnits">
-        </select>
+      <div class="checkbox" ng-if="repository.content_type === 'yum'">
+        <label>
+          <input id="ignore_srpms" name="ignore_srpms" ng-model="repository.ignore_srpms" type="checkbox"/>
+          <span translate>Ignore SRPMs</span>
+        </label>
 
         <p class="help-block">
-          <span translate>Select content units to ignore while synchronizing this repository.</span><br />
-          <span translate>Use Ctrl-click to multi-select/deselect items.</span>
+          <span translate>Selecting this option will exclude SRPMs from repository synchronization.</span><br />
         </p>
       </div>
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -26,6 +26,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
             repositoryId: 1
         };
         $scope.repository = repository;
+        $scope.repository['ignorable_content'] = [];
 
         translate = function(message) {
             return message;
@@ -164,10 +165,6 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
     it ('should set ostree upstream sync policies', function() {
        expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
-    });
-
-    it ('should set yum content units', function() {
-       expect($scope.ignorableYumContentUnits).toBe(YumContentUnits.units);
     });
 
     it('should set the upload status to success and refresh the repository if a file upload status is success', function() {

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -114,8 +114,4 @@ describe('Controller: NewRepositoryController', function() {
        expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
     });
 
-    it ('should set yum content units', function() {
-       expect($scope.ignorableYumContentUnits).toBe(YumContentUnits.units);
-    });
-
 });

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -625,7 +625,7 @@ module Katello
       @root.url = "http://foo.com"
       @root.ignorable_content = nil
       assert @root.valid?
-      @root.ignorable_content = ["srpm", "erratum"]
+      @root.ignorable_content = ["srpm"]
 
       assert @root.valid?
       @root.ignorable_content = ["boo"]


### PR DESCRIPTION
To test, simply play around with the "Ignore SRPMs" checkbox. Ensure it always matches the state of the repository's `ignorable_content`.  Also try syncing a repo with SRPMs such as https://fixtures.pulpproject.org/srpm-signed/ and ensure that the SRPMs are indeed excluded.