### PR TITLE
Refs #32923 - drop last Envrionment references

### DIFF
--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -36,10 +36,6 @@ module Katello
       host.reload
       host.expects(:update_candlepin_associations)
       host.update!(:content_facet_attributes => { :content_view_id => view2.id })
-      if host.environment
-        host.environment.organizations << host.organization
-        host.environment.locations << host.location
-      end
 
       host.reload
       host.content_facet.content_view_id = view.id

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -208,31 +208,6 @@ module Katello
     end
   end
 
-  class HostManagedPuppetTest < HostManagedExtensionsTestBase
-    def setup
-      super
-      @library_dev_staging_view = katello_content_views(:library_dev_staging_view)
-
-      @library_puppet_env = ::Environment.create!(:name => 'library_env')
-      @dev_puppet_env = ::Environment.create!(:name => 'dev_env')
-
-      @foreman_host = FactoryBot.create(:host, :with_content, :content_view => @library_dev_staging_view,
-                                     :lifecycle_environment => @library, :organization => @library.organization, :environment => @library_puppet_env)
-    end
-
-    def test_non_matching_puppet_environment
-      third_party_env = ::Environment.create!(:name => 'someotherenv',
-                                              :organizations => [@foreman_host.organization],
-                                              :locations => [@foreman_host.location])
-      @foreman_host.environment = third_party_env
-      @foreman_host.save!
-
-      @foreman_host.content_facet.lifecycle_environment = @dev
-      @foreman_host.save!
-
-      assert_equal third_party_env, @foreman_host.environment
-    end
-  end
   class HostInstalledPackagesTest < HostManagedExtensionsTestBase
     def setup
       super


### PR DESCRIPTION
We are still testing Puppet Environment in tests.
These should be the last references to get tests passing after puppet is
extracted.

Hopefully last katello blocker for #8510