### PR TITLE
Fixes #32901 - inc update doesn't generate metadata

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -17,6 +17,7 @@ module Actions
 
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
         def plan(old_version, environments, options = {})
           dep_solve = options.fetch(:resolve_dependencies, true)
           description = options.fetch(:description, '')
@@ -70,8 +71,15 @@ module Actions
                 unit_map = pulp3_content_mapping(content)
 
                 unless extended_repo_mapping.empty? || unit_map.values.flatten.empty?
-                  copy_action_outputs << plan_action(Pulp3::Repository::MultiCopyUnits, extended_repo_mapping, unit_map,
-                                                     dependency_solving: dep_solve).output
+                  sequence do
+                    copy_action_outputs << plan_action(Pulp3::Repository::MultiCopyUnits, extended_repo_mapping, unit_map,
+                                                       dependency_solving: dep_solve).output
+                    repos_to_clone.each do |source_repos|
+                      if separated_repo_map[:pulp3_yum].keys.include?(source_repos)
+                        copy_repos(repository_mapping[source_repos])
+                      end
+                    end
+                  end
                 end
               end
 

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -91,6 +91,8 @@ module ::Actions::Katello::ContentViewVersion
                                   pulp3_repo_map,
                                   { :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => false)
+        assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
+        assert_action_planed_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
       end
 
       it 'respects dep solving true' do


### PR DESCRIPTION
Inc update was missing the metadata generation and content indexing.

To test:
1) Incrementally update a content view version with a new package and/or erratum
2) Ensure the new content view version has a LCE and look at the repo metadata + content
3) See that the new package(s) are missing
4) Apply this PR
5) Run the incremental update again
6) Check the repo metadata and packages again. See that the appropriate content is now there