### PR TITLE
Registration API & activation key(s)

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
@@ -17,9 +17,8 @@ module Katello
           args
         end
 
-        def append_array_of_ids(hash_params)
-          return if registration_params['activation_key'].present? || registration_params['activation_keys'].present?
-          super
+        def append_array_of_ids(*)
+          return
         end
       end
 
@@ -28,8 +27,8 @@ module Katello
 
         update_api(:create) do
           param :registration_command, Hash do
-            param :activation_key, String, desc: N_('Activation key for subscription-manager client. Required for CentOS and Red Hat Enterprise Linux. Multiple keys add separated by comma, example: key1,key2,key3.'), deprecated: true
-            param :activation_keys, Array, required: true, desc: N_('Activation key(s) for subscription-manager client. Required for CentOS and Red Hat Enterprise Linux. Required only if host group has no activation keys')
+            param :activation_key, String, desc: N_('Activation key for subscription-manager client, required for CentOS and Red Hat Enterprise Linux. For multiple keys use `activation_keys` param instead.'), deprecated: true
+            param :activation_keys, Array, desc: N_('Activation keys for subscription-manager client, required for CentOS and Red Hat Enterprise Linux. Required only if host group has no activation keys.')
             param :lifecycle_environment_id, :number, required: false, desc: N_('Lifecycle environment for the host.')
             param :force, :bool, required: false, desc: N_('Clear any previous registration and run subscription-manager with --force.')
             param :ignore_subman_errors, :bool, required: false, desc: N_('Ignore subscription-manager errors for `subscription-manager register` command')
@@ -40,6 +39,28 @@ module Katello
       included do
         prepend Overrides
         include ApiPieExtensions
+
+        before_action :check_activation_keys, only: [:create]
+      end
+
+      private
+
+      def check_activation_keys
+        return if params['registration_command']['activation_key'].present? ||
+                  params['registration_command']['activation_keys'].present? ||
+                  hostgroup_have_acks?
+
+        render_error 'custom_error', status: :unprocessable_entity,
+                                     locals: { message: N_('Missing activation key!') }
+      end
+
+      def hostgroup_have_acks?
+        return unless params['registration_command']['hostgroup_id']
+
+        ::Hostgroup.authorized(:view_hostgroups)
+                   .find(params['registration_command']['hostgroup_id'])
+                   .params['kt_activation_keys']
+                   .present?
       end
     end
   end

--- a/test/controllers/foreman/registration_commands_controller_test.rb
+++ b/test/controllers/foreman/registration_commands_controller_test.rb
@@ -9,64 +9,103 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
 
   def test_ack_one_key
     post :create, params: { activation_key: ' key1 ' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1')
     refute_includes(JSON.parse(@response.body)['registration_command'], 'activation_key=key1')
   end
 
   def test_ack_two_keys
     post :create, params: { activation_key: ' key1 , key2 , ' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1%2Ckey2')
   end
 
-  def test_ack_formatting1
+  def test_ack_formatting
     post :create, params: { activation_key: ' , ,,key1, , key2, , ,,,  , ,' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1%2Ckey2')
   end
 
   def test_ack_key_with_space
     post :create, params: { activation_key: ' key1 with space ' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1+with+space')
   end
 
   def test_ack_keys_with_spaces
     post :create, params: { activation_key: ' key1 with space , key2 with space ' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1+with+space%2Ckey2+with+space')
   end
 
   def test_ack_formatting_keys
     post :create, params: { activation_key: ' key1 with space , key2 with space ,, ,, , ' }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1+with+space%2Ckey2+with+space')
   end
 
   def test_ack_empty_key
     post :create, params: { activation_key: '' }
-    refute_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=')
-    refute_includes(JSON.parse(@response.body)['registration_command'], 'activation_key=')
+    assert_response :unprocessable_entity
   end
 
   def test_ack_nil_key
     post :create
-    refute_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=')
-    refute_includes(JSON.parse(@response.body)['registration_command'], 'activation_key=')
+    assert_response :unprocessable_entity
   end
 
   def test_acks_array
-    post :create, params: { activation_keys: ['key1', 'key2']}
+    post :create, params: { activation_keys: ['key1', 'key2'] }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key1%2Ckey2')
   end
 
+  def test_acks_empty_array
+    post :create, params: { activation_keys: [] }
+    assert_response :unprocessable_entity
+  end
+
   def test_ack_and_acks
-    post :create, params: { activation_key: 'key1, key2', activation_keys: ['key3', 'key4']}
+    post :create, params: { activation_key: 'key1, key2', activation_keys: ['key3', 'key4'] }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'activation_keys=key3%2Ckey4')
   end
 
   def test_with_ignore_subman_errors
-    post :create, params: { ignore_subman_errors: true }
+    post :create, params: { ignore_subman_errors: true, activation_keys: ['key1'] }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'ignore_subman_errors=true')
   end
 
   def test_with_lifecycle_environment_id
-    post :create, params: { lifecycle_environment_id: 23 }
+    post :create, params: { lifecycle_environment_id: 23, activation_keys: ['key1'] }
+
+    assert_response :success
     assert_includes(JSON.parse(@response.body)['registration_command'], 'lifecycle_environment_id=23')
+  end
+
+  def test_hostgroup_with_ack
+    hostgroup = FactoryBot.create(:hostgroup)
+    FactoryBot.create(:hostgroup_parameter, hostgroup: hostgroup, name: 'kt_activation_keys', value: 'key1')
+    hostgroup.reload
+
+    post :create, params: { hostgroup_id: hostgroup.id }
+    assert_response :success
+  end
+
+  def test_hostgroup_without_ack
+    hostgroup = FactoryBot.create(:hostgroup)
+    post :create, params: { hostgroup_id: hostgroup.id }
+
+    assert_response :unprocessable_entity
   end
 end


### PR DESCRIPTION
Fix issue with hammer tool & synchronize behavior with UI form,
where activation key is required only in the case
when selected host group doesn't have assigned any activation keys.

If no host group is selected, `:activation_key` (deprecated)
or `:activation_keys` is required

**How to test**
```
hammer host-registration generate-command # => error no keys
hammer host-registration generate-command --activation-key key_one # => ok
hammer host-registration generate-command --activation-keys key_one,key_two # => ok
hammer host-registration generate-command --hostgroup-id 1 # => Error if host group has no acks
```