### PR TITLE
Fixes 33173 - ignore katello_events and candlepin in ping check 

### DIFF
--- a/lib/katello/tasks/pulp3_migration_approve_corrupted.rake
+++ b/lib/katello/tasks/pulp3_migration_approve_corrupted.rake
@@ -1,13 +1,18 @@
 namespace :katello do
   desc "Marks corrupted or missing content as approved to be ignored during the migration"
-  task :approve_corrupted_migration_content => ["dynflow:client", "check_ping"] do
+  task :approve_corrupted_migration_content => ["dynflow:client"] do
+    services = [:candlepin, :foreman_tasks, :pulp3, :pulp, :pulp_auth]
+    Katello::Ping.ping!(services: services)
+
     Katello::Pulp3::Migration::CORRUPTABLE_CONTENT_TYPES.each do |type|
       type.missing_migrated_content.update_all(:ignore_missing_from_migration => true)
     end
     puts "Any missing or corrupt content will be ignored on migration to Pulp 3.  This can be undone with 'foreman-rake katello:unapprove_corrupted_migration_content'"
   end
 
-  task :unapprove_corrupted_migration_content => ["dynflow:client", "check_ping"] do
+  task :unapprove_corrupted_migration_content => ["dynflow:client"] do
+    services = [:candlepin, :foreman_tasks, :pulp3, :pulp, :pulp_auth]
+    Katello::Ping.ping!(services: services)
     Katello::Pulp3::Migration::CORRUPTABLE_CONTENT_TYPES.each do |type|
       type.ignored_missing_migrated_content.update_all(:ignore_missing_from_migration => false)
     end


### PR DESCRIPTION
During this migration task, ignore all but some services in the ping check.

Example before:
```
[vagrant@centos7-katello-3-18 ~]$ sudo foreman-rake katello:approve_corrupted_migration_content
enabled
{:services=>
  {:candlepin=>{:status=>"ok", :duration_ms=>"448"},
   :candlepin_auth=>{:status=>"ok", :duration_ms=>"70"},
   :foreman_tasks=>
    {:status=>"FAIL",
     :message=>
      "some executors are not responding, check /foreman_tasks/dynflow/status"},
   :katello_events=>
    {:status=>"FAIL", :message=>"Not running", :duration_ms=>"1"},
   :candlepin_events=>
    {:status=>"FAIL", :message=>"Not running", :duration_ms=>"1"},
   :pulp3=>{:status=>"ok", :duration_ms=>"283"},
   :pulp=>{:status=>"ok", :duration_ms=>"99"},
   :pulp_auth=>{:status=>"ok", :duration_ms=>"58"}},
 :status=>"FAIL"}
rake aborted!
Not all the services have been started. Check the status report above and try again.
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.18.3.1/lib/katello/tasks/reimport.rake:10:in `block (2 levels) in <top (required)>'
/opt/rh/rh-ruby25/root/usr/share/gems/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
Tasks: TOP => katello:approve_corrupted_migration_content => katello:check_ping
(See full trace by running task with --trace)
```
And after:
```
[vagrant@centos7-katello-3-18 katello-3.18.3.1]$ sudo foreman-rake katello:approve_corrupted_migration_content
Any missing or corrupt content will be ignored on migration to Pulp 3.  This can be undone with 'foreman-rake katello:unapprove_corrupted_migration_content'
[vagrant@centos7-katello-3-18 katello-3.18.3.1]$ echo $?
0
```
