### PR TITLE
Fixes #33150 - don't migrate repos mid-creation

### DIFF
--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -216,7 +216,7 @@ module Katello
 
           if to_find
             found = migrated_repo_items.find { |migrated_repo| migrated_repo.pulp2_repo_id == to_find.pulp_id }
-            import_repo(yum_repo, found)
+            import_repo(yum_repo, found) if found
           end
         end
       end

--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -63,6 +63,8 @@ module Katello
       def library_migration_for(root)
         repo = root.library_instance
 
+        return nil unless library_repo_safe_to_migrate?(repo)
+
         migration = {
           name: repo.pulp_id,
           repository_versions: [
@@ -76,10 +78,49 @@ module Katello
         migration
       end
 
+      def library_repo_safe_to_migrate?(repo)
+        publish_tasks = ForemanTasks::Task.where(label: 'Actions::Katello::ContentView::Publish')
+        publishing_repo_ids = publish_tasks.where(state: ['scheduled', 'running']).collect do |task|
+          ::Katello::ContentViewVersion.find(task.input[:content_view_version_id]).library_repos.pluck(:id)
+        end
+        publishing_repo_ids = publishing_repo_ids.flatten
+
+        if publishing_repo_ids.include?(repo.id)
+          warn_string = "Library repository with ID #{repo.id} and name #{repo.name} unmigrated due to being "\
+            "associated with an actively-publishing content view.  The migration will need to be run again."
+          Rails.logger.warn(warn_string)
+          return false
+        end
+
+        create_root_tasks = ForemanTasks::Task.where(label: 'Actions::Katello::Repository::CreateRoot')
+        active_creation_task = create_root_tasks.where(state: ['scheduled', 'running']).detect do |task|
+          task.input[:repository][:id] == repo.id
+        end
+
+        if active_creation_task.present?
+          warn_string = "Repository with ID #{repo.id} and name #{repo.name} unmigrated due to being "\
+            "created during the Pulp 3 migration.  The migration will need to be run again."
+          Rails.logger.warn(warn_string)
+          return false
+        end
+        true
+      end
+
       def content_view_migrations_for(root)
+        publish_tasks = ForemanTasks::Task.where(label: 'Actions::Katello::ContentView::Publish')
+        publishing_cv_ids = publish_tasks.where(state: ['scheduled', 'running']).collect do |task|
+          task.input[:content_view_id]
+        end
+
         plans = []
         ContentView.non_default.published_with_repositories(root).sort_by(&:label).each do |cv|
-          plans << content_view_migration(cv, root)
+          if publishing_cv_ids.include?(cv.id)
+            warn_string = "Repositories belonging to Content View with ID #{cv.id} and name #{cv.name} unmigrated "\
+              "due to being created during the Pulp 3 migration.  The migration will need to be run again."
+            Rails.logger.warn(warn_string)
+          else
+            plans << content_view_migration(cv, root)
+          end
         end
         plans
       end


### PR DESCRIPTION
Issues have cropped up when half-created repositories are put through the migration process, such as the one in the issue description.  This PR skips migrating repositories that are either being created, or are associated in any way to content views that are being published.

To test:

1) Patch in this PR on a 3.18 system
2) Introduce time delays in ::Actions::Katello::Repository::Create and ::Actions::Katello::ContentView::Publish
3) Test running both actions above at the same time as starting a content migration
4) See the warnings in the logs
5) Check that the related repositories were not migrated to Pulp 3 (check the `version_href`, it should be `nil`)

Questions:
1) Do we need to skip migrating repositories for other types of actions?
2) Are the log messages sufficient?