### PR TITLE
Fixes #33171 - Hide some fields from docker/collection/ostree details

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -109,19 +109,19 @@
             readonly="denied('edit_products', product)"
             edit-trigger="uploadedFile">
         </dd>
+
+        <dt translate>Auth URL</dt>
+        <dd bst-edit-text="repository.ansible_collection_auth_url"
+            on-save="save(repository)"
+            readonly="product.redhat || denied('edit_products', product)">
+        </dd>
+
+        <dt translate>Auth Token</dt>
+        <dd bst-edit-text="repository.ansible_collection_auth_token"
+            on-save="save(repository)"
+            readonly="product.redhat || denied('edit_products', product)">
+        </dd>
       </span>
-
-      <dt ng-show="repository.content_type == 'ansible_collection'" translate>Auth URL</dt>
-      <dd bst-edit-text="repository.ansible_collection_auth_url"
-          on-save="save(repository)"
-          readonly="product.redhat || denied('edit_products', product)">
-      </dd>
-
-      <dt ng-show="repository.content_type == 'ansible_collection'" translate>Auth Token</dt>
-      <dd bst-edit-text="repository.ansible_collection_auth_token"
-          on-save="save(repository)"
-          readonly="product.redhat || denied('edit_products', product)">
-      </dd>
 
       <dt translate>Verify SSL</dt>
       <dd bst-edit-checkbox="repository.verify_ssl_on_sync"
@@ -230,7 +230,7 @@
       <dt translate>Publish via HTTPS</dt>
       <dd translate>Yes</dd>
 
-      <span ng-hide="repository.content_type === 'ostree' || repository.content_type === 'docker'">
+      <span ng-hide="repository.content_type === 'ostree' || repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <dt translate>Publish via HTTP</dt>
         <dd bst-edit-checkbox="repository.unprotected"
             formatter="booleanToYesNo"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -274,8 +274,8 @@
       </span>
     </div>
 
-    <div ng-show="repository.content_type === 'yum' || repository.content_type === 'deb' || repository.content_type === 'file'">
-      <h4 ng-show="repository.content_type !== undefined" translate> Published Repository Information </h4>
+    <div ng-show="repository.content_type !== undefined">
+      <h4 translate> Published Repository Information </h4>
 
       <div bst-form-group label="{{ 'Checksum' | translate }}" ng-show="repository.content_type === 'yum'">
         <select id="checksum_type"
@@ -288,7 +288,7 @@
         </p>
       </div>
 
-      <div class="checkbox">
+      <div class="checkbox" ng-hide="repository.content_type === 'ostree' || repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <label>
           <input id="unprotected" name="unprotected" ng-model="repository.unprotected" type="checkbox"/>
           <span translate>Publish via HTTP</span>


### PR DESCRIPTION
There are some discrepancies between what fields we show on new repository page vs repository details page.
Collections and docker repos skip publication so they don't have content guard associated. Hence fields like ssl-cert and CA are unnecessary and should be hidden from both new and details page.