### PR TITLE
Fixes #32869 - migration plan showing up as error in logs

### DIFF
--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -166,7 +166,7 @@ module Katello
 
       def create_migrations
         plan = migration_plan
-        Rails.logger.info("Migration Plan: #{plan}")
+        Rails.logger.info("Migration Plan: #{plan.to_yaml}")
 
         if plan['plugins'].empty?
           Rails.logger.error("No Repositories to migrate")

--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -14,7 +14,6 @@ module Katello
         Katello::Logging.time("CONTENT_MIGRATION - Generating Migration plan") do
           plan[:plugins] = generate_plugins
         end
-        Rails.logger.error("Migration Plan: #{plan.to_json}")
         plan
       end
 


### PR DESCRIPTION
This PR removes an unnecessary error log and prints the plan in a nicer (yaml) format.

To test, spin up a 3.18 box, switch it to Pulp 2, create a repo, and migrate. Then check `/var/log/messages` for "Migration Plan".

Questions for reviewer:
1) Should the migration plan be an info log?
2) Is printing the migration plan hash in yaml sufficiently pretty?  Example:

```yaml
2021-06-24T13:57:09 [I|app|] Migration Plan: ---
 | plugins:
 | - type: rpm
 |   repositories:
 |   - name: f721f1b7-7ea4-492d-ba75-4a98f27a9a3c
 |     repository_versions:
 |     - pulp2_repository_id: f721f1b7-7ea4-492d-ba75-4a98f27a9a3c
 |       pulp2_distributor_repository_ids:
 |       - f721f1b7-7ea4-492d-ba75-4a98f27a9a3c
 |     pulp2_importer_repository_id: f721f1b7-7ea4-492d-ba75-4a98f27a9a3c
 |
```