### PR TITLE
Fixes #32303 - Add show_all endpoint for component content_views

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -107,6 +107,10 @@ module Katello
       joins(:content_view_versions => :repositories).where("katello_repositories.root_id" => root_repository.id).uniq
     end
 
+    def self.in_organization(org)
+      where(organization_id: org.id)
+    end
+
     def to_s
       name
     end

--- a/app/services/katello/component_view_presenter.rb
+++ b/app/services/katello/component_view_presenter.rb
@@ -1,0 +1,15 @@
+module Katello
+  class ComponentViewPresenter < SimpleDelegator
+    attr_accessor :view, :component_view
+
+    def initialize(cv, content_view)
+      @view = content_view
+      @component_view = Katello::ContentViewComponent.where(:composite_content_view_id => cv.id, :content_view_id => @view.id).first_or_initialize
+      super(@component_view)
+    end
+
+    def self.component_presenter(cv, views:)
+      views.map { |content_view| ComponentViewPresenter.new(cv, content_view) }
+    end
+  end
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -63,6 +63,7 @@ Katello::Engine.routes.draw do
         end
 
         match '/content_views/:composite_content_view_id/content_view_components' => 'content_view_components#index', :via => :get
+        match '/content_views/:composite_content_view_id/content_view_components/show_all' => 'content_view_components#show_all', :via => :get
         match '/content_views/:composite_content_view_id/content_view_components/:id' => 'content_view_components#show', :via => :get
         match '/content_views/:composite_content_view_id/content_view_components/add' => 'content_view_components#add_components', :via => :put
         match '/content_views/:composite_content_view_id/content_view_components/remove' => 'content_view_components#remove_components', :via => :put

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -75,7 +75,7 @@ module Katello
                    'katello/api/v2/content_view_histories' => [:index, :auto_complete_search],
                    'katello/api/v2/content_view_repositories' => [:show_all],
                    'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search],
-                   'katello/api/v2/content_view_components' => [:index, :show],
+                   'katello/api/v2/content_view_components' => [:index, :show, :show_all],
                    'katello/api/v2/packages' => [:index],
                    'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search, :compare],
                    'katello/api/v2/errata' => [:index, :show, :auto_complete_search, :compare],

--- a/test/controllers/api/v2/content_view_components_controller_test.rb
+++ b/test/controllers/api/v2/content_view_components_controller_test.rb
@@ -91,6 +91,13 @@ module Katello
       end
     end
 
+    def test_show_all
+      get :show_all, params: { :composite_content_view_id => @composite.id }
+
+      assert_response :success
+      assert_template 'api/v2/content_view_components/index'
+    end
+
     def test_show
       component = create_component
       get :show, params: { :composite_content_view_id => @composite.id, :id => component.id }


### PR DESCRIPTION
This is similar to repository/show_all endpoint and will be used in the UI to easily show added/not added cvs for a composite cv

The new endpoint is: /katello/api/v2/content_views/$CV_ID/content_view_components/show_all
It should also support pagination and searching.