### PR TITLE
Fixes #32905 - correct reverse association

### DIFF
--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -7,7 +7,7 @@ module Katello
     self.table_name = "katello_environments"
     include Ext::LabelFromName
 
-    belongs_to :organization, :class_name => "Organization", :inverse_of => :environments
+    belongs_to :organization, :class_name => "Organization", :inverse_of => :kt_environments
     has_many :activation_keys, :class_name => "Katello::ActivationKey",
                                :dependent => :restrict_with_exception, :foreign_key => :environment_id
 


### PR DESCRIPTION
We were accidently using reverse association environments, as there were
no failures caused by it, it got silently overlooked.

This needs to get fixed as the `environments` association goes away from
foreman core and this will cause katello not be able to start.

EZ straightforward one liner I'd love to get merged fast :dog:
https://github.com/theforeman/foreman/pull/8510 is blocked by this.