### PR TITLE
Fixes #32815 - Display checkbox/select column for grouped subscriptions

### DIFF
--- a/webpack/components/pf3Table/formatters/selectionHeaderCellFormatter.js
+++ b/webpack/components/pf3Table/formatters/selectionHeaderCellFormatter.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import TableSelectionHeaderCell from '../components/TableSelectionHeaderCell';
 
-export default (selectionController, label) => (
+export default (selectionController, label, selectionEnabled) => (
   <TableSelectionHeaderCell
     label={label}
     checked={selectionController.allRowsSelected()}
     onChange={() => selectionController.selectAllRows()}
+    disabled={!selectionEnabled}
   />
 );

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
@@ -30,13 +30,15 @@ export const createSubscriptionsTableSchema = (
     property: 'select',
     header: {
       label: __('Select all rows'),
-      formatters: [label => selectionHeaderCellFormatter(selectionController, label)],
+      formatters: [
+        label => selectionHeaderCellFormatter(selectionController, label, hasPermission),
+      ],
     },
     cell: {
       formatters: [
         (value, additionalData) => {
           // eslint-disable-next-line no-param-reassign
-          additionalData.disabled = additionalData.rowData.available === -1;
+          additionalData.disabled = !hasPermission || additionalData.rowData.available === -1;
 
           return collapseableAndSelectionCellFormatter(
             groupingController,

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -325,6 +325,22 @@ exports[`subscriptions table should render subscription name without hyperlink f
         class=""
       >
         <th
+          aria-label="Select all rows"
+          class="table-view-pf-select"
+        >
+          <label
+            class="control-label sr-only"
+            for="selectAll"
+          >
+            Select all rows
+          </label>
+          <input
+            disabled=""
+            id="selectAll"
+            type="checkbox"
+          />
+        </th>
+        <th
           class=""
         >
           Name
@@ -355,6 +371,14 @@ exports[`subscriptions table should render subscription name without hyperlink f
       <tr
         class=""
       >
+        <td
+          class="table-view-pf-select"
+        >
+          <span
+            aria-hidden="true"
+            class="fa fa-angle-right collapse-subscription-group-button"
+          />
+        </td>
         <td>
           hsdfhsdh
         </td>

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
@@ -34,9 +34,12 @@ const Table = ({
     toggle: ({ rowData }) => toggleSubscriptionGroup(rowData.product_id),
   };
 
+  const collapsibleGroup =
+    Object.values(groupedSubscriptions).some(v => v.subscriptions.length > 1);
+
   const alwaysDisplayColumns = [];
 
-  if (selectionEnabled) {
+  if (selectionEnabled || collapsibleGroup) {
     alwaysDisplayColumns.push('select');
   }
 


### PR DESCRIPTION
Fix an issue with disconnected Satellite where checkbox/select column is not displayed even with grouped subscriptions.