### PR TITLE
Fixes #33039 - to_s docker whitelist tags

### DIFF
--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -15,7 +15,7 @@ module Katello
         def remote_options
           options = {url: root.url, upstream_name: root.docker_upstream_name}
           if root.docker_tags_whitelist&.any?
-            options[:include_tags] = root.docker_tags_whitelist
+            options[:include_tags] = root.docker_tags_whitelist.map(&:to_s)
           else
             options[:include_tags] = nil
           end


### PR DESCRIPTION
as pulp does not like floats/ints

When using hammer, you can pass `--docker-tags-whitelist "16.1"`  and hammer will treat 16.1 as a float when creating an array to be sent to the api:  [16.1]

If you pass a non-float value, it properly passes a string, for example `--docker-tags-whitelist "16.1a"`   would properly pass ["16.1a"] to the api.

Pulp however doesn't seem to handle floats properly, and treats them as if nothing was passed.   

Since our api does not exclude floats (or integers) today within the array, i thought it would be simple to just fix the integration with pulp to convert it to a string prior to passing to pulp.