### PR TITLE
Fixes #33103 - Content view publish for generic types

### DIFF
--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -5,8 +5,9 @@ module Katello
                                 Repository::OSTREE_TYPE,
                                 Repository::FILE_TYPE,
                                 Repository::DEB_TYPE,
-                                Repository::ANSIBLE_COLLECTION_TYPE
-                               ].freeze
+                                Repository::ANSIBLE_COLLECTION_TYPE,
+                                Katello::RepositoryTypeManager.generic_repository_types(enabled_only: false).keys.flatten
+                               ].flatten.freeze
 
     ALLOWED_IMPORT_REPOSITORY_TYPES = Repository::EXPORTABLE_TYPES
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -311,11 +311,13 @@ module Katello
 
     def update_content_counts!
       self.content_counts = {}
-      RepositoryTypeManager.indexable_content_types.map(&:model_class).each do |content_type|
-        if content_type::CONTENT_TYPE == DockerTag::CONTENT_TYPE
+      RepositoryTypeManager.indexable_content_types.each do |content_type|
+        if content_type&.model_class::CONTENT_TYPE == DockerTag::CONTENT_TYPE
           content_counts[DockerTag::CONTENT_TYPE] = docker_tags.count
+        elsif content_type&.model_class::CONTENT_TYPE == GenericContentUnit::CONTENT_TYPE
+          content_counts[content_type.content_type] = content_type&.model_class&.in_repositories(self.repositories.archived)&.where(:content_type => content_type.content_type)&.count
         else
-          content_counts[content_type::CONTENT_TYPE] = content_type.in_repositories(self.repositories.archived).count
+          content_counts[content_type&.model_class::CONTENT_TYPE] = content_type&.model_class&.in_repositories(self.repositories.archived)&.count
         end
       end
       save!

--- a/test/fixtures/models/katello_content_view_repositories.yml
+++ b/test/fixtures/models/katello_content_view_repositories.yml
@@ -21,3 +21,7 @@ library_view_docker2:
 library_view_solve_deps_fedora:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view_solve_deps) %>
   repository_id:   <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+library_view_python:
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
+  repository_id:   <%= ActiveRecord::FixtureSet.identify(:pulp3_python_1) %>

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -121,6 +121,18 @@ module Katello
       assert_equal tag_count, counts["docker_tag_count"]
     end
 
+    def test_python_package_count
+      SmartProxy.stubs(:pulp_primary).returns(SmartProxy.pulp_primary)
+      cv = katello_content_views(:acme_default)
+      cvv = cv.versions.first
+
+      assert cvv.repositories.generic_type.count > 0
+      cvv.update_content_counts!
+      counts = cvv.content_counts_map
+
+      assert_equal 0, counts["python_package_count"]
+    end
+
     def test_active_history_nil_task
       @cvv.history = [ContentViewHistory.new(:status => ContentViewHistory::IN_PROGRESS, :user => 'admin', :action => 'publish')]
       assert_empty @cvv.active_history


### PR DESCRIPTION
Adds generic repositories as allowable types for content views.

Test by updating content view to include a python repository (Not supported in UI. I used API request). Then interact with content view as usual.