### PR TITLE
Fixes #33102 - Allow validate to return if disc mode is enabled

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -44,7 +44,7 @@ module Katello
       end
 
       def validate!
-        return if katello_content_type == Repository::OSTREE_TYPE
+        return if katello_content_type == Repository::OSTREE_TYPE || Setting[:content_disconnected]
         substitutor.validate_substitutions(content, substitutions)
       end
 

--- a/test/models/candlepin/repository_mapper_test.rb
+++ b/test/models/candlepin/repository_mapper_test.rb
@@ -33,6 +33,13 @@ module Katello
       assert_equal mapper.unprotected?, false
     end
 
+    def test_disconnected_no_http
+      Setting[:content_disconnected] = true
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
+      mapper.expects(:substitutor).never
+      mapper.validate!
+    end
+
     def test_download_policy
       mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
 


### PR DESCRIPTION
To test:

On your devel box or a production install do the following:

* Create an export org
* Import a manifest and sync a RH repo as immediate
* Run the export command `hammer content-export complete library --organization-id x`
* Move the export from `/var/lib/pulp/exports` to `/var/lib/pulp/imports` so that we can import
* Create a new import org
* Change the `disconnected mode` setting to `true`
* Import a different manifest
* If using a devel box, stop the server and run the firewalld commands below:
* `systemctl start firewalld`
* `firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p tcp -m tcp --dport=443 -j DROP`
* `firewall-cmd --direct --add-rule ipv4 filter OUTPUT 1 -j ACCEPT`
* Run the import command and see if it goes through
* `import library --organization-id x --path /var/lib/pulp/imports/xx`

Before patch we would see this:

```bash
Could not import the archive.:
a) Forbidden - server refused to process the request.
b) Request Timeout
```

With patch we should see it go through:

```bash
[vagrant@centos7-katello-devel-stable hammer-cli-katello]$ hammer content-import library --organization-id 4 --metadata-file metadata-1.json --path /var/lib/pulp/imports/Default_Organization/Export-Library/1.0/2021-07-21T17-41-17-00-00/
[.............................................................................................................................................................................................................................................................................................................................................] [100%]
```