### PR TITLE
Fixes #33199 - Possible fix for katello-master-source-release pipeline from JS test

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.test.js
@@ -19,6 +19,10 @@ let searchDelayScope;
 let autoSearchScope;
 
 beforeEach(() => {
+  // This is a workaround to avoid intermittent failures
+  // on this test in katello-master-source-release pipeline
+  jest.resetModules();
+
   const { results } = repoData;
   [firstRepo] = results;
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);


### PR DESCRIPTION
Trying this as a possible solution to intermittent failures on this test in the katello-master-source-release pipeline https://ci.theforeman.org/job/katello-master-source-release/1491/execution/node/116/log/

Other relevant threads: 
https://github.com/nock/nock/issues/2057#issuecomment-663698619
To restore nocks after every test: https://github.com/nock/nock/issues/2057#issuecomment-702401375
I believe the jest.resetModules does the same thing by reloading modules. Will probably need to try out these if this doesn't resolve the pipeline issue.

The other workaround I saw in a few places is using the --no-cache option but it will increase our react test run times..