### PR TITLE
Fixes #32965 - Have repo delete go directly to task instead of toast

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -65,10 +65,7 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
             var success, error, params = getParams(), removalPromise;
 
             success = function (response) {
-                var message = translate('Removal of selected repositories initiated successfully.');
-                var link = ("/foreman_tasks/tasks/%taskId").replace('%taskId', response.task.id);
-                var alertBody = { children: translate("Click to view task"), href: link };
-                Notification.setSuccessMessage(message, {link: alertBody});
+                $state.go('product.tasks.details', {taskId: response.task.id});
             };
 
             error = function (response) {


### PR DESCRIPTION
This PR removes the toast notification and sends the user to the task upon a repo delete