### PR TITLE
Registration & Life Cycle environment

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -19,7 +19,9 @@ module Katello
 
       def host_setup_extension
         if params['host']['lifecycle_environment_id']
-          @host.update!(lifecycle_environment: KTEnvironment.readable.find(params['host']['lifecycle_environment_id']))
+          new_lce = KTEnvironment.readable.find(params['host']['lifecycle_environment_id'])
+          @host.content_facet.lifecycle_environment = new_lce
+          @host.update_candlepin_associations
         end
 
         super


### PR DESCRIPTION
When user generates registration command and
select LCE (in the UI form or in API), this user's LCE
should override LCE from activation key