### PR TITLE
Fixes #33057 - apipie cache repo & content type params missing

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -10,9 +10,11 @@ module Katello
     param :repository_id, :number, :required => true, :desc => N_("repository id")
     param :size, :number, :required => true, :desc => N_("Size of file to upload")
     param :checksum, String, :required => false, :desc => N_("Checksum of file to upload")
-    param :content_type, RepositoryTypeManager.uploadable_content_types.map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'rpm', 'srpm')")
+    param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'rpm', 'srpm')")
     def create
       content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type).default_managed_content_type.label
+      RepositoryTypeManager.check_content_matches_repo_type!(@repository, content_type)
+
       unit_type_id = SmartProxy.pulp_primary.content_service(content_type).content_type
       render :json => @repository.backend_content_service(::SmartProxy.pulp_primary).create_upload(params[:size], params[:checksum], unit_type_id)
     end

--- a/app/lib/actions/katello/repository/remove_content.rb
+++ b/app/lib/actions/katello/repository/remove_content.rb
@@ -17,6 +17,7 @@ module Actions
 
           content_unit_ids = content_units.map(&:id)
           content_unit_type = options[:content_type] || content_units.first.class::CONTENT_TYPE
+          ::Katello::RepositoryTypeManager.check_content_matches_repo_type!(repository, content_unit_type)
 
           generate_applicability = options.fetch(:generate_applicability, repository.yum?)
 

--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -13,6 +13,8 @@ module Actions
           tmp_files = prepare_tmp_files(files)
 
           content_type ||= ::Katello::RepositoryTypeManager.find(repository.content_type).default_managed_content_type.label
+          ::Katello::RepositoryTypeManager.check_content_matches_repo_type!(repository, content_type)
+
           unit_type_id = SmartProxy.pulp_primary.content_service(content_type)::CONTENT_TYPE
           upload_actions = []
 

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -83,7 +83,7 @@ module Katello
     validates :content_type, :inclusion => {
       :in => ->(_) { Katello::RepositoryTypeManager.enabled_repository_types.keys },
       :allow_blank => false,
-      :message => ->(_, _) { _("must be one of the following: %s") % Katello::RepositoryTypeManager.enabled_repository_types.keys.join(', ') }
+      :message => ->(_, _) { _("is not enabled. must be one of the following: %s") % Katello::RepositoryTypeManager.enabled_repository_types.keys.join(', ') }
     }
     validates :download_policy, inclusion: {
       :in => ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES,

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -27,6 +27,7 @@ module Katello
 
     def test_create_upload_request
       mock_pulp_server(:create_upload_request => [])
+      ::Katello::RepositoryTypeManager.expects(:check_content_matches_repo_type!).returns(true)
       post :create, params: { :repository_id => @repo.id, :size => 100, :checksum => 'test_checksum' }
       assert_response :success
     end

--- a/test/services/katello/repository_type_manager_test.rb
+++ b/test/services/katello/repository_type_manager_test.rb
@@ -30,5 +30,19 @@ module Katello
       ::Katello::RepositoryTypeManager.expects(:update_enabled_repository_type).once
       ::Katello::RepositoryTypeManager.find('yum')
     end
+
+    def test_check_content_type_matches_repo_type_fails_properly
+      @feature.update(capabilities: ['ansible', 'certguard', 'container', 'core', 'deb', 'file', 'rpm', 'python'])
+      repo = Repository.find_by(pulp_id: "pulp-uuid-rhel_6_x86_64")
+      assert_raises_with_message(RuntimeError, 'Content type ostree is incompatible with repositories of type yum') do
+        RepositoryTypeManager.check_content_matches_repo_type!(repo, 'ostree')
+      end
+    end
+
+    def test_check_content_type_matches_repo_type_passes_properly
+      @feature.update(capabilities: ['ansible', 'certguard', 'container', 'core', 'deb', 'file', 'rpm', 'python'])
+      repo = Repository.find_by(pulp_id: "pulp-uuid-rhel_6_x86_64")
+      RepositoryTypeManager.check_content_matches_repo_type!(repo, 'rpm')
+    end
   end
 end


### PR DESCRIPTION
TODO:
- [x] Write tests

The params in the repository controller cannot be based off of `RepositoryTypeManager.enabled_repository_types`.  I've changed them to be based off of `RepositoryTypeManager.defined_repository_types`.

I've also hardened our failure conditions for doing things with repo types that don't exist. I also noticed that, for uploads and removals, there is no check that the content type matches the repository type. I've fixed this.

Things to test:

1) Repo creation in the API and Hammer.  Test repo types that don't exist repo types that exist but aren't in the `enabled_repository_types`.
2) Repo uploads and deletions.   Test repo types that don't exist repo types that exist but aren't in the `enabled_repository_types`.  Also test a combination of repo type and content type that don't match ("yum" with "ostree" for example).
3) Remove your smart proxy's capabilities with ` Feature.find_by(name: "Pulpcore").smart_proxy_features.first.update(capabilities: [])` (ensure that first smart proxy feature does belong to your Pulp primary) and make sure that the API docs still show the proper repository and content type params.
  -> Don't forget to check for all of the upload-related API endpoints too like upload_content, remove_content, import_upload, etc.