### PR TITLE
Fixes #31853 - Ignore timeout events to avoid errors if they cannot be delivered

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -47,14 +47,14 @@ module Actions
 
             dispatch_message(history) unless input[:bulk]
 
-            schedule_timeout(timeout)
+            schedule_timeout(timeout, optional: true)
           end
         when Dynflow::Action::Skip
           # Do not fail and goto a paused state, instead skip and send the state to warning so we do not block other host actions
         when Dynflow::Action::Timeouts::Timeout
           process_timeout
         when 'accepted'
-          schedule_timeout(finish_timeout)
+          schedule_timeout(finish_timeout, optional: true)
           suspend
         else
           fail_on_errors

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", ">= 4.0"
   gem.add_dependency "foreman_remote_execution", ">= 3.0"
-  gem.add_dependency "dynflow", ">= 1.2.0"
+  gem.add_dependency "dynflow", ">= 1.5.0"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "qpid_proton"
   gem.add_dependency "stomp"


### PR DESCRIPTION
Related to https://github.com/Dynflow/dynflow/pull/383.