### PR TITLE
Fixes #33086 - Enable option via Katello-agent in errata installation of host-collections

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -55,6 +55,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.initialLoad = true;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.allHostsSelected = hostIds.allResultsSelected;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 


### PR DESCRIPTION
### Steps to test
1. Enable katello-agent
2. Register Content host with some installable errata.
3. Navigate to Hosts -> Host Collections -> Select -> Errata Installation
4. Choose errata to install, and click `Install Selected`. 
Verify option "via Katello-agent" exists in the dropdown.