### PR TITLE
Adjuts foreman-tasks-core

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", "~> 4.0"
-  gem.add_dependency "foreman-tasks-core", "<= 0.3.5"
+  gem.add_dependency "foreman-tasks-core", "< 0.4"
   gem.add_dependency "foreman_remote_execution", ">= 3.0"
   gem.add_dependency "dynflow", ">= 1.2.0"
   gem.add_dependency "activerecord-import"


### PR DESCRIPTION
foreman-tasks-core-0.3.6 was released somewhat unexpectedly. Anything in the 0.3 line should be fine.

Prompted by https://community.theforeman.org/t/tfm-rubygem-katello-4-1-2-1-el7-noarch-dependency/24699