### PR TITLE
Fixes #32835 - Add RHSM and content URL as info providers

### DIFF
--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -16,6 +16,15 @@ module Katello
         if host.content_facet.present?
           info['parameters']['kickstart_repository'] = host.content_facet.kickstart_repository.try(:label)
         end
+
+        if (rhsm_url = host.content_source&.rhsm_url)
+          info['parameters']['rhsm_url'] = rhsm_url.to_s
+        end
+
+        if (content_url = host.content_source&.pulp_content_url)
+          info['parameters']['content_url'] = content_url.to_s
+        end
+
         info
       end
 


### PR DESCRIPTION
This introduces two Smart Proxy extension methods and exposes them as info providers. This allows clients to use the ENC API to (re)configure subscription-manager.

First of all, this implements logic to determine the RHSM URL. This is constructed by looking at Pulp. While this is really the wrong way, there is currently no alternative. (I started https://github.com/ekohl/smart_proxy_rhsm a while back and that could solve it - another is to bolt it onto the Pulp module).

Ideally this would be exposed as a setting as well. There is a plan to align everything on port 443. If the Smart Proxy exposes a setting, Katello doesn't need to guess and a smooth migration can be realized.

This all becomes more important when the host subscription RPM is phased out.

Then it also introduces pulp_content_url which is already a setting that's exposed via the Smart Proxy Pulp feature. This is also used in the various places where it's needed.

It does highlight a missing setting for pulp_ansible content. Again, Katello should not have to guess URLs but discover it from the infrastructure.

Another potential use case that this allows is using REX to move a host from one content source to another.

Currently a draft since I have not verified this at all. However, I did want to link it and share it. What's also probably missing is provisioning macros.