### PR TITLE
Fixes #33211 - changes smart proxy label to avoid confusion

### DIFF
--- a/app/views/smart_proxies/plugins/_pulpcore.html.erb
+++ b/app/views/smart_proxies/plugins/_pulpcore.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <h3><%= _('Pulpcore') %></h3>
+  <h3><%= _('Content') %></h3>
 </div>
 <%= show_feature_version('pulpcore') %>
 <div class="row">


### PR DESCRIPTION
It is often confusing to users that the smart proxy displays "Pulpcore" plugin version, when it is in fact the smart proxy content plugin version.

![image](https://user-images.githubusercontent.com/266755/128223643-378ba374-1890-45a5-8de3-9b9295724b44.png)
