### PR TITLE
Refs #33147 - Allow Auth token without Auth URL

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -413,7 +413,7 @@ module Katello
       elsif ostree?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/web/#{relative_path}"
       elsif ansible_collection?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp_ansible/galaxy/#{relative_path}/api"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp_ansible/galaxy/#{relative_path}/api/"
       else
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/#{relative_path}/"
       end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -283,9 +283,7 @@ module Katello
         return
       end
 
-      if self.ansible_collection_auth_url.blank?
-        errors.add(:base, N_("Auth token requires Auth URL be set."))
-      elsif !self.ansible_collection_auth_token
+      if !self.ansible_collection_auth_url.blank? && self.ansible_collection_auth_token.blank?
         errors.add(:base, N_("Auth URL requires Auth token be set."))
       end
     end
@@ -351,7 +349,7 @@ module Katello
                                  ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id http_proxy_policy http_proxy_id download_concurrency)
       changeable_attributes += %w(name container_repository_name docker_tags_whitelist) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
-      changeable_attributes += %w(ansible_collection_requirements) if ansible_collection?
+      changeable_attributes += %w(ansible_collection_requirements ansible_collection_auth_url ansible_collection_auth_token) if ansible_collection?
       changeable_attributes.any? { |key| previous_changes.key?(key) }
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -96,7 +96,7 @@
           <input id="requirementFile" type="file" name="file_path" onclick="this.value = null" onchange="angular.element(this).scope().handleFiles(this)"/>
           <p bst-alert='info' ng-show="repository.content_type == 'ansible_collection'">
           <span translate>
-            You can upload a requirements.yml file above to auto-fill contents <b>OR</b> paste contents of <a ng-href="https://docs.ansible.com/ansible/devel/dev_guide/collections_tech_preview.html#install-multiple-collections-with-a-requirements-file" target="_blank"> Requirements.yml </a>below.
+            You can upload a requirements.yml file above to auto-fill contents <b>OR</b> paste contents of <a ng-href="https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#install-multiple-collections-with-a-requirements-file" target="_blank"> Requirements.yml </a>below.
           </span>
       </p>
         </dd>

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -583,7 +583,9 @@ module Katello
       assert ansible_repo_root.valid?
       assert_nil ansible_repo_root.ansible_collection_auth_url
       assert_nil ansible_repo_root.ansible_collection_auth_token
-      assert ansible_repo_root.valid?
+
+      ansible_repo_root.ansible_collection_auth_token = '12345'
+      assert ansible_repo_root.valid? # Should be able to specify token only
     end
   end
 


### PR DESCRIPTION
In the PR: https://github.com/Katello/katello/pull/9500 we wrongly added the validation that auth_token can not be provided without an auth URL.

The only validation needed is that auth_url can not be provided without a token. The vice-versa is fine and both fields blank is also valid.

Another issue I notice around collections is updating auth_url and token wasn't triggering a pulp remote update. That is fixed with this PR too.