### PR TITLE
Fixes #32911 - Create content view button fix

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -29,13 +29,13 @@ const CreateContentViewForm = ({ setModalOpen }) => {
 
   useDeepCompareEffect(() => {
     const { id } = response;
-    if (id && status === STATUS.RESOLVED) {
+    if (id && status === STATUS.RESOLVED && saving) {
       setSaving(false);
       setRedirect(true);
     } else if (status === STATUS.ERROR) {
       setSaving(false);
     }
-  }, [response, status, error]);
+  }, [response, status, error, saving]);
 
   const onSave = () => {
     setSaving(true);


### PR DESCRIPTION
Steps to reproduce:

1. On the new CV page, click the Create content view button
2. Fill out the form and click Create
3. It takes you to the Versions tab for the newly created CV
4. Click 'Content Views' in the breadcrumb
5. Click the Create content view button again

Expected: The Create Content View modal shows.