### PR TITLE
Fixes #32711 - add btn-group to react-bootstrap-select form control

### DIFF
--- a/webpack/components/react-bootstrap-select/index.js
+++ b/webpack/components/react-bootstrap-select/index.js
@@ -62,7 +62,7 @@ class BootstrapSelect extends React.Component {
                         data-count-selected-text={__('{0} items selected')}
                         defaultValue={initialValue}
                         componentClass="select"
-                        className="without_select2 without_jquery_multiselect"
+                        className="btn-group without_select2 without_jquery_multiselect"
     />;
   }
 }


### PR DESCRIPTION
PR updated to reflect **Short term solution 1** - left everything below for future reference.

To test:

Verify that the dropdowns on RH Repositories page continue to work. In prod, apply the 'btn-group' class to the two form-control div elements for the dropdowns, confirm that they work as normal.

Files https://projects.theforeman.org/issues/32799 to track upgrade of this page to PF4 which has a suitable replacement component for bootstrap-select.

**Problem**

bootstrap-select was updated earlier this year to 1.13.6 from 1.12.2 due to a security vulnerability.
In devel no issues were noticed, but in production the Product and content type filter dropdowns aren't rendered correctly.

It turns out that devel continues to use 1.12.2 (it's a dependency of patternfly) and no issues are observed. Production correctly uses 1.13.6 but there is a problem with the CSS preventing proper display.

I don't really love the solution in this PR, but it's an option. With it, we'll rely on the bootstrap-select brought in by patternfly. I believe it implies we would update the RPM to remove the bootstrap-select dep as well. This could cause confusion or problems later (patternfly removing bootstral-select) so ... not super great. Some other options below:

**Short term solution 1** - add the correct css class ('btn-group') to the BootstrapSelect component in our code as that seems to fix the problem in production
**Short term solution 2** - downgrade to 1.12.2 (this will bring back the security vulnerability which the upgrade resolved)
**Short term solution 3** - see if updating to the latest 1.13.x fixes production (a read of the code seems to indicate _no_)
**Short term solution 4**  - can we enforce/guarantee that 1.13.6 is used in devel, and go from there (possible combination with 1)
**Long term solution** - use another patternfly component on the RH repositories page, removing direct bootstrap select dependency completely