### PR TITLE
Fixes #32739 - module stream applicability incorrect w/ enabled+inactive modules

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -214,10 +214,15 @@ module Katello
         new_ids = new_available_module_streams.keys - old_associated_ids
         new_ids.each do |new_id|
           module_stream = new_available_module_streams[new_id]
+          status = module_stream["status"]
+          # Set status to "unknown" only if the active field is in use and set to false and the module is enabled
+          if enabled_module_stream_inactive?(module_stream)
+            status = "unknown"
+          end
           self.host_available_module_streams.create!(host_id: self.id,
                                                      available_module_stream_id: new_id,
                                                      installed_profiles: module_stream["installed_profiles"],
-                                                     status: module_stream["status"])
+                                                     status: status)
         end
 
         upgradable_streams.each do |hams|
@@ -226,6 +231,10 @@ module Katello
           module_stream_data = module_stream.slice(*shared_keys)
           if hams.attributes.slice(*shared_keys) != module_stream_data
             hams.update!(module_stream_data)
+          end
+          # Set status to "unknown" only if the active field is in use and set to false and the module is enabled
+          if enabled_module_stream_inactive?(module_stream)
+            hams.update!(status: "unknown")
           end
         end
       end
@@ -345,6 +354,10 @@ module Katello
       def update_trace_status
         self.get_status(::Katello::TraceStatus).refresh!
         self.refresh_global_status!
+      end
+
+      def enabled_module_stream_inactive?(module_stream)
+        !module_stream["active"].nil? && module_stream["active"] == false && module_stream["status"] == "enabled"
       end
     end
   end

--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -92,7 +92,8 @@ module Katello
         ::Katello::ModuleStream.
           joins("inner join katello_available_module_streams on
             katello_module_streams.name = katello_available_module_streams.name and
-            katello_module_streams.stream = katello_available_module_streams.stream").
+            katello_module_streams.stream = katello_available_module_streams.stream and
+            katello_module_streams.context = katello_available_module_streams.context").
           joins("inner join katello_host_available_module_streams on
             katello_available_module_streams.id = katello_host_available_module_streams.available_module_stream_id").
           where("katello_host_available_module_streams.host_id = :content_facet_id and

--- a/test/fixtures/models/katello_available_module_streams.yml
+++ b/test/fixtures/models/katello_available_module_streams.yml
@@ -1,15 +1,19 @@
 available_module_stream_river:
   name: Ohio
   stream: noitsariver
+  context: buckeye
 
 available_module_stream_one:
   name: one
   stream: noitsariver
+  context: buckeye
 
 available_module_stream_two:
   name: two
   stream: noitsariver
+  context: buckeye
 
 available_module_stream_three:
   name: three
   stream: noitsariver
+  context: buckeye

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -257,7 +257,7 @@ module Katello
   end
 
   class HostAvailableModulesTest < HostManagedExtensionsTestBase
-    def make_module_json(name = "foo", status = "unknown", context = nil, installed_profiles = [])
+    def make_module_json(name = "foo", status = "unknown", context = nil, installed_profiles = [], active = nil)
       {
         "name" => name,
         "stream" => "8",
@@ -270,7 +270,8 @@ module Katello
           "default"
         ],
         "installed_profiles" => installed_profiles,
-        "status" => status
+        "status" => status,
+        "active" => active
       }
     end
 
@@ -297,6 +298,22 @@ module Katello
       refute_empty installed.installed_profiles
 
       assert_equal 'abacadaba', @foreman_host.host_available_module_streams.disabled.first.available_module_stream.context
+    end
+
+    def test_import_modules_with_active_field
+      modules_json = [
+        make_module_json("enabled-varying-activity", "enabled", "12347", [], true),
+        make_module_json("enabled-varying-activity", "enabled", "12345", [], false),
+        make_module_json("enabled-varying-activity", "enabled", "12346", [], false)
+      ]
+
+      @foreman_host.import_module_streams(modules_json)
+
+      assert_equal "12347", @foreman_host.host_available_module_streams.enabled.first.available_module_stream.context
+      assert_equal 1, @foreman_host.host_available_module_streams.enabled.count
+      assert_equal "12345", @foreman_host.host_available_module_streams.unknown.min_by(&:id).available_module_stream.context
+      assert_equal "12346", @foreman_host.host_available_module_streams.unknown.max_by(&:id).available_module_stream.context
+      assert_equal 2, @foreman_host.host_available_module_streams.unknown.count
     end
 
     def test_import_modules_with_update


### PR DESCRIPTION
See the related sub-man PR for a good description of the issue: https://github.com/candlepin/subscription-manager/pull/2708

This PR uses the proposed "active" key for the module stream profile to only import enabled+active module streams.

To test:

1) Register a CentOS 8 client
2) Sync AppStream
3) Enable the `perl:5.26` module
4) See that there are perl-IO-Socket-SSL modular packages applicable.  There should likely be no applicable modular packages.
5) Apply this PR and see the wrong applicable modular packages are still there.
  -> This tests that the PR won't break the profile upload if the sub-man fix isn't present.
6) Apply the sub-man patch, force a new profile upload, and recalculate applicability.  The wrong applicable packages should be gone now.