### PR TITLE
Fixes #32788 - Fix wording on new CV page empty state

### DIFF
--- a/locale/bn/katello.po
+++ b/locale/bn/katello.po
@@ -363,7 +363,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/cs/katello.po
+++ b/locale/cs/katello.po
@@ -320,7 +320,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/de/katello.po
+++ b/locale/de/katello.po
@@ -303,7 +303,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "Ein Back-End-Dienst [ %s ] kann nicht erreicht werden"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/en/katello.po
+++ b/locale/en/katello.po
@@ -296,7 +296,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/es/katello.po
+++ b/locale/es/katello.po
@@ -305,7 +305,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "No se puede acceder a un servicio de segundo plano [ %s ]"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/fr/katello.po
+++ b/locale/fr/katello.po
@@ -306,7 +306,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "Un service d'arrière-plan [ %s ] est injoignable"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/gu/katello.po
+++ b/locale/gu/katello.po
@@ -364,7 +364,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/hi/katello.po
+++ b/locale/hi/katello.po
@@ -362,7 +362,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/it/katello.po
+++ b/locale/it/katello.po
@@ -304,7 +304,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "Impossibile raggiungere un servizio backend [ %s ]"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/ja/katello.po
+++ b/locale/ja/katello.po
@@ -312,7 +312,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "バックエンドサービス [ %s ] には到達不能です"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/katello.pot
+++ b/locale/katello.pot
@@ -9016,7 +9016,7 @@ msgid "You currently don't have any Content Views."
 msgstr ""
 
 #: ../webpack/scenes/ContentViews/Table/ContentViewsTable.js:141
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #: ../webpack/scenes/ContentViews/Table/tableDataGenerator.js:15

--- a/locale/kn/katello.po
+++ b/locale/kn/katello.po
@@ -364,7 +364,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/ko/katello.po
+++ b/locale/ko/katello.po
@@ -302,7 +302,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "백엔드 서비스 [ %s ]를 사용할 수 없음 "
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/mr/katello.po
+++ b/locale/mr/katello.po
@@ -361,7 +361,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/or/katello.po
+++ b/locale/or/katello.po
@@ -363,7 +363,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/pa/katello.po
+++ b/locale/pa/katello.po
@@ -363,7 +363,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/pt/katello.po
+++ b/locale/pt/katello.po
@@ -296,7 +296,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/pt_BR/katello.po
+++ b/locale/pt_BR/katello.po
@@ -306,7 +306,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "Um serviço de backend [%s] não pode ser alcançado"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/ru/katello.po
+++ b/locale/ru/katello.po
@@ -305,7 +305,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "Служба [ %s ] недоступна"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/ta/katello.po
+++ b/locale/ta/katello.po
@@ -362,7 +362,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/te/katello.po
+++ b/locale/te/katello.po
@@ -362,7 +362,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr ""
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 #, fuzzy

--- a/locale/zh_CN/katello.po
+++ b/locale/zh_CN/katello.po
@@ -299,7 +299,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "无法获取后端服务 [ %s ]"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/locale/zh_TW/katello.po
+++ b/locale/zh_TW/katello.po
@@ -319,7 +319,7 @@ msgstr ""
 msgid "A backend service [ %s ] is unreachable"
 msgstr "無法連上後端服務 [ %s ]"
 
-msgid "A content view can be added by using the \"New content view\" button below."
+msgid "A content view can be added by using the \"Create content view\" button above."
 msgstr ""
 
 msgid "A content_type must be provided."

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -138,7 +138,7 @@ const ContentViewTable = () => {
 
   const additionalListeners = new Array(isPublishModalOpen);
   const emptyContentTitle = __("You currently don't have any Content Views.");
-  const emptyContentBody = __('A content view can be added by using the "New content view" button below.');
+  const emptyContentBody = __('A content view can be added by using the "Create content view" button above.');
   const emptySearchTitle = __('No matching content views found');
   const emptySearchBody = __('Try changing your search settings.');
 


### PR DESCRIPTION
The empty state in `/labs/content_views` currently says "A content view can be added by using the "New content view" button below." However, the button is actually above and is called "Create content view."