### PR TITLE
Fixes #33131 - run orphan cleanup before the content migration

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
 
   #pulp3
-  gem.add_dependency "pulpcore_client", ">= 3.6.0", "< 3.8.0"
+  gem.add_dependency "pulpcore_client", ">= 3.6.0", "< 3.7.7"
   gem.add_dependency "pulp_file_client", ">= 1.2.0", "< 1.4.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.2", "< 0.5"
   gem.add_dependency "pulp_container_client", ">= 2.0.0", "< 2.2.0"

--- a/lib/katello/tasks/pulp3_migration.rake
+++ b/lib/katello/tasks/pulp3_migration.rake
@@ -18,6 +18,7 @@ namespace :katello do
       preserve_output = ::Foreman::Cast.to_bool(ENV['preserve_output'])
 
       User.current = User.anonymous_api_admin
+      Katello::Pulp3::MigrationSwitchover.new(SmartProxy.pulp_primary).remove_orphaned_content
       task = ForemanTasks.async_task(Actions::Pulp3::ContentMigration, SmartProxy.pulp_primary, reimport_all: reimport_all)
 
       if wait


### PR DESCRIPTION
To test:

Do a Pulp 2 to Pulp 3 migration on Katello 3.18.  See that orphan cleanup is run before the migration task in the task browser.