### PR TITLE
Fixes #32787 - Ping checks pulpcore api service correctly

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -9,7 +9,7 @@ module Katello
         SETTINGS[:katello][:use_pulp_2_for_content_type].nil? || (!SETTINGS[:katello][:use_pulp_2_for_content_type][:yum] &&
         !SETTINGS[:katello][:use_pulp_2_for_content_type][:docker] &&
         !SETTINGS[:katello][:use_pulp_2_for_content_type][:file]) ||
-        system('systemctl is-enabled pulpcore-api.service')
+        File.exist?('/etc/systemd/system/multi-user.target.wants/pulpcore-api.service')
       end
 
       def services(capsule_id = nil)


### PR DESCRIPTION
The previous check used 'systemctl is-enabled' to figure out. This would
not work well for production systems with selinux content barring
running the systemctl commands.
The change here instead just checks if the file exists.