### PR TITLE
Fixes #32740 - Orphan cleanup fails on boxes with only pulp3

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -1,13 +1,13 @@
 module Actions
   module Katello
     module OrphanCleanup
-      class RemoveOrphans < Pulp::Abstract
+      class RemoveOrphans < Actions::Base
         input_format do
           param :capsule_id
         end
         def plan(proxy)
           sequence do
-            plan_action(Actions::Pulp::Orchestration::OrphanCleanup::RemoveOrphans, proxy)
+            plan_action(Actions::Pulp::Orchestration::OrphanCleanup::RemoveOrphans, proxy) if (proxy.has_feature?(SmartProxy::PULP_FEATURE) || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE))
             if proxy.pulp3_enabled? && ::Katello::Ping.pulpcore_enabled
               plan_action(
                 Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans,

--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -2,7 +2,7 @@ module Actions
   module Pulp3
     module Orchestration
       module OrphanCleanup
-        class RemoveOrphans < Pulp::Abstract
+        class RemoveOrphans < Pulp3::Abstract
           def plan(proxy)
             if proxy.pulp3_enabled?
               sequence do


### PR DESCRIPTION
To test:
On a pulp3 only box:
1. Run bundle exec rails katello:delete_orphaned_content
