### PR TITLE
Fixes #32802 - Sync/Index Python repo with remote options

### DIFF
--- a/app/models/katello/generic_content_unit.rb
+++ b/app/models/katello/generic_content_unit.rb
@@ -1,0 +1,16 @@
+module Katello
+  class GenericContentUnit < Katello::Model
+    self.table_name = 'katello_generic_content_units'
+    include Concerns::PulpDatabaseUnit
+
+    CONTENT_TYPE = 'generic_content_unit'.freeze
+
+    def self.default_sort
+      order(:name)
+    end
+
+    def self.total_for_repositories(repos)
+      self.in_repositories(repos).count
+    end
+  end
+end

--- a/app/models/katello/repository_generic_content_unit.rb
+++ b/app/models/katello/repository_generic_content_unit.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryGenericContentUnit < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_generic_content_units, :class_name => 'Katello::Repository'
+    belongs_to :generic_content_unit, :inverse_of => :repository_generic_content_units, :class_name => 'Katello::GenericContentUnit'
+  end
+end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class RootRepository < Katello::Model
     audited :except => [:content_id]
     serialize :ignorable_content
@@ -118,6 +119,10 @@ module Katello
 
     def self.repositories
       Repository.where(:root => self)
+    end
+
+    def repository_type
+      RepositoryTypeManager.find(self.content_type)
     end
 
     def custom?
@@ -311,6 +316,10 @@ module Katello
 
     def ansible_collection?
       self.content_type == Repository::ANSIBLE_COLLECTION_TYPE
+    end
+
+    def generic?
+      Katello::RepositoryTypeManager.generic_repository_types(enabled_only: false).values.map(&:id).map(&:to_s).flatten.include? self.content_type
     end
 
     def metadata_generate_needed?

--- a/app/services/katello/pulp3/api/generic.rb
+++ b/app/services/katello/pulp3/api/generic.rb
@@ -1,4 +1,5 @@
 require "pulpcore_client"
+
 module Katello
   module Pulp3
     module Api
@@ -14,24 +15,24 @@ module Katello
           fail NotImplementedError
         end
 
-        def self.client_module
-          fail NotImplementedError
+        def self.client_module(repository_type)
+          repository_type.client_module_class
         end
 
-        def self.remote_class
-          fail NotImplementedError
+        def self.remote_class(repository_type)
+          repository_type.remote_class
         end
 
-        def self.distribution_class
-          fail NotImplementedError
+        def self.distribution_class(repository_type)
+          repository_type.distribution_class
         end
 
-        def self.publication_class
-          fail NotImplementedError
+        def self.publication_class(repository_type)
+          repository_type.publication_class
         end
 
-        def self.repository_sync_url_class
-          fail NotImplementedError
+        def self.repository_sync_url_class(repository_type)
+          repository_type.repo_sync_url_class
         end
 
         def self.add_remove_content_class
@@ -55,7 +56,7 @@ module Katello
         end
 
         def publications_api
-          fail NotImplementedError
+          @repository_type.publications_api_class.new(api_client)
         end
 
         def distributions_api

--- a/app/services/katello/pulp3/generic_content_unit.rb
+++ b/app/services/katello/pulp3/generic_content_unit.rb
@@ -1,0 +1,29 @@
+module Katello
+  module Pulp3
+    class GenericContentUnit < PulpContentUnit
+      include LazyAccessor
+      CONTENT_TYPE = "generic_content_unit".freeze
+
+      def self.fetch_content_list(page_opts, repository_type, content_type)
+        content_unit_list page_opts, repository_type, content_type
+      end
+
+      def self.content_unit_list(page_opts, repository_type, content_type)
+        self.content_api(repository_type, content_type).list page_opts
+      end
+
+      def self.content_api(repository_type, content_type)
+        repository_type.content_types.find { |type| type.content_type == content_type }.pulp3_api.new(repository_type.pulp3_api_class.new(SmartProxy.pulp_primary!, repository_type).api_client)
+      end
+
+      def update_model(model, repository_type, content_type)
+        custom_json = {}
+        custom_json['pulp_id'] = backend_data['pulp_href']
+        custom_json['name'] = repository_type.model_name.call(backend_data)
+        custom_json['version'] = repository_type.model_version.call(backend_data)
+        custom_json['content_type'] = content_type
+        model.update!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -72,7 +72,11 @@ module Katello
               (response["count"] && page_opts["offset"] < response["count"]) ||
               page_opts["offset"] == 0)
             page_opts = page_options page_opts
-            response = fetch_content_list page_opts
+            if repository.generic?
+              response = fetch_content_list page_opts, repository.repository_type, options[:content_type]
+            else
+              response = fetch_content_list page_opts
+            end
             response = response.as_json.with_indifferent_access
             yielder.yield response[:results]
             page_opts[:offset] += page_size

--- a/app/services/katello/pulp3/repository/generic.rb
+++ b/app/services/katello/pulp3/repository/generic.rb
@@ -15,7 +15,12 @@ module Katello
         end
 
         def remote_options
-          common_remote_options
+          generic_remote_options = JSON.parse(root.generic_remote_options)
+          if generic_remote_options.any?
+            common_remote_options.merge(generic_remote_options.select { |_, v| !v.nil? }).symbolize_keys
+          else
+            common_remote_options
+          end
         end
 
         def partial_repo_path
@@ -29,6 +34,59 @@ module Katello
         def self.api(smart_proxy, repo)
           api_class = RepositoryTypeManager.find_by(:pulp3_service_class, self).pulp3_api_class
           api_class ? api_class.new(smart_proxy, repo) : Katello::Pulp3::Api::Core.new(smart_proxy)
+        end
+
+        def create_distribution(path)
+          distribution_data = api.class.distribution_class(repo.repository_type).new(secure_distribution_options(path))
+          api.distributions_api.create(distribution_data)
+        end
+
+        def create_remote
+          remote_file_data = api.class.remote_class(repo.repository_type).new(remote_options)
+          response = api.remotes_api.create(remote_file_data)
+          repo.update!(:remote_href => response.pulp_href)
+        end
+
+        def refresh_distributions
+          dist = lookup_distributions(base_path: repo.relative_path).first
+
+          # First check if the distribution exists
+          if dist
+            dist_ref = distribution_reference
+            # If we have a DistributionReference, update the distribution
+            if dist_ref
+              return update_distribution
+              # If no DistributionReference, create a DistributionReference and return
+            else
+              save_distribution_references([dist.pulp_href])
+              return []
+            end
+          end
+
+          # So far, it looks like there is no distribution. Try to create one.
+          begin
+            create_distribution(relative_path)
+          rescue api.class.client_module(repo.repository_type)::ApiError => e
+            # Now it seems there is a distribution. Fetch it and save the reference.
+            if e.message.include?("\"base_path\":[\"This field must be unique.\"]") ||
+              e.message.include?("\"base_path\":[\"Overlaps with existing distribution\"")
+              dist = lookup_distributions(base_path: repo.relative_path).first
+              save_distribution_references([dist.pulp_href])
+              return []
+            else
+              raise e
+            end
+          end
+        end
+
+        def sync(options = {})
+          repository_sync_url_data = api.class.repository_sync_url_class(repo.repository_type).new(sync_url_params(options))
+          [api.repositories_api.sync(repository_reference.repository_href, repository_sync_url_data)]
+        end
+
+        def create_publication
+          publication_data = api.class.publication_class(repo.repository_type).new(publication_options(repo.version_href))
+          api.publications_api.create(publication_data)
         end
       end
     end

--- a/db/migrate/20210624221630_katello_generic_content.rb
+++ b/db/migrate/20210624221630_katello_generic_content.rb
@@ -1,0 +1,22 @@
+class KatelloGenericContent < ActiveRecord::Migration[6.0]
+  def change
+    create_table "katello_generic_content_units" do |t|
+      t.string 'name'
+      t.string 'version'
+      t.string 'pulp_id'
+      t.string 'content_type'
+      t.timestamps
+    end
+
+    create_table "katello_repository_generic_content_units" do |t|
+      t.references :generic_content_unit, :null => false, index: { :name => 'index_katello_repo_generic_content_unit' }
+      t.references :repository, index: false
+      t.timestamps
+    end
+
+    add_index :katello_repository_generic_content_units, [:generic_content_unit_id, :repository_id], :unique => true, :name => 'repository_generic_content_unit_ids'
+
+    add_foreign_key "katello_repository_generic_content_units", "katello_generic_content_units", :column => "generic_content_unit_id"
+    add_foreign_key "katello_repository_generic_content_units", "katello_repositories", :column => "repository_id"
+  end
+end

--- a/db/migrate/20210628182553_add_generic_remote_options_to_root_repository.rb
+++ b/db/migrate/20210628182553_add_generic_remote_options_to_root_repository.rb
@@ -1,0 +1,5 @@
+class AddGenericRemoteOptionsToRootRepository < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_root_repositories, :generic_remote_options, :text
+  end
+end

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -13,4 +13,25 @@ Katello::RepositoryTypeManager.register('python') do
   remotes_api_class PulpPythonClient::RemotesPythonApi
   distributions_api_class PulpPythonClient::DistributionsPypiApi
   repository_versions_api_class PulpPythonClient::RepositoriesPythonVersionsApi
+  remote_class PulpPythonClient::PythonPythonRemote
+  repo_sync_url_class PulpPythonClient::RepositorySyncURL
+  client_module_class PulpPythonClient
+  distribution_class PulpPythonClient::PythonPythonDistribution
+  publication_class PulpPythonClient::PythonPythonPublication
+  publications_api_class PulpPythonClient::PublicationsPypiApi
+
+  generic_remote_option :includes, type: Array, description: "A list containing project specifiers for Python packages to include."
+  generic_remote_option :excludes, type: Array, description: "A list containing project specifiers for Python packages to exclude."
+  generic_remote_option :package_types, type: Array, description: "A list of package types to sync for Python content. Leave blank to get every package type."
+
+  model_name lambda { |pulp_unit| pulp_unit["name"] }
+  model_version lambda { |pulp_unit| pulp_unit["version"] }
+
+  generic_content_type 'python_package',
+                       model_class: Katello::GenericContentUnit,
+                       pulp3_api: PulpPythonClient::ContentPackagesApi,
+                       pulp3_model: PulpPythonClient::PythonPythonPackageContent,
+                       pulp3_service_class: Katello::Pulp3::GenericContentUnit,
+                       removable: true,
+                       uploadable: true
 end

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/delete.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/delete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:42 GMT
+      - Wed, 21 Jul 2021 19:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - bcc88358bac64246924183237d6fdabb
+      - b3b10bfab1a242eba01adf7ac6d5631f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:42 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:33 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:42 GMT
+      - Wed, 21 Jul 2021 19:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 3c21f6b6f9284643b67a8549b1f28fa6
+      - 501e631ff41d4d709b8b95a22042cfc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:42 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:33 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/python/pypi/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:42 GMT
+      - Wed, 21 Jul 2021 19:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 74064b676cb7469a9334aa0ce58c0f59
+      - 802a3d25333b40019b57c305be09e738
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:42 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:33 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:42 GMT
+      - Wed, 21 Jul 2021 19:00:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,21 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 1b751fc4474e455bb105ba0c9bddba07
+      - f0932eac637d486992beb2959e9243e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:42 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:33 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/
     body:
       encoding: UTF-8
       base64_string: |
@@ -221,13 +221,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:42 GMT
+      - Wed, 21 Jul 2021 19:00:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/python/python/72f4518e-c348-4c01-b9c7-2131c89ca113/"
+      - "/pulp/api/v3/repositories/python/python/6d433631-a4d2-457c-a0ac-2c1cab12b5c0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -237,31 +237,103 @@ http_interactions:
       Content-Length:
       - '504'
       Correlation-Id:
-      - 7b15798966bb4705afb8f9537aedfd75
+      - 1108564f72914ed8a437e47d6a4a37d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhv
-        bi9weXRob24vNzJmNDUxOGUtYzM0OC00YzAxLWI5YzctMjEzMWM4OWNhMTEz
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6Mjk6NDIuNzQxMTAz
+        bi9weXRob24vNmQ0MzM2MzEtYTRkMi00NTdjLWEwYWMtMmMxY2FiMTJiNWMw
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzQuNDk1MzU0
         WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3B5dGhvbi9weXRob24vNzJmNDUxOGUtYzM0OC00YzAxLWI5YzctMjEzMWM4
-        OWNhMTEzL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
+        L3B5dGhvbi9weXRob24vNmQ0MzM2MzEtYTRkMi00NTdjLWEwYWMtMmMxY2Fi
+        MTJiNWMwL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcHl0aG9u
-        L3B5dGhvbi83MmY0NTE4ZS1jMzQ4LTRjMDEtYjljNy0yMTMxYzg5Y2ExMTMv
+        L3B5dGhvbi82ZDQzMzYzMS1hNGQyLTQ1N2MtYTBhYy0yYzFjYWIxMmI1YzAv
         dmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2Fi
         aW5ldC1wdWxwM19QeXRob25fMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5lZF92ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlz
         aCI6ZmFsc2V9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:42 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:34 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Q
+        eXRob25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0Ijpu
+        dWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwidGxz
+        X3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHJveHlfdXNl
+        cm5hbWUiOm51bGwsInByb3h5X3Bhc3N3b3JkIjpudWxsLCJ0b3RhbF90aW1l
+        b3V0IjozMDAsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdLCJrZWVwX2xh
+        dGVzdF9wYWNrYWdlcyI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/python/python/6dada960-ec74-43a2-ab75-1d7188bd270c/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '679'
+      Correlation-Id:
+      - 75d776c5c12643cf8f0e48f2aaf06ec7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0
+        aG9uLzZkYWRhOTYwLWVjNzQtNDNhMi1hYjc1LTFkNzE4OGJkMjcwYy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDE5OjAwOjM0LjgwNzQ4MloiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19QeXRo
+        b25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0IjpudWxs
+        LCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInBy
+        b3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzQuODA3NTEzWiIsImRvd25sb2Fk
+        X2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5
+        Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNvbm5lY3Rf
+        dGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51bGwsInNv
+        Y2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xp
+        bWl0IjpudWxsLCJpbmNsdWRlcyI6WyJzaGVsZi1yZWFkZXIiXSwiZXhjbHVk
+        ZXMiOltdLCJwcmVyZWxlYXNlcyI6ZmFsc2UsInBhY2thZ2VfdHlwZXMiOltd
+        LCJrZWVwX2xhdGVzdF9wYWNrYWdlcyI6MCwiZXhjbHVkZV9wbGF0Zm9ybXMi
+        OltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:34 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/72f4518e-c348-4c01-b9c7-2131c89ca113/
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/6d433631-a4d2-457c-a0ac-2c1cab12b5c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -282,7 +354,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:43 GMT
+      - Wed, 21 Jul 2021 19:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -296,21 +368,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - c4553f4bee3e4e9cb9e061bca378c672
+      - 7e0cdbf568c84a2d981c9a8a264e66a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyZjZkMzcyLTZiYjktNGVi
-        MS1hNWE3LWMyZDM2OWI0MjdiZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1YmExY2Y5LTg2OWQtNDk5
+        NC1hOWM1LWIwNGJiMDY1OWQ2Mi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:43 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/d2f6d372-6bb9-4eb1-a5a7-c2d369b427bd/
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/45ba1cf9-869d-4994-a9c5-b04bb0659d62/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -318,7 +390,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -331,7 +403,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:43 GMT
+      - Wed, 21 Jul 2021 19:00:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -343,30 +415,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 382609f9acd14b04b8f19849ebd07958
+      - b5b571690fd342c1a11ba6a87ff64edd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
       Content-Length:
-      - '375'
+      - '377'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDJmNmQzNzItNmJi
-        OS00ZWIxLWE1YTctYzJkMzY5YjQyN2JkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6Mjk6NDMuMTg1NDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDViYTFjZjktODY5
+        ZC00OTk0LWE5YzUtYjA0YmIwNjU5ZDYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6MzUuMzIyNTc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjNDU1M2Y0YmVlM2U0ZTljYjllMDYxYmNh
-        Mzc4YzY3MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjI5OjQzLjI5
-        MjE1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6Mjk6NDMuNDE1
-        MjkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3ZTBjZGJmNTY4Yzg0YTJkOTgxYzlhOGEy
+        NjRlNjZhNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjM1LjM5
+        OTE1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6MzUuNDc0
+        NzEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8yMzBkNmY2NC00YTBiLTQ3Y2ItOTFkMy04OWIxZmUwOGMxNTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vNzJmNDUxOGUtYzM0
-        OC00YzAxLWI5YzctMjEzMWM4OWNhMTEzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vNmQ0MzM2MzEtYTRk
+        Mi00NTdjLWEwYWMtMmMxY2FiMTJiNWMwLyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:43 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/index_on_sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/index_on_sync.yml
@@ -1,0 +1,2150 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f6ef14db73bc4a45b64f28d6ce369647
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '275'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cHl0aG9uL3B5dGhvbi9hY2IxNmQ1Mi1hYWJmLTQ5ZWYtOWMzOS01ZTZlNTFk
+        ZWFjODkvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxOTowMDozNy4x
+        ODAzODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcHl0aG9uL3B5dGhvbi9hY2IxNmQ1Mi1hYWJmLTQ5ZWYtOWMzOS01
+        ZTZlNTFkZWFjODkvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
+        eXRob24vcHl0aG9uL2FjYjE2ZDUyLWFhYmYtNDllZi05YzM5LTVlNmU1MWRl
+        YWM4OS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
+        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
+        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
+        dWJsaXNoIjpmYWxzZX1dfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/acb16d52-aabf-49ef-9c39-5e6e51deac89/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a0472b3657474444bb5d5bb70be2ef85
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhYTdlZDk5LTYzNTEtNDk2
+        My05NDNjLWEzZjc1MjI0MmE4Yy8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 451e3002b62042f2af779a52e9b6d190
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '424'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3B5dGhv
+        bi9weXRob24vNTU5YzdjYjMtYWE5NC00MGVlLTg2YzktMmEwNGMwZGE2NTU5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzcuNDA0MzQ4
+        WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X1B5dGhvbl8xIiwidXJsIjoiaHR0cHM6Ly9weXBpLm9yZyIsImNhX2NlcnQi
+        Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
+        ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxOTowMDozNy40MDQzNjRaIiwiZG93
+        bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
+        b2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
+        bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
+        bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOm51bGwsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdLCJl
+        eGNsdWRlcyI6W10sInByZXJlbGVhc2VzIjpmYWxzZSwicGFja2FnZV90eXBl
+        cyI6W10sImtlZXBfbGF0ZXN0X3BhY2thZ2VzIjowLCJleGNsdWRlX3BsYXRm
+        b3JtcyI6W119XX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/559c7cb3-aa94-40ee-86c9-2a04c0da6559/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d3fb36bd9ef5455a9b97464583deb2ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkM2I2N2NkLTgxMmUtNGY4
+        Ny04N2U2LWQ3ZDVlNzQwZjRmMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/8aa7ed99-6351-4963-943c-a3f752242a8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6f8ea6f666cc4262a2cdff15131b8d71
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '376'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGFhN2VkOTktNjM1
+        MS00OTYzLTk0M2MtYTNmNzUyMjQyYThjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6MzguNTAzNjY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhMDQ3MmIzNjU3NDc0NDQ0YmI1ZDViYjcw
+        YmUyZWY4NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjM4LjU2
+        ODc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6MzguNjQ0
+        ODM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jN2RhZjEwNi00MjA5LTQ4YjUtYTYxMy02ODk0N2VlMWI4ZjQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vYWNiMTZkNTItYWFi
+        Zi00OWVmLTljMzktNWU2ZTUxZGVhYzg5LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/0d3b67cd-812e-4f87-87e6-d7d5e740f4f1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e79ee4706f9e4872b996edf65b185e54
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGQzYjY3Y2QtODEy
+        ZS00Zjg3LTg3ZTYtZDdkNWU3NDBmNGYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6MzguNjI5MDA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkM2ZiMzZiZDllZjU0NTVhOWI5NzQ2NDU4
+        M2RlYjJiYSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjM4Ljcw
+        MDUzNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6MzguNzU5
+        NDU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8yMzBkNmY2NC00YTBiLTQ3Y2ItOTFkMy04OWIxZmUwOGMxNTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzU1OWM3Y2IzLWFhOTQtNDBl
+        ZS04NmM5LTJhMDRjMGRhNjU1OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?name=Default_Organization-Cabinet-pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 7ade48375ecf48a999dd6a58b2c91ddd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - b076c2cf1e984b03aa7e22220d7d737d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:38 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Q
+        eXRob25fMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/python/python/549a8fa0-c9f5-44c6-8845-5ddf13ef4961/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '504'
+      Correlation-Id:
+      - f109dc95cc4640cf8b550ffc2f9830bb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhv
+        bi9weXRob24vNTQ5YThmYTAtYzlmNS00NGM2LTg4NDUtNWRkZjEzZWY0OTYx
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzkuNDM0NTE1
+        WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3B5dGhvbi9weXRob24vNTQ5YThmYTAtYzlmNS00NGM2LTg4NDUtNWRkZjEz
+        ZWY0OTYxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcHl0aG9u
+        L3B5dGhvbi81NDlhOGZhMC1jOWY1LTQ0YzYtODg0NS01ZGRmMTNlZjQ5NjEv
+        dmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2Fi
+        aW5ldC1wdWxwM19QeXRob25fMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
+        aW5lZF92ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlz
+        aCI6ZmFsc2V9
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:39 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Q
+        eXRob25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0Ijpu
+        dWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwidGxz
+        X3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHJveHlfdXNl
+        cm5hbWUiOm51bGwsInByb3h5X3Bhc3N3b3JkIjpudWxsLCJ0b3RhbF90aW1l
+        b3V0IjozMDAsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdLCJrZWVwX2xh
+        dGVzdF9wYWNrYWdlcyI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/python/python/5152e7be-f26e-4fb0-9e65-691b06567a10/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '679'
+      Correlation-Id:
+      - cda6161a5fdd4a348121c20d5b1a7e06
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0
+        aG9uLzUxNTJlN2JlLWYyNmUtNGZiMC05ZTY1LTY5MWIwNjU2N2ExMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDE5OjAwOjM5LjY1MzQ1M1oiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19QeXRo
+        b25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0IjpudWxs
+        LCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInBy
+        b3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzkuNjUzNDcwWiIsImRvd25sb2Fk
+        X2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5
+        Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNvbm5lY3Rf
+        dGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51bGwsInNv
+        Y2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xp
+        bWl0IjpudWxsLCJpbmNsdWRlcyI6WyJzaGVsZi1yZWFkZXIiXSwiZXhjbHVk
+        ZXMiOltdLCJwcmVyZWxlYXNlcyI6ZmFsc2UsInBhY2thZ2VfdHlwZXMiOltd
+        LCJrZWVwX2xhdGVzdF9wYWNrYWdlcyI6MCwiZXhjbHVkZV9wbGF0Zm9ybXMi
+        OltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:39 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/5152e7be-f26e-4fb0-9e65-691b06567a10/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfUHl0aG9uXzEiLCJ1cmwiOiJodHRwczov
+        L3B5cGkub3JnIiwicHJveHlfdXJsIjpudWxsLCJwcm94eV91c2VybmFtZSI6
+        bnVsbCwicHJveHlfcGFzc3dvcmQiOm51bGwsInRvdGFsX3RpbWVvdXQiOjMw
+        MCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGwsImNhX2Nl
+        cnQiOm51bGwsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - ce7c594b70ff44f9b320bfd177a41e8f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FkOTVkMDVlLTQ1MDgtNGFk
+        MC05YzE1LWFlZDMwN2MwYmExZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:40 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/ad95d05e-4508-4ad0-9c15-aed307c0ba1f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7040010824d74cfea9e20b13968ab39b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWQ5NWQwNWUtNDUw
+        OC00YWQwLTljMTUtYWVkMzA3YzBiYTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6NDAuOTE4NTI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjZTdjNTk0YjcwZmY0NGY5YjMyMGJmZDE3
+        N2E0MWU4ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjQxLjAw
+        NDg5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6NDEuMDYy
+        NzU2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NDljMTVhNS04YTFjLTRkYTItOWY5Ni1jZjgyZjI2YmZmNGIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzUxNTJlN2JlLWYyNmUtNGZi
+        MC05ZTY1LTY5MWIwNjU2N2ExMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:41 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/549a8fa0-c9f5-44c6-8845-5ddf13ef4961/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0aG9u
+        LzUxNTJlN2JlLWYyNmUtNGZiMC05ZTY1LTY5MWIwNjU2N2ExMC8iLCJtaXJy
+        b3IiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7c36aeca32eb49128b17200ac0e45b68
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmYmFkNmY0LTMyNTgtNDJl
+        Ni05YzQ3LTZhNjEyNzcwYWJkNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:41 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/afbad6f4-3258-42e6-9c47-6a612770abd4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0b785597b46f46b3bdd831b172bf860d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '555'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWZiYWQ2ZjQtMzI1
+        OC00MmU2LTljNDctNmE2MTI3NzBhYmQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6NDEuMjc1NTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcHl0aG9uLmFwcC50YXNrcy5zeW5jLnN5bmMiLCJs
+        b2dnaW5nX2NpZCI6IjdjMzZhZWNhMzJlYjQ5MTI4YjE3MjAwYWMwZTQ1YjY4
+        Iiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6NDEuMzY0NzA2WiIs
+        ImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxOTowMDo0Mi4wMDcwOThaIiwi
+        ZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzIz
+        MGQ2ZjY0LTRhMGItNDdjYi05MWQzLTg5YjFmZTA4YzE1NC8iLCJwYXJlbnRf
+        dGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxs
+        LCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRmV0Y2hpbmcgUHJv
+        amVjdCBNZXRhZGF0YSIsImNvZGUiOiJzeW5jLmZldGNoaW5nLnByb2plY3Qi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoxLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0
+        cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6
+        bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNv
+        ZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRp
+        bmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjIsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vNTQ5
+        YThmYTAtYzlmNS00NGM2LTg4NDUtNWRkZjEzZWY0OTYxL3ZlcnNpb25zLzEv
+        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3Yz
+        L3JlbW90ZXMvcHl0aG9uL3B5dGhvbi81MTUyZTdiZS1mMjZlLTRmYjAtOWU2
+        NS02OTFiMDY1NjdhMTAvIiwiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
+        eXRob24vcHl0aG9uLzU0OWE4ZmEwLWM5ZjUtNDRjNi04ODQ1LTVkZGYxM2Vm
+        NDk2MS8iXX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:42 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/publications/python/pypi/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3B5dGhvbi9weXRob24vNTQ5YThmYTAtYzlmNS00NGM2LTg4NDUtNWRk
+        ZjEzZWY0OTYxL3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - fb6ce2d5a5b14fa6be60e09929fab404
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmYTZhMGVmLTMwOGItNGRj
+        My1hOWEzLTEzMTEwODk4MmMzYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/bfa6a0ef-308b-4dc3-a9a3-131108982c3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7a90c1d9482f40c7a535b55a74ed5f96
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '408'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmZhNmEwZWYtMzA4
+        Yi00ZGMzLWE5YTMtMTMxMTA4OTgyYzNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6NDIuMzQ5NjAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcHl0aG9uLmFwcC50YXNrcy5wdWJsaXNoLnB1Ymxp
+        c2giLCJsb2dnaW5nX2NpZCI6ImZiNmNlMmQ1YTViMTRmYTZiZTYwZTA5OTI5
+        ZmFiNDA0Iiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6NDIuNDE0
+        NjA5WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxOTowMDo0Mi41ODUx
+        NjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzIzMGQ2ZjY0LTRhMGItNDdjYi05MWQzLTg5YjFmZTA4YzE1NC8iLCJw
+        YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
+        IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJj
+        ZXMiOlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8x
+        YWUwODg4Ny1mN2I3LTQ2MDUtOWUxZS05NzVjY2VhNWRmZGEvIl0sInJlc2Vy
+        dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9weXRob24vcHl0aG9uLzU0OWE4ZmEwLWM5ZjUtNDRjNi04ODQ1LTVk
+        ZGYxM2VmNDk2MS8iXX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 876cb62b9ac4471b90a3310f1814edbd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:42 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX1B5dGhvbl8xIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfUHl0aG9uXzEiLCJw
+        dWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcHl0aG9u
+        L3B5cGkvMWFlMDg4ODctZjdiNy00NjA1LTllMWUtOTc1Y2NlYTVkZmRhLyIs
+        ImFsbG93X3VwbG9hZHMiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 58c4e8e4ad974216bb37c8d7a5c3741b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmMThiZTg1LTk1NDktNDM4
+        Yi1hYzcyLTU4Njc1Nzc5YWU5Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/ef18be85-9549-438b-ac72-58675779ae97/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 97c4e52b06654c31862ef47871d4e223
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '385'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWYxOGJlODUtOTU0
+        OS00MzhiLWFjNzItNTg2NzU3NzlhZTk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6NDIuODg4MTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1OGM0ZThlNGFkOTc0MjE2YmIzN2M4ZDdh
+        NWMzNzQxYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjQyLjk4
+        MDQ0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6NDMuMjQ2
+        NDA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NDljMTVhNS04YTFjLTRkYTItOWY5Ni1jZjgyZjI2YmZmNGIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3B5dGhvbi9weXBp
+        L2EyZjZmYTI4LWE1MzItNDNiOC04OWZjLWUwMGEyNGNmYzQyNC8iXSwicmVz
+        ZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlv
+        bnMvIl19
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/a2f6fa28-a532-43b8-89fc-e00a24cfc424/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - fa3d959bc78247db8d03a6ae6011ebb9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9weXRo
+        b24vcHlwaS9hMmY2ZmEyOC1hNTMyLTQzYjgtODlmYy1lMDBhMjRjZmM0MjQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxOTowMDo0My4yMTcyNDda
+        IiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
+        dWxwM19QeXRob25fMSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWth
+        dGVsbG8tZGV2ZWwtbmZzLmxvY2FsaG9zdC5leGFtcGxlLmNvbS9weXBpL0Rl
+        ZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfUHl0aG9uXzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoi
+        RGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19QeXRob25fMSIs
+        InJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8xYWUwODg4Ny1mN2I3LTQ2MDUt
+        OWUxZS05NzVjY2VhNWRmZGEvIiwiYWxsb3dfdXBsb2FkcyI6dHJ1ZX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/content/python/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/python/python/549a8fa0-c9f5-44c6-8845-5ddf13ef4961/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 33f9fe47fb6c4c639243b8a7bb582a22
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '9306'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3B5dGhv
+        bi9wYWNrYWdlcy9jOGRiZjkyNy0zZDRmLTQ4OGQtYTUwZC0wMjcxNTgzNmI5
+        ZTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0xNFQyMDowOToxNC41ODY0
+        NzBaIiwiYXJ0aWZhY3QiOm51bGwsImZpbGVuYW1lIjoic2hlbGYtcmVhZGVy
+        LTAuMS50YXIuZ3oiLCJwYWNrYWdldHlwZSI6InNkaXN0IiwibmFtZSI6InNo
+        ZWxmLXJlYWRlciIsInZlcnNpb24iOiIwLjEiLCJzaGEyNTYiOiIwNGNmZDhi
+        YjRmODQzZTM1ZDUxYmZkZWYyMDM1MTA5YmRlYTgzMWI1NWE1N2MzZTZhMTU0
+        ZDE0YmUxMTYzOThjIiwibWV0YWRhdGFfdmVyc2lvbiI6IiIsInN1bW1hcnki
+        OiJNYWtlIHN1cmUgeW91ciBjb2xsZWN0aW9ucyBhcmUgaW4gY2FsbCBudW1i
+        ZXIgb3JkZXIuIiwiZGVzY3JpcHRpb24iOiIuLiBpbWFnZTo6IGh0dHBzOi8v
+        dHJhdmlzLWNpLm9yZy9hc21hY2RvL3NoZWxmLXJlYWRlci5zdmc/YnJhbmNo
+        PW1hc3RlclxuICAgIDp0YXJnZXQ6IGh0dHBzOi8vdHJhdmlzLWNpLm9yZy9h
+        c21hY2RvL3NoZWxmLXJlYWRlclxuXG49PT09PT09PT09PT1cblNoZWxmIFJl
+        YWRlclxuPT09PT09PT09PT09XG5cblNoZWxmIFJlYWRlciBpcyBhIHRvb2wg
+        Zm9yIGxpYnJhcmllcyB0aGF0IHJldHJpZXZlcyBjYWxsIG51bWJlcnMgb2Yg
+        aXRlbXMgXG5mcm9tIHRoZWlyIGJhcmNvZGUgYW5kIGRldGVybWluZXMgaWYg
+        dGhleSBhcmUgaW4gdGhlIGNvcnJlY3Qgb3JkZXIuIEJlY2F1c2Vcbml0IGNh
+        biBzZWFyY2ggYnkgYmFyY29kZSB0aGUgc2NyaXB0IGFsbG93cyBsaWJyYXJ5
+        IHN0YWZmIHRvIGNvbm5lY3QgYSBcbmJhcmNvZGUgcmVhZGVyIHRvIHF1aWNr
+        bHkgYW5kIGFjY3VyYXRlbHkgc2NhbiB0aGVpciBzaGVsdmVzIGZvciBpdGVt
+        cyB0aGF0IFxuYXJlIG91dCBvZiBwbGFjZS5cblxuVGhpcyBjb25jZXB0IGlz
+        IG5vdCBuZXcsIGl0IGhhcyBwcm9iYWJseSBiZWVuIGFyb3VuZCBzaW5jZSBs
+        aWJyYXJpZXMgYmVnYW5cbnRvIGRpZ2l0aXplIHRoZWlyIHJlY29yZHMsIGJ1
+        dCBJIGhhdmUgbm90IGJlZW4gYWJsZSB0byBmaW5kIGEgZnJlZSBvcGVuIFxu
+        c291cmNlIGltcGxlbWVudGF0aW9uLlxuXG5JbnN0YWxsXG4tLS0tLS0tXG5c
+        bi4uIGNvZGUtYmxvY2s6OiBiYXNoXG5cbiAgICAkIHBpcCBpbnN0YWxsIHNo
+        ZWxmLXJlYWRlclxuXG5SZXF1aXJlcyBQeXRob24gPj0gMi43XG5cblVzZVxu
+        LS0tXG5cbkdldCBhIGR1bXAgb2YgYmFyY29kZXMgYW5kIGNhbGwgbnVtYmVy
+        cyBhbmQgc2F2ZSB0aGVtIGluIGEgY3N2IGZpbGUgd2l0aFxuYmFyY29kZXMg
+        aW4gdGhlIGxlZnQgY29sdW1uIGFuZCBjYWxsIG51bWJlcnMgaW4gdGhlIHJp
+        Z2h0LiBcblxuVGhlIHByb2plY3QgcmVxdWlyZXMgbm8gZGVwZW5lbmNpZXMg
+        KGV4Y2VwdCBub3NlIGlmIHlvdSB3YW50IHRvIHJ1biB0aGUgdGVzdHMpLiBc
+        bk1ha2Ugc3VyZSB0aGF0IHlvdSBoYXZlIHB5dGhvbiBpbnN0YWxsZWQgKHRl
+        c3RlZCBmb3IgMi42IGFuZCAyLjcpLiBcblxuVG8gcnVuOlxuXG4uLiBjb2Rl
+        LWJsb2NrOjogYmFzaFxuXG4gICAgJCBzaGVsZi1yZWFkZXIgcGF0aC90by9m
+        aWxlbmFtZS5jc3ZcblxuTGljZW5zZVxuLS0tLS0tLVxuXG5HUEwgMiIsImRl
+        c2NyaXB0aW9uX2NvbnRlbnRfdHlwZSI6IiIsImtleXdvcmRzIjoibGlicmFy
+        eSBiYXJjb2RlIGNhbGwgbnVtYmVyIHNoZWxmIGNvbGxlY3Rpb24iLCJob21l
+        X3BhZ2UiOiJodHRwczovL2dpdGh1Yi5jb20vYXNtYWNkby9zaGVsZi1yZWFk
+        ZXIiLCJkb3dubG9hZF91cmwiOiJVTktOT1dOIiwiYXV0aG9yIjoiQXVzdGlu
+        IE1hY2RvbmFsZCIsImF1dGhvcl9lbWFpbCI6ImFzbWFjZG9AZ21haWwuY29t
+        IiwibWFpbnRhaW5lciI6IiIsIm1haW50YWluZXJfZW1haWwiOiIiLCJsaWNl
+        bnNlIjoiR05VIEdFTkVSQUwgUFVCTElDIExJQ0VOU0VcbiAgICAgICAgICAg
+        ICAgICAgICAgICAgVmVyc2lvbiAyLCBKdW5lIDE5OTFcblxuIENvcHlyaWdo
+        dCAoQykgMTk4OSwgMTk5MSBGcmVlIFNvZnR3YXJlIEZvdW5kYXRpb24sIElu
+        Yy4sIDxodHRwOi8vZnNmLm9yZy8+XG4gNTEgRnJhbmtsaW4gU3RyZWV0LCBG
+        aWZ0aCBGbG9vciwgQm9zdG9uLCBNQSAwMjExMC0xMzAxIFVTQVxuIEV2ZXJ5
+        b25lIGlzIHBlcm1pdHRlZCB0byBjb3B5IGFuZCBkaXN0cmlidXRlIHZlcmJh
+        dGltIGNvcGllc1xuIG9mIHRoaXMgbGljZW5zZSBkb2N1bWVudCwgYnV0IGNo
+        YW5naW5nIGl0IGlzIG5vdCBhbGxvd2VkLlxuXG4gICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgUHJlYW1ibGVcblxuICBUaGUgbGljZW5zZXMgZm9yIG1v
+        c3Qgc29mdHdhcmUgYXJlIGRlc2lnbmVkIHRvIHRha2UgYXdheSB5b3VyXG5m
+        cmVlZG9tIHRvIHNoYXJlIGFuZCBjaGFuZ2UgaXQuICBCeSBjb250cmFzdCwg
+        dGhlIEdOVSBHZW5lcmFsIFB1YmxpY1xuTGljZW5zZSBpcyBpbnRlbmRlZCB0
+        byBndWFyYW50ZWUgeW91ciBmcmVlZG9tIHRvIHNoYXJlIGFuZCBjaGFuZ2Ug
+        ZnJlZVxuc29mdHdhcmUtLXRvIG1ha2Ugc3VyZSB0aGUgc29mdHdhcmUgaXMg
+        ZnJlZSBmb3IgYWxsIGl0cyB1c2Vycy4gIFRoaXNcbkdlbmVyYWwgUHVibGlj
+        IExpY2Vuc2UgYXBwbGllcyB0byBtb3N0IG9mIHRoZSBGcmVlIFNvZnR3YXJl
+        XG5Gb3VuZGF0aW9uJ3Mgc29mdHdhcmUgYW5kIHRvIGFueSBvdGhlciBwcm9n
+        cmFtIHdob3NlIGF1dGhvcnMgY29tbWl0IHRvXG51c2luZyBpdC4gIChTb21l
+        IG90aGVyIEZyZWUgU29mdHdhcmUgRm91bmRhdGlvbiBzb2Z0d2FyZSBpcyBj
+        b3ZlcmVkIGJ5XG50aGUgR05VIExlc3NlciBHZW5lcmFsIFB1YmxpYyBMaWNl
+        bnNlIGluc3RlYWQuKSAgWW91IGNhbiBhcHBseSBpdCB0b1xueW91ciBwcm9n
+        cmFtcywgdG9vLlxuXG4gIFdoZW4gd2Ugc3BlYWsgb2YgZnJlZSBzb2Z0d2Fy
+        ZSwgd2UgYXJlIHJlZmVycmluZyB0byBmcmVlZG9tLCBub3RcbnByaWNlLiAg
+        T3VyIEdlbmVyYWwgUHVibGljIExpY2Vuc2VzIGFyZSBkZXNpZ25lZCB0byBt
+        YWtlIHN1cmUgdGhhdCB5b3VcbmhhdmUgdGhlIGZyZWVkb20gdG8gZGlzdHJp
+        YnV0ZSBjb3BpZXMgb2YgZnJlZSBzb2Z0d2FyZSAoYW5kIGNoYXJnZSBmb3Jc
+        bnRoaXMgc2VydmljZSBpZiB5b3Ugd2lzaCksIHRoYXQgeW91IHJlY2VpdmUg
+        c291cmNlIGNvZGUgb3IgY2FuIGdldCBpdFxuaWYgeW91IHdhbnQgaXQsIHRo
+        YXQgeW91IGNhbiBjaGFuZ2UgdGhlIHNvZnR3YXJlIG9yIHVzZSBwaWVjZXMg
+        b2YgaXRcbmluIG5ldyBmcmVlIHByb2dyYW1zOyBhbmQgdGhhdCB5b3Uga25v
+        dyB5b3UgY2FuIGRvIHRoZXNlIHRoaW5ncy5cblxuICBUbyBwcm90ZWN0IHlv
+        dXIgcmlnaHRzLCB3ZSBuZWVkIHRvIG1ha2UgcmVzdHJpY3Rpb25zIHRoYXQg
+        Zm9yYmlkXG5hbnlvbmUgdG8gZGVueSB5b3UgdGhlc2UgcmlnaHRzIG9yIHRv
+        IGFzayB5b3UgdG8gc3VycmVuZGVyIHRoZSByaWdodHMuXG5UaGVzZSByZXN0
+        cmljdGlvbnMgdHJhbnNsYXRlIHRvIGNlcnRhaW4gcmVzcG9uc2liaWxpdGll
+        cyBmb3IgeW91IGlmIHlvdVxuZGlzdHJpYnV0ZSBjb3BpZXMgb2YgdGhlIHNv
+        ZnR3YXJlLCBvciBpZiB5b3UgbW9kaWZ5IGl0LlxuXG4gIEZvciBleGFtcGxl
+        LCBpZiB5b3UgZGlzdHJpYnV0ZSBjb3BpZXMgb2Ygc3VjaCBhIHByb2dyYW0s
+        IHdoZXRoZXJcbmdyYXRpcyBvciBmb3IgYSBmZWUsIHlvdSBtdXN0IGdpdmUg
+        dGhlIHJlY2lwaWVudHMgYWxsIHRoZSByaWdodHMgdGhhdFxueW91IGhhdmUu
+        ICBZb3UgbXVzdCBtYWtlIHN1cmUgdGhhdCB0aGV5LCB0b28sIHJlY2VpdmUg
+        b3IgY2FuIGdldCB0aGVcbnNvdXJjZSBjb2RlLiAgQW5kIHlvdSBtdXN0IHNo
+        b3cgdGhlbSB0aGVzZSB0ZXJtcyBzbyB0aGV5IGtub3cgdGhlaXJcbnJpZ2h0
+        cy5cblxuICBXZSBwcm90ZWN0IHlvdXIgcmlnaHRzIHdpdGggdHdvIHN0ZXBz
+        OiAoMSkgY29weXJpZ2h0IHRoZSBzb2Z0d2FyZSwgYW5kXG4oMikgb2ZmZXIg
+        eW91IHRoaXMgbGljZW5zZSB3aGljaCBnaXZlcyB5b3UgbGVnYWwgcGVybWlz
+        c2lvbiB0byBjb3B5LFxuZGlzdHJpYnV0ZSBhbmQvb3IgbW9kaWZ5IHRoZSBz
+        b2Z0d2FyZS5cblxuICBBbHNvLCBmb3IgZWFjaCBhdXRob3IncyBwcm90ZWN0
+        aW9uIGFuZCBvdXJzLCB3ZSB3YW50IHRvIG1ha2UgY2VydGFpblxudGhhdCBl
+        dmVyeW9uZSB1bmRlcnN0YW5kcyB0aGF0IHRoZXJlIGlzIG5vIHdhcnJhbnR5
+        IGZvciB0aGlzIGZyZWVcbnNvZnR3YXJlLiAgSWYgdGhlIHNvZnR3YXJlIGlz
+        IG1vZGlmaWVkIGJ5IHNvbWVvbmUgZWxzZSBhbmQgcGFzc2VkIG9uLCB3ZVxu
+        d2FudCBpdHMgcmVjaXBpZW50cyB0byBrbm93IHRoYXQgd2hhdCB0aGV5IGhh
+        dmUgaXMgbm90IHRoZSBvcmlnaW5hbCwgc29cbnRoYXQgYW55IHByb2JsZW1z
+        IGludHJvZHVjZWQgYnkgb3RoZXJzIHdpbGwgbm90IHJlZmxlY3Qgb24gdGhl
+        IG9yaWdpbmFsXG5hdXRob3JzJyByZXB1dGF0aW9ucy5cblxuICBGaW5hbGx5
+        LCBhbnkgZnJlZSBwcm9ncmFtIGlzIHRocmVhdGVuZWQgY29uc3RhbnRseSBi
+        eSBzb2Z0d2FyZVxucGF0ZW50cy4gIFdlIHdpc2ggdG8gYXZvaWQgdGhlIGRh
+        bmdlciB0aGF0IHJlZGlzdHJpYnV0b3JzIG9mIGEgZnJlZVxucHJvZ3JhbSB3
+        aWxsIGluZGl2aWR1YWxseSBvYnRhaW4gcGF0ZW50IGxpY2Vuc2VzLCBpbiBl
+        ZmZlY3QgbWFraW5nIHRoZVxucHJvZ3JhbSBwcm9wcmlldGFyeS4gIFRvIHBy
+        ZXZlbnQgdGhpcywgd2UgaGF2ZSBtYWRlIGl0IGNsZWFyIHRoYXQgYW55XG5w
+        YXRlbnQgbXVzdCBiZSBsaWNlbnNlZCBmb3IgZXZlcnlvbmUncyBmcmVlIHVz
+        ZSBvciBub3QgbGljZW5zZWQgYXQgYWxsLlxuXG4gIFRoZSBwcmVjaXNlIHRl
+        cm1zIGFuZCBjb25kaXRpb25zIGZvciBjb3B5aW5nLCBkaXN0cmlidXRpb24g
+        YW5kXG5tb2RpZmljYXRpb24gZm9sbG93LlxuXG4gICAgICAgICAgICAgICAg
+        ICAgIEdOVSBHRU5FUkFMIFBVQkxJQyBMSUNFTlNFXG4gICBURVJNUyBBTkQg
+        Q09ORElUSU9OUyBGT1IgQ09QWUlORywgRElTVFJJQlVUSU9OIEFORCBNT0RJ
+        RklDQVRJT05cblxuICAwLiBUaGlzIExpY2Vuc2UgYXBwbGllcyB0byBhbnkg
+        cHJvZ3JhbSBvciBvdGhlciB3b3JrIHdoaWNoIGNvbnRhaW5zXG5hIG5vdGlj
+        ZSBwbGFjZWQgYnkgdGhlIGNvcHlyaWdodCBob2xkZXIgc2F5aW5nIGl0IG1h
+        eSBiZSBkaXN0cmlidXRlZFxudW5kZXIgdGhlIHRlcm1zIG9mIHRoaXMgR2Vu
+        ZXJhbCBQdWJsaWMgTGljZW5zZS4gIFRoZSBcIlByb2dyYW1cIiwgYmVsb3cs
+        XG5yZWZlcnMgdG8gYW55IHN1Y2ggcHJvZ3JhbSBvciB3b3JrLCBhbmQgYSBc
+        IndvcmsgYmFzZWQgb24gdGhlIFByb2dyYW1cIlxubWVhbnMgZWl0aGVyIHRo
+        ZSBQcm9ncmFtIG9yIGFueSBkZXJpdmF0aXZlIHdvcmsgdW5kZXIgY29weXJp
+        Z2h0IGxhdzpcbnRoYXQgaXMgdG8gc2F5LCBhIHdvcmsgY29udGFpbmluZyB0
+        aGUgUHJvZ3JhbSBvciBhIHBvcnRpb24gb2YgaXQsXG5laXRoZXIgdmVyYmF0
+        aW0gb3Igd2l0aCBtb2RpZmljYXRpb25zIGFuZC9vciB0cmFuc2xhdGVkIGlu
+        dG8gYW5vdGhlclxubGFuZ3VhZ2UuICAoSGVyZWluYWZ0ZXIsIHRyYW5zbGF0
+        aW9uIGlzIGluY2x1ZGVkIHdpdGhvdXQgbGltaXRhdGlvbiBpblxudGhlIHRl
+        cm0gXCJtb2RpZmljYXRpb25cIi4pICBFYWNoIGxpY2Vuc2VlIGlzIGFkZHJl
+        c3NlZCBhcyBcInlvdVwiLlxuXG5BY3Rpdml0aWVzIG90aGVyIHRoYW4gY29w
+        eWluZywgZGlzdHJpYnV0aW9uIGFuZCBtb2RpZmljYXRpb24gYXJlIG5vdFxu
+        Y292ZXJlZCBieSB0aGlzIExpY2Vuc2U7IHRoZXkgYXJlIG91dHNpZGUgaXRz
+        IHNjb3BlLiAgVGhlIGFjdCBvZlxucnVubmluZyB0aGUgUHJvZ3JhbSBpcyBu
+        b3QgcmVzdHJpY3RlZCwgYW5kIHRoZSBvdXRwdXQgZnJvbSB0aGUgUHJvZ3Jh
+        bVxuaXMgY292ZXJlZCBvbmx5IGlmIGl0cyBjb250ZW50cyBjb25zdGl0dXRl
+        IGEgd29yayBiYXNlZCBvbiB0aGVcblByb2dyYW0gKGluZGVwZW5kZW50IG9m
+        IGhhdmluZyBiZWVuIG1hZGUgYnkgcnVubmluZyB0aGUgUHJvZ3JhbSkuXG5X
+        aGV0aGVyIHRoYXQgaXMgdHJ1ZSBkZXBlbmRzIG9uIHdoYXQgdGhlIFByb2dy
+        YW0gZG9lcy5cblxuICAxLiBZb3UgbWF5IGNvcHkgYW5kIGRpc3RyaWJ1dGUg
+        dmVyYmF0aW0gY29waWVzIG9mIHRoZSBQcm9ncmFtJ3NcbnNvdXJjZSBjb2Rl
+        IGFzIHlvdSByZWNlaXZlIGl0LCBpbiBhbnkgbWVkaXVtLCBwcm92aWRlZCB0
+        aGF0IHlvdVxuY29uc3BpY3VvdXNseSBhbmQgYXBwcm9wcmlhdGVseSBwdWJs
+        aXNoIG9uIGVhY2ggY29weSBhbiBhcHByb3ByaWF0ZVxuY29weXJpZ2h0IG5v
+        dGljZSBhbmQgZGlzY2xhaW1lciBvZiB3YXJyYW50eTsga2VlcCBpbnRhY3Qg
+        YWxsIHRoZVxubm90aWNlcyB0aGF0IHJlZmVyIHRvIHRoaXMgTGljZW5zZSBh
+        bmQgdG8gdGhlIGFic2VuY2Ugb2YgYW55IHdhcnJhbnR5O1xuYW5kIGdpdmUg
+        YW55IG90aGVyIHJlY2lwaWVudHMgb2YgdGhlIFByb2dyYW0gYSBjb3B5IG9m
+        IHRoaXMgTGljZW5zZVxuYWxvbmcgd2l0aCB0aGUgUHJvZ3JhbS5cblxuWW91
+        IG1heSBjaGFyZ2UgYSBmZWUgZm9yIHRoZSBwaHlzaWNhbCBhY3Qgb2YgdHJh
+        bnNmZXJyaW5nIGEgY29weSwgYW5kXG55b3UgbWF5IGF0IHlvdXIgb3B0aW9u
+        IG9mZmVyIHdhcnJhbnR5IHByb3RlY3Rpb24gaW4gZXhjaGFuZ2UgZm9yIGEg
+        ZmVlLlxuXG4gIDIuIFlvdSBtYXkgbW9kaWZ5IHlvdXIgY29weSBvciBjb3Bp
+        ZXMgb2YgdGhlIFByb2dyYW0gb3IgYW55IHBvcnRpb25cbm9mIGl0LCB0aHVz
+        IGZvcm1pbmcgYSB3b3JrIGJhc2VkIG9uIHRoZSBQcm9ncmFtLCBhbmQgY29w
+        eSBhbmRcbmRpc3RyaWJ1dGUgc3VjaCBtb2RpZmljYXRpb25zIG9yIHdvcmsg
+        dW5kZXIgdGhlIHRlcm1zIG9mIFNlY3Rpb24gMVxuYWJvdmUsIHByb3ZpZGVk
+        IHRoYXQgeW91IGFsc28gbWVldCBhbGwgb2YgdGhlc2UgY29uZGl0aW9uczpc
+        blxuICAgIGEpIFlvdSBtdXN0IGNhdXNlIHRoZSBtb2RpZmllZCBmaWxlcyB0
+        byBjYXJyeSBwcm9taW5lbnQgbm90aWNlc1xuICAgIHN0YXRpbmcgdGhhdCB5
+        b3UgY2hhbmdlZCB0aGUgZmlsZXMgYW5kIHRoZSBkYXRlIG9mIGFueSBjaGFu
+        Z2UuXG5cbiAgICBiKSBZb3UgbXVzdCBjYXVzZSBhbnkgd29yayB0aGF0IHlv
+        dSBkaXN0cmlidXRlIG9yIHB1Ymxpc2gsIHRoYXQgaW5cbiAgICB3aG9sZSBv
+        ciBpbiBwYXJ0IGNvbnRhaW5zIG9yIGlzIGRlcml2ZWQgZnJvbSB0aGUgUHJv
+        Z3JhbSBvciBhbnlcbiAgICBwYXJ0IHRoZXJlb2YsIHRvIGJlIGxpY2Vuc2Vk
+        IGFzIGEgd2hvbGUgYXQgbm8gY2hhcmdlIHRvIGFsbCB0aGlyZFxuICAgIHBh
+        cnRpZXMgdW5kZXIgdGhlIHRlcm1zIG9mIHRoaXMgTGljZW5zZS5cblxuICAg
+        IGMpIElmIHRoZSBtb2RpZmllZCBwcm9ncmFtIG5vcm1hbGx5IHJlYWRzIGNv
+        bW1hbmRzIGludGVyYWN0aXZlbHlcbiAgICB3aGVuIHJ1biwgeW91IG11c3Qg
+        Y2F1c2UgaXQsIHdoZW4gc3RhcnRlZCBydW5uaW5nIGZvciBzdWNoXG4gICAg
+        aW50ZXJhY3RpdmUgdXNlIGluIHRoZSBtb3N0IG9yZGluYXJ5IHdheSwgdG8g
+        cHJpbnQgb3IgZGlzcGxheSBhblxuICAgIGFubm91bmNlbWVudCBpbmNsdWRp
+        bmcgYW4gYXBwcm9wcmlhdGUgY29weXJpZ2h0IG5vdGljZSBhbmQgYVxuICAg
+        IG5vdGljZSB0aGF0IHRoZXJlIGlzIG5vIHdhcnJhbnR5IChvciBlbHNlLCBz
+        YXlpbmcgdGhhdCB5b3UgcHJvdmlkZVxuICAgIGEgd2FycmFudHkpIGFuZCB0
+        aGF0IHVzZXJzIG1heSByZWRpc3RyaWJ1dGUgdGhlIHByb2dyYW0gdW5kZXJc
+        biAgICB0aGVzZSBjb25kaXRpb25zLCBhbmQgdGVsbGluZyB0aGUgdXNlciBo
+        b3cgdG8gdmlldyBhIGNvcHkgb2YgdGhpc1xuICAgIExpY2Vuc2UuICAoRXhj
+        ZXB0aW9uOiBpZiB0aGUgUHJvZ3JhbSBpdHNlbGYgaXMgaW50ZXJhY3RpdmUg
+        YnV0XG4gICAgZG9lcyBub3Qgbm9ybWFsbHkgcHJpbnQgc3VjaCBhbiBhbm5v
+        dW5jZW1lbnQsIHlvdXIgd29yayBiYXNlZCBvblxuICAgIHRoZSBQcm9ncmFt
+        IGlzIG5vdCByZXF1aXJlZCB0byBwcmludCBhbiBhbm5vdW5jZW1lbnQuKVxu
+        XG5UaGVzZSByZXF1aXJlbWVudHMgYXBwbHkgdG8gdGhlIG1vZGlmaWVkIHdv
+        cmsgYXMgYSB3aG9sZS4gIElmXG5pZGVudGlmaWFibGUgc2VjdGlvbnMgb2Yg
+        dGhhdCB3b3JrIGFyZSBub3QgZGVyaXZlZCBmcm9tIHRoZSBQcm9ncmFtLFxu
+        YW5kIGNhbiBiZSByZWFzb25hYmx5IGNvbnNpZGVyZWQgaW5kZXBlbmRlbnQg
+        YW5kIHNlcGFyYXRlIHdvcmtzIGluXG50aGVtc2VsdmVzLCB0aGVuIHRoaXMg
+        TGljZW5zZSwgYW5kIGl0cyB0ZXJtcywgZG8gbm90IGFwcGx5IHRvIHRob3Nl
+        XG5zZWN0aW9ucyB3aGVuIHlvdSBkaXN0cmlidXRlIHRoZW0gYXMgc2VwYXJh
+        dGUgd29ya3MuICBCdXQgd2hlbiB5b3VcbmRpc3RyaWJ1dGUgdGhlIHNhbWUg
+        c2VjdGlvbnMgYXMgcGFydCBvZiBhIHdob2xlIHdoaWNoIGlzIGEgd29yayBi
+        YXNlZFxub24gdGhlIFByb2dyYW0sIHRoZSBkaXN0cmlidXRpb24gb2YgdGhl
+        IHdob2xlIG11c3QgYmUgb24gdGhlIHRlcm1zIG9mXG50aGlzIExpY2Vuc2Us
+        IHdob3NlIHBlcm1pc3Npb25zIGZvciBvdGhlciBsaWNlbnNlZXMgZXh0ZW5k
+        IHRvIHRoZVxuZW50aXJlIHdob2xlLCBhbmQgdGh1cyB0byBlYWNoIGFuZCBl
+        dmVyeSBwYXJ0IHJlZ2FyZGxlc3Mgb2Ygd2hvIHdyb3RlIGl0LlxuXG5UaHVz
+        LCBpdCBpcyBub3QgdGhlIGludGVudCBvZiB0aGlzIHNlY3Rpb24gdG8gY2xh
+        aW0gcmlnaHRzIG9yIGNvbnRlc3RcbnlvdXIgcmlnaHRzIHRvIHdvcmsgd3Jp
+        dHRlbiBlbnRpcmVseSBieSB5b3U7IHJhdGhlciwgdGhlIGludGVudCBpcyB0
+        b1xuZXhlcmNpc2UgdGhlIHJpZ2h0IHRvIGNvbnRyb2wgdGhlIGRpc3RyaWJ1
+        dGlvbiBvZiBkZXJpdmF0aXZlIG9yXG5jb2xsZWN0aXZlIHdvcmtzIGJhc2Vk
+        IG9uIHRoZSBQcm9ncmFtLlxuXG5JbiBhZGRpdGlvbiwgbWVyZSBhZ2dyZWdh
+        dGlvbiBvZiBhbm90aGVyIHdvcmsgbm90IGJhc2VkIG9uIHRoZSBQcm9ncmFt
+        XG53aXRoIHRoZSBQcm9ncmFtIChvciB3aXRoIGEgd29yayBiYXNlZCBvbiB0
+        aGUgUHJvZ3JhbSkgb24gYSB2b2x1bWUgb2ZcbmEgc3RvcmFnZSBvciBkaXN0
+        cmlidXRpb24gbWVkaXVtIGRvZXMgbm90IGJyaW5nIHRoZSBvdGhlciB3b3Jr
+        IHVuZGVyXG50aGUgc2NvcGUgb2YgdGhpcyBMaWNlbnNlLlxuXG4gIDMuIFlv
+        dSBtYXkgY29weSBhbmQgZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYSB3
+        b3JrIGJhc2VkIG9uIGl0LFxudW5kZXIgU2VjdGlvbiAyKSBpbiBvYmplY3Qg
+        Y29kZSBvciBleGVjdXRhYmxlIGZvcm0gdW5kZXIgdGhlIHRlcm1zIG9mXG5T
+        ZWN0aW9ucyAxIGFuZCAyIGFib3ZlIHByb3ZpZGVkIHRoYXQgeW91IGFsc28g
+        ZG8gb25lIG9mIHRoZSBmb2xsb3dpbmc6XG5cbiAgICBhKSBBY2NvbXBhbnkg
+        aXQgd2l0aCB0aGUgY29tcGxldGUgY29ycmVzcG9uZGluZyBtYWNoaW5lLXJl
+        YWRhYmxlXG4gICAgc291cmNlIGNvZGUsIHdoaWNoIG11c3QgYmUgZGlzdHJp
+        YnV0ZWQgdW5kZXIgdGhlIHRlcm1zIG9mIFNlY3Rpb25zXG4gICAgMSBhbmQg
+        MiBhYm92ZSBvbiBhIG1lZGl1bSBjdXN0b21hcmlseSB1c2VkIGZvciBzb2Z0
+        d2FyZSBpbnRlcmNoYW5nZTsgb3IsXG5cbiAgICBiKSBBY2NvbXBhbnkgaXQg
+        d2l0aCBhIHdyaXR0ZW4gb2ZmZXIsIHZhbGlkIGZvciBhdCBsZWFzdCB0aHJl
+        ZVxuICAgIHllYXJzLCB0byBnaXZlIGFueSB0aGlyZCBwYXJ0eSwgZm9yIGEg
+        Y2hhcmdlIG5vIG1vcmUgdGhhbiB5b3VyXG4gICAgY29zdCBvZiBwaHlzaWNh
+        bGx5IHBlcmZvcm1pbmcgc291cmNlIGRpc3RyaWJ1dGlvbiwgYSBjb21wbGV0
+        ZVxuICAgIG1hY2hpbmUtcmVhZGFibGUgY29weSBvZiB0aGUgY29ycmVzcG9u
+        ZGluZyBzb3VyY2UgY29kZSwgdG8gYmVcbiAgICBkaXN0cmlidXRlZCB1bmRl
+        ciB0aGUgdGVybXMgb2YgU2VjdGlvbnMgMSBhbmQgMiBhYm92ZSBvbiBhIG1l
+        ZGl1bVxuICAgIGN1c3RvbWFyaWx5IHVzZWQgZm9yIHNvZnR3YXJlIGludGVy
+        Y2hhbmdlOyBvcixcblxuICAgIGMpIEFjY29tcGFueSBpdCB3aXRoIHRoZSBp
+        bmZvcm1hdGlvbiB5b3UgcmVjZWl2ZWQgYXMgdG8gdGhlIG9mZmVyXG4gICAg
+        dG8gZGlzdHJpYnV0ZSBjb3JyZXNwb25kaW5nIHNvdXJjZSBjb2RlLiAgKFRo
+        aXMgYWx0ZXJuYXRpdmUgaXNcbiAgICBhbGxvd2VkIG9ubHkgZm9yIG5vbmNv
+        bW1lcmNpYWwgZGlzdHJpYnV0aW9uIGFuZCBvbmx5IGlmIHlvdVxuICAgIHJl
+        Y2VpdmVkIHRoZSBwcm9ncmFtIGluIG9iamVjdCBjb2RlIG9yIGV4ZWN1dGFi
+        bGUgZm9ybSB3aXRoIHN1Y2hcbiAgICBhbiBvZmZlciwgaW4gYWNjb3JkIHdp
+        dGggU3Vic2VjdGlvbiBiIGFib3ZlLilcblxuVGhlIHNvdXJjZSBjb2RlIGZv
+        ciBhIHdvcmsgbWVhbnMgdGhlIHByZWZlcnJlZCBmb3JtIG9mIHRoZSB3b3Jr
+        IGZvclxubWFraW5nIG1vZGlmaWNhdGlvbnMgdG8gaXQuICBGb3IgYW4gZXhl
+        Y3V0YWJsZSB3b3JrLCBjb21wbGV0ZSBzb3VyY2VcbmNvZGUgbWVhbnMgYWxs
+        IHRoZSBzb3VyY2UgY29kZSBmb3IgYWxsIG1vZHVsZXMgaXQgY29udGFpbnMs
+        IHBsdXMgYW55XG5hc3NvY2lhdGVkIGludGVyZmFjZSBkZWZpbml0aW9uIGZp
+        bGVzLCBwbHVzIHRoZSBzY3JpcHRzIHVzZWQgdG9cbmNvbnRyb2wgY29tcGls
+        YXRpb24gYW5kIGluc3RhbGxhdGlvbiBvZiB0aGUgZXhlY3V0YWJsZS4gIEhv
+        d2V2ZXIsIGFzIGFcbnNwZWNpYWwgZXhjZXB0aW9uLCB0aGUgc291cmNlIGNv
+        ZGUgZGlzdHJpYnV0ZWQgbmVlZCBub3QgaW5jbHVkZVxuYW55dGhpbmcgdGhh
+        dCBpcyBub3JtYWxseSBkaXN0cmlidXRlZCAoaW4gZWl0aGVyIHNvdXJjZSBv
+        ciBiaW5hcnlcbmZvcm0pIHdpdGggdGhlIG1ham9yIGNvbXBvbmVudHMgKGNv
+        bXBpbGVyLCBrZXJuZWwsIGFuZCBzbyBvbikgb2YgdGhlXG5vcGVyYXRpbmcg
+        c3lzdGVtIG9uIHdoaWNoIHRoZSBleGVjdXRhYmxlIHJ1bnMsIHVubGVzcyB0
+        aGF0IGNvbXBvbmVudFxuaXRzZWxmIGFjY29tcGFuaWVzIHRoZSBleGVjdXRh
+        YmxlLlxuXG5JZiBkaXN0cmlidXRpb24gb2YgZXhlY3V0YWJsZSBvciBvYmpl
+        Y3QgY29kZSBpcyBtYWRlIGJ5IG9mZmVyaW5nXG5hY2Nlc3MgdG8gY29weSBm
+        cm9tIGEgZGVzaWduYXRlZCBwbGFjZSwgdGhlbiBvZmZlcmluZyBlcXVpdmFs
+        ZW50XG5hY2Nlc3MgdG8gY29weSB0aGUgc291cmNlIGNvZGUgZnJvbSB0aGUg
+        c2FtZSBwbGFjZSBjb3VudHMgYXNcbmRpc3RyaWJ1dGlvbiBvZiB0aGUgc291
+        cmNlIGNvZGUsIGV2ZW4gdGhvdWdoIHRoaXJkIHBhcnRpZXMgYXJlIG5vdFxu
+        Y29tcGVsbGVkIHRvIGNvcHkgdGhlIHNvdXJjZSBhbG9uZyB3aXRoIHRoZSBv
+        YmplY3QgY29kZS5cblxuICA0LiBZb3UgbWF5IG5vdCBjb3B5LCBtb2RpZnks
+        IHN1YmxpY2Vuc2UsIG9yIGRpc3RyaWJ1dGUgdGhlIFByb2dyYW1cbmV4Y2Vw
+        dCBhcyBleHByZXNzbHkgcHJvdmlkZWQgdW5kZXIgdGhpcyBMaWNlbnNlLiAg
+        QW55IGF0dGVtcHRcbm90aGVyd2lzZSB0byBjb3B5LCBtb2RpZnksIHN1Ymxp
+        Y2Vuc2Ugb3IgZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSBpc1xudm9pZCwgYW5k
+        IHdpbGwgYXV0b21hdGljYWxseSB0ZXJtaW5hdGUgeW91ciByaWdodHMgdW5k
+        ZXIgdGhpcyBMaWNlbnNlLlxuSG93ZXZlciwgcGFydGllcyB3aG8gaGF2ZSBy
+        ZWNlaXZlZCBjb3BpZXMsIG9yIHJpZ2h0cywgZnJvbSB5b3UgdW5kZXJcbnRo
+        aXMgTGljZW5zZSB3aWxsIG5vdCBoYXZlIHRoZWlyIGxpY2Vuc2VzIHRlcm1p
+        bmF0ZWQgc28gbG9uZyBhcyBzdWNoXG5wYXJ0aWVzIHJlbWFpbiBpbiBmdWxs
+        IGNvbXBsaWFuY2UuXG5cbiAgNS4gWW91IGFyZSBub3QgcmVxdWlyZWQgdG8g
+        YWNjZXB0IHRoaXMgTGljZW5zZSwgc2luY2UgeW91IGhhdmUgbm90XG5zaWdu
+        ZWQgaXQuICBIb3dldmVyLCBub3RoaW5nIGVsc2UgZ3JhbnRzIHlvdSBwZXJt
+        aXNzaW9uIHRvIG1vZGlmeSBvclxuZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSBv
+        ciBpdHMgZGVyaXZhdGl2ZSB3b3Jrcy4gIFRoZXNlIGFjdGlvbnMgYXJlXG5w
+        cm9oaWJpdGVkIGJ5IGxhdyBpZiB5b3UgZG8gbm90IGFjY2VwdCB0aGlzIExp
+        Y2Vuc2UuICBUaGVyZWZvcmUsIGJ5XG5tb2RpZnlpbmcgb3IgZGlzdHJpYnV0
+        aW5nIHRoZSBQcm9ncmFtIChvciBhbnkgd29yayBiYXNlZCBvbiB0aGVcblBy
+        b2dyYW0pLCB5b3UgaW5kaWNhdGUgeW91ciBhY2NlcHRhbmNlIG9mIHRoaXMg
+        TGljZW5zZSB0byBkbyBzbywgYW5kXG5hbGwgaXRzIHRlcm1zIGFuZCBjb25k
+        aXRpb25zIGZvciBjb3B5aW5nLCBkaXN0cmlidXRpbmcgb3IgbW9kaWZ5aW5n
+        XG50aGUgUHJvZ3JhbSBvciB3b3JrcyBiYXNlZCBvbiBpdC5cblxuICA2LiBF
+        YWNoIHRpbWUgeW91IHJlZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYW55
+        IHdvcmsgYmFzZWQgb24gdGhlXG5Qcm9ncmFtKSwgdGhlIHJlY2lwaWVudCBh
+        dXRvbWF0aWNhbGx5IHJlY2VpdmVzIGEgbGljZW5zZSBmcm9tIHRoZVxub3Jp
+        Z2luYWwgbGljZW5zb3IgdG8gY29weSwgZGlzdHJpYnV0ZSBvciBtb2RpZnkg
+        dGhlIFByb2dyYW0gc3ViamVjdCB0b1xudGhlc2UgdGVybXMgYW5kIGNvbmRp
+        dGlvbnMuICBZb3UgbWF5IG5vdCBpbXBvc2UgYW55IGZ1cnRoZXJcbnJlc3Ry
+        aWN0aW9ucyBvbiB0aGUgcmVjaXBpZW50cycgZXhlcmNpc2Ugb2YgdGhlIHJp
+        Z2h0cyBncmFudGVkIGhlcmVpbi5cbllvdSBhcmUgbm90IHJlc3BvbnNpYmxl
+        IGZvciBlbmZvcmNpbmcgY29tcGxpYW5jZSBieSB0aGlyZCBwYXJ0aWVzIHRv
+        XG50aGlzIExpY2Vuc2UuXG5cbiAgNy4gSWYsIGFzIGEgY29uc2VxdWVuY2Ug
+        b2YgYSBjb3VydCBqdWRnbWVudCBvciBhbGxlZ2F0aW9uIG9mIHBhdGVudFxu
+        aW5mcmluZ2VtZW50IG9yIGZvciBhbnkgb3RoZXIgcmVhc29uIChub3QgbGlt
+        aXRlZCB0byBwYXRlbnQgaXNzdWVzKSxcbmNvbmRpdGlvbnMgYXJlIGltcG9z
+        ZWQgb24geW91ICh3aGV0aGVyIGJ5IGNvdXJ0IG9yZGVyLCBhZ3JlZW1lbnQg
+        b3Jcbm90aGVyd2lzZSkgdGhhdCBjb250cmFkaWN0IHRoZSBjb25kaXRpb25z
+        IG9mIHRoaXMgTGljZW5zZSwgdGhleSBkbyBub3RcbmV4Y3VzZSB5b3UgZnJv
+        bSB0aGUgY29uZGl0aW9ucyBvZiB0aGlzIExpY2Vuc2UuICBJZiB5b3UgY2Fu
+        bm90XG5kaXN0cmlidXRlIHNvIGFzIHRvIHNhdGlzZnkgc2ltdWx0YW5lb3Vz
+        bHkgeW91ciBvYmxpZ2F0aW9ucyB1bmRlciB0aGlzXG5MaWNlbnNlIGFuZCBh
+        bnkgb3RoZXIgcGVydGluZW50IG9ibGlnYXRpb25zLCB0aGVuIGFzIGEgY29u
+        c2VxdWVuY2UgeW91XG5tYXkgbm90IGRpc3RyaWJ1dGUgdGhlIFByb2dyYW0g
+        YXQgYWxsLiAgRm9yIGV4YW1wbGUsIGlmIGEgcGF0ZW50XG5saWNlbnNlIHdv
+        dWxkIG5vdCBwZXJtaXQgcm95YWx0eS1mcmVlIHJlZGlzdHJpYnV0aW9uIG9m
+        IHRoZSBQcm9ncmFtIGJ5XG5hbGwgdGhvc2Ugd2hvIHJlY2VpdmUgY29waWVz
+        IGRpcmVjdGx5IG9yIGluZGlyZWN0bHkgdGhyb3VnaCB5b3UsIHRoZW5cbnRo
+        ZSBvbmx5IHdheSB5b3UgY291bGQgc2F0aXNmeSBib3RoIGl0IGFuZCB0aGlz
+        IExpY2Vuc2Ugd291bGQgYmUgdG9cbnJlZnJhaW4gZW50aXJlbHkgZnJvbSBk
+        aXN0cmlidXRpb24gb2YgdGhlIFByb2dyYW0uXG5cbklmIGFueSBwb3J0aW9u
+        IG9mIHRoaXMgc2VjdGlvbiBpcyBoZWxkIGludmFsaWQgb3IgdW5lbmZvcmNl
+        YWJsZSB1bmRlclxuYW55IHBhcnRpY3VsYXIgY2lyY3Vtc3RhbmNlLCB0aGUg
+        YmFsYW5jZSBvZiB0aGUgc2VjdGlvbiBpcyBpbnRlbmRlZCB0b1xuYXBwbHkg
+        YW5kIHRoZSBzZWN0aW9uIGFzIGEgd2hvbGUgaXMgaW50ZW5kZWQgdG8gYXBw
+        bHkgaW4gb3RoZXJcbmNpcmN1bXN0YW5jZXMuXG5cbkl0IGlzIG5vdCB0aGUg
+        cHVycG9zZSBvZiB0aGlzIHNlY3Rpb24gdG8gaW5kdWNlIHlvdSB0byBpbmZy
+        aW5nZSBhbnlcbnBhdGVudHMgb3Igb3RoZXIgcHJvcGVydHkgcmlnaHQgY2xh
+        aW1zIG9yIHRvIGNvbnRlc3QgdmFsaWRpdHkgb2YgYW55XG5zdWNoIGNsYWlt
+        czsgdGhpcyBzZWN0aW9uIGhhcyB0aGUgc29sZSBwdXJwb3NlIG9mIHByb3Rl
+        Y3RpbmcgdGhlXG5pbnRlZ3JpdHkgb2YgdGhlIGZyZWUgc29mdHdhcmUgZGlz
+        dHJpYnV0aW9uIHN5c3RlbSwgd2hpY2ggaXNcbmltcGxlbWVudGVkIGJ5IHB1
+        YmxpYyBsaWNlbnNlIHByYWN0aWNlcy4gIE1hbnkgcGVvcGxlIGhhdmUgbWFk
+        ZVxuZ2VuZXJvdXMgY29udHJpYnV0aW9ucyB0byB0aGUgd2lkZSByYW5nZSBv
+        ZiBzb2Z0d2FyZSBkaXN0cmlidXRlZFxudGhyb3VnaCB0aGF0IHN5c3RlbSBp
+        biByZWxpYW5jZSBvbiBjb25zaXN0ZW50IGFwcGxpY2F0aW9uIG9mIHRoYXRc
+        bnN5c3RlbTsgaXQgaXMgdXAgdG8gdGhlIGF1dGhvci9kb25vciB0byBkZWNp
+        ZGUgaWYgaGUgb3Igc2hlIGlzIHdpbGxpbmdcbnRvIGRpc3RyaWJ1dGUgc29m
+        dHdhcmUgdGhyb3VnaCBhbnkgb3RoZXIgc3lzdGVtIGFuZCBhIGxpY2Vuc2Vl
+        IGNhbm5vdFxuaW1wb3NlIHRoYXQgY2hvaWNlLlxuXG5UaGlzIHNlY3Rpb24g
+        aXMgaW50ZW5kZWQgdG8gbWFrZSB0aG9yb3VnaGx5IGNsZWFyIHdoYXQgaXMg
+        YmVsaWV2ZWQgdG9cbmJlIGEgY29uc2VxdWVuY2Ugb2YgdGhlIHJlc3Qgb2Yg
+        dGhpcyBMaWNlbnNlLlxuXG4gIDguIElmIHRoZSBkaXN0cmlidXRpb24gYW5k
+        L29yIHVzZSBvZiB0aGUgUHJvZ3JhbSBpcyByZXN0cmljdGVkIGluXG5jZXJ0
+        YWluIGNvdW50cmllcyBlaXRoZXIgYnkgcGF0ZW50cyBvciBieSBjb3B5cmln
+        aHRlZCBpbnRlcmZhY2VzLCB0aGVcbm9yaWdpbmFsIGNvcHlyaWdodCBob2xk
+        ZXIgd2hvIHBsYWNlcyB0aGUgUHJvZ3JhbSB1bmRlciB0aGlzIExpY2Vuc2Vc
+        bm1heSBhZGQgYW4gZXhwbGljaXQgZ2VvZ3JhcGhpY2FsIGRpc3RyaWJ1dGlv
+        biBsaW1pdGF0aW9uIGV4Y2x1ZGluZ1xudGhvc2UgY291bnRyaWVzLCBzbyB0
+        aGF0IGRpc3RyaWJ1dGlvbiBpcyBwZXJtaXR0ZWQgb25seSBpbiBvciBhbW9u
+        Z1xuY291bnRyaWVzIG5vdCB0aHVzIGV4Y2x1ZGVkLiAgSW4gc3VjaCBjYXNl
+        LCB0aGlzIExpY2Vuc2UgaW5jb3Jwb3JhdGVzXG50aGUgbGltaXRhdGlvbiBh
+        cyBpZiB3cml0dGVuIGluIHRoZSBib2R5IG9mIHRoaXMgTGljZW5zZS5cblxu
+        ICA5LiBUaGUgRnJlZSBTb2Z0d2FyZSBGb3VuZGF0aW9uIG1heSBwdWJsaXNo
+        IHJldmlzZWQgYW5kL29yIG5ldyB2ZXJzaW9uc1xub2YgdGhlIEdlbmVyYWwg
+        UHVibGljIExpY2Vuc2UgZnJvbSB0aW1lIHRvIHRpbWUuICBTdWNoIG5ldyB2
+        ZXJzaW9ucyB3aWxsXG5iZSBzaW1pbGFyIGluIHNwaXJpdCB0byB0aGUgcHJl
+        c2VudCB2ZXJzaW9uLCBidXQgbWF5IGRpZmZlciBpbiBkZXRhaWwgdG9cbmFk
+        ZHJlc3MgbmV3IHByb2JsZW1zIG9yIGNvbmNlcm5zLlxuXG5FYWNoIHZlcnNp
+        b24gaXMgZ2l2ZW4gYSBkaXN0aW5ndWlzaGluZyB2ZXJzaW9uIG51bWJlci4g
+        IElmIHRoZSBQcm9ncmFtXG5zcGVjaWZpZXMgYSB2ZXJzaW9uIG51bWJlciBv
+        ZiB0aGlzIExpY2Vuc2Ugd2hpY2ggYXBwbGllcyB0byBpdCBhbmQgXCJhbnlc
+        bmxhdGVyIHZlcnNpb25cIiwgeW91IGhhdmUgdGhlIG9wdGlvbiBvZiBmb2xs
+        b3dpbmcgdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zXG5laXRoZXIgb2YgdGhh
+        dCB2ZXJzaW9uIG9yIG9mIGFueSBsYXRlciB2ZXJzaW9uIHB1Ymxpc2hlZCBi
+        eSB0aGUgRnJlZVxuU29mdHdhcmUgRm91bmRhdGlvbi4gIElmIHRoZSBQcm9n
+        cmFtIGRvZXMgbm90IHNwZWNpZnkgYSB2ZXJzaW9uIG51bWJlciBvZlxudGhp
+        cyBMaWNlbnNlLCB5b3UgbWF5IGNob29zZSBhbnkgdmVyc2lvbiBldmVyIHB1
+        Ymxpc2hlZCBieSB0aGUgRnJlZSBTb2Z0d2FyZVxuRm91bmRhdGlvbi5cblxu
+        ICAxMC4gSWYgeW91IHdpc2ggdG8gaW5jb3Jwb3JhdGUgcGFydHMgb2YgdGhl
+        IFByb2dyYW0gaW50byBvdGhlciBmcmVlXG5wcm9ncmFtcyB3aG9zZSBkaXN0
+        cmlidXRpb24gY29uZGl0aW9ucyBhcmUgZGlmZmVyZW50LCB3cml0ZSB0byB0
+        aGUgYXV0aG9yXG50byBhc2sgZm9yIHBlcm1pc3Npb24uICBGb3Igc29mdHdh
+        cmUgd2hpY2ggaXMgY29weXJpZ2h0ZWQgYnkgdGhlIEZyZWVcblNvZnR3YXJl
+        IEZvdW5kYXRpb24sIHdyaXRlIHRvIHRoZSBGcmVlIFNvZnR3YXJlIEZvdW5k
+        YXRpb247IHdlIHNvbWV0aW1lc1xubWFrZSBleGNlcHRpb25zIGZvciB0aGlz
+        LiAgT3VyIGRlY2lzaW9uIHdpbGwgYmUgZ3VpZGVkIGJ5IHRoZSB0d28gZ29h
+        bHNcbm9mIHByZXNlcnZpbmcgdGhlIGZyZWUgc3RhdHVzIG9mIGFsbCBkZXJp
+        dmF0aXZlcyBvZiBvdXIgZnJlZSBzb2Z0d2FyZSBhbmRcbm9mIHByb21vdGlu
+        ZyB0aGUgc2hhcmluZyBhbmQgcmV1c2Ugb2Ygc29mdHdhcmUgZ2VuZXJhbGx5
+        LlxuXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgTk8gV0FSUkFOVFlc
+        blxuICAxMS4gQkVDQVVTRSBUSEUgUFJPR1JBTSBJUyBMSUNFTlNFRCBGUkVF
+        IE9GIENIQVJHRSwgVEhFUkUgSVMgTk8gV0FSUkFOVFlcbkZPUiBUSEUgUFJP
+        R1JBTSwgVE8gVEhFIEVYVEVOVCBQRVJNSVRURUQgQlkgQVBQTElDQUJMRSBM
+        QVcuICBFWENFUFQgV0hFTlxuT1RIRVJXSVNFIFNUQVRFRCBJTiBXUklUSU5H
+        IFRIRSBDT1BZUklHSFQgSE9MREVSUyBBTkQvT1IgT1RIRVIgUEFSVElFU1xu
+        UFJPVklERSBUSEUgUFJPR1JBTSBcIkFTIElTXCIgV0lUSE9VVCBXQVJSQU5U
+        WSBPRiBBTlkgS0lORCwgRUlUSEVSIEVYUFJFU1NFRFxuT1IgSU1QTElFRCwg
+        SU5DTFVESU5HLCBCVVQgTk9UIExJTUlURUQgVE8sIFRIRSBJTVBMSUVEIFdB
+        UlJBTlRJRVMgT0Zcbk1FUkNIQU5UQUJJTElUWSBBTkQgRklUTkVTUyBGT1Ig
+        QSBQQVJUSUNVTEFSIFBVUlBPU0UuICBUSEUgRU5USVJFIFJJU0sgQVNcblRP
+        IFRIRSBRVUFMSVRZIEFORCBQRVJGT1JNQU5DRSBPRiBUSEUgUFJPR1JBTSBJ
+        UyBXSVRIIFlPVS4gIFNIT1VMRCBUSEVcblBST0dSQU0gUFJPVkUgREVGRUNU
+        SVZFLCBZT1UgQVNTVU1FIFRIRSBDT1NUIE9GIEFMTCBORUNFU1NBUlkgU0VS
+        VklDSU5HLFxuUkVQQUlSIE9SIENPUlJFQ1RJT04uXG5cbiAgMTIuIElOIE5P
+        IEVWRU5UIFVOTEVTUyBSRVFVSVJFRCBCWSBBUFBMSUNBQkxFIExBVyBPUiBB
+        R1JFRUQgVE8gSU4gV1JJVElOR1xuV0lMTCBBTlkgQ09QWVJJR0hUIEhPTERF
+        UiwgT1IgQU5ZIE9USEVSIFBBUlRZIFdITyBNQVkgTU9ESUZZIEFORC9PUlxu
+        UkVESVNUUklCVVRFIFRIRSBQUk9HUkFNIEFTIFBFUk1JVFRFRCBBQk9WRSwg
+        QkUgTElBQkxFIFRPIFlPVSBGT1IgREFNQUdFUyxcbklOQ0xVRElORyBBTlkg
+        R0VORVJBTCwgU1BFQ0lBTCwgSU5DSURFTlRBTCBPUiBDT05TRVFVRU5USUFM
+        IERBTUFHRVMgQVJJU0lOR1xuT1VUIE9GIFRIRSBVU0UgT1IgSU5BQklMSVRZ
+        IFRPIFVTRSBUSEUgUFJPR1JBTSAoSU5DTFVESU5HIEJVVCBOT1QgTElNSVRF
+        RFxuVE8gTE9TUyBPRiBEQVRBIE9SIERBVEEgQkVJTkcgUkVOREVSRUQgSU5B
+        Q0NVUkFURSBPUiBMT1NTRVMgU1VTVEFJTkVEIEJZXG5ZT1UgT1IgVEhJUkQg
+        UEFSVElFUyBPUiBBIEZBSUxVUkUgT0YgVEhFIFBST0dSQU0gVE8gT1BFUkFU
+        RSBXSVRIIEFOWSBPVEhFUlxuUFJPR1JBTVMpLCBFVkVOIElGIFNVQ0ggSE9M
+        REVSIE9SIE9USEVSIFBBUlRZIEhBUyBCRUVOIEFEVklTRUQgT0YgVEhFXG5Q
+        T1NTSUJJTElUWSBPRiBTVUNIIERBTUFHRVMuXG5cbiAgICAgICAgICAgICAg
+        ICAgICAgIEVORCBPRiBURVJNUyBBTkQgQ09ORElUSU9OU1xuXG4gICAgICAg
+        ICAgICBIb3cgdG8gQXBwbHkgVGhlc2UgVGVybXMgdG8gWW91ciBOZXcgUHJv
+        Z3JhbXNcblxuICBJZiB5b3UgZGV2ZWxvcCBhIG5ldyBwcm9ncmFtLCBhbmQg
+        eW91IHdhbnQgaXQgdG8gYmUgb2YgdGhlIGdyZWF0ZXN0XG5wb3NzaWJsZSB1
+        c2UgdG8gdGhlIHB1YmxpYywgdGhlIGJlc3Qgd2F5IHRvIGFjaGlldmUgdGhp
+        cyBpcyB0byBtYWtlIGl0XG5mcmVlIHNvZnR3YXJlIHdoaWNoIGV2ZXJ5b25l
+        IGNhbiByZWRpc3RyaWJ1dGUgYW5kIGNoYW5nZSB1bmRlciB0aGVzZSB0ZXJt
+        cy5cblxuICBUbyBkbyBzbywgYXR0YWNoIHRoZSBmb2xsb3dpbmcgbm90aWNl
+        cyB0byB0aGUgcHJvZ3JhbS4gIEl0IGlzIHNhZmVzdFxudG8gYXR0YWNoIHRo
+        ZW0gdG8gdGhlIHN0YXJ0IG9mIGVhY2ggc291cmNlIGZpbGUgdG8gbW9zdCBl
+        ZmZlY3RpdmVseVxuY29udmV5IHRoZSBleGNsdXNpb24gb2Ygd2FycmFudHk7
+        IGFuZCBlYWNoIGZpbGUgc2hvdWxkIGhhdmUgYXQgbGVhc3RcbnRoZSBcImNv
+        cHlyaWdodFwiIGxpbmUgYW5kIGEgcG9pbnRlciB0byB3aGVyZSB0aGUgZnVs
+        bCBub3RpY2UgaXMgZm91bmQuXG5cbiAgICB7ZGVzY3JpcHRpb259XG4gICAg
+        Q29weXJpZ2h0IChDKSB7eWVhcn0gIHtmdWxsbmFtZX1cblxuICAgIFRoaXMg
+        cHJvZ3JhbSBpcyBmcmVlIHNvZnR3YXJlOyB5b3UgY2FuIHJlZGlzdHJpYnV0
+        ZSBpdCBhbmQvb3IgbW9kaWZ5XG4gICAgaXQgdW5kZXIgdGhlIHRlcm1zIG9m
+        IHRoZSBHTlUgR2VuZXJhbCBQdWJsaWMgTGljZW5zZSBhcyBwdWJsaXNoZWQg
+        YnlcbiAgICB0aGUgRnJlZSBTb2Z0d2FyZSBGb3VuZGF0aW9uOyBlaXRoZXIg
+        dmVyc2lvbiAyIG9mIHRoZSBMaWNlbnNlLCBvclxuICAgIChhdCB5b3VyIG9w
+        dGlvbikgYW55IGxhdGVyIHZlcnNpb24uXG5cbiAgICBUaGlzIHByb2dyYW0g
+        aXMgZGlzdHJpYnV0ZWQgaW4gdGhlIGhvcGUgdGhhdCBpdCB3aWxsIGJlIHVz
+        ZWZ1bCxcbiAgICBidXQgV0lUSE9VVCBBTlkgV0FSUkFOVFk7IHdpdGhvdXQg
+        ZXZlbiB0aGUgaW1wbGllZCB3YXJyYW50eSBvZlxuICAgIE1FUkNIQU5UQUJJ
+        TElUWSBvciBGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRS4gIFNl
+        ZSB0aGVcbiAgICBHTlUgR2VuZXJhbCBQdWJsaWMgTGljZW5zZSBmb3IgbW9y
+        ZSBkZXRhaWxzLlxuXG4gICAgWW91IHNob3VsZCBoYXZlIHJlY2VpdmVkIGEg
+        Y29weSBvZiB0aGUgR05VIEdlbmVyYWwgUHVibGljIExpY2Vuc2UgYWxvbmdc
+        biAgICB3aXRoIHRoaXMgcHJvZ3JhbTsgaWYgbm90LCB3cml0ZSB0byB0aGUg
+        RnJlZSBTb2Z0d2FyZSBGb3VuZGF0aW9uLCBJbmMuLFxuICAgIDUxIEZyYW5r
+        bGluIFN0cmVldCwgRmlmdGggRmxvb3IsIEJvc3RvbiwgTUEgMDIxMTAtMTMw
+        MSBVU0EuXG5cbkFsc28gYWRkIGluZm9ybWF0aW9uIG9uIGhvdyB0byBjb250
+        YWN0IHlvdSBieSBlbGVjdHJvbmljIGFuZCBwYXBlciBtYWlsLlxuXG5JZiB0
+        aGUgcHJvZ3JhbSBpcyBpbnRlcmFjdGl2ZSwgbWFrZSBpdCBvdXRwdXQgYSBz
+        aG9ydCBub3RpY2UgbGlrZSB0aGlzXG53aGVuIGl0IHN0YXJ0cyBpbiBhbiBp
+        bnRlcmFjdGl2ZSBtb2RlOlxuXG4gICAgR25vbW92aXNpb24gdmVyc2lvbiA2
+        OSwgQ29weXJpZ2h0IChDKSB5ZWFyIG5hbWUgb2YgYXV0aG9yXG4gICAgR25v
+        bW92aXNpb24gY29tZXMgd2l0aCBBQlNPTFVURUxZIE5PIFdBUlJBTlRZOyBm
+        b3IgZGV0YWlscyB0eXBlIGBzaG93IHcnLlxuICAgIFRoaXMgaXMgZnJlZSBz
+        b2Z0d2FyZSwgYW5kIHlvdSBhcmUgd2VsY29tZSB0byByZWRpc3RyaWJ1dGUg
+        aXRcbiAgICB1bmRlciBjZXJ0YWluIGNvbmRpdGlvbnM7IHR5cGUgYHNob3cg
+        YycgZm9yIGRldGFpbHMuXG5cblRoZSBoeXBvdGhldGljYWwgY29tbWFuZHMg
+        YHNob3cgdycgYW5kIGBzaG93IGMnIHNob3VsZCBzaG93IHRoZSBhcHByb3By
+        aWF0ZVxucGFydHMgb2YgdGhlIEdlbmVyYWwgUHVibGljIExpY2Vuc2UuICBP
+        ZiBjb3Vyc2UsIHRoZSBjb21tYW5kcyB5b3UgdXNlIG1heVxuYmUgY2FsbGVk
+        IHNvbWV0aGluZyBvdGhlciB0aGFuIGBzaG93IHcnIGFuZCBgc2hvdyBjJzsg
+        dGhleSBjb3VsZCBldmVuIGJlXG5tb3VzZS1jbGlja3Mgb3IgbWVudSBpdGVt
+        cy0td2hhdGV2ZXIgc3VpdHMgeW91ciBwcm9ncmFtLlxuXG5Zb3Ugc2hvdWxk
+        IGFsc28gZ2V0IHlvdXIgZW1wbG95ZXIgKGlmIHlvdSB3b3JrIGFzIGEgcHJv
+        Z3JhbW1lcikgb3IgeW91clxuc2Nob29sLCBpZiBhbnksIHRvIHNpZ24gYSBc
+        ImNvcHlyaWdodCBkaXNjbGFpbWVyXCIgZm9yIHRoZSBwcm9ncmFtLCBpZlxu
+        bmVjZXNzYXJ5LiAgSGVyZSBpcyBhIHNhbXBsZTsgYWx0ZXIgdGhlIG5hbWVz
+        OlxuXG4gIFlveW9keW5lLCBJbmMuLCBoZXJlYnkgZGlzY2xhaW1zIGFsbCBj
+        b3B5cmlnaHQgaW50ZXJlc3QgaW4gdGhlIHByb2dyYW1cbiAgYEdub21vdmlz
+        aW9uJyAod2hpY2ggbWFrZXMgcGFzc2VzIGF0IGNvbXBpbGVycykgd3JpdHRl
+        biBieSBKYW1lcyBIYWNrZXIuXG5cbiAge3NpZ25hdHVyZSBvZiBUeSBDb29u
+        fSwgMSBBcHJpbCAxOTg5XG4gIFR5IENvb24sIFByZXNpZGVudCBvZiBWaWNl
+        XG5cblRoaXMgR2VuZXJhbCBQdWJsaWMgTGljZW5zZSBkb2VzIG5vdCBwZXJt
+        aXQgaW5jb3Jwb3JhdGluZyB5b3VyIHByb2dyYW0gaW50b1xucHJvcHJpZXRh
+        cnkgcHJvZ3JhbXMuICBJZiB5b3VyIHByb2dyYW0gaXMgYSBzdWJyb3V0aW5l
+        IGxpYnJhcnksIHlvdSBtYXlcbmNvbnNpZGVyIGl0IG1vcmUgdXNlZnVsIHRv
+        IHBlcm1pdCBsaW5raW5nIHByb3ByaWV0YXJ5IGFwcGxpY2F0aW9ucyB3aXRo
+        IHRoZVxubGlicmFyeS4gIElmIHRoaXMgaXMgd2hhdCB5b3Ugd2FudCB0byBk
+        bywgdXNlIHRoZSBHTlUgTGVzc2VyIEdlbmVyYWxcblB1YmxpYyBMaWNlbnNl
+        IGluc3RlYWQgb2YgdGhpcyBMaWNlbnNlLiIsInJlcXVpcmVzX3B5dGhvbiI6
+        IiIsInByb2plY3RfdXJsIjoiaHR0cHM6Ly9weXBpLm9yZy9wcm9qZWN0L3No
+        ZWxmLXJlYWRlci8iLCJwcm9qZWN0X3VybHMiOiJ7XCJEb3dubG9hZFwiOiBc
+        IlVOS05PV05cIiwgXCJIb21lcGFnZVwiOiBcImh0dHBzOi8vZ2l0aHViLmNv
+        bS9hc21hY2RvL3NoZWxmLXJlYWRlclwifSIsInBsYXRmb3JtIjoiVU5LTk9X
+        TiIsInN1cHBvcnRlZF9wbGF0Zm9ybSI6IiIsInJlcXVpcmVzX2Rpc3QiOiJu
+        dWxsIiwicHJvdmlkZXNfZGlzdCI6IltdIiwib2Jzb2xldGVzX2Rpc3QiOiJb
+        XSIsInJlcXVpcmVzX2V4dGVybmFsIjoiW10iLCJjbGFzc2lmaWVycyI6Iltc
+        IkRldmVsb3BtZW50IFN0YXR1cyA6OiA0IC0gQmV0YVwiLCBcIkVudmlyb25t
+        ZW50IDo6IENvbnNvbGVcIiwgXCJJbnRlbmRlZCBBdWRpZW5jZSA6OiBEZXZl
+        bG9wZXJzXCIsIFwiTGljZW5zZSA6OiBPU0kgQXBwcm92ZWQgOjogR05VIEdl
+        bmVyYWwgUHVibGljIExpY2Vuc2UgdjIgKEdQTHYyKVwiLCBcIk5hdHVyYWwg
+        TGFuZ3VhZ2UgOjogRW5nbGlzaFwiLCBcIlByb2dyYW1taW5nIExhbmd1YWdl
+        IDo6IFB5dGhvbiA6OiAyXCIsIFwiUHJvZ3JhbW1pbmcgTGFuZ3VhZ2UgOjog
+        UHl0aG9uIDo6IDIuN1wiXSJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcHl0aG9uL3BhY2thZ2VzL2QxY2EwY2IyLTVmMTktNDQ3NS1i
+        ZTliLWJmZDQyNzIxOGRhMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTE0
+        VDE4OjAzOjMyLjU3Mzg1M1oiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMWI2MWM1NjUtZjA0Yi00MzdjLTk3N2YtMmU0NzE1MDA3YWU4
+        LyIsImZpbGVuYW1lIjoic2hlbGZfcmVhZGVyLTAuMS1weTItbm9uZS1hbnku
+        d2hsIiwicGFja2FnZXR5cGUiOiJiZGlzdF93aGVlbCIsIm5hbWUiOiJzaGVs
+        Zi1yZWFkZXIiLCJ2ZXJzaW9uIjoiMC4xIiwic2hhMjU2IjoiMmVjZWIxNjQz
+        YzEwYzVlNGE2NTk3MGJhZjYzYmRlNDNiNzljYmRhYzdkZTgxZGFlODUzY2U0
+        N2FiMDUxOTdlOSIsIm1ldGFkYXRhX3ZlcnNpb24iOiIyLjAiLCJzdW1tYXJ5
+        IjoiTWFrZSBzdXJlIHlvdXIgY29sbGVjdGlvbnMgYXJlIGluIGNhbGwgbnVt
+        YmVyIG9yZGVyLiIsImRlc2NyaXB0aW9uIjoiIENvcHlyaWdodCAoQykgMTk4
+        OSwgMTk5MSBGcmVlIFNvZnR3YXJlIEZvdW5kYXRpb24sIEluYy4sIDxodHRw
+        Oi8vZnNmLm9yZy8+XG4gNTEgRnJhbmtsaW4gU3RyZWV0LCBGaWZ0aCBGbG9v
+        ciwgQm9zdG9uLCBNQSAwMjExMC0xMzAxIFVTQVxuIEV2ZXJ5b25lIGlzIHBl
+        cm1pdHRlZCB0byBjb3B5IGFuZCBkaXN0cmlidXRlIHZlcmJhdGltIGNvcGll
+        c1xuIG9mIHRoaXMgbGljZW5zZSBkb2N1bWVudCwgYnV0IGNoYW5naW5nIGl0
+        IGlzIG5vdCBhbGxvd2VkLlxuXG4gICAgICAgICAgICAgICAgICAgICAgICAg
+        ICAgUHJlYW1ibGVcblxuICBUaGUgbGljZW5zZXMgZm9yIG1vc3Qgc29mdHdh
+        cmUgYXJlIGRlc2lnbmVkIHRvIHRha2UgYXdheSB5b3VyXG5mcmVlZG9tIHRv
+        IHNoYXJlIGFuZCBjaGFuZ2UgaXQuICBCeSBjb250cmFzdCwgdGhlIEdOVSBH
+        ZW5lcmFsIFB1YmxpY1xuTGljZW5zZSBpcyBpbnRlbmRlZCB0byBndWFyYW50
+        ZWUgeW91ciBmcmVlZG9tIHRvIHNoYXJlIGFuZCBjaGFuZ2UgZnJlZVxuc29m
+        dHdhcmUtLXRvIG1ha2Ugc3VyZSB0aGUgc29mdHdhcmUgaXMgZnJlZSBmb3Ig
+        YWxsIGl0cyB1c2Vycy4gIFRoaXNcbkdlbmVyYWwgUHVibGljIExpY2Vuc2Ug
+        YXBwbGllcyB0byBtb3N0IG9mIHRoZSBGcmVlIFNvZnR3YXJlXG5Gb3VuZGF0
+        aW9uJ3Mgc29mdHdhcmUgYW5kIHRvIGFueSBvdGhlciBwcm9ncmFtIHdob3Nl
+        IGF1dGhvcnMgY29tbWl0IHRvXG51c2luZyBpdC4gIChTb21lIG90aGVyIEZy
+        ZWUgU29mdHdhcmUgRm91bmRhdGlvbiBzb2Z0d2FyZSBpcyBjb3ZlcmVkIGJ5
+        XG50aGUgR05VIExlc3NlciBHZW5lcmFsIFB1YmxpYyBMaWNlbnNlIGluc3Rl
+        YWQuKSAgWW91IGNhbiBhcHBseSBpdCB0b1xueW91ciBwcm9ncmFtcywgdG9v
+        LlxuXG4gIFdoZW4gd2Ugc3BlYWsgb2YgZnJlZSBzb2Z0d2FyZSwgd2UgYXJl
+        IHJlZmVycmluZyB0byBmcmVlZG9tLCBub3RcbnByaWNlLiAgT3VyIEdlbmVy
+        YWwgUHVibGljIExpY2Vuc2VzIGFyZSBkZXNpZ25lZCB0byBtYWtlIHN1cmUg
+        dGhhdCB5b3VcbmhhdmUgdGhlIGZyZWVkb20gdG8gZGlzdHJpYnV0ZSBjb3Bp
+        ZXMgb2YgZnJlZSBzb2Z0d2FyZSAoYW5kIGNoYXJnZSBmb3JcbnRoaXMgc2Vy
+        dmljZSBpZiB5b3Ugd2lzaCksIHRoYXQgeW91IHJlY2VpdmUgc291cmNlIGNv
+        ZGUgb3IgY2FuIGdldCBpdFxuaWYgeW91IHdhbnQgaXQsIHRoYXQgeW91IGNh
+        biBjaGFuZ2UgdGhlIHNvZnR3YXJlIG9yIHVzZSBwaWVjZXMgb2YgaXRcbmlu
+        IG5ldyBmcmVlIHByb2dyYW1zOyBhbmQgdGhhdCB5b3Uga25vdyB5b3UgY2Fu
+        IGRvIHRoZXNlIHRoaW5ncy5cblxuICBUbyBwcm90ZWN0IHlvdXIgcmlnaHRz
+        LCB3ZSBuZWVkIHRvIG1ha2UgcmVzdHJpY3Rpb25zIHRoYXQgZm9yYmlkXG5h
+        bnlvbmUgdG8gZGVueSB5b3UgdGhlc2UgcmlnaHRzIG9yIHRvIGFzayB5b3Ug
+        dG8gc3VycmVuZGVyIHRoZSByaWdodHMuXG5UaGVzZSByZXN0cmljdGlvbnMg
+        dHJhbnNsYXRlIHRvIGNlcnRhaW4gcmVzcG9uc2liaWxpdGllcyBmb3IgeW91
+        IGlmIHlvdVxuZGlzdHJpYnV0ZSBjb3BpZXMgb2YgdGhlIHNvZnR3YXJlLCBv
+        ciBpZiB5b3UgbW9kaWZ5IGl0LlxuXG4gIEZvciBleGFtcGxlLCBpZiB5b3Ug
+        ZGlzdHJpYnV0ZSBjb3BpZXMgb2Ygc3VjaCBhIHByb2dyYW0sIHdoZXRoZXJc
+        bmdyYXRpcyBvciBmb3IgYSBmZWUsIHlvdSBtdXN0IGdpdmUgdGhlIHJlY2lw
+        aWVudHMgYWxsIHRoZSByaWdodHMgdGhhdFxueW91IGhhdmUuICBZb3UgbXVz
+        dCBtYWtlIHN1cmUgdGhhdCB0aGV5LCB0b28sIHJlY2VpdmUgb3IgY2FuIGdl
+        dCB0aGVcbnNvdXJjZSBjb2RlLiAgQW5kIHlvdSBtdXN0IHNob3cgdGhlbSB0
+        aGVzZSB0ZXJtcyBzbyB0aGV5IGtub3cgdGhlaXJcbnJpZ2h0cy5cblxuICBX
+        ZSBwcm90ZWN0IHlvdXIgcmlnaHRzIHdpdGggdHdvIHN0ZXBzOiAoMSkgY29w
+        eXJpZ2h0IHRoZSBzb2Z0d2FyZSwgYW5kXG4oMikgb2ZmZXIgeW91IHRoaXMg
+        bGljZW5zZSB3aGljaCBnaXZlcyB5b3UgbGVnYWwgcGVybWlzc2lvbiB0byBj
+        b3B5LFxuZGlzdHJpYnV0ZSBhbmQvb3IgbW9kaWZ5IHRoZSBzb2Z0d2FyZS5c
+        blxuICBBbHNvLCBmb3IgZWFjaCBhdXRob3IncyBwcm90ZWN0aW9uIGFuZCBv
+        dXJzLCB3ZSB3YW50IHRvIG1ha2UgY2VydGFpblxudGhhdCBldmVyeW9uZSB1
+        bmRlcnN0YW5kcyB0aGF0IHRoZXJlIGlzIG5vIHdhcnJhbnR5IGZvciB0aGlz
+        IGZyZWVcbnNvZnR3YXJlLiAgSWYgdGhlIHNvZnR3YXJlIGlzIG1vZGlmaWVk
+        IGJ5IHNvbWVvbmUgZWxzZSBhbmQgcGFzc2VkIG9uLCB3ZVxud2FudCBpdHMg
+        cmVjaXBpZW50cyB0byBrbm93IHRoYXQgd2hhdCB0aGV5IGhhdmUgaXMgbm90
+        IHRoZSBvcmlnaW5hbCwgc29cbnRoYXQgYW55IHByb2JsZW1zIGludHJvZHVj
+        ZWQgYnkgb3RoZXJzIHdpbGwgbm90IHJlZmxlY3Qgb24gdGhlIG9yaWdpbmFs
+        XG5hdXRob3JzJyByZXB1dGF0aW9ucy5cblxuICBGaW5hbGx5LCBhbnkgZnJl
+        ZSBwcm9ncmFtIGlzIHRocmVhdGVuZWQgY29uc3RhbnRseSBieSBzb2Z0d2Fy
+        ZVxucGF0ZW50cy4gIFdlIHdpc2ggdG8gYXZvaWQgdGhlIGRhbmdlciB0aGF0
+        IHJlZGlzdHJpYnV0b3JzIG9mIGEgZnJlZVxucHJvZ3JhbSB3aWxsIGluZGl2
+        aWR1YWxseSBvYnRhaW4gcGF0ZW50IGxpY2Vuc2VzLCBpbiBlZmZlY3QgbWFr
+        aW5nIHRoZVxucHJvZ3JhbSBwcm9wcmlldGFyeS4gIFRvIHByZXZlbnQgdGhp
+        cywgd2UgaGF2ZSBtYWRlIGl0IGNsZWFyIHRoYXQgYW55XG5wYXRlbnQgbXVz
+        dCBiZSBsaWNlbnNlZCBmb3IgZXZlcnlvbmUncyBmcmVlIHVzZSBvciBub3Qg
+        bGljZW5zZWQgYXQgYWxsLlxuXG4gIFRoZSBwcmVjaXNlIHRlcm1zIGFuZCBj
+        b25kaXRpb25zIGZvciBjb3B5aW5nLCBkaXN0cmlidXRpb24gYW5kXG5tb2Rp
+        ZmljYXRpb24gZm9sbG93LlxuXG4gICAgICAgICAgICAgICAgICAgIEdOVSBH
+        RU5FUkFMIFBVQkxJQyBMSUNFTlNFXG4gICBURVJNUyBBTkQgQ09ORElUSU9O
+        UyBGT1IgQ09QWUlORywgRElTVFJJQlVUSU9OIEFORCBNT0RJRklDQVRJT05c
+        blxuICAwLiBUaGlzIExpY2Vuc2UgYXBwbGllcyB0byBhbnkgcHJvZ3JhbSBv
+        ciBvdGhlciB3b3JrIHdoaWNoIGNvbnRhaW5zXG5hIG5vdGljZSBwbGFjZWQg
+        YnkgdGhlIGNvcHlyaWdodCBob2xkZXIgc2F5aW5nIGl0IG1heSBiZSBkaXN0
+        cmlidXRlZFxudW5kZXIgdGhlIHRlcm1zIG9mIHRoaXMgR2VuZXJhbCBQdWJs
+        aWMgTGljZW5zZS4gIFRoZSBcIlByb2dyYW1cIiwgYmVsb3csXG5yZWZlcnMg
+        dG8gYW55IHN1Y2ggcHJvZ3JhbSBvciB3b3JrLCBhbmQgYSBcIndvcmsgYmFz
+        ZWQgb24gdGhlIFByb2dyYW1cIlxubWVhbnMgZWl0aGVyIHRoZSBQcm9ncmFt
+        IG9yIGFueSBkZXJpdmF0aXZlIHdvcmsgdW5kZXIgY29weXJpZ2h0IGxhdzpc
+        bnRoYXQgaXMgdG8gc2F5LCBhIHdvcmsgY29udGFpbmluZyB0aGUgUHJvZ3Jh
+        bSBvciBhIHBvcnRpb24gb2YgaXQsXG5laXRoZXIgdmVyYmF0aW0gb3Igd2l0
+        aCBtb2RpZmljYXRpb25zIGFuZC9vciB0cmFuc2xhdGVkIGludG8gYW5vdGhl
+        clxubGFuZ3VhZ2UuICAoSGVyZWluYWZ0ZXIsIHRyYW5zbGF0aW9uIGlzIGlu
+        Y2x1ZGVkIHdpdGhvdXQgbGltaXRhdGlvbiBpblxudGhlIHRlcm0gXCJtb2Rp
+        ZmljYXRpb25cIi4pICBFYWNoIGxpY2Vuc2VlIGlzIGFkZHJlc3NlZCBhcyBc
+        InlvdVwiLlxuXG5BY3Rpdml0aWVzIG90aGVyIHRoYW4gY29weWluZywgZGlz
+        dHJpYnV0aW9uIGFuZCBtb2RpZmljYXRpb24gYXJlIG5vdFxuY292ZXJlZCBi
+        eSB0aGlzIExpY2Vuc2U7IHRoZXkgYXJlIG91dHNpZGUgaXRzIHNjb3BlLiAg
+        VGhlIGFjdCBvZlxucnVubmluZyB0aGUgUHJvZ3JhbSBpcyBub3QgcmVzdHJp
+        Y3RlZCwgYW5kIHRoZSBvdXRwdXQgZnJvbSB0aGUgUHJvZ3JhbVxuaXMgY292
+        ZXJlZCBvbmx5IGlmIGl0cyBjb250ZW50cyBjb25zdGl0dXRlIGEgd29yayBi
+        YXNlZCBvbiB0aGVcblByb2dyYW0gKGluZGVwZW5kZW50IG9mIGhhdmluZyBi
+        ZWVuIG1hZGUgYnkgcnVubmluZyB0aGUgUHJvZ3JhbSkuXG5XaGV0aGVyIHRo
+        YXQgaXMgdHJ1ZSBkZXBlbmRzIG9uIHdoYXQgdGhlIFByb2dyYW0gZG9lcy5c
+        blxuICAxLiBZb3UgbWF5IGNvcHkgYW5kIGRpc3RyaWJ1dGUgdmVyYmF0aW0g
+        Y29waWVzIG9mIHRoZSBQcm9ncmFtJ3NcbnNvdXJjZSBjb2RlIGFzIHlvdSBy
+        ZWNlaXZlIGl0LCBpbiBhbnkgbWVkaXVtLCBwcm92aWRlZCB0aGF0IHlvdVxu
+        Y29uc3BpY3VvdXNseSBhbmQgYXBwcm9wcmlhdGVseSBwdWJsaXNoIG9uIGVh
+        Y2ggY29weSBhbiBhcHByb3ByaWF0ZVxuY29weXJpZ2h0IG5vdGljZSBhbmQg
+        ZGlzY2xhaW1lciBvZiB3YXJyYW50eTsga2VlcCBpbnRhY3QgYWxsIHRoZVxu
+        bm90aWNlcyB0aGF0IHJlZmVyIHRvIHRoaXMgTGljZW5zZSBhbmQgdG8gdGhl
+        IGFic2VuY2Ugb2YgYW55IHdhcnJhbnR5O1xuYW5kIGdpdmUgYW55IG90aGVy
+        IHJlY2lwaWVudHMgb2YgdGhlIFByb2dyYW0gYSBjb3B5IG9mIHRoaXMgTGlj
+        ZW5zZVxuYWxvbmcgd2l0aCB0aGUgUHJvZ3JhbS5cblxuWW91IG1heSBjaGFy
+        Z2UgYSBmZWUgZm9yIHRoZSBwaHlzaWNhbCBhY3Qgb2YgdHJhbnNmZXJyaW5n
+        IGEgY29weSwgYW5kXG55b3UgbWF5IGF0IHlvdXIgb3B0aW9uIG9mZmVyIHdh
+        cnJhbnR5IHByb3RlY3Rpb24gaW4gZXhjaGFuZ2UgZm9yIGEgZmVlLlxuXG4g
+        IDIuIFlvdSBtYXkgbW9kaWZ5IHlvdXIgY29weSBvciBjb3BpZXMgb2YgdGhl
+        IFByb2dyYW0gb3IgYW55IHBvcnRpb25cbm9mIGl0LCB0aHVzIGZvcm1pbmcg
+        YSB3b3JrIGJhc2VkIG9uIHRoZSBQcm9ncmFtLCBhbmQgY29weSBhbmRcbmRp
+        c3RyaWJ1dGUgc3VjaCBtb2RpZmljYXRpb25zIG9yIHdvcmsgdW5kZXIgdGhl
+        IHRlcm1zIG9mIFNlY3Rpb24gMVxuYWJvdmUsIHByb3ZpZGVkIHRoYXQgeW91
+        IGFsc28gbWVldCBhbGwgb2YgdGhlc2UgY29uZGl0aW9uczpcblxuICAgIGEp
+        IFlvdSBtdXN0IGNhdXNlIHRoZSBtb2RpZmllZCBmaWxlcyB0byBjYXJyeSBw
+        cm9taW5lbnQgbm90aWNlc1xuICAgIHN0YXRpbmcgdGhhdCB5b3UgY2hhbmdl
+        ZCB0aGUgZmlsZXMgYW5kIHRoZSBkYXRlIG9mIGFueSBjaGFuZ2UuXG5cbiAg
+        ICBiKSBZb3UgbXVzdCBjYXVzZSBhbnkgd29yayB0aGF0IHlvdSBkaXN0cmli
+        dXRlIG9yIHB1Ymxpc2gsIHRoYXQgaW5cbiAgICB3aG9sZSBvciBpbiBwYXJ0
+        IGNvbnRhaW5zIG9yIGlzIGRlcml2ZWQgZnJvbSB0aGUgUHJvZ3JhbSBvciBh
+        bnlcbiAgICBwYXJ0IHRoZXJlb2YsIHRvIGJlIGxpY2Vuc2VkIGFzIGEgd2hv
+        bGUgYXQgbm8gY2hhcmdlIHRvIGFsbCB0aGlyZFxuICAgIHBhcnRpZXMgdW5k
+        ZXIgdGhlIHRlcm1zIG9mIHRoaXMgTGljZW5zZS5cblxuICAgIGMpIElmIHRo
+        ZSBtb2RpZmllZCBwcm9ncmFtIG5vcm1hbGx5IHJlYWRzIGNvbW1hbmRzIGlu
+        dGVyYWN0aXZlbHlcbiAgICB3aGVuIHJ1biwgeW91IG11c3QgY2F1c2UgaXQs
+        IHdoZW4gc3RhcnRlZCBydW5uaW5nIGZvciBzdWNoXG4gICAgaW50ZXJhY3Rp
+        dmUgdXNlIGluIHRoZSBtb3N0IG9yZGluYXJ5IHdheSwgdG8gcHJpbnQgb3Ig
+        ZGlzcGxheSBhblxuICAgIGFubm91bmNlbWVudCBpbmNsdWRpbmcgYW4gYXBw
+        cm9wcmlhdGUgY29weXJpZ2h0IG5vdGljZSBhbmQgYVxuICAgIG5vdGljZSB0
+        aGF0IHRoZXJlIGlzIG5vIHdhcnJhbnR5IChvciBlbHNlLCBzYXlpbmcgdGhh
+        dCB5b3UgcHJvdmlkZVxuICAgIGEgd2FycmFudHkpIGFuZCB0aGF0IHVzZXJz
+        IG1heSByZWRpc3RyaWJ1dGUgdGhlIHByb2dyYW0gdW5kZXJcbiAgICB0aGVz
+        ZSBjb25kaXRpb25zLCBhbmQgdGVsbGluZyB0aGUgdXNlciBob3cgdG8gdmll
+        dyBhIGNvcHkgb2YgdGhpc1xuICAgIExpY2Vuc2UuICAoRXhjZXB0aW9uOiBp
+        ZiB0aGUgUHJvZ3JhbSBpdHNlbGYgaXMgaW50ZXJhY3RpdmUgYnV0XG4gICAg
+        ZG9lcyBub3Qgbm9ybWFsbHkgcHJpbnQgc3VjaCBhbiBhbm5vdW5jZW1lbnQs
+        IHlvdXIgd29yayBiYXNlZCBvblxuICAgIHRoZSBQcm9ncmFtIGlzIG5vdCBy
+        ZXF1aXJlZCB0byBwcmludCBhbiBhbm5vdW5jZW1lbnQuKVxuXG5UaGVzZSBy
+        ZXF1aXJlbWVudHMgYXBwbHkgdG8gdGhlIG1vZGlmaWVkIHdvcmsgYXMgYSB3
+        aG9sZS4gIElmXG5pZGVudGlmaWFibGUgc2VjdGlvbnMgb2YgdGhhdCB3b3Jr
+        IGFyZSBub3QgZGVyaXZlZCBmcm9tIHRoZSBQcm9ncmFtLFxuYW5kIGNhbiBi
+        ZSByZWFzb25hYmx5IGNvbnNpZGVyZWQgaW5kZXBlbmRlbnQgYW5kIHNlcGFy
+        YXRlIHdvcmtzIGluXG50aGVtc2VsdmVzLCB0aGVuIHRoaXMgTGljZW5zZSwg
+        YW5kIGl0cyB0ZXJtcywgZG8gbm90IGFwcGx5IHRvIHRob3NlXG5zZWN0aW9u
+        cyB3aGVuIHlvdSBkaXN0cmlidXRlIHRoZW0gYXMgc2VwYXJhdGUgd29ya3Mu
+        ICBCdXQgd2hlbiB5b3VcbmRpc3RyaWJ1dGUgdGhlIHNhbWUgc2VjdGlvbnMg
+        YXMgcGFydCBvZiBhIHdob2xlIHdoaWNoIGlzIGEgd29yayBiYXNlZFxub24g
+        dGhlIFByb2dyYW0sIHRoZSBkaXN0cmlidXRpb24gb2YgdGhlIHdob2xlIG11
+        c3QgYmUgb24gdGhlIHRlcm1zIG9mXG50aGlzIExpY2Vuc2UsIHdob3NlIHBl
+        cm1pc3Npb25zIGZvciBvdGhlciBsaWNlbnNlZXMgZXh0ZW5kIHRvIHRoZVxu
+        ZW50aXJlIHdob2xlLCBhbmQgdGh1cyB0byBlYWNoIGFuZCBldmVyeSBwYXJ0
+        IHJlZ2FyZGxlc3Mgb2Ygd2hvIHdyb3RlIGl0LlxuXG5UaHVzLCBpdCBpcyBu
+        b3QgdGhlIGludGVudCBvZiB0aGlzIHNlY3Rpb24gdG8gY2xhaW0gcmlnaHRz
+        IG9yIGNvbnRlc3RcbnlvdXIgcmlnaHRzIHRvIHdvcmsgd3JpdHRlbiBlbnRp
+        cmVseSBieSB5b3U7IHJhdGhlciwgdGhlIGludGVudCBpcyB0b1xuZXhlcmNp
+        c2UgdGhlIHJpZ2h0IHRvIGNvbnRyb2wgdGhlIGRpc3RyaWJ1dGlvbiBvZiBk
+        ZXJpdmF0aXZlIG9yXG5jb2xsZWN0aXZlIHdvcmtzIGJhc2VkIG9uIHRoZSBQ
+        cm9ncmFtLlxuXG5JbiBhZGRpdGlvbiwgbWVyZSBhZ2dyZWdhdGlvbiBvZiBh
+        bm90aGVyIHdvcmsgbm90IGJhc2VkIG9uIHRoZSBQcm9ncmFtXG53aXRoIHRo
+        ZSBQcm9ncmFtIChvciB3aXRoIGEgd29yayBiYXNlZCBvbiB0aGUgUHJvZ3Jh
+        bSkgb24gYSB2b2x1bWUgb2ZcbmEgc3RvcmFnZSBvciBkaXN0cmlidXRpb24g
+        bWVkaXVtIGRvZXMgbm90IGJyaW5nIHRoZSBvdGhlciB3b3JrIHVuZGVyXG50
+        aGUgc2NvcGUgb2YgdGhpcyBMaWNlbnNlLlxuXG4gIDMuIFlvdSBtYXkgY29w
+        eSBhbmQgZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYSB3b3JrIGJhc2Vk
+        IG9uIGl0LFxudW5kZXIgU2VjdGlvbiAyKSBpbiBvYmplY3QgY29kZSBvciBl
+        eGVjdXRhYmxlIGZvcm0gdW5kZXIgdGhlIHRlcm1zIG9mXG5TZWN0aW9ucyAx
+        IGFuZCAyIGFib3ZlIHByb3ZpZGVkIHRoYXQgeW91IGFsc28gZG8gb25lIG9m
+        IHRoZSBmb2xsb3dpbmc6XG5cbiAgICBhKSBBY2NvbXBhbnkgaXQgd2l0aCB0
+        aGUgY29tcGxldGUgY29ycmVzcG9uZGluZyBtYWNoaW5lLXJlYWRhYmxlXG4g
+        ICAgc291cmNlIGNvZGUsIHdoaWNoIG11c3QgYmUgZGlzdHJpYnV0ZWQgdW5k
+        ZXIgdGhlIHRlcm1zIG9mIFNlY3Rpb25zXG4gICAgMSBhbmQgMiBhYm92ZSBv
+        biBhIG1lZGl1bSBjdXN0b21hcmlseSB1c2VkIGZvciBzb2Z0d2FyZSBpbnRl
+        cmNoYW5nZTsgb3IsXG5cbiAgICBiKSBBY2NvbXBhbnkgaXQgd2l0aCBhIHdy
+        aXR0ZW4gb2ZmZXIsIHZhbGlkIGZvciBhdCBsZWFzdCB0aHJlZVxuICAgIHll
+        YXJzLCB0byBnaXZlIGFueSB0aGlyZCBwYXJ0eSwgZm9yIGEgY2hhcmdlIG5v
+        IG1vcmUgdGhhbiB5b3VyXG4gICAgY29zdCBvZiBwaHlzaWNhbGx5IHBlcmZv
+        cm1pbmcgc291cmNlIGRpc3RyaWJ1dGlvbiwgYSBjb21wbGV0ZVxuICAgIG1h
+        Y2hpbmUtcmVhZGFibGUgY29weSBvZiB0aGUgY29ycmVzcG9uZGluZyBzb3Vy
+        Y2UgY29kZSwgdG8gYmVcbiAgICBkaXN0cmlidXRlZCB1bmRlciB0aGUgdGVy
+        bXMgb2YgU2VjdGlvbnMgMSBhbmQgMiBhYm92ZSBvbiBhIG1lZGl1bVxuICAg
+        IGN1c3RvbWFyaWx5IHVzZWQgZm9yIHNvZnR3YXJlIGludGVyY2hhbmdlOyBv
+        cixcblxuICAgIGMpIEFjY29tcGFueSBpdCB3aXRoIHRoZSBpbmZvcm1hdGlv
+        biB5b3UgcmVjZWl2ZWQgYXMgdG8gdGhlIG9mZmVyXG4gICAgdG8gZGlzdHJp
+        YnV0ZSBjb3JyZXNwb25kaW5nIHNvdXJjZSBjb2RlLiAgKFRoaXMgYWx0ZXJu
+        YXRpdmUgaXNcbiAgICBhbGxvd2VkIG9ubHkgZm9yIG5vbmNvbW1lcmNpYWwg
+        ZGlzdHJpYnV0aW9uIGFuZCBvbmx5IGlmIHlvdVxuICAgIHJlY2VpdmVkIHRo
+        ZSBwcm9ncmFtIGluIG9iamVjdCBjb2RlIG9yIGV4ZWN1dGFibGUgZm9ybSB3
+        aXRoIHN1Y2hcbiAgICBhbiBvZmZlciwgaW4gYWNjb3JkIHdpdGggU3Vic2Vj
+        dGlvbiBiIGFib3ZlLilcblxuVGhlIHNvdXJjZSBjb2RlIGZvciBhIHdvcmsg
+        bWVhbnMgdGhlIHByZWZlcnJlZCBmb3JtIG9mIHRoZSB3b3JrIGZvclxubWFr
+        aW5nIG1vZGlmaWNhdGlvbnMgdG8gaXQuICBGb3IgYW4gZXhlY3V0YWJsZSB3
+        b3JrLCBjb21wbGV0ZSBzb3VyY2VcbmNvZGUgbWVhbnMgYWxsIHRoZSBzb3Vy
+        Y2UgY29kZSBmb3IgYWxsIG1vZHVsZXMgaXQgY29udGFpbnMsIHBsdXMgYW55
+        XG5hc3NvY2lhdGVkIGludGVyZmFjZSBkZWZpbml0aW9uIGZpbGVzLCBwbHVz
+        IHRoZSBzY3JpcHRzIHVzZWQgdG9cbmNvbnRyb2wgY29tcGlsYXRpb24gYW5k
+        IGluc3RhbGxhdGlvbiBvZiB0aGUgZXhlY3V0YWJsZS4gIEhvd2V2ZXIsIGFz
+        IGFcbnNwZWNpYWwgZXhjZXB0aW9uLCB0aGUgc291cmNlIGNvZGUgZGlzdHJp
+        YnV0ZWQgbmVlZCBub3QgaW5jbHVkZVxuYW55dGhpbmcgdGhhdCBpcyBub3Jt
+        YWxseSBkaXN0cmlidXRlZCAoaW4gZWl0aGVyIHNvdXJjZSBvciBiaW5hcnlc
+        bmZvcm0pIHdpdGggdGhlIG1ham9yIGNvbXBvbmVudHMgKGNvbXBpbGVyLCBr
+        ZXJuZWwsIGFuZCBzbyBvbikgb2YgdGhlXG5vcGVyYXRpbmcgc3lzdGVtIG9u
+        IHdoaWNoIHRoZSBleGVjdXRhYmxlIHJ1bnMsIHVubGVzcyB0aGF0IGNvbXBv
+        bmVudFxuaXRzZWxmIGFjY29tcGFuaWVzIHRoZSBleGVjdXRhYmxlLlxuXG5J
+        ZiBkaXN0cmlidXRpb24gb2YgZXhlY3V0YWJsZSBvciBvYmplY3QgY29kZSBp
+        cyBtYWRlIGJ5IG9mZmVyaW5nXG5hY2Nlc3MgdG8gY29weSBmcm9tIGEgZGVz
+        aWduYXRlZCBwbGFjZSwgdGhlbiBvZmZlcmluZyBlcXVpdmFsZW50XG5hY2Nl
+        c3MgdG8gY29weSB0aGUgc291cmNlIGNvZGUgZnJvbSB0aGUgc2FtZSBwbGFj
+        ZSBjb3VudHMgYXNcbmRpc3RyaWJ1dGlvbiBvZiB0aGUgc291cmNlIGNvZGUs
+        IGV2ZW4gdGhvdWdoIHRoaXJkIHBhcnRpZXMgYXJlIG5vdFxuY29tcGVsbGVk
+        IHRvIGNvcHkgdGhlIHNvdXJjZSBhbG9uZyB3aXRoIHRoZSBvYmplY3QgY29k
+        ZS5cblxuICA0LiBZb3UgbWF5IG5vdCBjb3B5LCBtb2RpZnksIHN1YmxpY2Vu
+        c2UsIG9yIGRpc3RyaWJ1dGUgdGhlIFByb2dyYW1cbmV4Y2VwdCBhcyBleHBy
+        ZXNzbHkgcHJvdmlkZWQgdW5kZXIgdGhpcyBMaWNlbnNlLiAgQW55IGF0dGVt
+        cHRcbm90aGVyd2lzZSB0byBjb3B5LCBtb2RpZnksIHN1YmxpY2Vuc2Ugb3Ig
+        ZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSBpc1xudm9pZCwgYW5kIHdpbGwgYXV0
+        b21hdGljYWxseSB0ZXJtaW5hdGUgeW91ciByaWdodHMgdW5kZXIgdGhpcyBM
+        aWNlbnNlLlxuSG93ZXZlciwgcGFydGllcyB3aG8gaGF2ZSByZWNlaXZlZCBj
+        b3BpZXMsIG9yIHJpZ2h0cywgZnJvbSB5b3UgdW5kZXJcbnRoaXMgTGljZW5z
+        ZSB3aWxsIG5vdCBoYXZlIHRoZWlyIGxpY2Vuc2VzIHRlcm1pbmF0ZWQgc28g
+        bG9uZyBhcyBzdWNoXG5wYXJ0aWVzIHJlbWFpbiBpbiBmdWxsIGNvbXBsaWFu
+        Y2UuXG5cbiAgNS4gWW91IGFyZSBub3QgcmVxdWlyZWQgdG8gYWNjZXB0IHRo
+        aXMgTGljZW5zZSwgc2luY2UgeW91IGhhdmUgbm90XG5zaWduZWQgaXQuICBI
+        b3dldmVyLCBub3RoaW5nIGVsc2UgZ3JhbnRzIHlvdSBwZXJtaXNzaW9uIHRv
+        IG1vZGlmeSBvclxuZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSBvciBpdHMgZGVy
+        aXZhdGl2ZSB3b3Jrcy4gIFRoZXNlIGFjdGlvbnMgYXJlXG5wcm9oaWJpdGVk
+        IGJ5IGxhdyBpZiB5b3UgZG8gbm90IGFjY2VwdCB0aGlzIExpY2Vuc2UuICBU
+        aGVyZWZvcmUsIGJ5XG5tb2RpZnlpbmcgb3IgZGlzdHJpYnV0aW5nIHRoZSBQ
+        cm9ncmFtIChvciBhbnkgd29yayBiYXNlZCBvbiB0aGVcblByb2dyYW0pLCB5
+        b3UgaW5kaWNhdGUgeW91ciBhY2NlcHRhbmNlIG9mIHRoaXMgTGljZW5zZSB0
+        byBkbyBzbywgYW5kXG5hbGwgaXRzIHRlcm1zIGFuZCBjb25kaXRpb25zIGZv
+        ciBjb3B5aW5nLCBkaXN0cmlidXRpbmcgb3IgbW9kaWZ5aW5nXG50aGUgUHJv
+        Z3JhbSBvciB3b3JrcyBiYXNlZCBvbiBpdC5cblxuICA2LiBFYWNoIHRpbWUg
+        eW91IHJlZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYW55IHdvcmsgYmFz
+        ZWQgb24gdGhlXG5Qcm9ncmFtKSwgdGhlIHJlY2lwaWVudCBhdXRvbWF0aWNh
+        bGx5IHJlY2VpdmVzIGEgbGljZW5zZSBmcm9tIHRoZVxub3JpZ2luYWwgbGlj
+        ZW5zb3IgdG8gY29weSwgZGlzdHJpYnV0ZSBvciBtb2RpZnkgdGhlIFByb2dy
+        YW0gc3ViamVjdCB0b1xudGhlc2UgdGVybXMgYW5kIGNvbmRpdGlvbnMuICBZ
+        b3UgbWF5IG5vdCBpbXBvc2UgYW55IGZ1cnRoZXJcbnJlc3RyaWN0aW9ucyBv
+        biB0aGUgcmVjaXBpZW50cycgZXhlcmNpc2Ugb2YgdGhlIHJpZ2h0cyBncmFu
+        dGVkIGhlcmVpbi5cbllvdSBhcmUgbm90IHJlc3BvbnNpYmxlIGZvciBlbmZv
+        cmNpbmcgY29tcGxpYW5jZSBieSB0aGlyZCBwYXJ0aWVzIHRvXG50aGlzIExp
+        Y2Vuc2UuXG5cbiAgNy4gSWYsIGFzIGEgY29uc2VxdWVuY2Ugb2YgYSBjb3Vy
+        dCBqdWRnbWVudCBvciBhbGxlZ2F0aW9uIG9mIHBhdGVudFxuaW5mcmluZ2Vt
+        ZW50IG9yIGZvciBhbnkgb3RoZXIgcmVhc29uIChub3QgbGltaXRlZCB0byBw
+        YXRlbnQgaXNzdWVzKSxcbmNvbmRpdGlvbnMgYXJlIGltcG9zZWQgb24geW91
+        ICh3aGV0aGVyIGJ5IGNvdXJ0IG9yZGVyLCBhZ3JlZW1lbnQgb3Jcbm90aGVy
+        d2lzZSkgdGhhdCBjb250cmFkaWN0IHRoZSBjb25kaXRpb25zIG9mIHRoaXMg
+        TGljZW5zZSwgdGhleSBkbyBub3RcbmV4Y3VzZSB5b3UgZnJvbSB0aGUgY29u
+        ZGl0aW9ucyBvZiB0aGlzIExpY2Vuc2UuICBJZiB5b3UgY2Fubm90XG5kaXN0
+        cmlidXRlIHNvIGFzIHRvIHNhdGlzZnkgc2ltdWx0YW5lb3VzbHkgeW91ciBv
+        YmxpZ2F0aW9ucyB1bmRlciB0aGlzXG5MaWNlbnNlIGFuZCBhbnkgb3RoZXIg
+        cGVydGluZW50IG9ibGlnYXRpb25zLCB0aGVuIGFzIGEgY29uc2VxdWVuY2Ug
+        eW91XG5tYXkgbm90IGRpc3RyaWJ1dGUgdGhlIFByb2dyYW0gYXQgYWxsLiAg
+        Rm9yIGV4YW1wbGUsIGlmIGEgcGF0ZW50XG5saWNlbnNlIHdvdWxkIG5vdCBw
+        ZXJtaXQgcm95YWx0eS1mcmVlIHJlZGlzdHJpYnV0aW9uIG9mIHRoZSBQcm9n
+        cmFtIGJ5XG5hbGwgdGhvc2Ugd2hvIHJlY2VpdmUgY29waWVzIGRpcmVjdGx5
+        IG9yIGluZGlyZWN0bHkgdGhyb3VnaCB5b3UsIHRoZW5cbnRoZSBvbmx5IHdh
+        eSB5b3UgY291bGQgc2F0aXNmeSBib3RoIGl0IGFuZCB0aGlzIExpY2Vuc2Ug
+        d291bGQgYmUgdG9cbnJlZnJhaW4gZW50aXJlbHkgZnJvbSBkaXN0cmlidXRp
+        b24gb2YgdGhlIFByb2dyYW0uXG5cbklmIGFueSBwb3J0aW9uIG9mIHRoaXMg
+        c2VjdGlvbiBpcyBoZWxkIGludmFsaWQgb3IgdW5lbmZvcmNlYWJsZSB1bmRl
+        clxuYW55IHBhcnRpY3VsYXIgY2lyY3Vtc3RhbmNlLCB0aGUgYmFsYW5jZSBv
+        ZiB0aGUgc2VjdGlvbiBpcyBpbnRlbmRlZCB0b1xuYXBwbHkgYW5kIHRoZSBz
+        ZWN0aW9uIGFzIGEgd2hvbGUgaXMgaW50ZW5kZWQgdG8gYXBwbHkgaW4gb3Ro
+        ZXJcbmNpcmN1bXN0YW5jZXMuXG5cbkl0IGlzIG5vdCB0aGUgcHVycG9zZSBv
+        ZiB0aGlzIHNlY3Rpb24gdG8gaW5kdWNlIHlvdSB0byBpbmZyaW5nZSBhbnlc
+        bnBhdGVudHMgb3Igb3RoZXIgcHJvcGVydHkgcmlnaHQgY2xhaW1zIG9yIHRv
+        IGNvbnRlc3QgdmFsaWRpdHkgb2YgYW55XG5zdWNoIGNsYWltczsgdGhpcyBz
+        ZWN0aW9uIGhhcyB0aGUgc29sZSBwdXJwb3NlIG9mIHByb3RlY3RpbmcgdGhl
+        XG5pbnRlZ3JpdHkgb2YgdGhlIGZyZWUgc29mdHdhcmUgZGlzdHJpYnV0aW9u
+        IHN5c3RlbSwgd2hpY2ggaXNcbmltcGxlbWVudGVkIGJ5IHB1YmxpYyBsaWNl
+        bnNlIHByYWN0aWNlcy4gIE1hbnkgcGVvcGxlIGhhdmUgbWFkZVxuZ2VuZXJv
+        dXMgY29udHJpYnV0aW9ucyB0byB0aGUgd2lkZSByYW5nZSBvZiBzb2Z0d2Fy
+        ZSBkaXN0cmlidXRlZFxudGhyb3VnaCB0aGF0IHN5c3RlbSBpbiByZWxpYW5j
+        ZSBvbiBjb25zaXN0ZW50IGFwcGxpY2F0aW9uIG9mIHRoYXRcbnN5c3RlbTsg
+        aXQgaXMgdXAgdG8gdGhlIGF1dGhvci9kb25vciB0byBkZWNpZGUgaWYgaGUg
+        b3Igc2hlIGlzIHdpbGxpbmdcbnRvIGRpc3RyaWJ1dGUgc29mdHdhcmUgdGhy
+        b3VnaCBhbnkgb3RoZXIgc3lzdGVtIGFuZCBhIGxpY2Vuc2VlIGNhbm5vdFxu
+        aW1wb3NlIHRoYXQgY2hvaWNlLlxuXG5UaGlzIHNlY3Rpb24gaXMgaW50ZW5k
+        ZWQgdG8gbWFrZSB0aG9yb3VnaGx5IGNsZWFyIHdoYXQgaXMgYmVsaWV2ZWQg
+        dG9cbmJlIGEgY29uc2VxdWVuY2Ugb2YgdGhlIHJlc3Qgb2YgdGhpcyBMaWNl
+        bnNlLlxuXG4gIDguIElmIHRoZSBkaXN0cmlidXRpb24gYW5kL29yIHVzZSBv
+        ZiB0aGUgUHJvZ3JhbSBpcyByZXN0cmljdGVkIGluXG5jZXJ0YWluIGNvdW50
+        cmllcyBlaXRoZXIgYnkgcGF0ZW50cyBvciBieSBjb3B5cmlnaHRlZCBpbnRl
+        cmZhY2VzLCB0aGVcbm9yaWdpbmFsIGNvcHlyaWdodCBob2xkZXIgd2hvIHBs
+        YWNlcyB0aGUgUHJvZ3JhbSB1bmRlciB0aGlzIExpY2Vuc2Vcbm1heSBhZGQg
+        YW4gZXhwbGljaXQgZ2VvZ3JhcGhpY2FsIGRpc3RyaWJ1dGlvbiBsaW1pdGF0
+        aW9uIGV4Y2x1ZGluZ1xudGhvc2UgY291bnRyaWVzLCBzbyB0aGF0IGRpc3Ry
+        aWJ1dGlvbiBpcyBwZXJtaXR0ZWQgb25seSBpbiBvciBhbW9uZ1xuY291bnRy
+        aWVzIG5vdCB0aHVzIGV4Y2x1ZGVkLiAgSW4gc3VjaCBjYXNlLCB0aGlzIExp
+        Y2Vuc2UgaW5jb3Jwb3JhdGVzXG50aGUgbGltaXRhdGlvbiBhcyBpZiB3cml0
+        dGVuIGluIHRoZSBib2R5IG9mIHRoaXMgTGljZW5zZS5cblxuICA5LiBUaGUg
+        RnJlZSBTb2Z0d2FyZSBGb3VuZGF0aW9uIG1heSBwdWJsaXNoIHJldmlzZWQg
+        YW5kL29yIG5ldyB2ZXJzaW9uc1xub2YgdGhlIEdlbmVyYWwgUHVibGljIExp
+        Y2Vuc2UgZnJvbSB0aW1lIHRvIHRpbWUuICBTdWNoIG5ldyB2ZXJzaW9ucyB3
+        aWxsXG5iZSBzaW1pbGFyIGluIHNwaXJpdCB0byB0aGUgcHJlc2VudCB2ZXJz
+        aW9uLCBidXQgbWF5IGRpZmZlciBpbiBkZXRhaWwgdG9cbmFkZHJlc3MgbmV3
+        IHByb2JsZW1zIG9yIGNvbmNlcm5zLlxuXG5FYWNoIHZlcnNpb24gaXMgZ2l2
+        ZW4gYSBkaXN0aW5ndWlzaGluZyB2ZXJzaW9uIG51bWJlci4gIElmIHRoZSBQ
+        cm9ncmFtXG5zcGVjaWZpZXMgYSB2ZXJzaW9uIG51bWJlciBvZiB0aGlzIExp
+        Y2Vuc2Ugd2hpY2ggYXBwbGllcyB0byBpdCBhbmQgXCJhbnlcbmxhdGVyIHZl
+        cnNpb25cIiwgeW91IGhhdmUgdGhlIG9wdGlvbiBvZiBmb2xsb3dpbmcgdGhl
+        IHRlcm1zIGFuZCBjb25kaXRpb25zXG5laXRoZXIgb2YgdGhhdCB2ZXJzaW9u
+        IG9yIG9mIGFueSBsYXRlciB2ZXJzaW9uIHB1Ymxpc2hlZCBieSB0aGUgRnJl
+        ZVxuU29mdHdhcmUgRm91bmRhdGlvbi4gIElmIHRoZSBQcm9ncmFtIGRvZXMg
+        bm90IHNwZWNpZnkgYSB2ZXJzaW9uIG51bWJlciBvZlxudGhpcyBMaWNlbnNl
+        LCB5b3UgbWF5IGNob29zZSBhbnkgdmVyc2lvbiBldmVyIHB1Ymxpc2hlZCBi
+        eSB0aGUgRnJlZSBTb2Z0d2FyZVxuRm91bmRhdGlvbi5cblxuICAxMC4gSWYg
+        eW91IHdpc2ggdG8gaW5jb3Jwb3JhdGUgcGFydHMgb2YgdGhlIFByb2dyYW0g
+        aW50byBvdGhlciBmcmVlXG5wcm9ncmFtcyB3aG9zZSBkaXN0cmlidXRpb24g
+        Y29uZGl0aW9ucyBhcmUgZGlmZmVyZW50LCB3cml0ZSB0byB0aGUgYXV0aG9y
+        XG50byBhc2sgZm9yIHBlcm1pc3Npb24uICBGb3Igc29mdHdhcmUgd2hpY2gg
+        aXMgY29weXJpZ2h0ZWQgYnkgdGhlIEZyZWVcblNvZnR3YXJlIEZvdW5kYXRp
+        b24sIHdyaXRlIHRvIHRoZSBGcmVlIFNvZnR3YXJlIEZvdW5kYXRpb247IHdl
+        IHNvbWV0aW1lc1xubWFrZSBleGNlcHRpb25zIGZvciB0aGlzLiAgT3VyIGRl
+        Y2lzaW9uIHdpbGwgYmUgZ3VpZGVkIGJ5IHRoZSB0d28gZ29hbHNcbm9mIHBy
+        ZXNlcnZpbmcgdGhlIGZyZWUgc3RhdHVzIG9mIGFsbCBkZXJpdmF0aXZlcyBv
+        ZiBvdXIgZnJlZSBzb2Z0d2FyZSBhbmRcbm9mIHByb21vdGluZyB0aGUgc2hh
+        cmluZyBhbmQgcmV1c2Ugb2Ygc29mdHdhcmUgZ2VuZXJhbGx5LlxuXG4gICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgTk8gV0FSUkFOVFlcblxuICAxMS4g
+        QkVDQVVTRSBUSEUgUFJPR1JBTSBJUyBMSUNFTlNFRCBGUkVFIE9GIENIQVJH
+        RSwgVEhFUkUgSVMgTk8gV0FSUkFOVFlcbkZPUiBUSEUgUFJPR1JBTSwgVE8g
+        VEhFIEVYVEVOVCBQRVJNSVRURUQgQlkgQVBQTElDQUJMRSBMQVcuICBFWENF
+        UFQgV0hFTlxuT1RIRVJXSVNFIFNUQVRFRCBJTiBXUklUSU5HIFRIRSBDT1BZ
+        UklHSFQgSE9MREVSUyBBTkQvT1IgT1RIRVIgUEFSVElFU1xuUFJPVklERSBU
+        SEUgUFJPR1JBTSBcIkFTIElTXCIgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkg
+        S0lORCwgRUlUSEVSIEVYUFJFU1NFRFxuT1IgSU1QTElFRCwgSU5DTFVESU5H
+        LCBCVVQgTk9UIExJTUlURUQgVE8sIFRIRSBJTVBMSUVEIFdBUlJBTlRJRVMg
+        T0Zcbk1FUkNIQU5UQUJJTElUWSBBTkQgRklUTkVTUyBGT1IgQSBQQVJUSUNV
+        TEFSIFBVUlBPU0UuICBUSEUgRU5USVJFIFJJU0sgQVNcblRPIFRIRSBRVUFM
+        SVRZIEFORCBQRVJGT1JNQU5DRSBPRiBUSEUgUFJPR1JBTSBJUyBXSVRIIFlP
+        VS4gIFNIT1VMRCBUSEVcblBST0dSQU0gUFJPVkUgREVGRUNUSVZFLCBZT1Ug
+        QVNTVU1FIFRIRSBDT1NUIE9GIEFMTCBORUNFU1NBUlkgU0VSVklDSU5HLFxu
+        UkVQQUlSIE9SIENPUlJFQ1RJT04uXG5cbiAgMTIuIElOIE5PIEVWRU5UIFVO
+        TEVTUyBSRVFVSVJFRCBCWSBBUFBMSUNBQkxFIExBVyBPUiBBR1JFRUQgVE8g
+        SU4gV1JJVElOR1xuV0lMTCBBTlkgQ09QWVJJR0hUIEhPTERFUiwgT1IgQU5Z
+        IE9USEVSIFBBUlRZIFdITyBNQVkgTU9ESUZZIEFORC9PUlxuUkVESVNUUklC
+        VVRFIFRIRSBQUk9HUkFNIEFTIFBFUk1JVFRFRCBBQk9WRSwgQkUgTElBQkxF
+        IFRPIFlPVSBGT1IgREFNQUdFUyxcbklOQ0xVRElORyBBTlkgR0VORVJBTCwg
+        U1BFQ0lBTCwgSU5DSURFTlRBTCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMg
+        QVJJU0lOR1xuT1VUIE9GIFRIRSBVU0UgT1IgSU5BQklMSVRZIFRPIFVTRSBU
+        SEUgUFJPR1JBTSAoSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRFxuVE8gTE9T
+        UyBPRiBEQVRBIE9SIERBVEEgQkVJTkcgUkVOREVSRUQgSU5BQ0NVUkFURSBP
+        UiBMT1NTRVMgU1VTVEFJTkVEIEJZXG5ZT1UgT1IgVEhJUkQgUEFSVElFUyBP
+        UiBBIEZBSUxVUkUgT0YgVEhFIFBST0dSQU0gVE8gT1BFUkFURSBXSVRIIEFO
+        WSBPVEhFUlxuUFJPR1JBTVMpLCBFVkVOIElGIFNVQ0ggSE9MREVSIE9SIE9U
+        SEVSIFBBUlRZIEhBUyBCRUVOIEFEVklTRUQgT0YgVEhFXG5QT1NTSUJJTElU
+        WSBPRiBTVUNIIERBTUFHRVMuXG5cbiAgICAgICAgICAgICAgICAgICAgIEVO
+        RCBPRiBURVJNUyBBTkQgQ09ORElUSU9OU1xuXG4gICAgICAgICAgICBIb3cg
+        dG8gQXBwbHkgVGhlc2UgVGVybXMgdG8gWW91ciBOZXcgUHJvZ3JhbXNcblxu
+        ICBJZiB5b3UgZGV2ZWxvcCBhIG5ldyBwcm9ncmFtLCBhbmQgeW91IHdhbnQg
+        aXQgdG8gYmUgb2YgdGhlIGdyZWF0ZXN0XG5wb3NzaWJsZSB1c2UgdG8gdGhl
+        IHB1YmxpYywgdGhlIGJlc3Qgd2F5IHRvIGFjaGlldmUgdGhpcyBpcyB0byBt
+        YWtlIGl0XG5mcmVlIHNvZnR3YXJlIHdoaWNoIGV2ZXJ5b25lIGNhbiByZWRp
+        c3RyaWJ1dGUgYW5kIGNoYW5nZSB1bmRlciB0aGVzZSB0ZXJtcy5cblxuICBU
+        byBkbyBzbywgYXR0YWNoIHRoZSBmb2xsb3dpbmcgbm90aWNlcyB0byB0aGUg
+        cHJvZ3JhbS4gIEl0IGlzIHNhZmVzdFxudG8gYXR0YWNoIHRoZW0gdG8gdGhl
+        IHN0YXJ0IG9mIGVhY2ggc291cmNlIGZpbGUgdG8gbW9zdCBlZmZlY3RpdmVs
+        eVxuY29udmV5IHRoZSBleGNsdXNpb24gb2Ygd2FycmFudHk7IGFuZCBlYWNo
+        IGZpbGUgc2hvdWxkIGhhdmUgYXQgbGVhc3RcbnRoZSBcImNvcHlyaWdodFwi
+        IGxpbmUgYW5kIGEgcG9pbnRlciB0byB3aGVyZSB0aGUgZnVsbCBub3RpY2Ug
+        aXMgZm91bmQuXG5cbiAgICB7ZGVzY3JpcHRpb259XG4gICAgQ29weXJpZ2h0
+        IChDKSB7eWVhcn0gIHtmdWxsbmFtZX1cblxuICAgIFRoaXMgcHJvZ3JhbSBp
+        cyBmcmVlIHNvZnR3YXJlOyB5b3UgY2FuIHJlZGlzdHJpYnV0ZSBpdCBhbmQv
+        b3IgbW9kaWZ5XG4gICAgaXQgdW5kZXIgdGhlIHRlcm1zIG9mIHRoZSBHTlUg
+        R2VuZXJhbCBQdWJsaWMgTGljZW5zZSBhcyBwdWJsaXNoZWQgYnlcbiAgICB0
+        aGUgRnJlZSBTb2Z0d2FyZSBGb3VuZGF0aW9uOyBlaXRoZXIgdmVyc2lvbiAy
+        IG9mIHRoZSBMaWNlbnNlLCBvclxuICAgIChhdCB5b3VyIG9wdGlvbikgYW55
+        IGxhdGVyIHZlcnNpb24uXG5cbiAgICBUaGlzIHByb2dyYW0gaXMgZGlzdHJp
+        YnV0ZWQgaW4gdGhlIGhvcGUgdGhhdCBpdCB3aWxsIGJlIHVzZWZ1bCxcbiAg
+        ICBidXQgV0lUSE9VVCBBTlkgV0FSUkFOVFk7IHdpdGhvdXQgZXZlbiB0aGUg
+        aW1wbGllZCB3YXJyYW50eSBvZlxuICAgIE1FUkNIQU5UQUJJTElUWSBvciBG
+        SVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRS4gIFNlZSB0aGVcbiAg
+        ICBHTlUgR2VuZXJhbCBQdWJsaWMgTGljZW5zZSBmb3IgbW9yZSBkZXRhaWxz
+        LlxuXG4gICAgWW91IHNob3VsZCBoYXZlIHJlY2VpdmVkIGEgY29weSBvZiB0
+        aGUgR05VIEdlbmVyYWwgUHVibGljIExpY2Vuc2UgYWxvbmdcbiAgICB3aXRo
+        IHRoaXMgcHJvZ3JhbTsgaWYgbm90LCB3cml0ZSB0byB0aGUgRnJlZSBTb2Z0
+        d2FyZSBGb3VuZGF0aW9uLCBJbmMuLFxuICAgIDUxIEZyYW5rbGluIFN0cmVl
+        dCwgRmlmdGggRmxvb3IsIEJvc3RvbiwgTUEgMDIxMTAtMTMwMSBVU0EuXG5c
+        bkFsc28gYWRkIGluZm9ybWF0aW9uIG9uIGhvdyB0byBjb250YWN0IHlvdSBi
+        eSBlbGVjdHJvbmljIGFuZCBwYXBlciBtYWlsLlxuXG5JZiB0aGUgcHJvZ3Jh
+        bSBpcyBpbnRlcmFjdGl2ZSwgbWFrZSBpdCBvdXRwdXQgYSBzaG9ydCBub3Rp
+        Y2UgbGlrZSB0aGlzXG53aGVuIGl0IHN0YXJ0cyBpbiBhbiBpbnRlcmFjdGl2
+        ZSBtb2RlOlxuXG4gICAgR25vbW92aXNpb24gdmVyc2lvbiA2OSwgQ29weXJp
+        Z2h0IChDKSB5ZWFyIG5hbWUgb2YgYXV0aG9yXG4gICAgR25vbW92aXNpb24g
+        Y29tZXMgd2l0aCBBQlNPTFVURUxZIE5PIFdBUlJBTlRZOyBmb3IgZGV0YWls
+        cyB0eXBlIGBzaG93IHcnLlxuICAgIFRoaXMgaXMgZnJlZSBzb2Z0d2FyZSwg
+        YW5kIHlvdSBhcmUgd2VsY29tZSB0byByZWRpc3RyaWJ1dGUgaXRcbiAgICB1
+        bmRlciBjZXJ0YWluIGNvbmRpdGlvbnM7IHR5cGUgYHNob3cgYycgZm9yIGRl
+        dGFpbHMuXG5cblRoZSBoeXBvdGhldGljYWwgY29tbWFuZHMgYHNob3cgdycg
+        YW5kIGBzaG93IGMnIHNob3VsZCBzaG93IHRoZSBhcHByb3ByaWF0ZVxucGFy
+        dHMgb2YgdGhlIEdlbmVyYWwgUHVibGljIExpY2Vuc2UuICBPZiBjb3Vyc2Us
+        IHRoZSBjb21tYW5kcyB5b3UgdXNlIG1heVxuYmUgY2FsbGVkIHNvbWV0aGlu
+        ZyBvdGhlciB0aGFuIGBzaG93IHcnIGFuZCBgc2hvdyBjJzsgdGhleSBjb3Vs
+        ZCBldmVuIGJlXG5tb3VzZS1jbGlja3Mgb3IgbWVudSBpdGVtcy0td2hhdGV2
+        ZXIgc3VpdHMgeW91ciBwcm9ncmFtLlxuXG5Zb3Ugc2hvdWxkIGFsc28gZ2V0
+        IHlvdXIgZW1wbG95ZXIgKGlmIHlvdSB3b3JrIGFzIGEgcHJvZ3JhbW1lcikg
+        b3IgeW91clxuc2Nob29sLCBpZiBhbnksIHRvIHNpZ24gYSBcImNvcHlyaWdo
+        dCBkaXNjbGFpbWVyXCIgZm9yIHRoZSBwcm9ncmFtLCBpZlxubmVjZXNzYXJ5
+        LiAgSGVyZSBpcyBhIHNhbXBsZTsgYWx0ZXIgdGhlIG5hbWVzOlxuXG4gIFlv
+        eW9keW5lLCBJbmMuLCBoZXJlYnkgZGlzY2xhaW1zIGFsbCBjb3B5cmlnaHQg
+        aW50ZXJlc3QgaW4gdGhlIHByb2dyYW1cbiAgYEdub21vdmlzaW9uJyAod2hp
+        Y2ggbWFrZXMgcGFzc2VzIGF0IGNvbXBpbGVycykgd3JpdHRlbiBieSBKYW1l
+        cyBIYWNrZXIuXG5cbiAge3NpZ25hdHVyZSBvZiBUeSBDb29ufSwgMSBBcHJp
+        bCAxOTg5XG4gIFR5IENvb24sIFByZXNpZGVudCBvZiBWaWNlXG5cblRoaXMg
+        R2VuZXJhbCBQdWJsaWMgTGljZW5zZSBkb2VzIG5vdCBwZXJtaXQgaW5jb3Jw
+        b3JhdGluZyB5b3VyIHByb2dyYW0gaW50b1xucHJvcHJpZXRhcnkgcHJvZ3Jh
+        bXMuICBJZiB5b3VyIHByb2dyYW0gaXMgYSBzdWJyb3V0aW5lIGxpYnJhcnks
+        IHlvdSBtYXlcbmNvbnNpZGVyIGl0IG1vcmUgdXNlZnVsIHRvIHBlcm1pdCBs
+        aW5raW5nIHByb3ByaWV0YXJ5IGFwcGxpY2F0aW9ucyB3aXRoIHRoZVxubGli
+        cmFyeS4gIElmIHRoaXMgaXMgd2hhdCB5b3Ugd2FudCB0byBkbywgdXNlIHRo
+        ZSBHTlUgTGVzc2VyIEdlbmVyYWxcblB1YmxpYyBMaWNlbnNlIGluc3RlYWQg
+        b2YgdGhpcyBMaWNlbnNlLlxuXG5EZXNjcmlwdGlvbjogLi4gaW1hZ2U6OiBo
+        dHRwczovL3RyYXZpcy1jaS5vcmcvYXNtYWNkby9zaGVsZi1yZWFkZXIuc3Zn
+        P2JyYW5jaD1tYXN0ZXJcbiAgICAgICAgICAgIDp0YXJnZXQ6IGh0dHBzOi8v
+        dHJhdmlzLWNpLm9yZy9hc21hY2RvL3NoZWxmLXJlYWRlclxuICAgICAgICBc
+        biAgICAgICAgPT09PT09PT09PT09XG4gICAgICAgIFNoZWxmIFJlYWRlclxu
+        ICAgICAgICA9PT09PT09PT09PT1cbiAgICAgICAgXG4gICAgICAgIFNoZWxm
+        IFJlYWRlciBpcyBhIHRvb2wgZm9yIGxpYnJhcmllcyB0aGF0IHJldHJpZXZl
+        cyBjYWxsIG51bWJlcnMgb2YgaXRlbXMgXG4gICAgICAgIGZyb20gdGhlaXIg
+        YmFyY29kZSBhbmQgZGV0ZXJtaW5lcyBpZiB0aGV5IGFyZSBpbiB0aGUgY29y
+        cmVjdCBvcmRlci4gQmVjYXVzZVxuICAgICAgICBpdCBjYW4gc2VhcmNoIGJ5
+        IGJhcmNvZGUgdGhlIHNjcmlwdCBhbGxvd3MgbGlicmFyeSBzdGFmZiB0byBj
+        b25uZWN0IGEgXG4gICAgICAgIGJhcmNvZGUgcmVhZGVyIHRvIHF1aWNrbHkg
+        YW5kIGFjY3VyYXRlbHkgc2NhbiB0aGVpciBzaGVsdmVzIGZvciBpdGVtcyB0
+        aGF0IFxuICAgICAgICBhcmUgb3V0IG9mIHBsYWNlLlxuICAgICAgICBcbiAg
+        ICAgICAgVGhpcyBjb25jZXB0IGlzIG5vdCBuZXcsIGl0IGhhcyBwcm9iYWJs
+        eSBiZWVuIGFyb3VuZCBzaW5jZSBsaWJyYXJpZXMgYmVnYW5cbiAgICAgICAg
+        dG8gZGlnaXRpemUgdGhlaXIgcmVjb3JkcywgYnV0IEkgaGF2ZSBub3QgYmVl
+        biBhYmxlIHRvIGZpbmQgYSBmcmVlIG9wZW4gXG4gICAgICAgIHNvdXJjZSBp
+        bXBsZW1lbnRhdGlvbi5cbiAgICAgICAgXG4gICAgICAgIEluc3RhbGxcbiAg
+        ICAgICAgLS0tLS0tLVxuICAgICAgICBcbiAgICAgICAgLi4gY29kZS1ibG9j
+        azo6IGJhc2hcbiAgICAgICAgXG4gICAgICAgICAgICAkIHBpcCBpbnN0YWxs
+        IHNoZWxmLXJlYWRlclxuICAgICAgICBcbiAgICAgICAgUmVxdWlyZXMgUHl0
+        aG9uID49IDIuN1xuICAgICAgICBcbiAgICAgICAgVXNlXG4gICAgICAgIC0t
+        LVxuICAgICAgICBcbiAgICAgICAgR2V0IGEgZHVtcCBvZiBiYXJjb2RlcyBh
+        bmQgY2FsbCBudW1iZXJzIGFuZCBzYXZlIHRoZW0gaW4gYSBjc3YgZmlsZSB3
+        aXRoXG4gICAgICAgIGJhcmNvZGVzIGluIHRoZSBsZWZ0IGNvbHVtbiBhbmQg
+        Y2FsbCBudW1iZXJzIGluIHRoZSByaWdodC4gXG4gICAgICAgIFxuICAgICAg
+        ICBUaGUgcHJvamVjdCByZXF1aXJlcyBubyBkZXBlbmVuY2llcyAoZXhjZXB0
+        IG5vc2UgaWYgeW91IHdhbnQgdG8gcnVuIHRoZSB0ZXN0cykuIFxuICAgICAg
+        ICBNYWtlIHN1cmUgdGhhdCB5b3UgaGF2ZSBweXRob24gaW5zdGFsbGVkICh0
+        ZXN0ZWQgZm9yIDIuNiBhbmQgMi43KS4gXG4gICAgICAgIFxuICAgICAgICBU
+        byBydW46XG4gICAgICAgIFxuICAgICAgICAuLiBjb2RlLWJsb2NrOjogYmFz
+        aFxuICAgICAgICBcbiAgICAgICAgICAgICQgc2hlbGYtcmVhZGVyIHBhdGgv
+        dG8vZmlsZW5hbWUuY3N2XG4gICAgICAgIFxuICAgICAgICBMaWNlbnNlXG4g
+        ICAgICAgIC0tLS0tLS1cbiAgICAgICAgXG4gICAgICAgIEdQTCAyXG4gICAg
+        ICAgIFxuS2V5d29yZHM6IGxpYnJhcnkgYmFyY29kZSBjYWxsIG51bWJlciBz
+        aGVsZiBjb2xsZWN0aW9uXG5QbGF0Zm9ybTogVU5LTk9XTlxuQ2xhc3NpZmll
+        cjogRGV2ZWxvcG1lbnQgU3RhdHVzIDo6IDQgLSBCZXRhXG5DbGFzc2lmaWVy
+        OiBJbnRlbmRlZCBBdWRpZW5jZSA6OiBEZXZlbG9wZXJzXG5DbGFzc2lmaWVy
+        OiBMaWNlbnNlIDo6IE9TSSBBcHByb3ZlZCA6OiBHTlUgR2VuZXJhbCBQdWJs
+        aWMgTGljZW5zZSB2MiAoR1BMdjIpXG5DbGFzc2lmaWVyOiBOYXR1cmFsIExh
+        bmd1YWdlIDo6IEVuZ2xpc2hcbkNsYXNzaWZpZXI6IFByb2dyYW1taW5nIExh
+        bmd1YWdlIDo6IFB5dGhvbiA6OiAyXG5DbGFzc2lmaWVyOiBQcm9ncmFtbWlu
+        ZyBMYW5ndWFnZSA6OiBQeXRob24gOjogMi43XG5DbGFzc2lmaWVyOiBFbnZp
+        cm9ubWVudCA6OiBDb25zb2xlXG4iLCJkZXNjcmlwdGlvbl9jb250ZW50X3R5
+        cGUiOiIiLCJrZXl3b3JkcyI6IiIsImhvbWVfcGFnZSI6Imh0dHBzOi8vZ2l0
+        aHViLmNvbS9hc21hY2RvL3NoZWxmLXJlYWRlciIsImRvd25sb2FkX3VybCI6
+        IiIsImF1dGhvciI6IkF1c3RpbiBNYWNkb25hbGQiLCJhdXRob3JfZW1haWwi
+        OiJhc21hY2RvQGdtYWlsLmNvbSIsIm1haW50YWluZXIiOiIiLCJtYWludGFp
+        bmVyX2VtYWlsIjoiIiwibGljZW5zZSI6IkdOVSBHRU5FUkFMIFBVQkxJQyBM
+        SUNFTlNFIFZlcnNpb24gMiwgSnVuZSAxOTkxIiwicmVxdWlyZXNfcHl0aG9u
+        IjoiIiwicHJvamVjdF91cmwiOiIiLCJwcm9qZWN0X3VybHMiOiJ7fSIsInBs
+        YXRmb3JtIjoiIiwic3VwcG9ydGVkX3BsYXRmb3JtIjoiIiwicmVxdWlyZXNf
+        ZGlzdCI6IltdIiwicHJvdmlkZXNfZGlzdCI6IltdIiwib2Jzb2xldGVzX2Rp
+        c3QiOiJbXSIsInJlcXVpcmVzX2V4dGVybmFsIjoiW10iLCJjbGFzc2lmaWVy
+        cyI6IltdIn1dfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:44 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/update.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/python/update.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:45 GMT
+      - Wed, 21 Jul 2021 19:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 5d22557c6b2e46f7a2cd9695c577c8a1
+      - 6ad00e4bc3cc41f88baaaa7f544fabf6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:45 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,71 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:45 GMT
+      - Wed, 21 Jul 2021 19:00:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 26af42042fd442e28f015884d1c621c7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '426'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3B5dGhv
+        bi9weXRob24vNmRhZGE5NjAtZWM3NC00M2EyLWFiNzUtMWQ3MTg4YmQyNzBj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzQuODA3NDgy
+        WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAz
+        X1B5dGhvbl8xIiwidXJsIjoiaHR0cHM6Ly9weXBpLm9yZyIsImNhX2NlcnQi
+        Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
+        ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxOTowMDozNC44MDc1MTNaIiwiZG93
+        bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
+        b2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
+        bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
+        bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
+        dGVfbGltaXQiOm51bGwsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdLCJl
+        eGNsdWRlcyI6W10sInByZXJlbGVhc2VzIjpmYWxzZSwicGFja2FnZV90eXBl
+        cyI6W10sImtlZXBfbGF0ZXN0X3BhY2thZ2VzIjowLCJleGNsdWRlX3BsYXRm
+        b3JtcyI6W119XX0=
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/6dada960-ec74-43a2-ab75-1d7188bd270c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -80,27 +144,27 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '52'
+      - '67'
       Correlation-Id:
-      - 66827ca83d5d4e2082693d95d835d8f9
+      - 7d44181c2ec945c5a55aa7d0f07f1850
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmOGU3NzkyLTMxYTYtNGFl
+        ZC05MzdkLTUzOTVhNTA0YWNmNi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:45 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/python/pypi/?name=Default_Organization-Cabinet-pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/tasks/5f8e7792-31a6-4aed-937d-5395a504acf6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -108,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -121,35 +185,47 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:45 GMT
+      - Wed, 21 Jul 2021 19:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
-      Content-Length:
-      - '52'
       Correlation-Id:
-      - 50b6febd637642d5a3e53b78a46793f8
+      - 436faf49323e47b68dee45b38f036b64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+      Content-Length:
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWY4ZTc3OTItMzFh
+        Ni00YWVkLTkzN2QtNTM5NWE1MDRhY2Y2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDctMjFUMTk6MDA6MzYuMjQ0OTA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3ZDQ0MTgxYzJlYzk0NWM1YTU1YWE3ZDBm
+        MDdmMTg1MCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDE5OjAwOjM2LjMx
+        NDUyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTk6MDA6MzYuMzcw
+        NDIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jN2RhZjEwNi00MjA5LTQ4YjUtYTYxMy02ODk0N2VlMWI4ZjQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzZkYWRhOTYwLWVjNzQtNDNh
+        Mi1hYjc1LTFkNzE4OGJkMjcwYy8iXX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:45 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?name=Default_Organization-Cabinet-pulp3_Python_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +246,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:45 GMT
+      - Wed, 21 Jul 2021 19:00:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,21 +260,70 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 19adbe35b59e444f9a3b61d40bae4d85
+      - 943bc2172e0c4c68ad774aae64866421
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:45 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/distributions/python/pypi/?base_path=Default_Organization/library/pulp3_Python_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 485d51a073474a169594012caa32cdd8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:36 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/
     body:
       encoding: UTF-8
       base64_string: |
@@ -221,13 +346,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:45 GMT
+      - Wed, 21 Jul 2021 19:00:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/"
+      - "/pulp/api/v3/repositories/python/python/acb16d52-aabf-49ef-9c39-5e6e51deac89/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -237,31 +362,103 @@ http_interactions:
       Content-Length:
       - '504'
       Correlation-Id:
-      - 73e71a3e682b42b99b448e46d6f5c99b
+      - 8f2491208f164a178ab32e61e5cb9bfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhv
-        bi9weXRob24vMTAxM2U4ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUx
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6Mjk6NDUuNjMxMTIx
+        bi9weXRob24vYWNiMTZkNTItYWFiZi00OWVmLTljMzktNWU2ZTUxZGVhYzg5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzcuMTgwMzgz
         WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3B5dGhvbi9weXRob24vMTAxM2U4ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUw
-        MThjNzUxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
+        L3B5dGhvbi9weXRob24vYWNiMTZkNTItYWFiZi00OWVmLTljMzktNWU2ZTUx
+        ZGVhYzg5L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
         cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcHl0aG9u
-        L3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAxOGM3NTEv
+        L3B5dGhvbi9hY2IxNmQ1Mi1hYWJmLTQ5ZWYtOWMzOS01ZTZlNTFkZWFjODkv
         dmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2Fi
         aW5ldC1wdWxwM19QeXRob25fMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5lZF92ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlz
         aCI6ZmFsc2V9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:45 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:37 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/remotes/python/python/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Q
+        eXRob25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0Ijpu
+        dWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tleSI6bnVsbCwidGxz
+        X3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHJveHlfdXNl
+        cm5hbWUiOm51bGwsInByb3h5X3Bhc3N3b3JkIjpudWxsLCJ0b3RhbF90aW1l
+        b3V0IjozMDAsImluY2x1ZGVzIjpbInNoZWxmLXJlYWRlciJdLCJrZWVwX2xh
+        dGVzdF9wYWNrYWdlcyI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 21 Jul 2021 19:00:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/python/python/559c7cb3-aa94-40ee-86c9-2a04c0da6559/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '679'
+      Correlation-Id:
+      - 9ac6ade8a71b408b84277b7da03a8dea
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0
+        aG9uLzU1OWM3Y2IzLWFhOTQtNDBlZS04NmM5LTJhMDRjMGRhNjU1OS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDE5OjAwOjM3LjQwNDM0OFoiLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19QeXRo
+        b25fMSIsInVybCI6Imh0dHBzOi8vcHlwaS5vcmciLCJjYV9jZXJ0IjpudWxs
+        LCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInBy
+        b3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjEtMDctMjFUMTk6MDA6MzcuNDA0MzY0WiIsImRvd25sb2Fk
+        X2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5
+        Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNvbm5lY3Rf
+        dGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51bGwsInNv
+        Y2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xp
+        bWl0IjpudWxsLCJpbmNsdWRlcyI6WyJzaGVsZi1yZWFkZXIiXSwiZXhjbHVk
+        ZXMiOltdLCJwcmVyZWxlYXNlcyI6ZmFsc2UsInBhY2thZ2VfdHlwZXMiOltd
+        LCJrZWVwX2xhdGVzdF9wYWNrYWdlcyI6MCwiZXhjbHVkZV9wbGF0Zm9ybXMi
+        OltdfQ==
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 19:00:37 GMT
 - request:
     method: put
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/
+    uri: https://centos7-katello-devel-nfs.localhost.example.com/pulp/api/v3/repositories/python/python/acb16d52-aabf-49ef-9c39-5e6e51deac89/
     body:
       encoding: UTF-8
       base64_string: |
@@ -284,7 +481,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:29:46 GMT
+      - Wed, 21 Jul 2021 19:00:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -298,16 +495,16 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - d061f83312564bbb9c8dbc8c9149091f
+      - 0c81c68e98be44db878c54022e04777a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-katello-devel-nfs.localhost.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNmE3N2U2LWI4ODgtNDEy
-        MS04ODJhLTNkYjNhMzVjNWIyOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlY2E2NjQwLWFjMTItNDgz
+        Zi1hNzZhLWRlNWU1NzM0NDNjNi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:29:46 GMT
+  recorded_at: Wed, 21 Jul 2021 19:00:37 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/repository/python/repository_mirror_remote_options_test.rb
+++ b/test/services/katello/pulp3/repository/python/repository_mirror_remote_options_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class PythonRepositoryMirrorOptionsTest < ::ActiveSupport::TestCase
+        include RepositorySupport
+
+        def setup
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @mock_smart_proxy.stubs(:pulp_primary?).returns(false)
+          @repo = katello_repositories(:pulp3_python_1)
+          @repo_service = @repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_remote_options
+          @mock_smart_proxy.stubs(:download_policy).returns(SmartProxy::DOWNLOAD_INHERIT)
+          pulp3_repo = @repo.repository_type.pulp3_service_class.new(@repo, @mock_smart_proxy)
+          Katello::Pulp3::RepositoryMirror.any_instance.expects(:ssl_remote_options).at_least_once.returns({})
+          assert_equal "Default_Organization-Cabinet-pulp3_Python_1", pulp3_repo.with_mirror_adapter.remote_options[:name]
+          assert pulp3_repo.with_mirror_adapter.remote_options[:url].end_with?(pulp3_repo.partial_repo_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create a python repository via a POST request to the API in order to test with remote options. The UI for this is not implemented yet. Syncing through the UI is fine, however.

Include remote options as part of the data field. For example:

"generic_remote_options": { "includes":["[name of python libraries to include from url]"] } 

If using https://pypi.org as the url without specifying includes or excludes in generic_remote_options, all of pypi is synced during syncing.

In the console, use **::Katello::RepositoryGenericContentUnit.all** to see all the created generic content units. For a given repository **repo**, **repo.generic_content_units** will show the content units for that specific repository.