### PR TITLE
Fixes #32138 - Navigation doesn't display Content views without admin rights

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -201,7 +201,7 @@ Foreman::Plugin.register :katello do
   menu :labs_menu,
        :content_publication,
        :url => '/labs/content_views',
-       :url_hash => {:controller => 'katello/react',
+       :url_hash => {:controller => 'katello/api/v2/content_views',
                      :action => 'index'},
        :caption => N_('Content Views'),
        :parent => :lab_features_menu,


### PR DESCRIPTION
Steps to Reproduce:

1. Create a non-admin user
2. Login with said user
3. Attempt to view Lab Features > Content Views