### PR TITLE
Fixes #32663 - ensure unique name for each migrated repo

### DIFF
--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -105,7 +105,15 @@ module Katello
       end
 
       def name_for_content_view(content_view, root_repo)
-        "#{content_view.label}-#{root_repo.label}"
+        name = "#{content_view.label}-#{root_repo.label}"
+
+        if Katello::RootRepository.where(:label => root_repo.label).group(:label).count(:label)[root_repo.label] > 1
+          repo_query = Katello::Repository.joins(:root, :content_view_version => :content_view).
+              where("#{::Katello::RootRepository.table_name}.id != #{root_repo.id}").
+              where("#{::Katello::RootRepository.table_name}.label" => root_repo.label, "#{::Katello::ContentView.table_name}.label" => content_view.label)
+          name += "-#{root_repo.id}" if repo_query.any?
+        end
+        name
       end
 
       def content_view_migration(content_view, root)

--- a/test/services/katello/pulp3/migration_plan_test.rb
+++ b/test/services/katello/pulp3/migration_plan_test.rb
@@ -1,0 +1,24 @@
+require 'katello_test_helper'
+module Katello
+  module Service
+    module Pulp3
+      class MigrationPlanTest < ActiveSupport::TestCase
+        def setup
+          repo_label = 'foo'
+          repoa = katello_repositories(:fedora_17_x86_64_library_view_2)
+          repob = katello_repositories(:rhel_6_x86_64_dev_archive)
+
+          repoa.root.update_column(:label, repo_label)
+          repob.root.update_column(:label, repo_label)
+        end
+
+        def test_conflicting_labels
+          plan = Katello::Pulp3::MigrationPlan.new(['yum']).generate
+          name_list = plan[:plugins].first[:repositories].map { |i| i[:name] }
+          assert_equal name_list.size, name_list.uniq.size
+          assert_include name_list, 'published_dev_view-foo'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Steps to Reproduce:
1.  Create ProductA
2.  Create a repo in ProductA with label 'foo' pointed to some repo, sync it
3.  Create Product B
4.  Create a repo in ProductB with label 'foo' pointed to some repo, sync it
5.  Add both 'foo' repos to a content view and publish it
6.  run foreman-maintain content prepare
7.  run foreman-maintain content migration-stats

notice that not all repos are migrated