### PR TITLE
Fixes #32997 - Enabling a repo not reflected in list

### DIFF
--- a/webpack/redux/reducers/RedHatRepositories/enabled.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.js
@@ -1,6 +1,7 @@
 import Immutable from 'seamless-immutable';
 import { isEmpty } from 'lodash';
 
+
 import {
   ENABLED_REPOSITORIES_REQUEST,
   ENABLED_REPOSITORIES_SUCCESS,
@@ -82,7 +83,9 @@ export default (state = initialState, action) => {
           // server can return per_page: null when there's error in the search query,
           // don't store it in such case
           // eslint-disable-next-line camelcase
-          perPage: Number(per_page || state.pagination.perPage),
+          perPage: (per_page || state.pagination.perPage)
+          // eslint-disable-next-line camelcase
+            && Number(per_page || state.pagination.perPage),
         },
         itemCount: Number(subtotal),
         loading: false,


### PR DESCRIPTION
Steps to Reproduce:
1. A new Sat6.10 with imported manifest
2. WebUI: Content -> Red Hat Repositories (which shows no enabled repo, now - so far good)
3. Unwrap a few repo groups and enable some repo.
4. See what happens in "Enabled repositories" section.

This would only occur when an empty "enabled" list was set. If you add 1 repo and then delete it, a refresh would be required to get back into the erroring state.

This issue was due to an undefined "per_page" value being forced into a Number() function resulting in a NaN per_page value. 
The API that receives this output is: /api/v2/repositories (GET)
Upon receipt of the per_page value of NaN, the API, instead of returning a default value, returns NaN (which it likely evaluates as a number) but fails to supply a value for the "results":[] array. Likely due to the bad math of "numberOfResults".slice(NaN) or equivalent.

Although this PR amends the front-end issue, it is recommended we change the validation on the "per_page" variable to only accept the chosen pagination values (5,10,15,20, 25...), and return the default of 20 for all other values.