### PR TITLE
Fixes #32956 -  Table checkbox fix

### DIFF
--- a/webpack/components/Table/helpers.js
+++ b/webpack/components/Table/helpers.js
@@ -5,7 +5,7 @@ const onSelect = (rows, setRows) => (_event, isSelected, rowId) => {
     newRows = rows.map(row => ({ ...row, selected: isSelected }));
   } else {
     newRows = [...rows];
-    newRows[rowId].selected = isSelected;
+    newRows[rowId] = { ...newRows[rowId], selected: isSelected };
   }
 
   setRows(newRows);


### PR DESCRIPTION
Checkbox selection within the table did not work for usage with bulk action buttons above table.

Note: Bulk checkbox did work to select all and action on all.