### PR TITLE
Fixes #33220 - escape Pulp 2 proxy username and password 

### DIFF
--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -296,11 +296,13 @@ module Katello
 
         if proxy
           uri = URI(proxy.url)
+          username = CGI.escape(proxy.username) if proxy.username
+          password = CGI.escape(proxy.password) if proxy.password
           proxy_options = {
             proxy_host: uri.scheme + '://' + uri.host,
             proxy_port: uri.port,
-            proxy_username: proxy.username,
-            proxy_password: proxy.password
+            proxy_username: username,
+            proxy_password: password
           }
           return proxy_options
         end

--- a/test/services/katello/pulp/repository_test.rb
+++ b/test/services/katello/pulp/repository_test.rb
@@ -73,6 +73,22 @@ module Katello
         }
         assert_equal expected_options, @pulp_repo.proxy_options
       end
+
+      def test_special_chars_escaped_in_proxy_auth_credentials
+        another_proxy = FactoryBot.create(:http_proxy)
+        another_proxy.update(username: '# $ @ & { } [ ] + %')
+        another_proxy.update(password: '% $ @ & { } [ ] + #')
+        @repo.root.update(http_proxy_policy: RootRepository::USE_SELECTED_HTTP_PROXY,
+                          http_proxy: another_proxy)
+        uri = URI(another_proxy.url)
+        expected_options = {
+          proxy_host: uri.scheme + '://' + uri.host,
+          proxy_port: uri.port,
+          proxy_username: CGI.escape(another_proxy.username),
+          proxy_password: CGI.escape(another_proxy.password)
+        }
+        assert_equal expected_options, @pulp_repo.proxy_options
+      end
     end
   end
 end


### PR DESCRIPTION
To test:

1) Create an HTTP proxy (I tested with squid) with special chars in the username and password.
2) Make an HTTP proxy for your proxy in Katello.
3) Try to sync a repo using the HTTP proxy.  Ensure you see the error in the redmine without this PR.