### PR TITLE
Fixes #33036 - Make via Katello-agent option clickable on the content host errata page

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -115,7 +115,7 @@ module Katello
         fail HttpErrors::NotFound, _("Couldn't find errata ids '%s'") % missing.to_sentence if missing.any?
         @errata_ids = params[:errata_ids]
       else
-        @errata_ids = find_bulk_errata_ids([@host], params[:bulk_errata_ids])
+        @errata_ids = find_bulk_errata_ids([@host], params[:bulk_errata_ids].to_json)
       end
     end
   end


### PR DESCRIPTION
[find_bulk_errata_ids](https://github.com/Katello/katello/blob/02e2151a90717faf54cb6c3918d6d1dc2f777ae5/app/controllers/katello/concerns/api/v2/host_errata_extensions.rb#L6) expects `bulk_errata_ids` in JSON string format.