### PR TITLE
Fixes #33036 - Make via Katello-agent option clickable on content host errata page

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -115,7 +115,7 @@ module Katello
         fail HttpErrors::NotFound, _("Couldn't find errata ids '%s'") % missing.to_sentence if missing.any?
         @errata_ids = params[:errata_ids]
       else
-        @errata_ids = find_bulk_errata_ids([@host], params[:bulk_errata_ids].to_json)
+        @errata_ids = find_bulk_errata_ids([@host], params[:bulk_errata_ids])
       end
     end
   end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -126,7 +126,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
 
         $scope.performViaKatelloAgent = function () {
             var errataIds = $scope.selectedErrataIds();
-            HostErratum.apply({id: $scope.host.id, 'bulk_errata_ids': errataIds},
+            HostErratum.apply({id: $scope.host.id, 'bulk_errata_ids': angular.toJson(errataIds)},
                                function (task) {
                                     $scope.table.selectAll(false);
                                     $scope.transitionTo('content-host.tasks.details', {taskId: task.id});

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -99,12 +99,13 @@ describe('Controller: ContentHostErrataController', function() {
     });
 
     it("provide a way to apply errata", function() {
+        var bulk_errata_ids = angular.toJson({included: { ids: [mockErratum.errata_id], params: {} }});
+
         spyOn(HostErratum, "apply").and.callThrough();
         spyOn($scope.table, "selectAll");
         spyOn($scope, "transitionTo");
         $scope.applySelected();
-        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: {included: { ids: [mockErratum.errata_id], params: {} }}},
-                                                         jasmine.any(Function));
+        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: bulk_errata_ids}, jasmine.any(Function));
         expect($scope.transitionTo).toHaveBeenCalledWith('content-host.tasks.details', {taskId: mockTask.id});
         expect($scope.table.selectAll).toHaveBeenCalledWith(false);
     });


### PR DESCRIPTION
[find_bulk_errata_ids](https://github.com/Katello/katello/blob/02e2151a90717faf54cb6c3918d6d1dc2f777ae5/app/controllers/katello/concerns/api/v2/host_errata_extensions.rb#L6) expects `bulk_errata_ids` in JSON string format.

Followup of https://github.com/Katello/katello/pull/9470.