### PR TITLE
Refs #32867 - Create Remote in plan phase

### DIFF
--- a/app/lib/actions/pulp3/repository/create_remote.rb
+++ b/app/lib/actions/pulp3/repository/create_remote.rb
@@ -3,12 +3,7 @@ module Actions
     module Repository
       class CreateRemote < Pulp3::Abstract
         def plan(repository, smart_proxy)
-          plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id) if repository.root.url?
-        end
-
-        def run
-          repo = ::Katello::Repository.find(input[:repository_id])
-          output[:response] = repo.backend_service(smart_proxy).create_remote
+          repository.backend_service(smart_proxy).create_remote if repository.root.url?
         end
 
         def rescue_strategy

--- a/test/actions/katello/content_view_version/import_library_test.rb
+++ b/test/actions/katello/content_view_version/import_library_test.rb
@@ -64,6 +64,7 @@ module ::Actions::Katello::ContentViewVersion
       SmartProxy.any_instance.stubs(:ping_pulp).returns({})
       SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
       SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+      ::Katello::Pulp3::Repository.any_instance.stubs(:create_remote).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
       ::Katello::Repository.any_instance.stubs(:pulp_scratchpad_checksum_type).returns(nil)

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -68,6 +68,7 @@ module ::Actions::Katello::ContentViewVersion
       set_user
       SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
       SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+      ::Katello::Pulp3::Repository.any_instance.stubs(:create_remote).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
       ::Katello::Repository.any_instance.stubs(:pulp_scratchpad_checksum_type).returns(nil)


### PR DESCRIPTION
Example invalid requirements.yaml that passes normal yaml syntax check and fails in pulp:

```
---
collections:
- name: testing.ansible_testing_content
  version: ">=1.0.0,<=2.0.0"
  source: https://galaxy-dev.ansible.com
- testing.k8s_demo_collection
```