### PR TITLE
Fixes #32923 - do not use Puppet ENC in tests

### DIFF
--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -13,12 +13,7 @@ module Katello
       @library_view = ContentView.find(katello_content_views(:library_view).id)
 
       @foreman_host = FactoryBot.create(:host)
-      @foreman_host.puppetclasses = []
       @foreman_host.save!
-
-      new_puppet_environment = Environment.find(environments(:testing).id)
-
-      @foreman_host.environment = new_puppet_environment
     end
   end
 


### PR DESCRIPTION
We are still using Puppet Environment in tests for host extensions. This
needs to be dropped in order to not break tests once puppet bits are
extracted from Foreman.

This is blocking https://github.com/theforeman/foreman/pull/8510