### PR TITLE
Fixes #33207 - add time warning to Pulp 3 migration

### DIFF
--- a/app/lib/actions/pulp3/content_migration_presenter.rb
+++ b/app/lib/actions/pulp3/content_migration_presenter.rb
@@ -46,7 +46,8 @@ module Actions
           elsif report
             report['message']
           elsif task_progress_reports.empty?
-            "Content migration starting. "
+            "Content migration starting. These steps may take a while to complete. " \
+            "Refer to `foreman-maintain content migration-stats` for an estimate."
           else
             "Initial Migration steps complete."
           end


### PR DESCRIPTION
This PR adds another warning that the content migration can take a long time to complete.  Test this at the same time as testing out https://github.com/theforeman/foreman_maintain/pull/516.  Run `foreman-maintain content prepare --append-output` and give feedback on how it looks.