### PR TITLE
Fixes #32601 - Applicability regen after upload and remove

### DIFF
--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -13,6 +13,7 @@ module Actions
           unit_keys = repo_service.unit_keys(uploads)
           generate_metadata = options.fetch(:generate_metadata, true)
           sync_capsule = options.fetch(:sync_capsule, true)
+          generate_applicability = options.fetch(:generate_applicability, repository.yum?)
 
           options[:content_type] ||= ::Katello::RepositoryTypeManager.find(repository.content_type).default_managed_content_type.label
           unit_type_id = SmartProxy.pulp_primary.content_service(options[:content_type])::CONTENT_TYPE
@@ -38,6 +39,7 @@ module Actions
               end
             end
             plan_action(Katello::Repository::MetadataGenerate, repository) if generate_metadata
+            plan_action(Actions::Katello::Applicability::Repository::Regenerate, :repo_ids => [repository.id]) if generate_applicability
             plan_self(repository_id: repository.id, sync_capsule: sync_capsule, upload_results: upload_results)
           end
         end

--- a/app/lib/actions/katello/repository/remove_content.rb
+++ b/app/lib/actions/katello/repository/remove_content.rb
@@ -19,6 +19,8 @@ module Actions
           content_unit_ids = content_units.map(&:id)
           content_unit_type = options[:content_type] || content_units.first.class::CONTENT_TYPE
 
+          generate_applicability = options.fetch(:generate_applicability, repository.yum?)
+
           sequence do
             remove_content_args = {
               :contents => content_unit_ids,
@@ -31,6 +33,7 @@ module Actions
             return if pulp_action.error
             plan_self(:content_unit_class => content_units.first.class.name, :content_unit_ids => content_unit_ids)
             plan_action(CapsuleSync, repository) if sync_capsule
+            plan_action(Actions::Katello::Applicability::Repository::Regenerate, :repo_ids => [repository.id]) if generate_applicability
           end
         end
 


### PR DESCRIPTION
To test:

1) Register a content host
2) Create empty repo
3) Subscribe content host to product with empty repo
4) Install walrus-0.71 from [https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/](https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/) on content host
5) Add walrus-5.21 from [https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/](https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/) to empty repo
	- walrus-5.21 will be shown as an upgradable package on the content host (bug fix - did not previously update automatically)
6) Remove walrus-5.21 from repo
	- will no longer be shown as an upgradable package on the content host (bug fix - did not previously update automatically)