### PR TITLE
Fixes #33221 - Hide upload section for Collection repository

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -12,7 +12,9 @@ module Katello
     param :checksum, String, :required => false, :desc => N_("Checksum of file to upload")
     param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'rpm', 'srpm')")
     def create
-      content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type).default_managed_content_type.label
+      fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
+      content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type)&.default_managed_content_type&.label
+
       RepositoryTypeManager.check_content_matches_repo_type!(@repository, content_type)
 
       unit_type_id = SmartProxy.pulp_primary.content_service(content_type).content_type

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -360,6 +360,7 @@ module Katello
     param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'rpm', 'srpm')")
     def upload_content
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Container Image content.") if @repository.docker?
+      fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
 
       filepaths = Array.wrap(params[:content]).compact.collect do |content|
         {path: content.path, filename: content.original_filename}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -477,7 +477,7 @@
       <div class="divider" ng-if="repository.content_type === 'ostree'"/>
     </section>
 
-    <section class="well" ng-if="permitted('edit_products', product) && !product.redhat && repository.content_type !== 'docker' && repository.content_type !== 'ostree'">
+    <section class="well" ng-if="permitted('edit_products', product) && !product.redhat && repository.content_type !== 'docker' && repository.content_type !== 'ostree' && repository.content_type !== 'ansible_collection'">
       <h5 translate ng-show="repository.content_type === 'yum'">Upload Package</h5>
       <h5 translate ng-show="repository.content_type === 'file'">Upload File</h5>
 

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -32,6 +32,13 @@ module Katello
       assert_response :success
     end
 
+    def test_create_collection_upload_request
+      ansible_collection_repo = katello_repositories(:pulp3_ansible_collection_1)
+      post :create, params: { :repository_id => ansible_collection_repo.id, :size => 100, :checksum => 'test_checksum' }
+      assert_response :error
+      assert_match "Cannot upload Ansible collections", @response.body
+    end
+
     def test_create_upload_request_protected
       allowed_perms = [@update_permission]
       denied_perms = [@read_permission, @create_permission, @destroy_permission]

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -19,6 +19,7 @@ module Katello
       @docker_repo = katello_repositories(:busybox)
       @smart_proxy = SmartProxy.pulp_primary
       @srpm_repo = katello_repositories(:srpm_repo)
+      @ansible_collection_repo = katello_repositories(:pulp3_ansible_collection_1)
     end
 
     def permissions
@@ -818,6 +819,11 @@ module Katello
       # single file
       post :upload_content, params: { :id => @repository.id, :content => puppet_module }
       assert_response :success
+
+      #fail for collections
+      post :upload_content, params: { :id => @ansible_collection_repo.id, :content => puppet_module }
+      assert_response 422
+      assert_match "Cannot upload Ansible collections", @response.body
     end
 
     def test_upload_content_protected


### PR DESCRIPTION
Was looking into the uploads flow for collections and seems like it has to be a workflow of sorts to have these fields: https://docs.pulpproject.org/pulp_ansible/restapi.html#operation/content_ansible_collection_versions_create

For the purposes of current release, hiding the upload section on repo details and adding a user friendly error to the API.