### PR TITLE
Fixes #32699 - Katello 3.18 changed the way RH operating systems are named after sync

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -10,8 +10,15 @@ module Katello
           minor ||= '' # treat minor versions as empty string to not confuse with nil
           os = ::Redhat.where(:name => os_name, :major => major, :minor => minor).try(:first)
           return os if os
-          description = "#{os_name}-#{repo.distribution_version}"
-          create_os = lambda { ::Redhat.create!(:name => os_name, :major => major, :minor => minor, :description => description) }
+
+          if ::Redhat.where(:title => "#{os_name} #{repo.distribution_version}").present?
+            description = "#{os_name} #{repo.distribution_version} #{SecureRandom.uuid}"
+            create_os = lambda do
+              ::Redhat.create!(:name => os_name, :major => major, :minor => minor, :description => description)
+            end
+          else
+            create_os = lambda { ::Redhat.create!(:name => os_name, :major => major, :minor => minor) }
+          end
 
           begin
             create_os.call


### PR DESCRIPTION
The old fix to https://projects.theforeman.org/issues/30571 involved creating a description for new RH OS's that had a dash in it. This naming change broke environments for people who were expecting the naming convention to stay the same.

The old issue comes about when a user pre-creates an OS that has a description such as RedHat 8.2 but does not have a `name`, `major`, or `minor` that matches the description.  As such, when Katello creates the OS during sync time, an error would be thrown since the OS title is already taken.  The dash fixed this, but we need a new solution for the reason above. My PR here changes the fix to give OS created at sync time a description with a UUID at the end to avoid naming clashes.  This UUID will only appear in the rare corner case that a user did pre-create an OS with a description that does not match the `name`, `major`, and `minor`.

To test:

1) Create an OS with:
  - Name: `CentOS`
  - Major: 2
  - Minor: 5
  - Family: Red Hat
  - Description: `CentOS 7`
2) Sync the following repo: http://mirror.centos.org/centos/7/os/x86_64/
3) See the error: `Validation failed: Title has already been taken`
4) Patch in this PR
5) Try syncing again
6) See that an OS was created with the following description: `CentOS 7 <UUID>`