### PR TITLE
Fixes #32995 - URI.escape is obsolete warning

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -41,9 +41,9 @@ module Katello
       delete: Net::HTTP::Delete
     }.freeze
 
-    class_eval do
+    class << self
       REQUEST_MAP.keys.each do |key|
-        define_singleton_method(key) do |*args|
+        define_method(key) do |*args|
           issue_request(
             method: key,
             path: args.first,
@@ -52,9 +52,7 @@ module Katello
           )
         end
       end
-    end
 
-    class << self
       def logger
         fail NotImplementedError
       end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -46,7 +46,7 @@ module Katello
 
           def create(env_id, parameters, activation_key_cp_ids)
             parameters['installedProducts'] ||= [] #if installed products is nil, candlepin won't attach custom products
-            url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
+            url = "/candlepin/environments/#{env_id}/consumers/"
             url += "?activation_keys=" + activation_key_cp_ids.join(",") if activation_key_cp_ids.length > 0
 
             response = self.post(url, parameters.to_json, self.default_headers).body

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -1,0 +1,72 @@
+require 'katello_test_helper'
+
+module Katello
+  class HttpResourceTest < ActiveSupport::TestCase
+    class TestHttpResource < HttpResource
+      self.site = 'http://localhost'
+      def self.logger
+        Rails.logger
+      end
+    end
+
+    def test_hash_to_query_empty
+      params = {}
+
+      result = TestHttpResource.hash_to_query(params)
+
+      assert_equal "?", result
+    end
+
+    def test_hash_to_query
+      params = {
+        foo: 'fru',
+        bar: 'bru',
+        too: 'tru',
+        arr: [
+          :arr_one,
+          :arr_two
+        ]
+      }
+
+      result = TestHttpResource.hash_to_query(params)
+
+      assert_equal "?foo=fru&bar=bru&too=tru&arr=arr_one&arr=arr_two", result
+    end
+
+    def test_get
+      headers = { headerOne: 'headerOneValue' }
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:get).with(headers).returns(mock_response)
+      TestHttpResource.get('/path', headers)
+    end
+
+    def test_get_no_headers
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:get).returns(mock_response)
+      TestHttpResource.get('/path')
+    end
+
+    def test_delete
+      headers = { headerOne: 'headerOneValue' }
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:delete).with(headers).returns(mock_response)
+      TestHttpResource.delete('/path', headers)
+    end
+
+    def test_put
+      headers = { headerOne: 'headerOneValue' }
+      payload = { payloadKey: 'payloadValue' }
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:put).with(payload, headers).returns(mock_response)
+      TestHttpResource.put('/path', payload, headers)
+    end
+
+    def test_post
+      headers = { headerOne: 'headerOneValue' }
+      payload = { payloadKey: 'payloadValue' }
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:post).with(payload, headers).returns(mock_response)
+      TestHttpResource.post('/path', payload, headers)
+    end
+  end
+end


### PR DESCRIPTION
I broadened the scope of this PR a bit .... it fixes the URI.escape warning but also refactord the HTTP methods in HttpResource to DRY the code up pretty significantly, and re-implements `hash_to_query` to use `URI.encode_www_form` rather than our own concoction. The added test coverage should illustrate that it all works, but the real test is to ensure our Candlepin interactions still work