### PR TITLE
Fixes #33014 - Sync pulpcore capsules after promote

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -89,10 +89,19 @@ module Katello
         end
 
         def self.with_environment(environment, include_default = false)
+          (pulp2_proxies_with_environment(environment, include_default) + pulpcore_proxies_with_environment(environment)).try(:uniq)
+        end
+
+        def self.pulp2_proxies_with_environment(environment, include_default = false)
           features = [PULP_NODE_FEATURE]
           features << PULP_FEATURE if include_default
 
           unscoped.with_features(features).joins(:capsule_lifecycle_environments).
+              where(katello_capsule_lifecycle_environments: { lifecycle_environment_id: environment.id })
+        end
+
+        def self.pulpcore_proxies_with_environment(environment)
+          unscoped.where(id: unscoped.select { |p| p.pulp_mirror? }.pluck(:id)).joins(:capsule_lifecycle_environments).
               where(katello_capsule_lifecycle_environments: { lifecycle_environment_id: environment.id })
         end
 


### PR DESCRIPTION
To test:
Publish/Promote a CV to an env which is tied to a pulpcore only smart proxy.
With PR: The capsule should auto sync.
Without PR: The capsule doesn't auto sync.
