### PR TITLE
Refs #32580 - use plan_action instead of plan_pulp_action

### DIFF
--- a/app/lib/actions/katello/repository/refresh_repository.rb
+++ b/app/lib/actions/katello/repository/refresh_repository.rb
@@ -5,7 +5,7 @@ module Actions
         def plan(repo, options = {})
           User.as_anonymous_admin do
             repo = ::Katello::Repository.find(repo.id)
-            plan_pulp_action(Actions::Pulp3::Orchestration::Repository::RefreshIfNeeded,
+            plan_action(Actions::Pulp3::Orchestration::Repository::RefreshIfNeeded,
                              repo, SmartProxy.default_capsule!, :dependency => options[:dependency])
             plan_self(:name => repo.name, :dependency => options[:dependency])
           end


### PR DESCRIPTION
This was preventing me from adding new subscriptions from the UI (and anything else that'd call RefreshRepository). This broke when PulpSelector was removed from the class