### PR TITLE
Fixes #32839 - Make with_ansible? check more precise

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -260,6 +260,6 @@ module Katello
   end
 
   def self.with_ansible?
-    (ForemanAnsible rescue false) ? true : false
+    (ForemanAnsible::Engine rescue false) ? true : false
   end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -248,7 +248,7 @@ module Katello
 
   # check whether foreman_remote_execution to integrate is available in the system
   def self.with_remote_execution?
-    (RemoteExecutionFeature rescue false) ? true : false
+    Foreman::Plugin.installed?("foreman_remote_execution")
   end
 
   def self.with_katello_agent?
@@ -260,6 +260,6 @@ module Katello
   end
 
   def self.with_ansible?
-    (ForemanAnsible::Engine rescue false) ? true : false
+    Foreman::Plugin.installed?("foreman_ansible")
   end
 end


### PR DESCRIPTION
A recent foreman change re-used the `ForemanAnsible` namespace previously used only by the foreman_ansible plugin. The presence of the `ForemanAnsible` module threw a false positive for our `with_ansible?`. The fix here is to check specifically for the foreman_ansible engine itself.

See: https://github.com/theforeman/foreman/pull/8491