### PR TITLE
Fixes #33012 - refactors deletion of orphaned entries in docker tags

### DIFF
--- a/db/migrate/20200402130013_add_repsoitory_docker_meta_tag_f_key.rb
+++ b/db/migrate/20200402130013_add_repsoitory_docker_meta_tag_f_key.rb
@@ -17,7 +17,9 @@ class AddRepsoitoryDockerMetaTagFKey < ActiveRecord::Migration[5.2]
     add_index :katello_repository_docker_meta_tags, [:repository_id, :docker_meta_tag_id], :unique => true, :name => 'repository_docker_meta_tags_rid_dmtid'
 
     Katello::RepositoryDockerTag.where.not(:repository_id => Katello::Repository.select(:id)).delete_all
-    Katello::RepositoryDockerTag.where.not(:docker_tag_id => Katello::DockerTag.select(:id)).delete_all
+    # rubocop:disable Layout/LineLength
+    Katello::RepositoryDockerTag.delete_by('katello_repository_docker_tags.id IN (SELECT katello_repository_docker_tags.id FROM katello_repository_docker_tags LEFT JOIN katello_docker_tags d ON katello_repository_docker_tags.docker_tag_id = d.id GROUP BY katello_repository_docker_tags.id HAVING (count(d.id) = 0))')
+    # rubocop:enable Layout/LineLength
 
     add_foreign_key :katello_repository_docker_tags, :katello_repositories, :column => :repository_id
     add_foreign_key :katello_repository_docker_tags, :katello_docker_tags, :column => :docker_tag_id


### PR DESCRIPTION
This is a WIP.

The original issue comes into play when a large number of Docker Tags are scanned during a where.not/delete_all AR statement.

Added 500k DockerTags and created a RepositoryDockerTag with a docker_tag_id initially pointed at one of these records, then deleted the docker tag with that id (but suppressed dependent deletion). 

Original AR statement:

```
Katello::RepositoryDockerTag.where.not(:docker_tag_id => Katello::DockerTag.select(:id)).explain
=> EXPLAIN for: SELECT "katello_repository_docker_tags".* FROM "katello_repository_docker_tags" WHERE "katello_repository_docker_tags"."docker_tag_id" NOT IN (SELECT "katello_docker_tags"."id" FROM "katello_docker_tags")
                                        QUERY PLAN
------------------------------------------------------------------------------------------
 Seq Scan on katello_repository_docker_tags  (cost=0.00..11141993.60 rows=680 width=32)
   Filter: (NOT (SubPlan 1))
   SubPlan 1
     ->  Materialize  (cost=0.00..15135.21 rows=500014 width=4)
           ->  Seq Scan on katello_docker_tags  (cost=0.00..10681.14 rows=500014 width=4)
```

Modified as a join:
```
Katello::RepositoryDockerTag.joins("LEFT JOIN katello_docker_tags d on katello_repository_docker_tags.docker_tag_id = d.id").select("katello_repository_docker_tags.id").group("katello_repository_docker_tags.id").having("count(d.id) = 0").explain
=> EXPLAIN for: SELECT katello_repository_docker_tags.id FROM "katello_repository_docker_tags" LEFT JOIN katello_docker_tags d on katello_repository_docker_tags.docker_tag_id = d.id GROUP BY katello_repository_docker_tags.id HAVING (count(d.id) = 0)
                                                                QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=0.57..9190.75 rows=7 width=8)
   Group Key: katello_repository_docker_tags.id
   Filter: (count(d.id) = 0)
   ->  Nested Loop Left Join  (cost=0.57..9166.95 rows=1360 width=12)
         ->  Index Scan using katello_repository_docker_tags_pkey on katello_repository_docker_tags  (cost=0.15..68.55 rows=1360 width=12)
         ->  Index Only Scan using katello_docker_tags_pkey on katello_docker_tags d  (cost=0.42..6.69 rows=1 width=4)
               Index Cond: (id = katello_repository_docker_tags.docker_tag_id)
(7 rows)
```

For additional testing, perhaps wrapping the statement into a method which can then be added as a test without reference to the migration.