### PR TITLE
Refs #32901 - updates for Katello 4.0 where pulp2 is no longer supported

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -78,10 +78,7 @@ module Actions
                                                        dependency_solving: dep_solve).output
                     repos_to_clone.each do |source_repos|
                       if separated_repo_map[:pulp3_yum].keys.include?(source_repos)
-                        copy_repos(repository_mapping[source_repos],
-                          new_content_view_version,
-                          content,
-                          dep_solve)
+                        copy_repos(repository_mapping[source_repos])
                       end
                     end
                   end
@@ -161,15 +158,9 @@ module Actions
           end
         end
 
-        def copy_repos(new_repo, new_version, content, dep_solve)
+        def copy_repos(new_repo, _new_version = nil, _content = nil, _dep_solve = nil)
           copy_output = []
           sequence do
-            solve_dependencies = new_version.content_view.solve_dependencies || dep_solve
-            copy_output += copy_deb_content(new_repo, solve_dependencies, content[:deb_ids])
-            copy_output += copy_yum_content(new_repo, solve_dependencies,
-                                            content[:package_ids],
-                                            content[:errata_ids])
-
             plan_action(Katello::Repository::MetadataGenerate, new_repo)
             plan_action(Katello::Repository::IndexContent, id: new_repo.id)
           end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -39,85 +39,14 @@ module ::Actions::Katello::ContentViewVersion
       repository_mapping = {}
       repository_mapping[[library_repo]] = new_repo
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:repository_mapping).returns(repository_mapping)
-      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:new_puppet_environment).returns(Katello::ContentViewPuppetEnvironment)
       ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.expects(:repos_to_copy).returns(repository_mapping.keys)
       task = ForemanTasks::Task::DynflowTask.create!(state: :success, result: "good")
       action.stubs(:task).returns(task)
       action.expects(:action_subject).with(content_view_version.content_view)
       plan_action(action, content_view_version, [library], :content => {:package_ids => [@rpm.id]})
 
-      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyUnits,
-                                library_repo, new_repo,
-                                Katello::Rpm.with_identifiers(@rpm.id),
-                                :incremental_update => true)
-    end
-
-    it 'does not plan CopyUnits if rpm not there in repo.' do
-      SmartProxy.stubs(:pulp_primary).returns(SmartProxy.find_by(name: "Unused Proxy"))
-      SmartProxy.any_instance.stubs(:pulp3_support?).returns(false)
-      ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.stubs(:pulp3_dest_base_version).returns(1)
-      stub_remote_user
-      new_repo = ::Katello::Repository.new(:pulp_id => 387, :library_instance_id => library_repo.id, :root => library_repo.root)
-      repository_mapping = {}
-      repository_mapping[[library_repo]] = new_repo
-      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:repository_mapping).returns(repository_mapping)
-      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:new_puppet_environment).returns(Katello::ContentViewPuppetEnvironment)
-      ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.expects(:repos_to_copy).returns(repository_mapping.keys)
-      task = ForemanTasks::Task::DynflowTask.create!(state: :success, result: "good")
-      action.stubs(:task).returns(task)
-      action.expects(:action_subject).with(content_view_version.content_view)
-
-      # create a nonexistent rpm, and ask it to be incrementally copied over.
-      # Copy Units should not happen in that case since this rpm is not any of the repos in the cvv.
-      rpm = ::Katello::Rpm.create!(pulp_id: "I_dont_exist_really_in_a_repo")
-      plan_action(action, content_view_version, [library], :content => {:package_ids => [rpm.id]})
-
-      refute_action_planed action, ::Actions::Pulp::Repository::CopyUnits
-    end
-
-    it 'removes the correct puppet content during inc update' do
-      clone = katello_repositories(:lib_p_forge)
-      module1 = ::Katello::PuppetModule.create(
-        :pulp_id => "pulp_id1",
-        :name => "name1",
-        :author => "author1",
-        :version => "1.2.3"
-      )
-      module2 = ::Katello::PuppetModule.create(
-        :pulp_id => "pulp_id2",
-        :name => "name1",
-        :author => "author1",
-        :version => "2.2.3"
-      )
-      cvpe = ::Katello::ContentViewPuppetEnvironment.create(content_view_version_id: clone.content_view_version.id, pulp_id: "pulpidforcontentviewpuppetenviroment", name: "contentviewpuppetenvironment")
-      ::Katello::ContentViewPuppetEnvironmentPuppetModule.create(puppet_module_id: module1.id, content_view_puppet_environment_id: cvpe.id)
-      ::Katello::ContentViewPuppetEnvironmentPuppetModule.create(puppet_module_id: module2.id, content_view_puppet_environment_id: cvpe.id)
-
-      action.expects(:remove_puppet_modules).with(clone, [module1.id, module2.id]).returns(true)
-      mock_copy_puppet_module_output = "mock"
-      mock_copy_puppet_module_output.stubs(:output).returns("output")
-      action.stubs(:copy_puppet_module).returns(mock_copy_puppet_module_output)
-      action.expects(:plan_action).with(::Actions::Pulp::ContentViewPuppetEnvironment::IndexContent, id: clone.id).returns(true)
-      action.send(:copy_puppet_content, clone, [module2.id], clone.content_view_version)
-    end
-
-    it 'does not allow inc updating with multiple puppet modules of same name and author' do
-      module1 = ::Katello::PuppetModule.create(
-        :pulp_id => "pulp_id1",
-        :name => "name1",
-        :author => "author1",
-        :version => "1.2.3"
-      )
-      module2 = ::Katello::PuppetModule.create(
-        :pulp_id => "pulp_id2",
-        :name => "name1",
-        :author => "author1",
-        :version => "2.2.3"
-      )
-
-      assert_raise RuntimeError, "Adding multiple versions of the same Puppet Module is not supported by incremental update.  The following Puppet Modules have duplicate versions in the incremental update content list: [\"name1-author1\"]" do
-        action.send(:check_puppet_module_duplicates, [module1.id, module2.id])
-      end
+      assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
     end
 
     describe 'pulp3' do


### PR DESCRIPTION
This PR addresses a bad CP into the origin 4.0.2 release. Without it, CVV incremental updates will not work.