### PR TITLE
Fixes #32724 - Removes an unnecessary pulp3 ping check

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -8,7 +8,7 @@ module Actions
         def plan(proxy)
           sequence do
             plan_action(Actions::Pulp::Orchestration::OrphanCleanup::RemoveOrphans, proxy) if (proxy.has_feature?(SmartProxy::PULP_FEATURE) || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE))
-            if proxy.pulp3_enabled? && ::Katello::Ping.pulpcore_enabled
+            if proxy.pulp3_enabled?
               plan_action(
                 Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans,
                 proxy)

--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -5,17 +5,10 @@ module Katello
     PACKAGES = %w(katello candlepin pulp qpid foreman tfm hammer).freeze
 
     class << self
-      def pulpcore_enabled # for downstream 6.9, remove in 6.10
-        SETTINGS[:katello][:use_pulp_2_for_content_type].nil? || (!SETTINGS[:katello][:use_pulp_2_for_content_type][:yum] &&
-        !SETTINGS[:katello][:use_pulp_2_for_content_type][:docker] &&
-        !SETTINGS[:katello][:use_pulp_2_for_content_type][:file]) ||
-        system('systemctl is-enabled pulpcore-api.service &>/dev/null')
-      end
-
       def services(capsule_id = nil)
         proxy = fetch_proxy(capsule_id)
         services = [:candlepin, :candlepin_auth, :foreman_tasks, :katello_events, :candlepin_events]
-        services += [:pulp3] if proxy&.pulp3_enabled? && pulpcore_enabled
+        services += [:pulp3] if proxy&.pulp3_enabled?
         services += [:katello_agent] if ::Katello.with_katello_agent?
         if proxy.nil? || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) || proxy.has_feature?(SmartProxy::PULP_FEATURE)
           services += [:pulp, :pulp_auth]

--- a/test/models/ping_test.rb
+++ b/test/models/ping_test.rb
@@ -169,7 +169,6 @@ module Katello
 
   class PingTestPulp3 < ActiveSupport::TestCase
     def run_exception_test(json, message)
-      Katello::Ping.stubs(:pulpcore_enabled).returns(true)
       Katello::Ping.expects(:backend_status).returns(json)
       exception = assert_raises Exception do
         Katello::Ping.pulp3_without_auth(@url)


### PR DESCRIPTION
As a part of removing pulp2 references, taking out unnecesary code out
of the ping. Fixeing another issue