### PR TITLE
Ref #33199 - Try nock restore for pipeline failure

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.test.js
@@ -19,10 +19,9 @@ let searchDelayScope;
 let autoSearchScope;
 
 beforeEach(() => {
-  // This is a workaround to avoid intermittent failures
-  // on this test in katello-master-source-release pipeline
-  jest.resetModules();
-
+  if (!nock.isActive()) {
+    nock.activate();
+  }
   const { results } = repoData;
   [firstRepo] = results;
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
@@ -38,6 +37,7 @@ afterEach(() => {
   nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
+  nock.restore();
 });
 
 test('Can call API and show repositories on page load', async (done) => {


### PR DESCRIPTION
Going down the list of things we can do to resolve the intermittent katello-master-source-release pipeline failure.

The 2nd take is to use nock.restore() and nock.activate() between tests in this file. 

Also nudging @jeremylenz and @Andrewgdewar for awareness and ideas cause my next idea is to use jest --no-cache and it will slow down the test run times. It would probably be better to write new tests for the CVDetailsRepo component even though I don't see the issue with the way it is written today.

See for reference: https://github.com/Katello/katello/pull/9526