### PR TITLE
Fixes #33235 - Allow duplicate uploads to katello

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -14,7 +14,6 @@ module Katello
     def create
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
       content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type)&.default_managed_content_type&.label
-
       RepositoryTypeManager.check_content_matches_repo_type!(@repository, content_type)
 
       unit_type_id = SmartProxy.pulp_primary.content_service(content_type).content_type

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -63,7 +63,7 @@ module Actions
         def results_to_json(results)
           json_results = []
           results.each do |result|
-            result[:pulp_tasks].each do |task|
+            result[:pulp_tasks]&.each do |task|
               details = task ? task.dig(:result, :details, :unit) : nil
               if details && details.dig('type_id') == 'docker_manifest'
                 manifest = ::Katello::DockerManifest.find_by(:pulp_id => details.dig(:metadata, :id))
@@ -76,6 +76,11 @@ module Actions
                 json_result[:type] = 'docker_tag'
                 json_results << json_result
               else
+                json_results << {:type => 'file'}
+              end
+            end
+            unless json_results.size
+              if result[:content_unit_href]
                 json_results << {:type => 'file'}
               end
             end

--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -21,14 +21,12 @@ module Actions
           generate_applicability = options.fetch(:generate_applicability, repository.yum?)
 
           sequence do
-            concurrence do
-              tmp_files.each do |file|
-                sequence do
-                  upload_action = plan_action(Pulp3::Orchestration::Repository::UploadContent,
-                                                   repository, SmartProxy.pulp_primary!, file, unit_type_id)
+            tmp_files.each do |file|
+              sequence do
+                upload_action = plan_action(Pulp3::Orchestration::Repository::UploadContent,
+                                                 repository, SmartProxy.pulp_primary!, file, unit_type_id)
 
-                  upload_actions << upload_action.output
-                end
+                upload_actions << upload_action.output
               end
             end
 

--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -4,15 +4,36 @@ module Actions
     module Orchestration
       module Repository
         class ImportUpload < Pulp3::Abstract
+          # rubocop:disable Metrics/AbcSize
           def plan(repository, smart_proxy, args)
-            file = {:filename => args.dig(:unit_key, :name)}
+            file = {:filename => args.dig(:unit_key, :name), :sha256 => args.dig(:unit_key, :checksum) }
             content_unit_href = args.dig(:unit_key, :content_unit_id)
             docker_tag = (args.dig(:unit_type_id) == "docker_tag")
             sequence do
               if content_unit_href
-                plan_self(:commit_output => [], :content_unit_href => content_unit_href)
-                action_output = plan_action(Pulp3::Repository::ImportUpload, content_unit_href, repository, smart_proxy).output
-                plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks]).output
+                content_backend_service = SmartProxy.pulp_primary.content_service(args.dig(:unit_type_id))
+                duplicate_sha_path_content_list = content_backend_service.content_api.list(
+                    "sha256": file[:sha256],
+                    "relative_path": file[:filename])
+                duplicate_content_href = duplicate_sha_path_content_list&.results&.first&.pulp_href
+                if duplicate_content_href
+                  plan_self(:commit_output => [], :content_unit_href => duplicate_content_href)
+                  action_output = plan_action(Pulp3::Repository::ImportUpload, duplicate_content_href, repository, smart_proxy).output
+                  plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks]).output
+                else
+                  duplicate_sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": file[:sha256])
+                  duplicate_sha_artifact_href = duplicate_sha_artifact_list&.results&.first&.pulp_href
+                  if duplicate_sha_artifact_href
+                    artifact_output = plan_action(Pulp3::Repository::SaveArtifact,
+                                                         file, repository, smart_proxy,
+                                                         nil, args.dig(:unit_type_id),
+                                                         artifact_href: duplicate_sha_artifact_href).output
+                    content_unit_href = artifact_output[:pulp_tasks]
+                    plan_self(:commit_output => nil, :artifact_output => artifact_output[:pulp_tasks])
+                    action_output = plan_action(Pulp3::Repository::ImportUpload, content_unit_href, repository, smart_proxy).output
+                    plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks]).output
+                  end
+                end
               elsif docker_tag
                 tag_manifest_output = plan_action(Pulp3::Repository::UploadTag,
                             repository,

--- a/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
@@ -7,14 +7,26 @@ module Actions
           def plan(repository, smart_proxy, file, unit_type_id)
             sequence do
               content_backend_service = SmartProxy.pulp_primary.content_service(unit_type_id)
-              content_list = content_backend_service.content_api.list("sha256": Digest::SHA256.hexdigest(File.read(file[:path])))
-              content_href = content_list&.results&.first&.pulp_href
+              duplicate_sha_path_content_list = content_backend_service.content_api.list(
+                  "sha256": Digest::SHA256.hexdigest(File.read(file[:path])),
+                  "relative_path": file[:filename])
+              duplicate_content_href = duplicate_sha_path_content_list&.results&.first&.pulp_href
 
-              unless content_href
-                upload_action_output = plan_action(Pulp3::Repository::UploadFile, repository, smart_proxy, file[:path]).output
-                artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, upload_action_output[:pulp_tasks], unit_type_id).output
+              unless duplicate_content_href
+                duplicate_sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": Digest::SHA256.hexdigest(File.read(file[:path])))
+                duplicate_sha_artifact_href = duplicate_sha_artifact_list&.results&.first&.pulp_href
+              end
+
+              unless duplicate_content_href
+                if duplicate_sha_artifact_href
+                  artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, nil, unit_type_id, artifact_href: duplicate_sha_artifact_href).output
+                else
+                  upload_action_output = plan_action(Pulp3::Repository::UploadFile, repository, smart_proxy, file[:path]).output
+                  artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, upload_action_output[:pulp_tasks], unit_type_id).output
+                end
                 content_href = artifact_action_output[:pulp_tasks]
               end
+              content_href ||= duplicate_content_href
               action_output = plan_action(Pulp3::Repository::ImportUpload, content_href, repository, smart_proxy).output
               plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks]).output
               plan_self(:subaction_output => action_output)

--- a/app/lib/actions/pulp3/repository/commit_upload.rb
+++ b/app/lib/actions/pulp3/repository/commit_upload.rb
@@ -10,8 +10,31 @@ module Actions
           repo = ::Katello::Repository.find(input[:repository_id])
           repo_backend_service = repo.backend_service(smart_proxy)
           uploads_api = repo_backend_service.core_api.uploads_api
-          upload_commit = repo_backend_service.core_api.upload_commit_class.new(sha256: input[:sha256])
-          output[:pulp_tasks] = [uploads_api.commit(input[:upload_href], upload_commit)]
+          duplicate_sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": input[:sha256])
+          duplicate_sha_artifact_href = duplicate_sha_artifact_list&.results&.first&.pulp_href
+          if duplicate_sha_artifact_href
+            uploads_api.delete(upload_href)
+            output[:artifact_href] = duplicate_sha_artifact_href
+            output[:pulp_tasks] = nil
+          else
+            output[:artifact_href] = nil
+            upload_commit = repo_backend_service.core_api.upload_commit_class.new(sha256: input[:sha256])
+            output[:pulp_tasks] = [uploads_api.commit(input[:upload_href], upload_commit)]
+          end
+        end
+
+        def check_for_errors
+          combined_tasks.each do |task|
+            if unique_error task.error
+              warn _("Duplicate artifact detected")
+            else
+              super
+            end
+          end
+        end
+
+        def unique_error(message)
+          message&.include?("code='unique'")
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/save_artifact.rb
+++ b/app/lib/actions/pulp3/repository/save_artifact.rb
@@ -4,14 +4,21 @@ module Actions
       class SaveArtifact < Pulp3::AbstractAsyncTask
         def plan(file, repository, smart_proxy, tasks, unit_type_id, options = {})
           options[:file_name] = file[:filename]
+          options[:sha256] = file[:sha256] || Digest::SHA256.hexdigest(File.read(file[:path]))
           plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :tasks => tasks, :unit_type_id => unit_type_id, :options => options)
         end
 
         def invoke_external_task
-          artifact_href = input[:tasks].last[:created_resources].first
+          artifact_href = input[:options][:artifact_href] || fetch_artifact_href
+          fail _("Content not uploaded to pulp") unless artifact_href
           content_type = input[:unit_type_id]
           content_backend_service = SmartProxy.pulp_primary.content_service(content_type)
           output[:pulp_tasks] = [content_backend_service.content_api_create(relative_path: input[:options][:file_name], artifact: artifact_href)]
+        end
+
+        def fetch_artifact_href
+          sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": input[:options][:sha256])
+          sha_artifact_list&.results&.first&.pulp_href
         end
       end
     end

--- a/app/lib/actions/pulp3/repository/upload_file.rb
+++ b/app/lib/actions/pulp3/repository/upload_file.rb
@@ -6,6 +6,7 @@ module Actions
           plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :file => file)
         end
 
+        # rubocop:disable Metrics/MethodLength
         def invoke_external_task
           repo = ::Katello::Repository.find(input[:repository_id])
           repo_backend_service = repo.backend_service(smart_proxy)
@@ -34,10 +35,21 @@ module Actions
 
             if response
               upload_href = response.pulp_href
-              output[:pulp_tasks] = [uploads_api.commit(upload_href, sha256: sha256)]
+              #Check for any duplicate artifacts created in parallel subtasks
+              duplicate_sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": sha256)
+              duplicate_sha_artifact_href = duplicate_sha_artifact_list&.results&.first&.pulp_href
+              if duplicate_sha_artifact_href
+                uploads_api.delete(upload_href)
+                output[:artifact_href] = duplicate_sha_artifact_href
+                output[:pulp_tasks] = nil
+              else
+                output[:artifact_href] = nil
+                output[:pulp_tasks] = [uploads_api.commit(upload_href, sha256: sha256)]
+              end
             end
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         def external_task=(tasks)
           super
@@ -50,8 +62,18 @@ module Actions
         def check_error_details
           output[:pulp_tasks].each do |pulp_task|
             error_details = pulp_task.try(:[], "error")
-            if error_details && !error_details.nil?
-              fail _("An error occurred during the sync \n%{error_message}") % {:error_message => error_details}
+            if error_details && !error_details.nil? && !unique_error(error_details)
+              fail _("An error occurred during upload \n%{error_message}") % {:error_message => error_details}
+            end
+          end
+        end
+
+        def check_for_errors
+          combined_tasks.each do |task|
+            if unique_error task.error
+              warn _("Duplicate artifact detected")
+            else
+              super
             end
           end
         end
@@ -69,6 +91,10 @@ module Actions
         def content_range(start, finish, total)
           finish = finish > total ? total : finish
           "bytes #{start}-#{finish}/#{total}"
+        end
+
+        def unique_error(message)
+          message&.include?("code='unique'")
         end
       end
     end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -100,6 +100,10 @@ module Katello
           PulpcoreClient::OrphansApi.new(core_api_client)
         end
 
+        def artifacts_api
+          PulpcoreClient::ArtifactsApi.new(core_api_client)
+        end
+
         def core_api_client
           client = PulpcoreClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpcoreClient::Configuration))
           api_client_class(client)

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -258,6 +258,7 @@ module ::Actions::Katello::Repository
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::UploadContent }
     it 'plans for Pulp3 without duplicate' do
       proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
+      ::Katello::Pulp3::Api::Core.any_instance.stubs(:artifacts_api).returns(stub(:list => stub(:results => nil)))
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
       action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::UploadFile) do |content_create|

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
+      - Tue, 17 Aug 2021 15:28:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - c4568e8f5fb041df96d9dd3ad876dd66
+      - 6641900a12dd4b49be35ff3a48d267af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:23 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
+      - Tue, 17 Aug 2021 15:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 5e7be60c1dc34d0395074df3425236d5
+      - 734124c108694f60abe527ad958e4305
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
+      - Tue, 17 Aug 2021 15:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - d1cc798b2ed64d988794b10321390f47
+      - eb50082add7c4f9fb3ff082d147b310b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
+      - Tue, 17 Aug 2021 15:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,84 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - c5a9cdf8dd274271b5684c007a3180a7
+      - 439c7483605b40c0b9ef3af8fc29d7f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/file/file/d0fa6492-1eab-46e3-8ced-abd680a465f9/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '513'
-      Correlation-Id:
-      - c7ba80fa0eac44fa95e27ed693c47882
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS9kMGZhNjQ5Mi0xZWFiLTQ2ZTMtOGNlZC1hYmQ2ODBhNDY1ZjkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MToxNi43NTcxMzVaIiwi
-        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlL2QwZmE2NDkyLTFlYWItNDZlMy04Y2VkLWFiZDY4MGE0NjVmOS92
-        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9kMGZh
-        NjQ5Mi0xZWFiLTQ2ZTMtOGNlZC1hYmQ2ODBhNDY1ZjkvdmVyc2lvbnMvMC8i
-        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
-        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
-        IjoiUFVMUF9NQU5JRkVTVCJ9
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -288,13 +225,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:16 GMT
+      - Tue, 17 Aug 2021 15:28:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/574399e3-b4dd-4bff-bd04-e8336338b72a/"
+      - "/pulp/api/v3/remotes/file/file/d54becf6-8c9f-4642-adc9-cd82ef1b3ba6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -304,32 +241,157 @@ http_interactions:
       Content-Length:
       - '555'
       Correlation-Id:
-      - a4fb0cb92ab546668cdb107628cb8170
+      - 2a5c95c7e2ac4e6d9a75e9ab3938a3c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        NTc0Mzk5ZTMtYjRkZC00YmZmLWJkMDQtZTgzMzYzMzhiNzJhLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NDE6MTYuOTU0MDQ5WiIsIm5hbWUi
+        ZDU0YmVjZjYtOGM5Zi00NjQyLWFkYzktY2Q4MmVmMWIzYmE2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjQuMjU5MTQ1WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MToxNi45NTQwNzZaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0wOC0xN1QxNToyODoyNC4yNTkxNThaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:16 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/file/file/79f67fa5-5435-43f1-bc9b-58f4541ee5ff/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '513'
+      Correlation-Id:
+      - 1704e721988746adb334d2d331c47ee2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS83OWY2N2ZhNS01NDM1LTQzZjEtYmM5Yi01OGY0NTQxZWU1ZmYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToyODoyNC40MzE3MDlaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzc5ZjY3ZmE1LTU0MzUtNDNmMS1iYzliLTU4ZjQ1NDFlZTVmZi92
+        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OWY2
+        N2ZhNS01NDM1LTQzZjEtYmM5Yi01OGY0NTQxZWU1ZmYvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
+        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
+        IjoiUFVMUF9NQU5JRkVTVCJ9
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/79f67fa5-5435-43f1-bc9b-58f4541ee5ff/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c136a6756d9640448281cef242389b30
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '251'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS83OWY2N2ZhNS01NDM1LTQzZjEtYmM5Yi01OGY0NTQxZWU1ZmYvdmVy
+        c2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjI4OjI2
+        LjUzMjY5MVoiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OWY2N2ZhNS01NDM1LTQzZjEt
+        YmM5Yi01OGY0NTQxZWU1ZmYvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250
+        ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijox
+        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZmlsZS9maWxlLzc5ZjY3ZmE1LTU0MzUtNDNmMS1iYzliLTU4ZjQ1NDFl
+        ZTVmZi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsi
+        ZmlsZS5maWxlIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ZjY3ZmE1LTU0MzUtNDNm
+        MS1iYzliLTU4ZjQ1NDFlZTVmZi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/574399e3-b4dd-4bff-bd04-e8336338b72a/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/d54becf6-8c9f-4642-adc9-cd82ef1b3ba6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -350,7 +412,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:20 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -364,21 +426,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - cdce9a25d44643dfbc64d58d4921f782
+      - ce989854b89a4b8d80eb8b159e601997
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiNWQ2YTA2LTJhMGEtNDE2
-        Zi1hOTcyLTE2YTI3YTRlNWVjZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1YTZmNzFhLTFiZjItNDBh
+        MC04YzFlLWI1NTQ5NTY3YTE1ZS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:20 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/cb5d6a06-2a0a-416f-a972-16a27a4e5ecf/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/45a6f71a-1bf2-40a0-8c1e-b5549567a15e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +448,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -399,7 +461,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:20 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -411,35 +473,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - ee989ec019224de0b7b24ece84b5ec9a
+      - 189f83c9e89b402bb7b27e60b5f6deca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '372'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I1ZDZhMDYtMmEw
-        YS00MTZmLWE5NzItMTZhMjdhNGU1ZWNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MjAuNjQ5NjMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDVhNmY3MWEtMWJm
+        Mi00MGEwLThjMWUtYjU1NDk1NjdhMTVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjcuMjc0NDAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjZGNlOWEyNWQ0NDY0M2RmYmM2NGQ1OGQ0
-        OTIxZjc4MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjQxOjIwLjcx
-        NjY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MjAuNzg1
-        MjMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjZTk4OTg1NGI4OWE0YjhkODBlYjhiMTU5
+        ZTYwMTk5NyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjI3LjMy
+        MDg5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjcuMzYx
+        MjA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wMjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3ZDMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvNTc0Mzk5ZTMtYjRkZC00YmZmLWJk
-        MDQtZTgzMzYzMzhiNzJhLyJdfQ==
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZDU0YmVjZjYtOGM5Zi00NjQyLWFk
+        YzktY2Q4MmVmMWIzYmE2LyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:20 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/d0fa6492-1eab-46e3-8ced-abd680a465f9/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/79f67fa5-5435-43f1-bc9b-58f4541ee5ff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +522,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -474,21 +536,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 679fc6a813a849929244bcdcd5b9728e
+      - e3d18bd8327d4464aef04f866c14fbb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhZTlhYTVmLTM3YjQtNDI5
-        YS05ZjViLTM3ZDVmYjI2Yjc2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNjQ3MThhLTE2ZmQtNDI1
+        ZC05NDQ4LTQ5MzIyY2JhMThmNS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/fae9aa5f-37b4-429a-9f5b-37d5fb26b769/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2d64718a-16fd-425d-9448-49322cba18f5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -496,7 +558,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -509,7 +571,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -521,644 +583,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 736de2d568014229abd6b7fa99a07e29
+      - 31342e581e61432a99f3e38bb50c765b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '373'
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmFlOWFhNWYtMzdi
-        NC00MjlhLTlmNWItMzdkNWZiMjZiNzY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MjEuMDA3NTI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ2NDcxOGEtMTZm
+        ZC00MjVkLTk0NDgtNDkzMjJjYmExOGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjcuNDY5ODY4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NzlmYzZhODEzYTg0OTkyOTI0NGJjZGNk
-        NWI5NzI4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjQxOjIxLjA4
-        Mzc1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MjEuMTkx
-        NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlM2QxOGJkODMyN2Q0NDY0YWVmMDRmODY2
+        YzE0ZmJiMSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjI3LjUx
+        NDg0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjcuNTY4
+        MjQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVlMWQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9kMGZhNjQ5Mi0xZWFiLTQ2
-        ZTMtOGNlZC1hYmQ2ODBhNDY1ZjkvIl19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83OWY2N2ZhNS01NDM1LTQz
+        ZjEtYmM5Yi01OGY0NTQxZWU1ZmYvIl19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - fa78891b440a44d1b4b8e17301219a34
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '302'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNi
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQwOjQ1LjYxNTEy
-        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvOWE4MWFmMTYtZjkxMi00NjRjLThkNGYtMGJmMWVhNjdh
-        M2IxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNiMS92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
-        bHAzX0ZpbGVfMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJz
-        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
-        Im1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/9a81af16-f912-464c-8d4f-0bf1ea67a3b1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - f71c74d756c14d13af533445d786e52d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNi
-        MS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6
-        NDA6NDUuNjI0NTY1WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzlhODFhZjE2LWY5MTIt
-        NDY0Yy04ZDRmLTBiZjFlYTY3YTNiMS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
-        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
-        cmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - d03b42710fb347dcbf09283fa795e359
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MDoyOC40Mzk1MTVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQzNDE1
-        NzAyLTYzZGYtNGM3NC1hZGRlLTM0NWZjOTQwNThmNS92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2Fn
-        ZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwi
-        cGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVw
-        b19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFk
-        OWYyMGEtYmJkOC00ZTFiLWI2ZTAtZTk2ZGY2MDM5NzU0LyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMDctMjFUMTM6NDA6MjYuMzczMjAxWiIsInZlcnNpb25z
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFk
-        OWYyMGEtYmJkOC00ZTFiLWI2ZTAtZTk2ZGY2MDM5NzU0L3ZlcnNpb25zLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWQ5ZjIwYS1iYmQ4LTRl
-        MWItYjZlMC1lOTZkZjYwMzk3NTQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluZWRfdmVyc2lv
-        bnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJt
-        ZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdl
-        X3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJw
-        YWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBv
-        X2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMS0wNy0yMFQxOToyMjoxNy45OTgwNThaIiwidmVyc2lvbnNf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvdmVyc2lvbnMvIiwi
-        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwZmEzMWJlLTdlMmQtNGNk
-        NS04MjVmLTNjYWE4MGJiZDRkMy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJmb28z
-        LTM2NzMwIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0
-        YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92
-        ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFj
-        a2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19n
-        cGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxLyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjEtMDctMjBUMTk6MTM6MjQuODUyNjYzWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxL3ZlcnNpb25zLyIsInB1
-        bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMt
-        OGNiZi02YjRmZDJiYTQzZDEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZm9vLTE4
-        MjcyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpu
-        dWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRh
-        dGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJz
-        aW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2Fn
-        ZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdj
-        aGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/43415702-63df-4c74-adde-345fc94058f5/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 786179b23e1e4cb3afa8a4aa251c5c4a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '232'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQw
-        OjI4LjQ0OTU5M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDM0MTU3MDItNjNkZi00Yzc0
-        LWFkZGUtMzQ1ZmM5NDA1OGY1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/71d9f20a-bbd8-4e1b-b6e0-e96df6039754/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 62c6b5c0b8584c77895c316ce000864d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MWQ5ZjIwYS1iYmQ4LTRlMWItYjZlMC1lOTZkZjYwMzk3NTQv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQw
-        OjI2LjM4MzMyN1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFkOWYyMGEtYmJkOC00ZTFi
-        LWI2ZTAtZTk2ZGY2MDM5NzU0LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e0fa31be-7e2d-4cd5-825f-3caa80bbd4d3/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 943f607349b8445a97db8506518f6920
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjIy
-        OjE4LjAwNzc5OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBmYTMxYmUtN2UyZC00Y2Q1
-        LTgyNWYtM2NhYTgwYmJkNGQzLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/30143471-8eac-4e83-8cbf-6b4fd2ba43d1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - b1b0d5e7366d4357afe30acdff950f64
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMtOGNiZi02YjRmZDJiYTQzZDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjEz
-        OjI0Ljg1ODUzOVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - db014ec2540d4b52a11bbf5e1e1660e4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '275'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzoyOTo0NS42
-        MzExMjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00
-        YWIyNTAxOGM3NTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzEwMTNlOGRiLTdjNWItNDNjMy05M2ZjLTRhYjI1MDE4
-        Yzc1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
-        dWJsaXNoIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:21 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 420d8cdab4624811b36ebf57ae07d8ae
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '233'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIx
-        VDEzOjI5OjQ1LjYzOTQ1OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMTAxM2U4
-        ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUxLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.8.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - b6b564d16f4e473faa270af55df18940
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1179,7 +632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1193,21 +646,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - b6ae8b5c99f04854ade46cfafd520759
+      - 56d72662a7314f5cbfef5dfd711617be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1228,7 +681,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
+      - Tue, 17 Aug 2021 15:28:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 4aed04e66f2a4a18a8c329cba3544c87
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1240,34 +742,55 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 7386235af0f34c6bb0da3fb8347f6e0c
+      - 22fb5156eaeb4f8dad0f595be0b5aa65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '262'
+      - '399'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMFQyMTow
-        Mjo0OC41MjE4MjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFi
-        LTQ1NzUtODQ4Ny1jMTA2M2ZiNGU0MDgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2FmZjc1NDdmLTU3MWIt
-        NDU3NS04NDg3LWMxMDYzZmI0ZTQwOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUi
-        Om51bGx9XX0=
+        ZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZj
+        Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjEzOjQ1Ljk2NDk4
+        NFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZl
+        NmNjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9u
+        cy8yMS8iLCJuYW1lIjoiZmlsZTItMzI5NDciLCJkZXNjcmlwdGlvbiI6bnVs
+        bCwicmV0YWluZWRfdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0
+        b3B1Ymxpc2giOmZhbHNlLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1QifSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjA3OjQ2LjgzMjAyN1oiLCJ2
+        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
+        L2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3Zl
+        cnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5
+        ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy8xMi8i
+        LCJuYW1lIjoiZmlsZTEtMjgzNTQiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0
+        YWluZWRfdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxp
+        c2giOmZhbHNlLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1QifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0
+        ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThjNi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjAwOjQzLjg1ODEyNFoiLCJ2ZXJzaW9u
+        c19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        YzQ4M2M3ZjktOTljMi00ZTQwLTk3ZGEtYzlkODJkM2FhOGM2L3ZlcnNpb25z
+        LyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0ODNjN2Y5LTk5
+        YzItNGU0MC05N2RhLWM5ZDgyZDNhYThjNi92ZXJzaW9ucy8zLyIsIm5hbWUi
+        OiJmaWxlLTE3OTk4IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:27 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/aff7547f-571b-4575-8487-c1063fb4e408/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1275,7 +798,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1288,7 +811,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
+      - Tue, 17 Aug 2021 15:28:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1300,30 +823,342 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - a926ed7e6ff348479ef02564f58d6b91
+      - b4d45b0b42aa4934980894b5bfe44053
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '235'
+      - '783'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIwVDIxOjAyOjQ4LjU3MDA5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvYWZmNzU0N2YtNTcxYi00NTc1LTg0ODctYzEwNjNmYjRlNDA4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MjIsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2
+        Y2MvdmVyc2lvbnMvMjEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1Qx
+        NToxNDozOC40NzI5MjVaIiwibnVtYmVyIjoyMSwicmVwb3NpdG9yeSI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1
+        ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51
+        bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2Zp
+        bGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAt
+        ZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzIxLyJ9fSwicmVtb3ZlZCI6e30sInBy
+        ZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoyMSwiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBi
+        Yi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMjEvIn19
+        fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
+        bGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2Mv
+        dmVyc2lvbnMvMjAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTox
+        NDozOC4yOTQ0OTdaIiwibnVtYmVyIjoyMCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMt
+        NDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291
+        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVz
+        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMw
+        M2JjYjZlNmNjL3ZlcnNpb25zLzIwLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoyMCwiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0y
+        NWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMjAvIn19fX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVy
+        c2lvbnMvMTkvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDoz
+        OC4wMTU5MTZaIiwibnVtYmVyIjoxOSwicmVwb3NpdG9yeSI6Ii9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5
+        MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNv
+        bnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQi
+        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2Jj
+        YjZlNmNjL3ZlcnNpb25zLzE5LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
+        OnsiZmlsZS5maWxlIjp7ImNvdW50IjoxOSwiaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQz
+        LTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTkvIn19fX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lv
+        bnMvMTgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNy43
+        NzA4MjBaIiwibnVtYmVyIjoxOCwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05
+        NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRl
+        bnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEs
+        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBv
+        c2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZl
+        NmNjL3ZlcnNpb25zLzE4LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsi
+        ZmlsZS5maWxlIjp7ImNvdW50IjoxOCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQx
+        OTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTgvIn19fX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8x
+        NWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMv
+        MTcvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNy41MjA2
+        NTlaIiwibnVtYmVyIjoxNywicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMw
+        LWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNj
+        L3ZlcnNpb25zLzE3LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmls
+        ZS5maWxlIjp7ImNvdW50IjoxNywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAt
+        OTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTcvIn19fX0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4
+        YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNy4yNTMxODha
+        IiwibnVtYmVyIjoxNiwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVj
+        MDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
+        bWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5
+        X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
+        L2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3Zl
+        cnNpb25zLzE2LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5m
+        aWxlIjp7ImNvdW50IjoxNiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRj
+        MC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTYvIn19fX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBi
+        Yi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTUvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNi45ODc5NjNaIiwi
+        bnVtYmVyIjoxNSwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNi
+        Y2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFy
+        eSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3Zl
+        cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
+        bGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNp
+        b25zLzE1LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxl
+        Ijp7ImNvdW50IjoxNSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
+        bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1l
+        YzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTUvIn19fX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0y
+        NWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNi43NTk4MDNaIiwibnVt
+        YmVyIjoxNCwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2
+        ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6
+        eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
+        MTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25z
+        LzE0LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7
+        ImNvdW50IjoxNCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAz
+        YmNiNmU2Y2MvdmVyc2lvbnMvMTQvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQz
+        LTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTMvIiwicHVscF9j
+        cmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNi41NzA3MDZaIiwibnVtYmVy
+        IjoxMywicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZj
+        Yy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJh
+        ZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25f
+        YWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTVi
+        OGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzEz
+        LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNv
+        dW50IjoxMywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmls
+        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNi
+        NmU2Y2MvdmVyc2lvbnMvMTMvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQx
+        OTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTIvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0wOC0xN1QxNToxNDozNi4zNTg3NDJaIiwibnVtYmVyIjox
+        MiwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8i
+        LCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRl
+        ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
+        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEw
+        YmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzEyLyJ9
+        fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50
+        IjoxMiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMv
+        P3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2
+        Y2MvdmVyc2lvbnMvMTIvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAt
+        OTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTEvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyMS0wOC0xN1QxNToxNDozNi4xMDU1MTBaIiwibnVtYmVyIjoxMSwi
+        cmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJi
+        YXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6
+        eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmIt
+        MjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzExLyJ9fSwi
+        cmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijox
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3Jl
+        cG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
+        bGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2Mv
+        dmVyc2lvbnMvMTEvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRj
+        MC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMTAvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xN1QxNToxNDozNS44OTU5NzBaIiwibnVtYmVyIjoxMCwicmVw
+        b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVk
+        My00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzEwLyJ9fSwicmVt
+        b3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxMCwi
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9z
+        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVy
+        c2lvbnMvMTAvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1l
+        YzAzYmNiNmU2Y2MvdmVyc2lvbnMvOS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
+        LTA4LTE3VDE1OjE0OjI4LjExODM1NloiLCJudW1iZXIiOjksInJlcG9zaXRv
+        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4
+        YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvIiwiYmFzZV92ZXJz
+        aW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5m
+        aWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5
+        MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9ucy85LyJ9fSwicmVtb3ZlZCI6
+        e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijo5LCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92
+        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1
+        YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9ucy85
+        LyJ9fX19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZl
+        NmNjL3ZlcnNpb25zLzgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1Qx
+        NToxNDoyNy45Mzc4ODhaIiwibnVtYmVyIjo4LCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVk
+        My00MTkwLTk0YzAtZWMwM2JjYjZlNmNjLyIsImJhc2VfdmVyc2lvbiI6bnVs
+        bCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJj
+        b3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmls
+        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1l
+        YzAzYmNiNmU2Y2MvdmVyc2lvbnMvOC8ifX0sInJlbW92ZWQiOnt9LCJwcmVz
+        ZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6OCwiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0y
+        NWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvOC8ifX19fSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJz
+        aW9ucy83LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6MTQ6Mjcu
+        NzYxMjg4WiIsIm51bWJlciI6NywicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05
+        NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRl
+        bnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEs
+        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBv
+        c2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZl
+        NmNjL3ZlcnNpb25zLzcvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjcsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkw
+        LTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzcvIn19fX0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4
+        YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvNi8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjE0OjI3LjU2NzY0MVoi
+        LCJudW1iZXIiOjYsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAz
+        YmNiNmU2Y2MvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1h
+        cnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92
+        ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJz
+        aW9ucy82LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxl
+        Ijp7ImNvdW50Ijo2LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmls
+        ZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVj
+        MDNiY2I2ZTZjYy92ZXJzaW9ucy82LyJ9fX19LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVk
+        My00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzUvIiwicHVscF9j
+        cmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxNDoyNy4zMDg4OTJaIiwibnVtYmVy
+        Ijo1LCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNj
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4
+        YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvNS8i
+        fX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3Vu
+        dCI6NSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMv
+        P3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2
+        Y2MvdmVyc2lvbnMvNS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05
+        NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9ucy80LyIsInB1bHBfY3JlYXRlZCI6
+        IjIwMjEtMDgtMTdUMTU6MTQ6MjMuNDcwNTY5WiIsIm51bWJlciI6NCwicmVw
+        b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVk
+        My00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzQvIn19LCJyZW1v
+        dmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjQsImhy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
+        bGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNjL3ZlcnNp
+        b25zLzQvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAz
+        YmNiNmU2Y2MvdmVyc2lvbnMvMy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4
+        LTE3VDE1OjE0OjIzLjE2OTg4OVoiLCJudW1iZXIiOjMsInJlcG9zaXRvcnki
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBi
+        Yi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvIiwiYmFzZV92ZXJzaW9u
+        IjpudWxsLCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxl
+        Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmls
+        ZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05
+        NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9ucy8zLyJ9fSwicmVtb3ZlZCI6e30s
+        InByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1Yjhh
+        MGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9ucy8zLyJ9
+        fX19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNj
+        L3ZlcnNpb25zLzIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTox
+        NDoyMi45MzIwODVaIiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00
+        MTkwLTk0YzAtZWMwM2JjYjZlNmNjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
+        Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3Vu
+        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMv
+        P3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAz
+        YmNiNmU2Y2MvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50
+        Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQz
+        LTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMi8ifX19fSx7InB1
+        bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9u
+        cy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6MTQ6MjIuNzY3
+        MDgxWiIsIm51bWJlciI6MSwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMw
+        LWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRf
+        c3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZlNmNj
+        L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxl
+        LmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0
+        YzAtZWMwM2JjYjZlNmNjL3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xNWI4YTBi
+        Yi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNiNmU2Y2MvdmVyc2lvbnMvMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjEzOjQ1Ljk3MzMzMFoiLCJu
+        dW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS8xNWI4YTBiYi0yNWQzLTQxOTAtOTRjMC1lYzAzYmNi
+        NmU2Y2MvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fV19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:28 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1331,7 +1166,488 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b23d92c4925547e58a4fa5c10e1accde
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '583'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4
+        OTIvdmVyc2lvbnMvMTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1Qx
+        NToxMzoxMC43MDc5MTFaIiwibnVtYmVyIjoxMiwicmVwb3NpdG9yeSI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFi
+        NjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJiYXNlX3ZlcnNpb24iOm51
+        bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2Zp
+        bGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUt
+        NTAwYzZmN2FjODkyL3ZlcnNpb25zLzEyLyJ9fSwicmVtb3ZlZCI6e30sInBy
+        ZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxMiwiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQx
+        Yy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvMTIvIn19
+        fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Zp
+        bGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIv
+        dmVyc2lvbnMvMTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTox
+        MzowNi45NzkwMDNaIiwibnVtYmVyIjoxMSwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjkt
+        NDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291
+        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVz
+        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAw
+        YzZmN2FjODkyL3ZlcnNpb25zLzExLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxMSwiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0x
+        YjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvMTEvIn19fX0s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVy
+        c2lvbnMvMTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToxMzow
+        NC4zMDgxNTVaIiwibnVtYmVyIjoxMCwicmVwb3NpdG9yeSI6Ii9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDEx
+        NS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNv
+        bnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQi
+        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZm
+        N2FjODkyL3ZlcnNpb25zLzEwLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
+        OnsiZmlsZS5maWxlIjp7ImNvdW50IjoxMCwiaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5
+        LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvMTAvIn19fX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lv
+        bnMvOS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjA4OjQyLjE5
+        MDcyN1oiLCJudW1iZXIiOjksInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0
+        ZS01MDBjNmY3YWM4OTIvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50
+        X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJo
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3Np
+        dG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5
+        Mi92ZXJzaW9ucy85LyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmls
+        ZS5maWxlIjp7ImNvdW50Ijo5LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04
+        MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy85LyJ9fX19LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlk
+        MWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTowODo0MS43NDc3MjRaIiwi
+        bnVtYmVyIjo4LCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZm
+        N2FjODkyLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
+        Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
+        c2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lv
+        bnMvOC8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        eyJjb3VudCI6OCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBj
+        NmY3YWM4OTIvdmVyc2lvbnMvOC8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjkt
+        NDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy83LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTdUMTU6MDg6NDEuMzIzNjQ4WiIsIm51bWJlciI6
+        NywicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8i
+        LCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRl
+        ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
+        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlk
+        MWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzcvIn19
+        LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQi
+        OjcsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        aWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODky
+        L3ZlcnNpb25zLzcvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0
+        ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvNi8iLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDIxLTA4LTE3VDE1OjA4OjQwLjk3Mzc3MVoiLCJudW1iZXIiOjYsInJlcG9z
+        aXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81
+        OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvIiwiYmFzZV92
+        ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmls
+        ZS5maWxlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjkt
+        NDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy82LyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijo2LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9u
+        cy82LyJ9fX19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZm
+        N2FjODkyL3ZlcnNpb25zLzUvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0x
+        N1QxNTowODo0MC40NDE2NTRaIiwibnVtYmVyIjo1LCJyZXBvc2l0b3J5Ijoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMt
+        MWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyLyIsImJhc2VfdmVyc2lvbiI6
+        bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0
+        ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvNS8ifX0sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6NSwiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQx
+        Yy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMvNS8ifX19
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92
+        ZXJzaW9ucy80LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6MDg6
+        NDAuMDMwMDU5WiIsIm51bWJlciI6NCwicmVwb3NpdG9yeSI6Ii9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDEx
+        NS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNv
+        bnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQi
+        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZm
+        N2FjODkyL3ZlcnNpb25zLzQvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6
+        eyJmaWxlLmZpbGUiOnsiY291bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00
+        MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzQvIn19fX0seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81
+        OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMv
+        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjA4OjM5LjYzNzE3
+        OVoiLCJudW1iZXIiOjMsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01
+        MDBjNmY3YWM4OTIvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1
+        bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi92
+        ZXJzaW9ucy8zLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmlsZS5m
+        aWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRl
+        LTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy8zLyJ9fX19LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMt
+        MWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzIvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTowODozOC44MTI1NTlaIiwibnVt
+        YmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2Fj
+        ODkyLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7
+        ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81
+        OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVyc2lvbnMv
+        Mi8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJj
+        b3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmls
+        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3
+        YWM4OTIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDEx
+        NS04MDRlLTUwMGM2ZjdhYzg5Mi92ZXJzaW9ucy8xLyIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjEtMDgtMTdUMTU6MDg6MzguNDMxMDQwWiIsIm51bWJlciI6MSwi
+        cmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJi
+        YXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6
+        eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlkMWMt
+        MWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzEvIn19LCJy
+        ZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEs
+        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBv
+        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
+        L2ZpbGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3Zl
+        cnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01
+        MDBjNmY3YWM4OTIvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
+        LTA4LTE3VDE1OjA3OjQ2LjgzOTMwMFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
+        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81OTEz
+        OWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvIiwiYmFzZV92ZXJz
+        aW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnt9LCJyZW1v
+        dmVkIjp7fSwicHJlc2VudCI6e319fV19
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:28 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c483c7f9-99c2-4e40-97da-c9d82d3aa8c6/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c4514fe3454a4326afef27618761f84c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '363'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThj
+        Ni92ZXJzaW9ucy8zLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6
+        MDM6MDYuMzAxOTY3WiIsIm51bWJlciI6MywicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzIt
+        NGU0MC05N2RhLWM5ZDgyZDNhYThjNi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291
+        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVz
+        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvYzQ4M2M3ZjktOTljMi00ZTQwLTk3ZGEtYzlk
+        ODJkM2FhOGM2L3ZlcnNpb25zLzMvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
+        dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvYzQ4M2M3ZjktOTlj
+        Mi00ZTQwLTk3ZGEtYzlkODJkM2FhOGM2L3ZlcnNpb25zLzMvIn19fX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS9jNDgzYzdmOS05OWMyLTRlNDAtOTdkYS1jOWQ4MmQzYWE4YzYvdmVyc2lv
+        bnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjAzOjAxLjY0
+        MDUyMVoiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9jNDgzYzdmOS05OWMyLTRlNDAtOTdk
+        YS1jOWQ4MmQzYWE4YzYvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50
+        X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjoxLCJo
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3Np
+        dG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThj
+        Ni92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZmls
+        ZS5maWxlIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzItNGU0MC05
+        N2RhLWM5ZDgyZDNhYThjNi92ZXJzaW9ucy8yLyJ9fX19LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvYzQ4M2M3
+        ZjktOTljMi00ZTQwLTk3ZGEtYzlkODJkM2FhOGM2L3ZlcnNpb25zLzEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNTowMjo1Ni44MzQxMzhaIiwi
+        bnVtYmVyIjoxLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvYzQ4M2M3ZjktOTljMi00ZTQwLTk3ZGEtYzlkODJk
+        M2FhOGM2LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
+        Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
+        c2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
+        ZS9jNDgzYzdmOS05OWMyLTRlNDAtOTdkYS1jOWQ4MmQzYWE4YzYvdmVyc2lv
+        bnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS9jNDgzYzdmOS05OWMyLTRlNDAtOTdkYS1jOWQ4
+        MmQzYWE4YzYvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzIt
+        NGU0MC05N2RhLWM5ZDgyZDNhYThjNi92ZXJzaW9ucy8wLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTdUMTU6MDA6NDMuODY5MTkxWiIsIm51bWJlciI6
+        MCwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlL2M0ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThjNi8i
+        LCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRl
+        ZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:28 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - d72ace648f9c407bb896e9d72360e21e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:28 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - afc131df57434774aeb90ca128424e52
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 35f2cc62ad3a44e28a048bfae23f7fb1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/21/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1344,7 +1660,1771 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b0143825c84f4491b9b0aeb42491b19b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0MjliOTZlLTY0MWUtNDM2
+        OC05NWNmLWI0ZjY2YTcxYzkwMy8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/20/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3972a7057aaa44559ada8e93ca724315
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3YmU5YWJjLTliNDUtNDYx
+        ZC1iOTE0LTY5MGVhNmJiOTBkYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/19/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 93a42be3d1e74b5681bb79676d2ee896
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkMzNiNzBhLWM3ZTQtNDk3
+        MS1hNTA0LWMzY2QyNDFlMDA4Yi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/18/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3edd1c50c87d4e64b858f754a454fb2a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3OTBlZTAzLWZlZmQtNGNm
+        Zi04OTJhLTdmZmUzODA1NGNkOS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - cb3ed1d898174f67be9f40d8655d29de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlMDU4NGI2LTMxYjQtNDUw
+        ZC1iNTMyLTE0N2Y3YWYzMWE3Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/16/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a5fc9eb27ad04c55ba290f5d1a118177
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkYWMwOTJiLTM0YzItNDM3
+        Ny04OTYxLTgwNjFmOGFkOWJjZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/15/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 16e4b57bdd014393aa7aba19fe4dea62
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4N2Q2MTRkLWRjZjQtNDM2
+        MS05MDYwLTVlNTQ0Yzc3OTk3My8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/14/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 89855b359a7243a0a2c996aa5f5310a0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzYzJkMjVjLThkNWQtNDFi
+        MC1hNTM2LTEwOTNjYWJhMTFiYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/13/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 17661ef2f32a4510ac0939078cf46312
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0NGIzOTZkLTQ3ZTgtNDgw
+        Yy04NjNhLTFkMzdkOWUzNGQyMi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 17336e794ac947de85f98f92a0fb150f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyNzMxMTgwLTNkMjUtNDRm
+        Yy05MmVjLTYyMTBiZjk3OTRiNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/11/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 782e74a2ed3742dda797a8c42a8589ec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyODI2YzAyLWM5YTAtNDk5
+        My1hNzZmLTNlNDI3NzZjMTQwNC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/10/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 13e4713da8ff4cef8e5195fa2bb12119
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkOGVhOTUyLTcyZWEtNGY4
+        YS1hOTk4LTdkMjUzYzE4ZjhkNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 54d3dd01696e47e5bf172086ba075768
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwNTM1M2MyLTMyNTUtNGI5
+        NS04Y2UzLWU2ZDFkMDA5Mzk0Ni8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 269440c93f564a2fab7b3f7b68831282
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc4YWIwZmQzLTQwYjktNGJh
+        OS05NGY4LTA3MjkwOGY2ZTI1Ni8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5a6662bf5d004cf6b005dc16a3cc78b0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmN2I1NjBhLWI3NDMtNDY5
+        ZC04OTk2LTY2YzRjZmIzZmQ2OS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:29 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - c517a55d375e4fe2bf274a1a182442ae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1M2NkYmQzLTM3OWYtNGY3
+        My1iOGM1LTNjMDY1YTlhNjk0NS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3be39d510fc74272bd59d05baa108ef1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MjljOTQ2LTJmZTAtNDBl
+        NC1hNWI0LTg0NjI1NWUzOWI3OC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b03780a5818f4c9c9241b26b86c76b68
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxOGQ2NzUyLTE0OTktNDE1
+        ZC1iZTRjLTYzNjUxMTVjNTZmYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 288c32a8d60542449533faa12fe3adc8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmNjdlYjNkLWE0Y2QtNDdl
+        ZC1hZDU5LTMyNzJlMWMxYjc4OS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - bbb0c01d3237403a90d43393e8fff67f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxZTRhM2VjLTM5MTctNDdj
+        ZC1hNDI1LTNlNmU3NTdhYzI3YS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 4846a60c646648df9b3a4f3a51d49dd0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZGNhNzRiLTI1YWYtNDYy
+        Mi05NzM2LTA1NjUzYzM2ZThmOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 994a0383cd134116b8315bfdbc3853ee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U2ZjA2NjU5LWVlNGMtNDFm
+        YS1iNDA5LTkwZDA2MGYxZDM5MC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/11/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d3f4c6087a7646b09b6078dcda391949
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4ZmU4ZjdiLTQxZWItNGVk
+        My04MGMzLTdiZDAyMTM1Zjk0My8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/10/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7618d714df0546b185da659a9af2d09b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzMTRjMWI0LWVlNjYtNGM2
+        OC05ZDk0LTJmNDljOGQzZTY1Yi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 1a3d50cb99f74e53a57a83c3f4df64f0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkZTU1OGE3LWM2NDMtNGUw
+        Zi1iZTA2LThlZTI1OWZjY2NkYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 9096ff58209b4a56b8d671a10189eb4d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmNjYzNWZkLTIwOGYtNDEz
+        My1iNzYyLTVjZTQyMjk4ODI1ZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 81ff50f1271545de98b0ef347ef5d32b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I1OGZiNzM1LWE3MWQtNDRh
+        Zi1iYzJmLTE5NjA4NzBmZWFjMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d3fb7ba5f4ee4199beff6befa4592c40
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y1MGVlYmI3LWMyOTctNDVj
+        NC04ZTFlLWFlMWI2ZWU3ODAxMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:30 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 21e52d8def934a98894806559642433c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmZGI1NTljLTRiYjMtNGNh
+        Yi04NzE0LWE2Y2VjNDMwMmM5Mi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - fd1820a3e2bd4d33a5981f27b7e49c4f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkOGE3ZWZkLWRlZWQtNDg0
+        My1hMGRiLWNjNmE3NzA2ZDllYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 01f1be0411bf49a688c9a5ef37b24e9f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4ZGI1ZTU5LTIwNWYtNGIx
+        YS1hOWY4LTE2ZWQzNDYwN2ZjZC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - f4aa8886c34b4df0b043d3103151658e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0YzkzNmNiLTFlZTYtNGQ0
+        Yi04Njc5LWVkZTIxNjY2MzJiOS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 81cccf2f4c3043698dadf2427ec0e4aa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlODZhNGM4LTAwNGUtNDFm
+        My05NmIzLTdhYmRkOGU5OGIzZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c483c7f9-99c2-4e40-97da-c9d82d3aa8c6/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5790524c4561436f90ff8cec274661f9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3MGJmNmFhLWY5YzYtNGNm
+        My04OTJhLTAxYzExZTAwMjI3NS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c483c7f9-99c2-4e40-97da-c9d82d3aa8c6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - cd275d15d31a4e31b943e8bd7255c797
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmMjJhZWFiLTYyNGQtNDE4
+        MS04Y2I1LWM1Yzg2MmRmMjVlZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c483c7f9-99c2-4e40-97da-c9d82d3aa8c6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3fb88b6bd00d478f95bdda6d35b39b83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2NWJlYWJjLTA4MjctNDVk
+        Ny04MmIxLWUwMTE4YThiNDdkYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:31 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1358,21 +3438,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 78968d5ea4cb4d6fbc03164ca391cdfc
+      - c863fb4173244370b79b91b0f40785e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjOTQ4OWFlLWMzNWQtNGQ2
-        Mi04MDRiLTI3MGIxMTlhNjk5MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1ZGFiZWJlLWEwMzEtNDYx
+        NC04ZGJkLWFmZjFhMWI3MzVkMS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:31 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3c9489ae-c35d-4d62-804b-270b119a6991/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/15dabebe-a031-4614-8dbd-aff1a1b735d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1380,7 +3460,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1393,7 +3473,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:22 GMT
+      - Tue, 17 Aug 2021 15:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1405,34 +3485,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 4ae250dab3d14bb09f361ba12b3abde6
+      - e1323a47ee2243309c2ceb9352bb9442
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '408'
+      - '418'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2M5NDg5YWUtYzM1
-        ZC00ZDYyLTgwNGItMjcwYjExOWE2OTkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MjIuMzc5OTA2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTVkYWJlYmUtYTAz
+        MS00NjE0LThkYmQtYWZmMWExYjczNWQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzEuNzMyMjQxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6Ijc4OTY4ZDVlYTRjYjRkNmZiYzAzMTY0
-        Y2EzOTFjZGZjIiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MjIu
-        NDQyNTMyWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxMzo0MToyMi43
-        NDQ4NTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzL2I4ZDU5N2E0LTdkYTktNGZhYS1hZjg4LTViZGFkMmMxYTllMC8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImM4NjNmYjQxNzMyNDQzNzBiNzliOTFi
+        MGY0MDc4NWUxIiwic3RhcnRlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzEu
+        ODc4NTUxWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wOC0xN1QxNToyODozMi4x
+        NzY5OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzAyOWExMmRiLTdmYjEtNGZhYS05M2FmLTBlZjk5MTk3NzdkMy8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
-        YW4gdXAgb3JwaGFuIEFydGlmYWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250
-        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29u
-        dGVudCIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNy
-        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6W119
+        YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjI1LCJkb25lIjoyNSwi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0
+        aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjoxNSwiZG9uZSI6MTUsInN1ZmZpeCI6bnVsbH1d
+        LCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:22 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:32 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
@@ -9307,60 +9307,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:17 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/68cc019b-1166-4a93-9d4d-54f2a4ea8e7e/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '130'
-      Correlation-Id:
-      - 6fef8df2eafe48ce963d02827bb90550
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy82OGNjMDE5Yi0x
-        MTY2LTRhOTMtOWQ0ZC01NGYyYTRlYThlN2UvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo0MToxNy40MDY3NzhaIiwic2l6ZSI6NzQwfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:17 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/68cc019b-1166-4a93-9d4d-54f2a4ea8e7e/
     body:
@@ -9552,66 +9498,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:17 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI3NmE0YjU5N2YxOWY0
-        YTdhYTA1MGZhMGExYzUwNDA2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMjc2YTRiNTk3
-        ZjE5ZjRhN2FhMDUwZmEwYTFjNTA0MDYNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvOGU2OTUyZjItMWFiMi00ZjM0LWFmMTQtNTY5NTM3Mjk4MmRl
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI3NmE0YjU5N2Yx
-        OWY0YTdhYTA1MGZhMGExYzUwNDA2LS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-276a4b597f19f4a7aa050fa0a1c50406
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - '019a69355ad5403fad37577902d8627d'
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhNDYyM2Y4LWJkNTktNDg3
-        NC1hYmIxLTYyMzA1OTE4OTRiZS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:17 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8a4623f8-bd59-4874-abb1-6230591894be/
     body:
@@ -9788,4 +9674,4492 @@ http_interactions:
         NDZlMy04Y2VkLWFiZDY4MGE0NjVmOS8iXX0=
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:18 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/a55deddf-8f13-449d-9a8c-e58f08637ad7/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhYjRhZTBhNTBiMWU2
+        ZDJkOTUzMzBlYzM1NzY2OTFmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtNjU1NS0xZDdiZzVzIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhYjRhZTBhNTBi
+        MWU2ZDJkOTUzMzBlYzM1NzY2OTFmLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-eab4ae0a50b1e6d2d95330ec3576691f
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 837573fea6ae47d9bcf7651bc0e3efec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9hNTVkZWRkZi04
+        ZjEzLTQ0OWQtOWE4Yy1lNThmMDg2MzdhZDcvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMDo1MDozMS44NzgxODVaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:31 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/a55deddf-8f13-449d-9a8c-e58f08637ad7/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d15c8f1ab8ff427b86c9269404c73c61
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4Yzc3ZDY2LTQ3NmYtNGUz
+        Ny05NDYzLWM4NmViZTk3ODNkMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:31 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/48c77d66-476f-4e37-9463-c86ebe9783d1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b539cde9735e49cc8ca0656009718e1b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDhjNzdkNjYtNDc2
+        Zi00ZTM3LTk0NjMtYzg2ZWJlOTc4M2QxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzEuOTcxNDc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJkMTVjOGYxYWI4ZmY0MjdiODZjOTI2OTQwNGM3M2M2
+        MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUwOjMyLjAxNjEwOVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6MzIuMDg5NDc1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZjQ2OTdkN2YtM2JiZi00YTM5LTk2
+        ZTQtZDliMzM1ZGViNGMwLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2E1NWRlZGRmLThmMTMtNDQ5ZC05
+        YThjLWU1OGYwODYzN2FkNy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:32 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/1c6cf1ef-0ed2-4a15-98d2-bdd3506195cd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - '059f3314fe0e47fe8b541d3c1cb1a801'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWM2Y2YxZWYtMGVk
+        Mi00YTE1LTk4ZDItYmRkMzUwNjE5NWNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzIuMTg1MDAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYWNjOTdlNGY2ODQ0MGZlYjJmMTZkYWNh
+        Mzk5MWM5YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUwOjMyLjIy
+        NDg2MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6MzIuMzMw
+        MDc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvN2ZhMTEy
+        ZDYtN2NiNS00ODNjLWFhNDYtMDNjM2NiYTQ3NTQ0LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZjQ2
+        OTdkN2YtM2JiZi00YTM5LTk2ZTQtZDliMzM1ZGViNGMwLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:32 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/76384d95-12b7-4636-ab7c-f38da3f18914/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzdmYTExMmQ2LTdjYjUtNDgzYy1hYTQ2LTAzYzNjYmE0NzU0
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - dda334f1035a467b89c486b43a893e7a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4MDZhNDg0LTZhYzQtNGQx
+        MS1hNjA1LWRjNzZiMjc5OTk0YS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:32 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/c806a484-6ac4-4d11-a605-dc76b279994a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 17311e222c9d4e7d9b1ab82e54a07fc9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzgwNmE0ODQtNmFj
+        NC00ZDExLWE2MDUtZGM3NmIyNzk5OTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzIuNDkxMzYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkZGEzMzRmMTAzNWE0NjdiODlj
+        NDg2YjQzYTg5M2U3YSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUw
+        OjMyLjUzNjUyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6
+        MzIuNjMwNjE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzc2Mzg0ZDk1LTEyYjctNDYzNi1hYjdjLWYzOGRhM2YxODkxNC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc2Mzg0ZDk1LTEyYjct
+        NDYzNi1hYjdjLWYzOGRhM2YxODkxNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:32 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/9f182596-349a-42f6-a845-9840203a91aa/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzA3N2IzNjQ5LTU1YjktNDcwYy04OWQzLTNiNzE2MTg3Y2Y0
+        ZS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a9c8b6fe9aa84654abb989f47bdcc2d4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0MDFiZjRhLTVhMjQtNDdl
+        NC04ZDlmLTVmZDY1MmM2YjVjNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:04 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2401bf4a-5a24-47e4-8d9f-5fd652c6b5c7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a367b91f432b4dc6acf46e6ab9abe84b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQwMWJmNGEtNWEy
+        NC00N2U0LThkOWYtNWZkNjUyYzZiNWM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6MDQuMjc3MTE5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhOWM4YjZmZTlhYTg0NjU0YWJi
+        OTg5ZjQ3YmRjYzJkNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEx
+        OjA0LjMzMzQ2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6
+        MDQuNDI3MDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzlmMTgyNTk2LTM0OWEtNDJmNi1hODQ1LTk4NDAyMDNhOTFhYS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzlmMTgyNTk2LTM0OWEt
+        NDJmNi1hODQ1LTk4NDAyMDNhOTFhYS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:04 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/68df7189-dc02-421c-aaa2-ace5e6b891a7/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTFiYThkZTJiYTk0NGZk
+        OTZjNWRkZDlkZTEzNTY4NzBmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODMyNi0xM3hkdjI1Ig0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTFiYThkZTJiYTk0
+        NGZkOTZjNWRkZDlkZTEzNTY4NzBmLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-1ba8de2ba944fd96c5ddd9de1356870f
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 60143b88980f4f9cbb4f158ce85a963c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy82OGRmNzE4OS1k
+        YzAyLTQyMWMtYWFhMi1hY2U1ZTZiODkxYTcvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxNToyNi43MjM0MTBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:26 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/68df7189-dc02-421c-aaa2-ace5e6b891a7/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 1a89d6befb9b48e2b257a61743d23190
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2ODcxNGVjLTAxYWQtNDYz
+        MS1hNjhmLTBjNzMwM2ZlZTc0My8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f68714ec-01ad-4631-a68f-0c7303fee743/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 3bf2c2631e894a6dbf218f7e7147a499
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjY4NzE0ZWMtMDFh
+        ZC00NjMxLWE2OGYtMGM3MzAzZmVlNzQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjYuODIwMTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIxYTg5ZDZiZWZiOWI0OGUyYjI1N2E2MTc0M2QyMzE5
+        MCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1OjI2Ljg2MDE1NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6MjYuOTI3OTI4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDA0ZTYwNTItMTFiYS00ODYyLTgy
+        YzAtZWYzYmY0ZDI0ZWUxLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzY4ZGY3MTg5LWRjMDItNDIxYy1h
+        YWEyLWFjZTVlNmI4OTFhNy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/d9e61941-8a38-468f-9124-493cacd3a47c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ca2e9f10c64343fabe342aa68536ebfe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDllNjE5NDEtOGEz
+        OC00NjhmLTkxMjQtNDkzY2FjZDNhNDdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjcuMDczNzQwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1NDNlMTUwN2NhYzM0OGViODViOTYxNDlk
+        M2Y5NDVlOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1OjI3LjEx
+        MzcyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6MjcuMjE4
+        NTEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYzQ5N2Yw
+        ZDMtNmRjOC00ZTUyLTliOGMtMGY5NmMwOTJhNTUwLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDA0
+        ZTYwNTItMTFiYS00ODYyLTgyYzAtZWYzYmY0ZDI0ZWUxLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:27 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/3529b12c-7a41-484b-ba95-624222ace269/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2M0OTdmMGQzLTZkYzgtNGU1Mi05YjhjLTBmOTZjMDkyYTU1
+        MC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 471ba12242e14336bc8660daea694da9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliNWVmN2UwLTdjOTktNDY3
+        MS1iYWY1LWE2NTQ0Y2Q5YWIxMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9b5ef7e0-7c99-4671-baf5-a6544cd9ab12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 61ee1b3ff4de41c98055c36e4ba8a110
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWI1ZWY3ZTAtN2M5
+        OS00NjcxLWJhZjUtYTY1NDRjZDlhYjEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjcuMzQzNjk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NzFiYTEyMjQyZTE0MzM2YmM4
+        NjYwZGFlYTY5NGRhOSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1
+        OjI3LjM4OTU3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6
+        MjcuNTA0MDQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzM1MjliMTJjLTdhNDEtNDg0Yi1iYTk1LTYyNDIyMmFjZTI2OS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzM1MjliMTJjLTdhNDEt
+        NDg0Yi1iYTk1LTYyNDIyMmFjZTI2OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:27 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/da127273-f8cc-4f4e-a697-a052ffaaad71/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LThkODAyMTRkNTAwNzM2
+        YWU0YTlhYjA5NzYyMzFlMGJkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODU4NS1vN2sxaTAiDQpDb250ZW50LUxlbmd0aDogNzQwDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1UcmFu
+        c2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCnsidW5pdF9rZXkiOiB7ImlkIjog
+        InRlc3QifSwgInVuaXRfbWV0YWRhdGEiOiB7InN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTItNy0yNSAwMDowMDowMCIsICJkZXNjcmlwdGlv
+        biI6IG51bGwsICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxw
+        LWxpc3RAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
+        VGVzdCBFcnJhdGEgcmVmZXJyaW5nIHRvIHRlc3QtcGFja2FnZS0wLjIiLCAi
+        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlbGVhc2UiOiAiIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5oYW5jZW1lbnRzIiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEu
+        ZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhY2thZ2UiLCAic3VtIjog
+        WyJtZDUiLCAiNWI1OTBjYzk1ZmRmZjE0NTYwMDM0YTFmMzM0YTQ3NTMiXSwg
+        ImZpbGVuYW1lIjogInRlc3QtcGFja2FnZS0wLjItMS5lbDYubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2Ui
+        OiAiMS5lbDYiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIlB1bHAg
+        VGVzdCBQYWNrYWdlcyIsICJzaG9ydCI6ICJUZXN0Q29sbGVjdGlvbiJ9XX19
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtOGQ4MDIxNGQ1MDA3
+        MzZhZTRhOWFiMDk3NjIzMWUwYmQtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-8d80214d500736ae4a9ab0976231e0bd
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1059'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9fa15ad372d440aab5ae976eb8aadd22
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9kYTEyNzI3My1m
+        OGNjLTRmNGUtYTY5Ny1hMDUyZmZhYWFkNzEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxNzowOS45ODg0NTVaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/da127273-f8cc-4f4e-a697-a052ffaaad71/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 53966fe9f9a54f04bde029208b42f088
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlNWY0N2JjLTM5MDUtNGM3
+        Ny1hYjE1LTQ1OTZiMDI5ZWUyOS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5e5f47bc-3905-4c77-ab15-4596b029ee29/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - bfe1e9a6739a4022ac9d326edc24cf95
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWU1ZjQ3YmMtMzkw
+        NS00Yzc3LWFiMTUtNDU5NmIwMjllZTI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTc6MTAuMDgyNzI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI1Mzk2NmZlOWY5YTU0ZjA0YmRlMDI5MjA4YjQyZjA4
+        OCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE3OjEwLjEyNzc5MFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTc6MTAuMjAyNjE4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYzIxMjU5ZjQtYTkyYS00OTMyLTgz
+        M2YtMjlmNzU4ZDYwMzBkLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2RhMTI3MjczLWY4Y2MtNGY0ZS1h
+        Njk3LWEwNTJmZmFhYWQ3MS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e4eefd9c-e86c-4408-8efe-0b660f730f68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 46faf83162e444cb9327424709ef080a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTRlZWZkOWMtZTg2
+        Yy00NDA4LThlZmUtMGI2NjBmNzMwZjY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTc6MTAuMzA5MDk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlZDA4OGJlMjQ0YWI0OTk5ODJmNTc5NTA0
+        MmU3ZGRhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE3OjEwLjM1
+        MzAyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTc6MTAuNDYw
+        NDE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMzdlMTc3
+        NDItZTRiMC00NTAyLWJlMGMtNmI5OTdhNmJmN2FlLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYzIx
+        MjU5ZjQtYTkyYS00OTMyLTgzM2YtMjlmNzU4ZDYwMzBkLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c9d1aae0-b857-41c4-99c6-2879f21df237/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzM3ZTE3NzQyLWU0YjAtNDUwMi1iZTBjLTZiOTk3YTZiZjdh
+        ZS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 1e8855c5a2864031a1bb350aa736f8d8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzYzRiYmFkLTE1N2EtNDEy
+        Mi1hMTRhLTc1MjM4NDMyNmQ3OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/13c4bbad-157a-4122-a14a-752384326d79/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - '098aa8c089dd471c8761f9a616f639b0'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTNjNGJiYWQtMTU3
+        YS00MTIyLWExNGEtNzUyMzg0MzI2ZDc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTc6MTAuNTg3NzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxZTg4NTVjNWEyODY0MDMxYTFi
+        YjM1MGFhNzM2ZjhkOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE3
+        OjEwLjYzNDAyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTc6
+        MTAuNzI4ODE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2M5ZDFhYWUwLWI4NTctNDFjNC05OWM2LTI4NzlmMjFkZjIzNy92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M5ZDFhYWUwLWI4NTct
+        NDFjNC05OWM2LTI4NzlmMjFkZjIzNy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:10 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/34d4c437-8629-44b7-9837-3733f5c77ea8/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU5MmY3N2JlNjQ2OTM3
+        ZDRiN2VlMmZmMjM3YTAyNTEwDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODk3NC0xcTg5cThzIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU5MmY3N2JlNjQ2
+        OTM3ZDRiN2VlMmZmMjM3YTAyNTEwLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-592f77be646937d4b7ee2ff237a02510
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - bafb7774a44a48be97db1b90a3c7f080
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8zNGQ0YzQzNy04
+        NjI5LTQ0YjctOTgzNy0zNzMzZjVjNzdlYTgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxODo1NC44MTYyMzdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:54 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/34d4c437-8629-44b7-9837-3733f5c77ea8/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 34ee6c4708a64ef4a04588d989b23294
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5YzIxYTEzLTljMjctNGYw
+        Zi1iNmY0LWYwMzU5MTRiOWYzYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/59c21a13-9c27-4f0f-b6f4-f035914b9f3b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 102cd3fa6eb24c4b97f7351e13d284f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTljMjFhMTMtOWMy
+        Ny00ZjBmLWI2ZjQtZjAzNTkxNGI5ZjNiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTQuOTA4MDQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIzNGVlNmM0NzA4YTY0ZWY0YTA0NTg4ZDk4OWIyMzI5
+        NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4OjU0Ljk2MTMyMVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6NTUuMDIyOTg1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjVhZGMzZTItYjkzYy00MDM1LWJm
+        ZTItYWJhOTAwZjE0NzdlLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzM0ZDRjNDM3LTg2MjktNDRiNy05
+        ODM3LTM3MzNmNWM3N2VhOC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/7a9bdad9-6636-47f2-a71b-1e586e35ba75/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 04eedd4fa9224d58ae2f63944dad492d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2E5YmRhZDktNjYz
+        Ni00N2YyLWE3MWItMWU1ODZlMzViYTc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTUuMTIwOTAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmZmNjYmU1NmIwNzI0ZDY4YTVjZjMyZTY2
+        N2UwODVkMyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4OjU1LjE4
+        MDU4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6NTUuMjk1
+        MDE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvOWQyNjZk
+        ZDctMDhjZS00NzZlLWJiMWMtZGVkNmE0MjRmODg2LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjVh
+        ZGMzZTItYjkzYy00MDM1LWJmZTItYWJhOTAwZjE0NzdlLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:55 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/564e1934-fc4c-43d6-951c-f1f85c95b449/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzlkMjY2ZGQ3LTA4Y2UtNDc2ZS1iYjFjLWRlZDZhNDI0Zjg4
+        Ni8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a3d9cadf9c8244fb9f629064c86521fd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjMTMwZjIxLWQwYWItNGNh
+        ZS05OWI0LTQ4Y2EwMjFlNTY1MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/1c130f21-d0ab-4cae-99b4-48ca021e5651/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a74e250199d945d59c8eeaca1f704372
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWMxMzBmMjEtZDBh
+        Yi00Y2FlLTk5YjQtNDhjYTAyMWU1NjUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTUuNDcyMzk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhM2Q5Y2FkZjljODI0NGZiOWY2
+        MjkwNjRjODY1MjFmZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4
+        OjU1LjUxNDY0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6
+        NTUuNjIxNDE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzU2NGUxOTM0LWZjNGMtNDNkNi05NTFjLWYxZjg1Yzk1YjQ0OS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU2NGUxOTM0LWZjNGMt
+        NDNkNi05NTFjLWYxZjg1Yzk1YjQ0OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:55 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/dde2e9cb-d621-4b19-97b0-edba38ac0c6a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRkNWRlNWM1MGU0NGQ2
+        ODU1MjY5NWJlMTU5NDEwMjA3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtOTIzNS1idjlwZHMiDQpDb250ZW50LUxlbmd0aDogNzQwDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1UcmFu
+        c2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCnsidW5pdF9rZXkiOiB7ImlkIjog
+        InRlc3QifSwgInVuaXRfbWV0YWRhdGEiOiB7InN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTItNy0yNSAwMDowMDowMCIsICJkZXNjcmlwdGlv
+        biI6IG51bGwsICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxw
+        LWxpc3RAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
+        VGVzdCBFcnJhdGEgcmVmZXJyaW5nIHRvIHRlc3QtcGFja2FnZS0wLjIiLCAi
+        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlbGVhc2UiOiAiIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5oYW5jZW1lbnRzIiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEu
+        ZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhY2thZ2UiLCAic3VtIjog
+        WyJtZDUiLCAiNWI1OTBjYzk1ZmRmZjE0NTYwMDM0YTFmMzM0YTQ3NTMiXSwg
+        ImZpbGVuYW1lIjogInRlc3QtcGFja2FnZS0wLjItMS5lbDYubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2Ui
+        OiAiMS5lbDYiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIlB1bHAg
+        VGVzdCBQYWNrYWdlcyIsICJzaG9ydCI6ICJUZXN0Q29sbGVjdGlvbiJ9XX19
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZGQ1ZGU1YzUwZTQ0
+        ZDY4NTUyNjk1YmUxNTk0MTAyMDctLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-dd5de5c50e44d68552695be159410207
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1059'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 23d882f46eee44eea260cc728040877c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9kZGUyZTljYi1k
+        NjIxLTRiMTktOTdiMC1lZGJhMzhhYzBjNmEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToyMjowNy4zMTA2MjBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:07 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/dde2e9cb-d621-4b19-97b0-edba38ac0c6a/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8011e22d9c1c43deb981409d51ea582d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjMDVkMjE1LWU1ZmYtNDVl
+        NC05ZGZjLTQyODBmYjk1ZWYwYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6c05d215-e5ff-45e4-9dfc-4280fb95ef0c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9b6bc07f7665495eb8e01142c7404237
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMwNWQyMTUtZTVm
+        Zi00NWU0LTlkZmMtNDI4MGZiOTVlZjBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDcuNDE1MzYxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI4MDExZTIyZDljMWM0M2RlYjk4MTQwOWQ1MWVhNTgy
+        ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIyOjA3LjQ2MjA3MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6MDcuNTM2NTkzWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzZkZWFhYjMtODE4My00YTBiLWI3
+        YjgtZjY5NDBkNGY0NGQ4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2RkZTJlOWNiLWQ2MjEtNGIxOS05
+        N2IwLWVkYmEzOGFjMGM2YS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b1b000f1-0157-4f16-a69b-48f0b983288c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4bbfd82e812849db8090fbf632a9c28a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjFiMDAwZjEtMDE1
+        Ny00ZjE2LWE2OWItNDhmMGI5ODMyODhjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDcuNjQ5NDYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJjYWY5NTYwNGE2YWY0ODNhOGQyNzRjYWQ4
+        NTg3YWY3ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIyOjA3LjY5
+        MTQwMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6MDcuODAy
+        NjU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvOTFhODA2
+        MzEtYjkxZi00NzA5LWI1YzItYjZjYWI3MDUxMTY4LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzZk
+        ZWFhYjMtODE4My00YTBiLWI3YjgtZjY5NDBkNGY0NGQ4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:07 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/53e2923c-3303-43fd-a87b-5f852c816572/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzkxYTgwNjMxLWI5MWYtNDcwOS1iNWMyLWI2Y2FiNzA1MTE2
+        OC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 392d2f297f1b4642aa49874d9a837f61
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwOTg0N2MxLWI0NTMtNGJm
+        Ny1iYjkyLWY4Y2I0NTcyOWE1Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/109847c1-b453-4bf7-bb92-f8cb45729a57/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 233c210207e94af499e6888341153733
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTA5ODQ3YzEtYjQ1
+        My00YmY3LWJiOTItZjhjYjQ1NzI5YTU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDcuOTQ0MDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOTJkMmYyOTdmMWI0NjQyYWE0
+        OTg3NGQ5YTgzN2Y2MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIy
+        OjA3Ljk5MzkxN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6
+        MDguMDg2OTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzUzZTI5MjNjLTMzMDMtNDNmZC1hODdiLTVmODUyYzgxNjU3Mi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzUzZTI5MjNjLTMzMDMt
+        NDNmZC1hODdiLTVmODUyYzgxNjU3Mi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:08 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/343c8f8d-560e-41ff-b9ba-dae13f988c2c/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRmZDJmMDZjYTU4OWU4
+        N2I2Mzg3MDdkZmM1OTdmNWI4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtOTg1Mi0xZWtlaXluIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRmZDJmMDZjYTU4
+        OWU4N2I2Mzg3MDdkZmM1OTdmNWI4LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-dfd2f06ca589e87b638707dfc597f5b8
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 53e5be7812c34c9598fca8981fff74b0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8zNDNjOGY4ZC01
+        NjBlLTQxZmYtYjliYS1kYWUxM2Y5ODhjMmMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMDowNS40NjI1NDBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:05 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/343c8f8d-560e-41ff-b9ba-dae13f988c2c/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8ce8f40abf044fc8954af8c3fc02b570
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5MjU0NzczLTZjN2EtNGIw
+        Zi1hNWQzLTEyYjU4ZDc0YjRiOC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/59254773-6c7a-4b0f-a5d3-12b58d74b4b8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e9b11c4946414cf8b1177ea2a2f9232d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTkyNTQ3NzMtNmM3
+        YS00YjBmLWE1ZDMtMTJiNThkNzRiNGI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDUuNTUwMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI4Y2U4ZjQwYWJmMDQ0ZmM4OTU0YWY4YzNmYzAyYjU3
+        MCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMwOjA1LjU5MDA2Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6MDUuNjU1NTgwWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjkzNTEyNTYtYTRmZS00YWIyLTg5
+        ZmYtOWU2OGNjYjEwZTE5LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzM0M2M4ZjhkLTU2MGUtNDFmZi1i
+        OWJhLWRhZTEzZjk4OGMyYy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/dbba23c8-73cd-484d-b135-e12d6cdda8a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8e6e0bdbaac54d08b70b313b33af842e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGJiYTIzYzgtNzNj
+        ZC00ODRkLWIxMzUtZTEyZDZjZGRhOGEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDUuNzQ5OTI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4YTZiOGUzZTZlZDA0NWQ1YTc4YzY3Yzg1
+        YTBhNmRiZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMwOjA1Ljc5
+        MDQ3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6MDUuOTAw
+        ODgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYWU5YTAx
+        NTYtNDM3NC00NTIzLThhNTQtMzhhMDY0YzRlOWQ3LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjkz
+        NTEyNTYtYTRmZS00YWIyLTg5ZmYtOWU2OGNjYjEwZTE5LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:06 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/b9124b62-cc57-4158-a66e-7f1106006f56/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2FlOWEwMTU2LTQzNzQtNDUyMy04YTU0LTM4YTA2NGM0ZTlk
+        Ny8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 913fbd748ae24007a27b6e76bd200444
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlNjQ3OGYyLTY1OWMtNDM2
+        NS1iMzgzLTk5YjU1ZmJmYWQxNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ae6478f2-659c-4365-b383-99b55fbfad16/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7a9c4e31aebf43e287bc2ed893de41b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWU2NDc4ZjItNjU5
+        Yy00MzY1LWIzODMtOTliNTVmYmZhZDE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDYuMDcyNTE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5MTNmYmQ3NDhhZTI0MDA3YTI3
+        YjZlNzZiZDIwMDQ0NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMw
+        OjA2LjEyNTU4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6
+        MDYuMjExMzk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2I5MTI0YjYyLWNjNTctNDE1OC1hNjZlLTdmMTEwNjAwNmY1Ni92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2I5MTI0YjYyLWNjNTct
+        NDE1OC1hNjZlLTdmMTEwNjAwNmY1Ni8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:06 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/53e92852-f058-48fc-bedc-8543179eaa0c/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYwYWU3OGE2NTkxY2Fh
+        NjIyYWI5ZWMyN2NiYTZjN2I4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTAxMzAtNXhsZndiIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYwYWU3OGE2NTkx
+        Y2FhNjIyYWI5ZWMyN2NiYTZjN2I4LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-60ae78a6591caa622ab9ec27cba6c7b8
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 152061c792bd4a1c92dc02007fe91895
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81M2U5Mjg1Mi1m
+        MDU4LTQ4ZmMtYmVkYy04NTQzMTc5ZWFhMGMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMjoxMC4wMTY5NzVaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/53e92852-f058-48fc-bedc-8543179eaa0c/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 4044e85ec6dd48a6b3abdfa45ba4e92d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAzNWZkNTFjLTg0OGYtNDJk
+        Yy04NmYyLTBkMzEzZjNkNDZmYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/035fd51c-848f-42dc-86f2-0d313f3d46fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 98b57f326c4a47e2b0c9efa121e9ed00
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDM1ZmQ1MWMtODQ4
+        Zi00MmRjLTg2ZjItMGQzMTNmM2Q0NmZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTAuMTA1NTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI0MDQ0ZTg1ZWM2ZGQ0OGE2YjNhYmRmYTQ1YmE0ZTky
+        ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMyOjEwLjE0NTU3M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6MTAuMjIyNjc3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDhmZDkwMTEtNDJjOC00ZWMyLWEy
+        NDgtYzE3ZTcyZjQwMjU4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzUzZTkyODUyLWYwNTgtNDhmYy1i
+        ZWRjLTg1NDMxNzllYWEwYy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/197af3d7-6099-4466-8ced-4a12052798c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 808304e242964ee8b3982e26bb927ef2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTk3YWYzZDctNjA5
+        OS00NDY2LThjZWQtNGExMjA1Mjc5OGM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTAuMzU4MjI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2ZTU4MTgzOWUxZWU0NjIxOTAyMjIyYzUy
+        NDMzMTk1OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMyOjEwLjQw
+        MzU5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6MTAuNTE4
+        OTQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMjVlOWE2
+        ZGQtOGQxNi00YzE4LWIwMzItMzY2NThkNzZjMTcyLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDhm
+        ZDkwMTEtNDJjOC00ZWMyLWEyNDgtYzE3ZTcyZjQwMjU4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/9b99c35c-5a15-41da-b554-dc8af7fdf1d0/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzI1ZTlhNmRkLThkMTYtNGMxOC1iMDMyLTM2NjU4ZDc2YzE3
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8a7374127f61420893885547d04c99e0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA2OWQwN2EyLTlmNDEtNGE4
+        OS1iYzcwLTFlMjY5YzQwNjZlNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/069d07a2-9f41-4a89-bc70-1e269c4066e6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - eceb8e9ad04a4ef48e6c3b5fe1608703
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDY5ZDA3YTItOWY0
+        MS00YTg5LWJjNzAtMWUyNjljNDA2NmU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTAuNjM0MTQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4YTczNzQxMjdmNjE0MjA4OTM4
+        ODU1NDdkMDRjOTllMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMy
+        OjEwLjY4MTE2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6
+        MTAuNzcxOTUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzliOTljMzVjLTVhMTUtNDFkYS1iNTU0LWRjOGFmN2ZkZjFkMC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzliOTljMzVjLTVhMTUt
+        NDFkYS1iNTU0LWRjOGFmN2ZkZjFkMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:10 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/99951285-c080-4c62-b1ef-b94799ecd910/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI0ZGEwZGU4ODg2N2Rm
+        NDliYWViMjBkYThkNGIyMjg2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTAzOTMteDNuZnJrIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI0ZGEwZGU4ODg2
+        N2RmNDliYWViMjBkYThkNGIyMjg2LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-24da0de88867df49baeb20da8d4b2286
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 060753002e1643789bff1b12ad0b3c31
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy85OTk1MTI4NS1j
+        MDgwLTRjNjItYjFlZi1iOTQ3OTllY2Q5MTAvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMzozMS4xMTQwNzRaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/99951285-c080-4c62-b1ef-b94799ecd910/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 42cce4a0b9894a179bc792b282b5155d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUxODM3YzBhLTc0NmUtNDA1
+        Yi1hYmE5LTdlNTI4NDYyMTI2Yy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/51837c0a-746e-405b-aba9-7e528462126c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 34b0b10a42bf4505a7883964bad2dc89
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTE4MzdjMGEtNzQ2
+        ZS00MDViLWFiYTktN2U1Mjg0NjIxMjZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzEuMjA1MDU4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI0MmNjZTRhMGI5ODk0YTE3OWJjNzkyYjI4MmI1MTU1
+        ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMzOjMxLjI0NTc5Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6MzEuMzAwOTE3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTY4NzA4ZDEtN2M5YS00MDRmLTg2
+        NWYtNjdhNTVkMzQxYjE4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzk5OTUxMjg1LWMwODAtNGM2Mi1i
+        MWVmLWI5NDc5OWVjZDkxMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/d10d550f-6783-43a6-a6ac-87162039cd31/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2c7e00aac7d047efbe6ffd10591688c6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDEwZDU1MGYtNjc4
+        My00M2E2LWE2YWMtODcxNjIwMzljZDMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzEuNDA0MDQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlYjFmOTYzOWY5OWE0Yjc1ODlkMDEwMmEy
+        Mjk2ZDE0MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMzOjMxLjQ0
+        NTYwNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6MzEuNTYy
+        OTc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMzRkYzIx
+        MzQtYzgxMi00ODQwLWFiOWYtNmJhNjA3NTAzMjQ3LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTY4
+        NzA4ZDEtN2M5YS00MDRmLTg2NWYtNjdhNTVkMzQxYjE4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/5ad2568d-bf7d-43e1-b1e3-d85b7d654ea4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzM0ZGMyMTM0LWM4MTItNDg0MC1hYjlmLTZiYTYwNzUwMzI0
+        Ny8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 20c655314ead40ebb43317ed33f8df48
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1ZTZhMDY3LWMxNjYtNGEy
+        Yy04YzFiLTZmYTc2MzZiN2ZmNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/05e6a067-c166-4a2c-8c1b-6fa7636b7ff4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - d838ec5a2394421f947323bfc1a8afe7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDVlNmEwNjctYzE2
+        Ni00YTJjLThjMWItNmZhNzYzNmI3ZmY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzEuNjc4MTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMGM2NTUzMTRlYWQ0MGViYjQz
+        MzE3ZWQzM2Y4ZGY0OCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMz
+        OjMxLjc0NzY1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6
+        MzEuODc0NTUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzVhZDI1NjhkLWJmN2QtNDNlMS1iMWUzLWQ4NWI3ZDY1NGVhNC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVhZDI1NjhkLWJmN2Qt
+        NDNlMS1iMWUzLWQ4NWI3ZDY1NGVhNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:31 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5b9c7c21-ad08-41b2-bcb8-9aa71f4a8087/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTEzYzdlOGYyMWIxNWQ3
+        NDdlNWEyNjBiMGExYjgzNGI3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTI1NDYtZGp3NDEiDQpDb250ZW50LUxlbmd0aDogNzQwDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1UcmFu
+        c2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCnsidW5pdF9rZXkiOiB7ImlkIjog
+        InRlc3QifSwgInVuaXRfbWV0YWRhdGEiOiB7InN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTItNy0yNSAwMDowMDowMCIsICJkZXNjcmlwdGlv
+        biI6IG51bGwsICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxw
+        LWxpc3RAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
+        VGVzdCBFcnJhdGEgcmVmZXJyaW5nIHRvIHRlc3QtcGFja2FnZS0wLjIiLCAi
+        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlbGVhc2UiOiAiIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5oYW5jZW1lbnRzIiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEu
+        ZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhY2thZ2UiLCAic3VtIjog
+        WyJtZDUiLCAiNWI1OTBjYzk1ZmRmZjE0NTYwMDM0YTFmMzM0YTQ3NTMiXSwg
+        ImZpbGVuYW1lIjogInRlc3QtcGFja2FnZS0wLjItMS5lbDYubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2Ui
+        OiAiMS5lbDYiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIlB1bHAg
+        VGVzdCBQYWNrYWdlcyIsICJzaG9ydCI6ICJUZXN0Q29sbGVjdGlvbiJ9XX19
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMTNjN2U4ZjIxYjE1
+        ZDc0N2U1YTI2MGIwYTFiODM0YjctLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-13c7e8f21b15d747e5a260b0a1b834b7
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1059'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 40a56233fc484dce9fe4cb19892f8d11
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81YjljN2MyMS1h
+        ZDA4LTQxYjItYmNiOC05YWE3MWY0YTgwODcvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMzo1ODoxNS44MTIxNTlaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:15 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5b9c7c21-ad08-41b2-bcb8-9aa71f4a8087/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - ab751ebe429742938d9e9323529c7710
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkNTJiYzU2LWVkNTctNDdk
+        Mi1iOGViLWEyZTE4OWQzMmEwYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/dd52bc56-ed57-47d2-b8eb-a2e189d32a0c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 96d63e478af64ebc90f2b58bde2efdee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGQ1MmJjNTYtZWQ1
+        Ny00N2QyLWI4ZWItYTJlMTg5ZDMyYTBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTUuOTAxNDk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJhYjc1MWViZTQyOTc0MjkzOGQ5ZTkzMjM1MjljNzcx
+        MCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4OjE1Ljk0NzkxNVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6MTYuMDMwNzc4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjEwZWFlMjEtYzNhNi00NjM1LTk3
+        YzYtMWMxMDQ1ZmFhMGEzLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzViOWM3YzIxLWFkMDgtNDFiMi1i
+        Y2I4LTlhYTcxZjRhODA4Ny8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/22fa9069-78f2-4e69-bf60-2b2dbdbf90c9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 07fdfcf8f88444d6b5deff8e1bdd58f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjJmYTkwNjktNzhm
+        Mi00ZTY5LWJmNjAtMmIyZGJkYmY5MGM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTYuMTY5NTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4OGQ0YjZiZmE0ZTY0OTczODU4YTU5OWE1
+        MDg2NzY0NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4OjE2LjIw
+        ODI3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6MTYuMzI3
+        MjY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZjZhODAx
+        ODktYzBiMC00ZDkyLTkxM2MtNTMzOWNjNThmNzNkLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjEw
+        ZWFlMjEtYzNhNi00NjM1LTk3YzYtMWMxMDQ1ZmFhMGEzLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:16 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/6590c292-4a40-411e-a941-9eae08bf3778/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2Y2YTgwMTg5LWMwYjAtNGQ5Mi05MTNjLTUzMzljYzU4Zjcz
+        ZC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7d749babfd8c42508ffedf5fa8afa3f5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkNmU3Nzk3LTI1YjctNDBm
+        Mi1iOTI0LTA2ZDhmYzkwNTZlMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6d6e7797-25b7-40f2-b924-06d8fc9056e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 5fe9892d8c04434ba6a51911ef92b301
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQ2ZTc3OTctMjVi
+        Ny00MGYyLWI5MjQtMDZkOGZjOTA1NmUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTYuNDQyNDQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZDc0OWJhYmZkOGM0MjUwOGZm
+        ZWRmNWZhOGFmYTNmNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4
+        OjE2LjQ4ODMzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6
+        MTYuNTc3MTY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzY1OTBjMjkyLTRhNDAtNDExZS1hOTQxLTllYWUwOGJmMzc3OC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzY1OTBjMjkyLTRhNDAt
+        NDExZS1hOTQxLTllYWUwOGJmMzc3OC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:16 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/a10e5c0f-abf3-4a4d-8ba5-7cfa6aada42d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTc3MWI2MWM3YjY3YWNj
+        Yjk2NTQ1MmQ1MjAyMjhhNGY0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTItMTI5MDQtNndpMGNiIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTc3MWI2MWM3YjY3
+        YWNjYjk2NTQ1MmQ1MjAyMjhhNGY0LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-771b61c7b67accb965452d520228a4f4
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - af614d430c5741ba8f7cad6898f0bddb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9hMTBlNWMwZi1h
+        YmYzLTRhNGQtOGJhNS03Y2ZhNmFhZGE0MmQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMlQwMDowMDo0My4xMTk2MjZaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/a10e5c0f-abf3-4a4d-8ba5-7cfa6aada42d/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a383cf15515a4c4eb4783d65d3c6b75e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0MDcyMzMyLTUyNWItNDM0
+        MC05MmQxLWMyNjFmYTNiNTA4Zi8ifQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/44072332-525b-4340-92d1-c261fa3b508f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0a89ce2fbd024362a1c199f1c1c12b3a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDQwNzIzMzItNTI1
+        Yi00MzQwLTkyZDEtYzI2MWZhM2I1MDhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDMuMjA4NjY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJhMzgzY2YxNTUxNWE0YzRlYjQ3ODNkNjVkM2M2Yjc1
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAwOjQzLjI0OTA0M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6NDMuMzA5Mzk0WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmI2MjMwMGEtNjI0My00YWQ1LWE1
+        ODktYTM4MDQyMDUyZmE5LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2ExMGU1YzBmLWFiZjMtNGE0ZC04
+        YmE1LTdjZmE2YWFkYTQyZC8iXX0=
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ae540f26-e891-4e82-a09b-84a30eed6a75/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4c6b069eab6147bbad8999cc406cb5f0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '401'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWU1NDBmMjYtZTg5
+        MS00ZTgyLWEwOWItODRhMzBlZWQ2YTc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDMuNDMxMDgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyZTIwMjBhMDcwZDQ0OWQ1ODliNWZhZmQ0
+        ZDUyZjdlZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAwOjQzLjQ3
+        MDk2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6NDMuNTc4
+        OTYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvN2I0ZGM3
+        ODctMWUzMy00ODVmLTk5YWEtZDhkNTBlNmQ0OTlhLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmI2
+        MjMwMGEtNjI0My00YWQ1LWE1ODktYTM4MDQyMDUyZmE5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/733d1fd2-3425-445c-b6e0-6c23f3868532/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzdiNGRjNzg3LTFlMzMtNDg1Zi05OWFhLWQ4ZDUwZTZkNDk5
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - dc09a41651e342b4b5bae320d8ecd0f6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0NTUxZmNhLTc0ZGUtNDc5
+        OS1hYTNmLTA5OTM4NTE0YjNiMS8ifQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b4551fca-74de-4799-aa3f-09938514b3b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 034cae5f255e40718a202141deddb647
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjQ1NTFmY2EtNzRk
+        ZS00Nzk5LWFhM2YtMDk5Mzg1MTRiM2IxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDMuNzEwMDE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYzA5YTQxNjUxZTM0MmI0YjVi
+        YWUzMjBkOGVjZDBmNiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAw
+        OjQzLjc2NjkwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6
+        NDMuODYzNzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzczM2QxZmQyLTM0MjUtNDQ1Yy1iNmUwLTZjMjNmMzg2ODUzMi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzczM2QxZmQyLTM0MjUt
+        NDQ1Yy1iNmUwLTZjMjNmMzg2ODUzMi8iXX0=
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - c675d14a3d8b451c8742665cef1d2cc2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - ce56434ee7aa4652a86decd62483ded8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/f81d09d1-a7d0-4b95-8e9d-da282b06082d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '130'
+      Correlation-Id:
+      - a6542ffd32fb406da9911efd4884958a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9mODFkMDlkMS1h
+        N2QwLTRiOTUtOGU5ZC1kYTI4MmIwNjA4MmQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xN1QxNToyODoyNC43OTU0OTdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/f81d09d1-a7d0-4b95-8e9d-da282b06082d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQ5Njc5ODgwMmE1NDcx
+        ODk4ZDQwOTE1ZjYwMWIyZGY5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTctMTE5MTQtN205NGoiDQpDb250ZW50LUxlbmd0aDogNzQwDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1UcmFu
+        c2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCnsidW5pdF9rZXkiOiB7ImlkIjog
+        InRlc3QifSwgInVuaXRfbWV0YWRhdGEiOiB7InN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTItNy0yNSAwMDowMDowMCIsICJkZXNjcmlwdGlv
+        biI6IG51bGwsICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxw
+        LWxpc3RAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
+        VGVzdCBFcnJhdGEgcmVmZXJyaW5nIHRvIHRlc3QtcGFja2FnZS0wLjIiLCAi
+        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlbGVhc2UiOiAiIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5oYW5jZW1lbnRzIiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEu
+        ZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhY2thZ2UiLCAic3VtIjog
+        WyJtZDUiLCAiNWI1OTBjYzk1ZmRmZjE0NTYwMDM0YTFmMzM0YTQ3NTMiXSwg
+        ImZpbGVuYW1lIjogInRlc3QtcGFja2FnZS0wLjItMS5lbDYubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2Ui
+        OiAiMS5lbDYiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIlB1bHAg
+        VGVzdCBQYWNrYWdlcyIsICJzaG9ydCI6ICJUZXN0Q29sbGVjdGlvbiJ9XX19
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZDk2Nzk4ODAyYTU0
+        NzE4OThkNDA5MTVmNjAxYjJkZjktLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-d96798802a5471898d40915f601b2df9
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1059'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 72171ec46af14a6ebf38ec2065e4d570
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9mODFkMDlkMS1h
+        N2QwLTRiOTUtOGU5ZC1kYTI4MmIwNjA4MmQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xN1QxNToyODoyNC43OTU0OTdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 6f353f60926a410fa0b16e63863b9a72
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/f81d09d1-a7d0-4b95-8e9d-da282b06082d/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 639c12767f924db69417d4ce85ea4195
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiY2VmYzEwLTNmMTYtNGRh
+        ZC04OTgwLTY2ZTA1NjZmZDc3Ny8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/4bcefc10-3f16-4dad-8980-66e0566fd777/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 42a662b0e4874a76b3af856a6cb92819
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGJjZWZjMTAtM2Yx
+        Ni00ZGFkLTg5ODAtNjZlMDU2NmZkNzc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjQuODg1NTQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI2MzljMTI3NjdmOTI0ZGI2OTQxN2Q0Y2U4NWVhNDE5
+        NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjI0LjkyODk0NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjQuOTg0Mjc2WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8z
+        NjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVlMWQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDQ0NmI3ZjItYTEyMy00MGFmLTk3
+        Y2UtMTVhY2Q3OTBiYTQ5LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2Y4MWQwOWQxLWE3ZDAtNGI5NS04
+        ZTlkLWRhMjgyYjA2MDgyZC8iXX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ff51055cce46408080cb2c5e1a3b4759
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '439'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDQ0
+        NmI3ZjItYTEyMy00MGFmLTk3Y2UtMTVhY2Q3OTBiYTQ5LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjQuOTU1ODYxWiIsImZpbGUiOiJh
+        cnRpZmFjdC9lZi8wYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
+        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNpemUiOjc0MCwibWQ1
+        IjpudWxsLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFi
+        OGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2
+        YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwic2hhMjU2Ijoi
+        ZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJk
+        NWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUyOGQyMTEwZDgw
+        NjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNh
+        OGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUx
+        MiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3
+        ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIy
+        ZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1d
+        fQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTk2ODdjYmIwNzVmNzJh
+        NmJlNzIwMmUzY2MwZTQxOGFjDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtOTY4N2NiYjA3
+        NWY3MmE2YmU3MjAyZTNjYzBlNDE4YWMNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMDQ0NmI3ZjItYTEyMy00MGFmLTk3Y2UtMTVhY2Q3OTBiYTQ5
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTk2ODdjYmIwNzVm
+        NzJhNmJlNzIwMmUzY2MwZTQxOGFjLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-9687cbb075f72a6be7202e3cc0e418ac
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 0c94c8cb731e4f6eb2c014d797f3521a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwYWVhOWQ2LTM3MGUtNDBk
+        ZS1iODJkLTAzOGM4ZDEzNzAxMi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/20aea9d6-370e-40de-b82d-038c8d137012/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 01feb0a83acd4b5ea4c7e3fc4014d167
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjBhZWE5ZDYtMzcw
+        ZS00MGRlLWI4MmQtMDM4YzhkMTM3MDEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjUuMDkwMzM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYzk0YzhjYjczMWU0ZjZlYjJjMDE0ZDc5
+        N2YzNTIxYSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjI1LjEz
+        Nzc2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjUuMjM1
+        ODc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wMjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3ZDMvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMWYxNDM4
+        NzgtZGJiYi00NjRlLTgyOGQtMjBkNDgwZGZmOGQxLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDQ0
+        NmI3ZjItYTEyMy00MGFmLTk3Y2UtMTVhY2Q3OTBiYTQ5LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/79f67fa5-5435-43f1-bc9b-58f4541ee5ff/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzFmMTQzODc4LWRiYmItNDY0ZS04MjhkLTIwZDQ4MGRmZjhk
+        MS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5eb3e8058f544d6c99908c356061bba3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyNGU1ZWYzLTc1NDAtNGI4
+        YS05MWM4LTQ2ZGNlNDlhNWEyZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/724e5ef3-7540-4b8a-91c8-46dce49a5a2e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4bf3d7d7bbc74dfab52831f33c8704b0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzI0ZTVlZjMtNzU0
+        MC00YjhhLTkxYzgtNDZkY2U0OWE1YTJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjUuMzQ5MDg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZWIzZTgwNThmNTQ0ZDZjOTk5
+        MDhjMzU2MDYxYmJhMyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4
+        OjI1LjM5MzMzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6
+        MjUuNDg3MDMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8wMjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3
+        ZDMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzc5ZjY3ZmE1LTU0MzUtNDNmMS1iYzliLTU4ZjQ1NDFlZTVmZi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ZjY3ZmE1LTU0MzUt
+        NDNmMS1iYzliLTU4ZjQ1NDFlZTVmZi8iXX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
@@ -3128,4 +3128,2359 @@ http_interactions:
         ZWFiLTQ2ZTMtOGNlZC1hYmQ2ODBhNDY1ZjkvIl19
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:20 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/76384d95-12b7-4636-ab7c-f38da3f18914/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzdmYTExMmQ2LTdjYjUtNDgzYy1hYTQ2LTAzYzNjYmE0NzU0
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 4a22071d9bad40dd81781b61bd585b4f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzMTdiYTA4LTU0MzMtNGFh
+        OC1hZjQ2LTI3ZTU3ZDhmOWQ4MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b317ba08-5433-4aa8-af46-27e57d8f9d81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - fec6c35f0bed4f78a0dfd9326ab27b3f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjMxN2JhMDgtNTQz
+        My00YWE4LWFmNDYtMjdlNTdkOGY5ZDgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzMuMjQ1OTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0YTIyMDcxZDliYWQ0MGRkODE3
+        ODFiNjFiZDU4NWI0ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUw
+        OjMzLjI5Nzk4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6
+        MzMuMzc5Mjc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83NjM4NGQ5NS0x
+        MmI3LTQ2MzYtYWI3Yy1mMzhkYTNmMTg5MTQvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a6bcd0c0fc8140e69278268859b420dd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '487'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMDc3YjM2NDktNTViOS00NzBjLTg5ZDMtM2I3MTYxODdjZjRlLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTA6MTcuNDY1MjAyWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wNmM5MTdlMi1k
+        M2M2LTQ4YmEtOTI0MC0zYmRmODRhYjlkZWQvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjpudWxsLCJzaGExIjoiNjA5ODg1
+        NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6
+        ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVh
+        ZDBkZjdhZDhlZDNjIiwic2hhMjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1
+        MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIs
+        InNoYTM4NCI6ImQzYzUyOGQyMTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFk
+        NDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1
+        YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFl
+        ODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdl
+        ODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAw
+        Nzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1dfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/9f182596-349a-42f6-a845-9840203a91aa/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzA3N2IzNjQ5LTU1YjktNDcwYy04OWQzLTNiNzE2MTg3Y2Y0
+        ZS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7875776e22364f8a8dd006b92c97960d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzZDA1MDgxLWE5ZmQtNDM5
+        ZS1hODJiLTk2ZDZmYmQ2ZTBlZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a3d05081-a9fd-439e-a82b-96d6fbd6e0ee/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a601b90149284a5584bf4ce45ff39707
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTNkMDUwODEtYTlm
+        ZC00MzllLWE4MmItOTZkNmZiZDZlMGVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6MDUuMDM2MzY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ODc1Nzc2ZTIyMzY0ZjhhOGRk
+        MDA2YjkyYzk3OTYwZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEx
+        OjA1LjA3NDM0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6
+        MDUuMTU2MjkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS85ZjE4MjU5Ni0z
+        NDlhLTQyZjYtYTg0NS05ODQwMjAzYTkxYWEvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/65696e73-5678-469c-80d5-db9a2f543420/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8803e4d07f77462f8374276c7ee36864
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '401'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjU2OTZlNzMtNTY3
+        OC00NjljLTgwZDUtZGI5YTJmNTQzNDIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjguMTQ4MDk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyOWVmMmUzYWE1Mzg0ZjM2YTNkMzY3M2Uz
+        YTU4ZDExYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1OjI4LjIw
+        NTEzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6MjguMzE0
+        NzcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYjM1NzVm
+        NDEtMmQ5OS00YjY5LWIxMzgtZWZlNjk3ZGIzNDZkLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDA0
+        ZTYwNTItMTFiYS00ODYyLTgyYzAtZWYzYmY0ZDI0ZWUxLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:28 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/3529b12c-7a41-484b-ba95-624222ace269/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2IzNTc1ZjQxLTJkOTktNGI2OS1iMTM4LWVmZTY5N2RiMzQ2
+        ZC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 98f71de115594ba482ddb5273aeeaa37
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5NTBlN2YwLTM2MzUtNDE1
+        Zi1hZTM0LTk3NGJkMzE2OTQyZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:28 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/c950e7f0-3635-415f-ae34-974bd316942e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 95aaaa096d1c44779a21988d719e8eb6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzk1MGU3ZjAtMzYz
+        NS00MTVmLWFlMzQtOTc0YmQzMTY5NDJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjguNDAyMzI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5OGY3MWRlMTE1NTk0YmE0ODJk
+        ZGI1MjczYWVlYWEzNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1
+        OjI4LjQ0MzE5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6
+        MjguNTQ0MDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzM1MjliMTJjLTdhNDEtNDg0Yi1iYTk1LTYyNDIyMmFjZTI2OS92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzM1MjliMTJjLTdhNDEt
+        NDg0Yi1iYTk1LTYyNDIyMmFjZTI2OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:28 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/dc3abbdd-5584-4214-9e90-04a2f70a0ca9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b3352df98328408bbc7b957d69ccc2db
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGMzYWJiZGQtNTU4
+        NC00MjE0LTllOTAtMDRhMmY3MGEwY2E5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTc6MTEuNDc1MDM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3Mzc5ZTY0MzViN2M0NjdlOTFmMjM0ZDg4
+        MDNkZWMzMSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE3OjExLjUx
+        NjQ5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTc6MTEuNjQx
+        MTg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYWMwYWY3
+        YmItY2M5My00NDhiLTkwN2UtMzY4NzVjMzliNGY4LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYzIx
+        MjU5ZjQtYTkyYS00OTMyLTgzM2YtMjlmNzU4ZDYwMzBkLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c9d1aae0-b857-41c4-99c6-2879f21df237/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2FjMGFmN2JiLWNjOTMtNDQ4Yi05MDdlLTM2ODc1YzM5YjRm
+        OC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 98413c14f91344a08b77bc90aa083b64
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzNDEzZmUwLThkZjEtNDdh
+        OC1hMjRkLTA1YWZkMzkzOGFlZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/53413fe0-8df1-47a8-a24d-05afd3938aef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:17:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a381f7f315d546859925572c93e65921
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTM0MTNmZTAtOGRm
+        MS00N2E4LWEyNGQtMDVhZmQzOTM4YWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTc6MTEuNzQxNTcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ODQxM2MxNGY5MTM0NGEwOGI3
+        N2JjOTBhYTA4M2I2NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE3
+        OjExLjc5MDU3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTc6
+        MTEuODk0Mjg0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2M5ZDFhYWUwLWI4NTctNDFjNC05OWM2LTI4NzlmMjFkZjIzNy92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M5ZDFhYWUwLWI4NTct
+        NDFjNC05OWM2LTI4NzlmMjFkZjIzNy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:17:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/933c1089-7b2a-4e11-a0bc-6d91dd3c1529/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b8953c3e27fe44e99104dfed3067191a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTMzYzEwODktN2Iy
+        YS00ZTExLWEwYmMtNmQ5MWRkM2MxNTI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTYuMzg2NzA5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhOGMwMGViMTAzZjQ0MDRiODU1MzcyNTUx
+        NDdkY2U1OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4OjU2LjQy
+        Njg5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6NTYuNTM0
+        MDcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZGRmZjQ2
+        NWYtMjllNy00MjlhLWFjODMtOGJmM2I4N2Y4MWQxLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjVh
+        ZGMzZTItYjkzYy00MDM1LWJmZTItYWJhOTAwZjE0NzdlLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/564e1934-fc4c-43d6-951c-f1f85c95b449/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2RkZmY0NjVmLTI5ZTctNDI5YS1hYzgzLThiZjNiODdmODFk
+        MS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8042a83cc74d45caac5e069abddb3afa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY0ODg3YzhiLTE1OWUtNGEy
+        ZS05NTU4LWU2MzUwYzk4OGFmMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/64887c8b-159e-4a2e-9558-e6350c988af0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2d0e6771ac6b4816b886327256327cd1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjQ4ODdjOGItMTU5
+        ZS00YTJlLTk1NTgtZTYzNTBjOTg4YWYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTYuNjU3MDMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4MDQyYTgzY2M3NGQ0NWNhYWM1
+        ZTA2OWFiZGRiM2FmYSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4
+        OjU2LjcwNzE2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6
+        NTYuODM1MzQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzU2NGUxOTM0LWZjNGMtNDNkNi05NTFjLWYxZjg1Yzk1YjQ0OS92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU2NGUxOTM0LWZjNGMt
+        NDNkNi05NTFjLWYxZjg1Yzk1YjQ0OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6d240880-374b-4dd5-b4fc-4ce3693668cd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a583c730edb846da870a5823ae6620d2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmQyNDA4ODAtMzc0
+        Yi00ZGQ1LWI0ZmMtNGNlMzY5MzY2OGNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDguOTI3OTQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyYThlZTk4NWZhOTQ0ODMwYWNiYzRhZDI5
+        NzM3ZGM4ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIyOjA4Ljk3
+        NDEyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6MDkuMDgy
+        NzU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYWEzZTk5
+        OGEtMWJkOC00NzdhLTkxMTQtYzAwYjkzZDY0MmU5LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzZk
+        ZWFhYjMtODE4My00YTBiLWI3YjgtZjY5NDBkNGY0NGQ4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:09 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/53e2923c-3303-43fd-a87b-5f852c816572/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2FhM2U5OThhLTFiZDgtNDc3YS05MTE0LWMwMGI5M2Q2NDJl
+        OS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 2181a0b82bb74d0daea317a7ae5294ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzMjE4NTFjLWMxYTItNDRj
+        OC1iMzc4LTkwNzNhNWY4MjBhOC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:09 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e321851c-c1a2-44c8-b378-9073a5f820a8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 27c0f65d3c0443c0b47a9920c52eee13
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTMyMTg1MWMtYzFh
+        Mi00NGM4LWIzNzgtOTA3M2E1ZjgyMGE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDkuMjEwNDAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMTgxYTBiODJiYjc0ZDBkYWVh
+        MzE3YTdhZTUyOTRhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIy
+        OjA5LjI1NjEwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6
+        MDkuMzg1NjA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzUzZTI5MjNjLTMzMDMtNDNmZC1hODdiLTVmODUyYzgxNjU3Mi92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzUzZTI5MjNjLTMzMDMt
+        NDNmZC1hODdiLTVmODUyYzgxNjU3Mi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:09 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f2e71d40-47f9-497e-b16c-3c46da6f4540/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0e2dfa4f7c82441f8d4145157473529f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '401'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjJlNzFkNDAtNDdm
+        OS00OTdlLWIxNmMtM2M0NmRhNmY0NTQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDcuMDMzNDk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI3OTkyODEwNTk5Y2M0Y2Q0YjgwMTMwYjg2
+        YzFkMjM2MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMwOjA3LjA4
+        MTM5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6MDcuMjAx
+        OTQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNjRlZjA2
+        ZDEtY2ViYy00NWMwLWEyMjYtN2RkNjViMDQ5NWU4LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjkz
+        NTEyNTYtYTRmZS00YWIyLTg5ZmYtOWU2OGNjYjEwZTE5LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:07 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/b9124b62-cc57-4158-a66e-7f1106006f56/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzY0ZWYwNmQxLWNlYmMtNDVjMC1hMjI2LTdkZDY1YjA0OTVl
+        OC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8e83b9f75f3b4573b601153d6e840d5f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxOWYyYTFjLWQ0ZmUtNGQz
+        Yi04ZDRmLTYxOTBjY2VkZTUwZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/919f2a1c-d4fe-4d3b-8d4f-6190ccede50f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f4338e8472bc4939ad73fea4372e7efe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTE5ZjJhMWMtZDRm
+        ZS00ZDNiLThkNGYtNjE5MGNjZWRlNTBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDcuMzMxNzg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4ZTgzYjlmNzVmM2I0NTczYjYw
+        MTE1M2Q2ZTg0MGQ1ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMw
+        OjA3LjM3NTk5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6
+        MDcuNTU3Nzg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2I5MTI0YjYyLWNjNTctNDE1OC1hNjZlLTdmMTEwNjAwNmY1Ni92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2I5MTI0YjYyLWNjNTct
+        NDE1OC1hNjZlLTdmMTEwNjAwNmY1Ni8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/d41c2d25-63b1-42e3-b45d-aa1c46898ca9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 22881131af054c73ae0d16dd5214e9fa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '401'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDQxYzJkMjUtNjNi
+        MS00MmUzLWI0NWQtYWExYzQ2ODk4Y2E5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTEuNDU2OTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYzI5NjgyZGFiNTE0OTUwOTJhMjUxYjY2
+        OTRlZjMwNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMyOjExLjQ5
+        NzMzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6MTEuNjI5
+        NjQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNTZiOWJi
+        NGUtNDNiZS00ZmY4LWJjNjYtM2IzYzM2NTA3ZTllLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDhm
+        ZDkwMTEtNDJjOC00ZWMyLWEyNDgtYzE3ZTcyZjQwMjU4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/9b99c35c-5a15-41da-b554-dc8af7fdf1d0/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzU2YjliYjRlLTQzYmUtNGZmOC1iYzY2LTNiM2MzNjUwN2U5
+        ZS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 75689420276346919b370ff6dd163f2c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxMjdmOTAwLWQ5NzMtNGZk
+        Zi05MDBlLTJmNGIzNmYyNDdkNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/8127f900-d973-4fdf-900e-2f4b36f247d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - d37dd546f48e4be19923f82d044a4265
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODEyN2Y5MDAtZDk3
+        My00ZmRmLTkwMGUtMmY0YjM2ZjI0N2Q3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTEuNzIyMTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3NTY4OTQyMDI3NjM0NjkxOWIz
+        NzBmZjZkZDE2M2YyYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMy
+        OjExLjc2MzQ0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6
+        MTEuODY1MzU1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzliOTljMzVjLTVhMTUtNDFkYS1iNTU0LWRjOGFmN2ZkZjFkMC92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzliOTljMzVjLTVhMTUt
+        NDFkYS1iNTU0LWRjOGFmN2ZkZjFkMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/8a229e72-44fa-4dad-96ee-477ed7b53482/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - d3088194c8bb44a9aae3fe727c961d9d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGEyMjllNzItNDRm
+        YS00ZGFkLTk2ZWUtNDc3ZWQ3YjUzNDgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzIuNjUzNDQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NmM0NDEyMTkxMjI0ZTM4OTdhNGI4MDQ1
+        YzE3MzU4NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMzOjMyLjY5
+        ODg2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6MzIuODM3
+        Nzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvOGNhMzMx
+        MzktOWU5My00MzcxLTlkODQtMjA0MDJiZjRiMDdiLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTY4
+        NzA4ZDEtN2M5YS00MDRmLTg2NWYtNjdhNTVkMzQxYjE4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:32 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b7e86859-ac69-4c44-a743-393644c46b94/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - dd75e7dfd6af4d5192517037c5a28ddb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjdlODY4NTktYWM2
+        OS00YzQ0LWE3NDMtMzkzNjQ0YzQ2Yjk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzIuOTM1MTI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0MzU2NWM1ODg4MzA0OWRhYjkz
+        MDdjYTgwNjJjNDI0ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMz
+        OjMyLjk3OTk5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6
+        MzMuMDg2MTU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzVhZDI1NjhkLWJmN2QtNDNlMS1iMWUzLWQ4NWI3ZDY1NGVhNC92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVhZDI1NjhkLWJmN2Qt
+        NDNlMS1iMWUzLWQ4NWI3ZDY1NGVhNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:33 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/5ad2568d-bf7d-43e1-b1e3-d85b7d654ea4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzhjYTMzMTM5LTllOTMtNDM3MS05ZDg0LTIwNDAyYmY0YjA3
+        Yi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7dd24d3641724353a1c4eb787c7d66d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxNDUyMjcwLTk2NmEtNGUw
+        MC05ZmFhLTNhZTllZGNkOWM3NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/81452270-966a-4e00-9faa-3ae9edcd9c74/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6a3e6e2a73c6450090213c8d1b94ff40
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODE0NTIyNzAtOTY2
+        YS00ZTAwLTlmYWEtM2FlOWVkY2Q5Yzc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MzMuNjY5MDcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3ZGQyNGQzNjQxNzI0MzUzYTFj
+        NGViNzg3YzdkNjZkOSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMz
+        OjMzLjczMTMyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6
+        MzMuODEzMzQyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS81YWQyNTY4ZC1i
+        ZjdkLTQzZTEtYjFlMy1kODViN2Q2NTRlYTQvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e5f58015-94e8-4102-b463-f5bf3935dd2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c80661dc14c046d5a0656947ae71771d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVmNTgwMTUtOTRl
+        OC00MTAyLWI0NjMtZjViZjM5MzVkZDJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTcuMzE5MzMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmNjRhZGZmZjA2MDE0NmQyODY0OGMxOTE1
+        ZWU0N2ZlNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4OjE3LjM1
+        ODkzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6MTcuNDY0
+        NDMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMmE2ZGQy
+        NDAtOTExOS00MzBiLThjMzQtNzYwOTc1ZjkwY2JiLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjEw
+        ZWFlMjEtYzNhNi00NjM1LTk3YzYtMWMxMDQ1ZmFhMGEzLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/d5ae4908-56dc-4cc9-9b36-de6ba8b583c9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f09eea1ed6c84214ae79379b06e78a52
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDVhZTQ5MDgtNTZk
+        Yy00Y2M5LTliMzYtZGU2YmE4YjU4M2M5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTcuNTg2NjIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNWZjMzE3NzlmYmE0NzNiYTcx
+        MWJmOTgyNDg2YjgzZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4
+        OjE3LjY1MDA3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6
+        MTcuNzQ0MDI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzY1OTBjMjkyLTRhNDAtNDExZS1hOTQxLTllYWUwOGJmMzc3OC92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzY1OTBjMjkyLTRhNDAt
+        NDExZS1hOTQxLTllYWUwOGJmMzc3OC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/6590c292-4a40-411e-a941-9eae08bf3778/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzJhNmRkMjQwLTkxMTktNDMwYi04YzM0LTc2MDk3NWY5MGNi
+        Yi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - f9ae259c1ca44fbbb91c6de649676962
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzODNjOGUxLTNhMWYtNDlj
+        YS1hYTc1LTA0OGI5M2UzMTA5OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2383c8e1-3a1f-49ca-aa75-048b93e31099/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1740bbc05f8146f88165ccc6b78f045f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjM4M2M4ZTEtM2Ex
+        Zi00OWNhLWFhNzUtMDQ4YjkzZTMxMDk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTguMjQ3MDQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmOWFlMjU5YzFjYTQ0ZmJiYjkx
+        YzZkZTY0OTY3Njk2MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4
+        OjE4LjI4NzU0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6
+        MTguNDA0MDI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82NTkwYzI5Mi00
+        YTQwLTQxMWUtYTk0MS05ZWFlMDhiZjM3NzgvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/59bec0f0-c3d7-4422-a49c-a48aae664312/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f6145d048d854be2b309736e9e69c29b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTliZWMwZjAtYzNk
+        Ny00NDIyLWE0OWMtYTQ4YWFlNjY0MzEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDQuNjkwNDMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NWU4NWY2ZGYzNjc0NGZlOTg0MDUzODhi
+        YjYyOTczZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAwOjQ0Ljc0
+        ODk2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6NDQuODcw
+        MjU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZDFhNzhj
+        MDQtZDM3My00OWIzLWE3ZWMtNmFjNGEzMzJmMjYyLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmI2
+        MjMwMGEtNjI0My00YWQ1LWE1ODktYTM4MDQyMDUyZmE5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:44 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/733d1fd2-3425-445c-b6e0-6c23f3868532/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2QxYTc4YzA0LWQzNzMtNDliMy1hN2VjLTZhYzRhMzMyZjI2
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 2a540f70e53045d79f4a2d7a8a858b02
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxOTBiZDhmLTJlMzgtNDJk
+        Yi05ZTFmLWE2OGRmOWVkYThmYi8ifQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:45 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6190bd8f-2e38-42db-9e1f-a68df9eda8fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 0e84d8e42e9c40548ab41be084432c53
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjE5MGJkOGYtMmUz
+        OC00MmRiLTllMWYtYTY4ZGY5ZWRhOGZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDQuOTkzMjQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyYTU0MGY3MGU1MzA0NWQ3OWY0
+        YTJkN2E4YTg1OGIwMiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAw
+        OjQ1LjAzNjM1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6
+        NDUuMTY2ODQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzczM2QxZmQyLTM0MjUtNDQ1Yy1iNmUwLTZjMjNmMzg2ODUzMi92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzczM2QxZmQyLTM0MjUt
+        NDQ1Yy1iNmUwLTZjMjNmMzg2ODUzMi8iXX0=
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:45 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 7b1deda2a8e049eea83be5d1126aefb8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 571bde65726c4c3c8ddcd81119581f53
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '439'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDQ0
+        NmI3ZjItYTEyMy00MGFmLTk3Y2UtMTVhY2Q3OTBiYTQ5LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjQuOTU1ODYxWiIsImZpbGUiOiJh
+        cnRpZmFjdC9lZi8wYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
+        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNpemUiOjc0MCwibWQ1
+        IjpudWxsLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFi
+        OGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2
+        YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwic2hhMjU2Ijoi
+        ZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJk
+        NWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUyOGQyMTEwZDgw
+        NjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNh
+        OGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUx
+        MiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3
+        ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIy
+        ZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1d
+        fQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWY1OWI4MjYyODRhOWZm
+        YjkyMGU4MTg2MDQ0N2FlNzM1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
+        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWY1OWI4MjYy
+        ODRhOWZmYjkyMGU4MTg2MDQ0N2FlNzM1DQpDb250ZW50LURpc3Bvc2l0aW9u
+        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzA0NDZiN2YyLWExMjMtNDBhZi05N2NlLTE1YWNkNzkwYmE0
+        OS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1mNTliODI2Mjg0
+        YTlmZmI5MjBlODE4NjA0NDdhZTczNS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-f59b826284a9ffb920e81860447ae735
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '386'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5720ad0d9bde4e58b98faa09637f23b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjNGY3MGJhLWFmNzctNGQx
+        MS1hZGM5LTUwYWNkOWZhMTg1NC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/8c4f70ba-af77-4d11-adc9-50acd9fa1854/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 73598b86d699415280d4fc42e87c2322
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGM0ZjcwYmEtYWY3
+        Ny00ZDExLWFkYzktNTBhY2Q5ZmExODU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjYuMTk0NjQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1NzIwYWQwZDliZGU0ZTU4Yjk4ZmFhMDk2
+        MzdmMjNiOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjI2LjI0
+        MjY2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MjYuMzUx
+        ODg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVlMWQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMjIxMmVj
+        NjEtNDAxZS00Y2M3LWI5NTktZjU2NTFjM2JlZGI4LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDQ0
+        NmI3ZjItYTEyMy00MGFmLTk3Y2UtMTVhY2Q3OTBiYTQ5LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/79f67fa5-5435-43f1-bc9b-58f4541ee5ff/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzIyMTJlYzYxLTQwMWUtNGNjNy1iOTU5LWY1NjUxYzNiZWRi
+        OC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - caf3801ba0a74b6ea31fed58e8c4ca45
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkMTYzYWQxLWU1OTctNDRh
+        OS1iMWUzLTQ2YzI2MDg4ZTEyNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/4d163ad1-e597-44a9-b1e3-46c26088e126/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - fb5ffe17f0934bf883b2a865ef34bfd4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGQxNjNhZDEtZTU5
+        Ny00NGE5LWIxZTMtNDZjMjYwODhlMTI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MjYuNDU5NTMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjYWYzODAxYmEwYTc0YjZlYTMx
+        ZmVkNThlOGM0Y2E0NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4
+        OjI2LjUwMjg3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6
+        MjYuNjAwMjQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVl
+        MWQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzc5ZjY3ZmE1LTU0MzUtNDNmMS1iYzliLTU4ZjQ1NDFlZTVmZi92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc5ZjY3ZmE1LTU0MzUt
+        NDNmMS1iYzliLTU4ZjQ1NDFlZTVmZi8iXX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:02 GMT
+      - Tue, 17 Aug 2021 15:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - d06c145c3c3744e196a61c391e28411a
+      - cce50108555b43159840834dc1de43a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:02 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:32 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:02 GMT
+      - Tue, 17 Aug 2021 15:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 7fd2a47fb7f1412e93b88f44ab3fce69
+      - 3bb42c80e6c74a9b8f2363f69c987f2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:02 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:32 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:02 GMT
+      - Tue, 17 Aug 2021 15:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 05d7bfda93bf48d9aca0148e629536be
+      - bf3107e22ed844c9b53eee2ffefe36cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:02 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:32 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:02 GMT
+      - Tue, 17 Aug 2021 15:28:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,84 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - a86d7ee43e314ac89adf68a2a5f10a57
+      - ab8d706b886d471eaecf2d39beedf1c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:02 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:32 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:02 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/file/file/4f366d43-9ff5-49f2-9b3f-349deba7dfef/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '513'
-      Correlation-Id:
-      - 752c0eb2010d4c6087905e83ba560dc2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS80ZjM2NmQ0My05ZmY1LTQ5ZjItOWIzZi0zNDlkZWJhN2RmZWYvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MTowMi45MDEyMTZaIiwi
-        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzRmMzY2ZDQzLTlmZjUtNDlmMi05YjNmLTM0OWRlYmE3ZGZlZi92
-        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80ZjM2
-        NmQ0My05ZmY1LTQ5ZjItOWIzZi0zNDlkZWJhN2RmZWYvdmVyc2lvbnMvMC8i
-        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
-        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
-        IjoiUFVMUF9NQU5JRkVTVCJ9
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:02 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -288,13 +225,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:03 GMT
+      - Tue, 17 Aug 2021 15:28:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/da24962f-99cd-4079-9d46-0d8b026771b1/"
+      - "/pulp/api/v3/remotes/file/file/6858089b-c420-4114-a62e-9c44f724208b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -304,32 +241,95 @@ http_interactions:
       Content-Length:
       - '555'
       Correlation-Id:
-      - 17960e3a7a6845c490d8d536c36d5143
+      - 6a1745e5182f422cb873c921d4feba7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ZGEyNDk2MmYtOTljZC00MDc5LTlkNDYtMGQ4YjAyNjc3MWIxLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NDE6MDMuMzU2OTgyWiIsIm5hbWUi
+        Njg1ODA4OWItYzQyMC00MTE0LWE2MmUtOWM0NGY3MjQyMDhiLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzMuMDc2MTY1WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MTowMy4zNTcwMzBaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0wOC0xN1QxNToyODozMy4wNzYxNzlaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:03 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/file/file/84af8ee1-aada-4cb4-a0a4-97d2384bd92b/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '513'
+      Correlation-Id:
+      - 5fc3231e9d744fd49d90edd39d0d8f03
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS84NGFmOGVlMS1hYWRhLTRjYjQtYTBhNC05N2QyMzg0YmQ5MmIvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xN1QxNToyODozMy4xOTg0NjZaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzg0YWY4ZWUxLWFhZGEtNGNiNC1hMGE0LTk3ZDIzODRiZDkyYi92
+        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84NGFm
+        OGVlMS1hYWRhLTRjYjQtYTBhNC05N2QyMzg0YmQ5MmIvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
+        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
+        IjoiUFVMUF9NQU5JRkVTVCJ9
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/da24962f-99cd-4079-9d46-0d8b026771b1/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/6858089b-c420-4114-a62e-9c44f724208b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -350,7 +350,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:07 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -364,21 +364,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 934d32c5d7a445948d363482967ca20f
+      - 5fb643e4b295435890151c17070f8c91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5M2E4Njk1LWQ1ZTgtNGI2
-        Mi1iZmQ2LWY5ODc4YzgxOTE2MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5Mzk0MmY4LWM2YWEtNGE2
+        ZC1hZGRkLTE0NmRmODJjMjUzZC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:07 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b93a8695-d5e8-4b62-bfd6-f9878c819160/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/c93942f8-c6aa-4a6d-addd-146df82c253d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -399,7 +399,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:07 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -411,791 +411,145 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - ec6ef7a642754ca9b21e4ddaeeee69f5
+      - a118092d9e7c463fbca7f80c3508a374
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzkzOTQyZjgtYzZh
+        YS00YTZkLWFkZGQtMTQ2ZGY4MmMyNTNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzUuMTAyODYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZmI2NDNlNGIyOTU0MzU4OTAxNTFjMTcw
+        NzBmOGM5MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjM1LjE0
+        ODE4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzUuMTg2
+        NzI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVlMWQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvNjg1ODA4OWItYzQyMC00MTE0LWE2
+        MmUtOWM0NGY3MjQyMDhiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/84af8ee1-aada-4cb4-a0a4-97d2384bd92b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - add8d36fd53244fd958506f9ed03aa5c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1MTc2ZWMyLWYzNmMtNGJj
+        NS1hNzcyLTI0ODAxMzA3NTJhMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/45176ec2-f36c-4bc5-a772-2480130752a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b1b7a5b3b60042be8c8b65c8034960e9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjkzYTg2OTUtZDVl
-        OC00YjYyLWJmZDYtZjk4NzhjODE5MTYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MDcuNDg5MzE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDUxNzZlYzItZjM2
+        Yy00YmM1LWE3NzItMjQ4MDEzMDc1MmEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzUuMjg2NTQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MzRkMzJjNWQ3YTQ0NTk0OGQzNjM0ODI5
-        NjdjYTIwZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjQxOjA3LjU2
-        NjE5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MDcuNjI4
-        MzI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZGQ4ZDM2ZmQ1MzI0NGZkOTU4NTA2Zjll
+        ZDAzYWE1YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjM1LjMz
+        MDU1OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzUuMzg4
+        NzgxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wMjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3ZDMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZGEyNDk2MmYtOTljZC00MDc5LTlk
-        NDYtMGQ4YjAyNjc3MWIxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84NGFmOGVlMS1hYWRhLTRj
+        YjQtYTBhNC05N2QyMzg0YmQ5MmIvIl19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:07 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/4f366d43-9ff5-49f2-9b3f-349deba7dfef/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:07 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 0c4572a12f964127b8a0de947e6503e6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzZjlhMjg0LWM0MGMtNDI4
-        YS1iYmVhLTk3MjMwYjkzZWYwMS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:07 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/33f9a284-c40c-428a-bbea-97230b93ef01/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - ac8b6d1a17f447259942e58e8a2d8eb3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '376'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzNmOWEyODQtYzQw
-        Yy00MjhhLWJiZWEtOTcyMzBiOTNlZjAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MDcuODQzNTIxWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYzQ1NzJhMTJmOTY0MTI3YjhhMGRlOTQ3
-        ZTY1MDNlNiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjQxOjA3Ljk0
-        MTY5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MDguMDU2
-        MTQwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS80ZjM2NmQ0My05ZmY1LTQ5
-        ZjItOWIzZi0zNDlkZWJhN2RmZWYvIl19
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 5902109d71e24c67af6d73a666a6614d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '302'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNi
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQwOjQ1LjYxNTEy
-        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvOWE4MWFmMTYtZjkxMi00NjRjLThkNGYtMGJmMWVhNjdh
-        M2IxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNiMS92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
-        bHAzX0ZpbGVfMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJz
-        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
-        Im1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/9a81af16-f912-464c-8d4f-0bf1ea67a3b1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 4537948d5b154eb892b665b6cdfaea4b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzlhODFhZjE2LWY5MTItNDY0Yy04ZDRmLTBiZjFlYTY3YTNi
-        MS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6
-        NDA6NDUuNjI0NTY1WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzlhODFhZjE2LWY5MTIt
-        NDY0Yy04ZDRmLTBiZjFlYTY3YTNiMS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
-        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
-        cmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 9f2540be141647a4b72991cb9547d8c6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MDoyOC40Mzk1MTVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzQzNDE1
-        NzAyLTYzZGYtNGM3NC1hZGRlLTM0NWZjOTQwNThmNS92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2Fn
-        ZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwi
-        cGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVw
-        b19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFk
-        OWYyMGEtYmJkOC00ZTFiLWI2ZTAtZTk2ZGY2MDM5NzU0LyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMDctMjFUMTM6NDA6MjYuMzczMjAxWiIsInZlcnNpb25z
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFk
-        OWYyMGEtYmJkOC00ZTFiLWI2ZTAtZTk2ZGY2MDM5NzU0L3ZlcnNpb25zLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWQ5ZjIwYS1iYmQ4LTRl
-        MWItYjZlMC1lOTZkZjYwMzk3NTQvdmVyc2lvbnMvMS8iLCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluZWRfdmVyc2lv
-        bnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJt
-        ZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdl
-        X3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJw
-        YWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBv
-        X2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMS0wNy0yMFQxOToyMjoxNy45OTgwNThaIiwidmVyc2lvbnNf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvdmVyc2lvbnMvIiwi
-        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwZmEzMWJlLTdlMmQtNGNk
-        NS04MjVmLTNjYWE4MGJiZDRkMy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJmb28z
-        LTM2NzMwIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0
-        YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92
-        ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFj
-        a2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19n
-        cGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxLyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjEtMDctMjBUMTk6MTM6MjQuODUyNjYzWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxL3ZlcnNpb25zLyIsInB1
-        bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMt
-        OGNiZi02YjRmZDJiYTQzZDEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZm9vLTE4
-        MjcyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpu
-        dWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRh
-        dGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJz
-        aW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2Fn
-        ZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdj
-        aGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/43415702-63df-4c74-adde-345fc94058f5/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 57b52567a93f469d904e2fa1a4a4c4d6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '303'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS80MzQxNTcwMi02M2RmLTRjNzQtYWRkZS0zNDVmYzk0MDU4ZjUv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQw
-        OjM1LjU1NDA5NVoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDM0MTU3MDItNjNkZi00Yzc0
-        LWFkZGUtMzQ1ZmM5NDA1OGY1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlIjp7ImNvdW50
-        IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzQzNDE1NzAyLTYzZGYtNGM3NC1hZGRlLTM0NWZj
-        OTQwNThmNS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
-        OnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDM0MTU3MDItNjNk
-        Zi00Yzc0LWFkZGUtMzQ1ZmM5NDA1OGY1L3ZlcnNpb25zLzEvIn19fX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        NDM0MTU3MDItNjNkZi00Yzc0LWFkZGUtMzQ1ZmM5NDA1OGY1L3ZlcnNpb25z
-        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MDoyOC40NDk1
-        OTNaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzQzNDE1NzAyLTYzZGYtNGM3NC1hZGRlLTM0
-        NWZjOTQwNThmNS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
-        bWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19
-        XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/71d9f20a-bbd8-4e1b-b6e0-e96df6039754/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - b640b8dee4674861b5554b6dc3bc0fe1
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '328'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83MWQ5ZjIwYS1iYmQ4LTRlMWItYjZlMC1lOTZkZjYwMzk3NTQv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQw
-        OjMwLjU5MDY3MFoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzFkOWYyMGEtYmJkOC00ZTFi
-        LWI2ZTAtZTk2ZGY2MDM5NzU0LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzcxZDlmMjBhLWJiZDgtNGUxYi1iNmUwLWU5
-        NmRmNjAzOTc1NC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJjb3Vu
-        dCI6MzIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
-        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNzFkOWYyMGEtYmJkOC00ZTFiLWI2ZTAtZTk2
-        ZGY2MDM5NzU0L3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
-        dCI6eyJycG0uYWR2aXNvcnkiOnsiY291bnQiOjQsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83MWQ5ZjIw
-        YS1iYmQ4LTRlMWItYjZlMC1lOTZkZjYwMzk3NTQvdmVyc2lvbnMvMS8ifSwi
-        cnBtLnBhY2thZ2UiOnsiY291bnQiOjMyLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcxZDlmMjBhLWJiZDgt
-        NGUxYi1iNmUwLWU5NmRmNjAzOTc1NC92ZXJzaW9ucy8xLyJ9fX19LHsicHVs
-        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzcx
-        ZDlmMjBhLWJiZDgtNGUxYi1iNmUwLWU5NmRmNjAzOTc1NC92ZXJzaW9ucy8w
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NDA6MjYuMzgzMzI3
-        WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS83MWQ5ZjIwYS1iYmQ4LTRlMWItYjZlMC1lOTZk
-        ZjYwMzk3NTQvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1h
-        cnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fV19
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:08 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e0fa31be-7e2d-4cd5-825f-3caa80bbd4d3/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 628d89934c0e47019b34b4ba51fb19ad
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjIy
-        OjE4LjAwNzc5OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBmYTMxYmUtN2UyZC00Y2Q1
-        LTgyNWYtM2NhYTgwYmJkNGQzLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/30143471-8eac-4e83-8cbf-6b4fd2ba43d1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 24dd8727b6b6452bb4c57ab7d03c6c4c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMtOGNiZi02YjRmZDJiYTQzZDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjEz
-        OjI0Ljg1ODUzOVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 557358ad47ff4baf93bec9fc776a3109
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '275'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzoyOTo0NS42
-        MzExMjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00
-        YWIyNTAxOGM3NTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzEwMTNlOGRiLTdjNWItNDNjMy05M2ZjLTRhYjI1MDE4
-        Yzc1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
-        dWJsaXNoIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - a0014e82df894f9c9bed8a9bcacd0f6d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '233'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIx
-        VDEzOjI5OjQ1LjYzOTQ1OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMTAxM2U4
-        ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUxLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.8.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 69326bdb0ee44de3850f52de99077ab2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1216,7 +570,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1230,21 +584,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - ec757a177336495da4b8e0d199e9c1b4
+      - b5450e10d1a54433b7ddd1110f64c0eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1265,7 +619,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 9e7443e3b47b40d782927ed20b452fbd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1277,34 +680,55 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 8d6debf5a89648dead9f5ba8dfd55aef
+      - 29d2dbe7cb084fa0aa3a257b06f9a9cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '262'
+      - '397'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMFQyMTow
-        Mjo0OC41MjE4MjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFi
-        LTQ1NzUtODQ4Ny1jMTA2M2ZiNGU0MDgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2FmZjc1NDdmLTU3MWIt
-        NDU3NS04NDg3LWMxMDYzZmI0ZTQwOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUi
-        Om51bGx9XX0=
+        ZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZj
+        Yy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTE3VDE1OjEzOjQ1Ljk2NDk4
+        NFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMTViOGEwYmItMjVkMy00MTkwLTk0YzAtZWMwM2JjYjZl
+        NmNjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZjYy92ZXJzaW9u
+        cy8wLyIsIm5hbWUiOiJmaWxlMi0zMjk0NyIsImRlc2NyaXB0aW9uIjpudWxs
+        LCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRv
+        cHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
+        bGUvNTkxMzlkMWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6MDc6NDYuODMyMDI3WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS81OTEzOWQxYy0xYjY5LTQxMTUtODA0ZS01MDBjNmY3YWM4OTIvdmVy
+        c2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvNTkxMzlk
+        MWMtMWI2OS00MTE1LTgwNGUtNTAwYzZmN2FjODkyL3ZlcnNpb25zLzAvIiwi
+        bmFtZSI6ImZpbGUxLTI4MzU0IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFp
+        bmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNo
+        IjpmYWxzZSwibWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn0seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9jNDgz
+        YzdmOS05OWMyLTRlNDAtOTdkYS1jOWQ4MmQzYWE4YzYvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0wOC0xN1QxNTowMDo0My44NTgxMjRaIiwidmVyc2lvbnNf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0
+        ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThjNi92ZXJzaW9ucy8i
+        LCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9jNDgzYzdmOS05OWMy
+        LTRlNDAtOTdkYS1jOWQ4MmQzYWE4YzYvdmVyc2lvbnMvMC8iLCJuYW1lIjoi
+        ZmlsZS0xNzk5OCIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9XX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/aff7547f-571b-4575-8487-c1063fb4e408/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/15b8a0bb-25d3-4190-94c0-ec03bcb6e6cc/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1312,7 +736,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1325,7 +749,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1337,30 +761,142 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 3b21470e31f14d1791283bf1fe0ca095
+      - 5bda06f5aebb4ecf9d697554949e16b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '235'
+      - '231'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIwVDIxOjAyOjQ4LjU3MDA5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvYWZmNzU0N2YtNTcxYi00NTc1LTg0ODctYzEwNjNmYjRlNDA4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        ZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMtNDE5MC05NGMwLWVjMDNiY2I2ZTZj
+        Yy92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6
+        MTM6NDUuOTczMzMwWiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE1YjhhMGJiLTI1ZDMt
+        NDE5MC05NGMwLWVjMDNiY2I2ZTZjYy8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/43415702-63df-4c74-adde-345fc94058f5/versions/1/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/59139d1c-1b69-4115-804e-500c6f7ac892/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - dc2275c4e732447a8eca96a826f7e442
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjktNDExNS04MDRlLTUwMGM2ZjdhYzg5
+        Mi92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6
+        MDc6NDYuODM5MzAwWiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU5MTM5ZDFjLTFiNjkt
+        NDExNS04MDRlLTUwMGM2ZjdhYzg5Mi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/c483c7f9-99c2-4e40-97da-c9d82d3aa8c6/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7a05972a5ba7428ab51b641f8466aed7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzItNGU0MC05N2RhLWM5ZDgyZDNhYThj
+        Ni92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTdUMTU6
+        MDA6NDMuODY5MTkxWiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2M0ODNjN2Y5LTk5YzIt
+        NGU0MC05N2RhLWM5ZDgyZDNhYThjNi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1377,11 +913,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1389,27 +925,27 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Correlation-Id:
-      - 68e6d556338945d184cf957de80245a2
+      - cfa385ae800640f3ba4555524105128e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3NzFkMmNiLTk0ODItNDIz
-        Yi1iMTBjLTgyZTEzYTE0MzE3MS8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/71d9f20a-bbd8-4e1b-b6e0-e96df6039754/versions/1/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1417,7 +953,105 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 39e970f239564999b153093f14f90296
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 076353daa13c4d4f89b1978be2452d9b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1430,56 +1064,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 39c15dabefaf4f7e952986ed7992b9ba
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZTQxMWNmLTA2YmItNDFj
-        Ni1iNWQ3LTNiYjFlOTYzZWNmMS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:09 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:10 GMT
+      - Tue, 17 Aug 2021 15:28:35 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1493,21 +1078,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 524cd8b419e7468b8125c1339c8d9c2b
+      - ffc1c9c203a94e4c9276f45c35b0d22b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwMThhNzRjLTQ5Y2YtNGIz
-        Yi05YjA5LTg1ODhjZjY2YWQzMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IxNzlmOGU5LTkzMzktNDJk
+        YS04NGZiLTI4NmE2ZDYyYWVlYS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:10 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:35 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8018a74c-49cf-4b3b-9b09-8588cf66ad30/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b179f8e9-9339-42da-84fb-286a6d62aeea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1515,7 +1100,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1528,7 +1113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:41:14 GMT
+      - Tue, 17 Aug 2021 15:28:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1540,34 +1125,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 3bde7f035e1f477c9b46a5c88d535c6c
+      - cb18a7bb73d34e2cadee35461a3f95fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '421'
+      - '412'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODAxOGE3NGMtNDlj
-        Zi00YjNiLTliMDktODU4OGNmNjZhZDMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NDE6MTAuMTAzMDc2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjE3OWY4ZTktOTMz
+        OS00MmRhLTg0ZmItMjg2YTZkNjJhZWVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzUuOTI2NjAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjUyNGNkOGI0MTllNzQ2OGI4MTI1YzEz
-        MzljOGQ5YzJiIiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTM6NDE6MTAu
-        MzkxMDE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxMzo0MToxNC40
-        NDk3NzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzc0ZjQ1YTlhLWEyOGItNDg2Ni1iNmIzLTM4YTJlNTY0MmRmOS8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImZmYzFjOWMyMDNhOTRlNGM5Mjc2ZjQ1
+        YzM1YjBkMjJiIiwic3RhcnRlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzUu
+        OTc2OTU2WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wOC0xN1QxNToyODozNi4x
+        ODU2ODBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzM2M2M3NmE1LThmN2UtNDAxNS1iMjc2LWQ1MTIyNmU0NWUxZC8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjM1MywiZG9uZSI6MzUz
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBB
-        cnRpZmFjdHMiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOjM4NiwiZG9uZSI6Mzg2LCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
-        ZXNfcmVjb3JkIjpbXX0=
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
+        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MiwiZG9uZSI6Miwic3VmZml4IjpudWxsfV0sImNy
+        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6W119
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:14 GMT
+  recorded_at: Tue, 17 Aug 2021 15:28:36 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
@@ -10027,60 +10027,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:03 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/b54881a8-1697-4515-8886-88ec53f9cb55/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '130'
-      Correlation-Id:
-      - f14f86a02a13468bb0e4dd470ed41093
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9iNTQ4ODFhOC0x
-        Njk3LTQ1MTUtODg4Ni04OGVjNTNmOWNiNTUvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo0MTowNC4xNDc2MDlaIiwic2l6ZSI6NzQwfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:04 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/b54881a8-1697-4515-8886-88ec53f9cb55/
     body:
@@ -10272,66 +10218,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:04 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA0ZWE5Y2JlODZkNzY2
-        MTIwZDY0NzRlODlhYjg0OGM5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMDRlYTljYmU4
-        NmQ3NjYxMjBkNjQ3NGU4OWFiODQ4YzkNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvYTJkNDUxZmQtYjE5NS00MmQzLTgwZTYtYTIyNGM3NTE1MDQ5
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA0ZWE5Y2JlODZk
-        NzY2MTIwZDY0NzRlODlhYjg0OGM5LS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-04ea9cbe86d766120d6474e89ab848c9
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:41:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 4c68c019f60f453abc2df7218e0ae8c8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3MmZhNjYwLWFmMzItNGU5
-        Ni1iNzViLTE5ZDQyZDQxM2JiOS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:41:05 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/072fa660-af32-4e96-b75b-19d42d413bb9/
     body:
@@ -10508,4 +10394,4745 @@ http_interactions:
         NDlmMi05YjNmLTM0OWRlYmE3ZGZlZi8iXX0=
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:41:06 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5b698d55-fa83-47ee-907f-127b5ff99431/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTAyN2FmYTI3YTY1
+        M2M5MmI4NDVkYzIxNWUwY2IyDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtNjU1NS0xd250c3kzIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTAyN2FmYTI3
+        YTY1M2M5MmI4NDVkYzIxNWUwY2IyLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-c5e027afa27a653c92b845dc215e0cb2
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c34bfc5186aa49fd86b24ca1d8ff2617
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81YjY5OGQ1NS1m
+        YTgzLTQ3ZWUtOTA3Zi0xMjdiNWZmOTk0MzEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMDo1MDozNi4wNDQ3MjZaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:36 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5b698d55-fa83-47ee-907f-127b5ff99431/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b87ca9010aae4941939493c3cac1ec7c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0YTcxNWJkLWI3MDItNGQw
+        YS04MTYwLTNhZWY4ZTk1MGNkNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:36 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/24a715bd-b702-4d0a-8160-3aef8e950cd6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ddecc00c556f4930b398bfbe8c5de3eb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjRhNzE1YmQtYjcw
+        Mi00ZDBhLTgxNjAtM2FlZjhlOTUwY2Q2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzYuMTQ3NjE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJiODdjYTkwMTBhYWU0OTQxOTM5NDkzYzNjYWMxZWM3
+        YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUwOjM2LjE5MTEwNloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6MzYuMjUzMjQ1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNThhMjBlZTgtNGQxNC00YTA0LWFm
+        NzEtMDlmNjNmZDUzN2E4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzViNjk4ZDU1LWZhODMtNDdlZS05
+        MDdmLTEyN2I1ZmY5OTQzMS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:36 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/93b1d5a0-7046-4a1b-9100-1dacf6a6d407/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 914b8b97681b42cdbe4767e7f9010ea3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTNiMWQ1YTAtNzA0
+        Ni00YTFiLTkxMDAtMWRhY2Y2YTZkNDA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzYuMzU3NjEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYjJlNTMxYjRkNDE0MGU5YWEzNmY4MDY5
+        N2FiNjY4ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUwOjM2LjQw
+        NzE0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6MzYuNTQ3
+        MjY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZDZjY2Q4
+        ZDAtNjYxYy00MWQ0LThkZDItYmIzZGYxYmY1YTBkLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvNThh
+        MjBlZTgtNGQxNC00YTA0LWFmNzEtMDlmNjNmZDUzN2E4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:36 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/977865dc-e575-4459-8a8b-dc832eedaf43/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2Q2Y2NkOGQwLTY2MWMtNDFkNC04ZGQyLWJiM2RmMWJmNWEw
+        ZC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b0c16dc62ca0450e868cc96c102f9094
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5ZTU3NjJiLTU4NWYtNGNl
+        ZS1hZWJhLWEyNzdiZjZjMzU5NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:36 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/39e5762b-585f-4cee-aeba-a277bf6c3594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:50:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - db01168d279d4008a764d3f8648b8aec
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzllNTc2MmItNTg1
+        Zi00Y2VlLWFlYmEtYTI3N2JmNmMzNTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NTA6MzYuODAwOTAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiMGMxNmRjNjJjYTA0NTBlODY4
+        Y2M5NmMxMDJmOTA5NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjUw
+        OjM2Ljg2MTYwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NTA6
+        MzYuOTUxODY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzk3Nzg2NWRjLWU1NzUtNDQ1OS04YThiLWRjODMyZWVkYWY0My92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzk3Nzg2NWRjLWU1NzUt
+        NDQ1OS04YThiLWRjODMyZWVkYWY0My8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:50:37 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/55e2d5a2-963b-4078-9ca6-0eb23585ff79/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdjMzdkZjA5NjBmYTI4
+        MzQzNDY2YzIxN2U4NWI3ZWZlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtNzc5My1rNjk0aHgiDQpDb250ZW50LUxlbmd0aDogNzQwDQpDb250ZW50
+        LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1UcmFu
+        c2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCnsidW5pdF9rZXkiOiB7ImlkIjog
+        InRlc3QifSwgInVuaXRfbWV0YWRhdGEiOiB7InN0YXR1cyI6ICJmaW5hbCIs
+        ICJ1cGRhdGVkIjogIjIwMTItNy0yNSAwMDowMDowMCIsICJkZXNjcmlwdGlv
+        biI6IG51bGwsICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxw
+        LWxpc3RAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
+        VGVzdCBFcnJhdGEgcmVmZXJyaW5nIHRvIHRlc3QtcGFja2FnZS0wLjIiLCAi
+        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
+        dmVyc2lvbiI6ICIxIiwgInJlbGVhc2UiOiAiIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5oYW5jZW1lbnRzIiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEu
+        ZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhY2thZ2UiLCAic3VtIjog
+        WyJtZDUiLCAiNWI1OTBjYzk1ZmRmZjE0NTYwMDM0YTFmMzM0YTQ3NTMiXSwg
+        ImZpbGVuYW1lIjogInRlc3QtcGFja2FnZS0wLjItMS5lbDYubm9hcmNoLnJw
+        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2Ui
+        OiAiMS5lbDYiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIlB1bHAg
+        VGVzdCBQYWNrYWdlcyIsICJzaG9ydCI6ICJUZXN0Q29sbGVjdGlvbiJ9XX19
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtN2MzN2RmMDk2MGZh
+        MjgzNDM0NjZjMjE3ZTg1YjdlZmUtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-7c37df0960fa28343466c217e85b7efe
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1059'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 10b78a3cc03242a187f1ba8dec030cf7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81NWUyZDVhMi05
+        NjNiLTQwNzgtOWNhNi0wZWIyMzU4NWZmNzkvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMTowOC4wMzU0NDNaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/55e2d5a2-963b-4078-9ca6-0eb23585ff79/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b5b42d7ade9e4922a12b6a22cc531061
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5MDIzZWYxLWNjMmEtNDM4
+        Mi05Yjc3LTVkNzcxMzMyZDU0YS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e9023ef1-cc2a-4382-9b77-5d771332d54a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 16937b1e927244539f600390b0a6bc8b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTkwMjNlZjEtY2My
+        YS00MzgyLTliNzctNWQ3NzEzMzJkNTRhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6MDguMTI0MjEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJiNWI0MmQ3YWRlOWU0OTIyYTEyYjZhMjJjYzUzMTA2
+        MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjA4LjE2MjY2MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6MDguMjI4NzU2WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjNmYWM5ZDYtNGY5Ny00ZGNhLWI5
+        ZTctYWZmNDM0YjZiYWEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzU1ZTJkNWEyLTk2M2ItNDA3OC05
+        Y2E2LTBlYjIzNTg1ZmY3OS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6fe5a32c-adc5-481c-8a02-91c65c9db082/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 6bccae3be3194e489e0f86def7a0b8fc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZlNWEzMmMtYWRj
+        NS00ODFjLThhMDItOTFjNjVjOWRiMDgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6MDguNTA1NDg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI4M2MxYzU2MjRhZWU0MWVjYjA2MTAyNTkw
+        Y2VhMzlmZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjA4LjU0
+        NzQ3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6MDguNjUw
+        OTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYzg3NTIz
+        ZDctNDE4MC00MWMwLTk1YmItNThlNzU2Njk0MWFiLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjNm
+        YWM5ZDYtNGY5Ny00ZGNhLWI5ZTctYWZmNDM0YjZiYWEyLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/de26e2b2-f37b-4be4-bfd2-377a5be982d0/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2M4NzUyM2Q3LTQxODAtNDFjMC05NWJiLTU4ZTc1NjY5NDFh
+        Yi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - aa091e24924b4f24b7e88c9920e83e92
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiNDUwZjNmLTA1YzQtNDdh
+        Ny05YTE0LTQzZmUxMDAwNmRkNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ab450f3f-05c4-47a7-9a14-43fe10006dd7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 98b4e0abc4194cb2b0e5ce5df6abc9c2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWI0NTBmM2YtMDVj
+        NC00N2E3LTlhMTQtNDNmZTEwMDA2ZGQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6MDguNzU2ODMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhYTA5MWUyNDkyNGI0ZjI0Yjdl
+        ODhjOTkyMGU4M2U5MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEx
+        OjA4Ljc5NjQzNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6
+        MDguODkwMTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2RlMjZlMmIyLWYzN2ItNGJlNC1iZmQyLTM3N2E1YmU5ODJkMC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2RlMjZlMmIyLWYzN2It
+        NGJlNC1iZmQyLTM3N2E1YmU5ODJkMC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:08 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/406634da-d518-441d-9801-fdc0e8770998/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQwNDRiZDMxNTFhZTI4
+        MzJhMmJkM2U3MzdkYzZkMGE2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODMyNi0xMzVsOW10Ig0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQwNDRiZDMxNTFh
+        ZTI4MzJhMmJkM2U3MzdkYzZkMGE2LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-d044bd3151ae2832a2bd3e737dc6d0a6
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 10246177d93e4675a4005f6f56b4c5bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy80MDY2MzRkYS1k
+        NTE4LTQ0MWQtOTgwMS1mZGMwZTg3NzA5OTgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxNToyMi45NzM4MDFaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/406634da-d518-441d-9801-fdc0e8770998/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5a888e50b7af46e39950a878479af334
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5N2FjZDc3LWYzNjUtNGNi
+        My1iNzNmLTIyNmQ2YzU3NmFmNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f97acd77-f365-4cb3-b73f-226d6c576af4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 71d76fec7ea24606beeb80c1023c375a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjk3YWNkNzctZjM2
+        NS00Y2IzLWI3M2YtMjI2ZDZjNTc2YWY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjMuMDg2NjU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI1YTg4OGU1MGI3YWY0NmUzOTk1MGE4Nzg0NzlhZjMz
+        NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1OjIzLjEyNjU5MFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6MjMuMTkxMzE0WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTYyY2ZjNDAtOTgyMy00ZTUxLWE4
+        ZGItMmYwZTY3OTg2MTUwLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzQwNjYzNGRhLWQ1MTgtNDQxZC05
+        ODAxLWZkYzBlODc3MDk5OC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ca748d33-eae0-4fc3-be86-ad9687157200/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e5b1f6a27f8348028839e94325fda1cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2E3NDhkMzMtZWFl
+        MC00ZmMzLWJlODYtYWQ5Njg3MTU3MjAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjMuMzE1MjY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5NjQ1MjVkNDkwMjU0MjczODYwZjBiOTc5
+        MDFjYTE5YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1OjIzLjM1
+        OTQ1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6MjMuNDYz
+        ODc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNjU2OWVk
+        MDctYzM0Zi00MmVmLTk0NmQtZjM3ZWU3NjAzODc1LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTYy
+        Y2ZjNDAtOTgyMy00ZTUxLWE4ZGItMmYwZTY3OTg2MTUwLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/4fb02ee2-a9e7-40f5-bb3b-b4700b511a2d/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzY1NjllZDA3LWMzNGYtNDJlZi05NDZkLWYzN2VlNzYwMzg3
+        NS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 7405a51d2a244b9aa7c3aa097034dcc2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNzJiODAwLTg1N2EtNDQ2
+        Mi05MmI3LWZmZGYyNGIzMTA3Mi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2d72b800-857a-4462-92b7-ffdf24b31072/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:15:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - bbffdc854d124ba59e08d02f4d3d52ea
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ3MmI4MDAtODU3
+        YS00NDYyLTkyYjctZmZkZjI0YjMxMDcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTU6MjMuNjI2MzkzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3NDA1YTUxZDJhMjQ0YjlhYTdj
+        M2FhMDk3MDM0ZGNjMiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE1
+        OjIzLjY2NjI3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTU6
+        MjMuNzU5MzYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzRmYjAyZWUyLWE5ZTctNDBmNS1iYjNiLWI0NzAwYjUxMWEyZC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzRmYjAyZWUyLWE5ZTct
+        NDBmNS1iYjNiLWI0NzAwYjUxMWEyZC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:15:23 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/44b5702a-391e-4023-a9b3-4bd8a587a660/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNmNmYzNTMzM2U3YzBk
+        MzNkM2EyZWJjODIyMjI3OWU1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODU4NS0xcW9yNDlyIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNmNmYzNTMzM2U3
+        YzBkMzNkM2EyZWJjODIyMjI3OWU1LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-cf6f35333e7c0d33d3a2ebc8222279e5
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 250333945fa146388040768f9dfcb87b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy80NGI1NzAyYS0z
+        OTFlLTQwMjMtYTliMy00YmQ4YTU4N2E2NjAvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxNjo1Ny4xMDY2MDRaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/44b5702a-391e-4023-a9b3-4bd8a587a660/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - f948078374ad459a845aba9cb5c3fe13
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0MWIxNjQzLWY0YjktNDg3
+        YS1iOTlhLTI5MjM1MTYwOGJmYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/241b1643-f4b9-487a-b99a-292351608bfa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 37af6763d30a497e8a099add6a9565b5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQxYjE2NDMtZjRi
+        OS00ODdhLWI5OWEtMjkyMzUxNjA4YmZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTY6NTcuMTk3ODU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJmOTQ4MDc4Mzc0YWQ0NTlhODQ1YWJhOWNiNWMzZmUx
+        MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE2OjU3LjIzNzY1Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTY6NTcuMjk1MzI5WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMGQ2ZGI1MzctMzcyMS00MzM2LWFl
+        NzYtMDgxM2FkNjQ1OTVhLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzQ0YjU3MDJhLTM5MWUtNDAyMy1h
+        OWIzLTRiZDhhNTg3YTY2MC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/df0fca98-8dec-4ec2-9ecd-8dd4df4e047b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 13b78e1a248e494daa5bb1b074a0bd5e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGYwZmNhOTgtOGRl
+        Yy00ZWMyLTllY2QtOGRkNGRmNGUwNDdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTY6NTcuNDE5MTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiOThmMmFiNzllNTA0Zjc4YmZlYmM4YzU1
+        M2QyMTJlNiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE2OjU3LjQ2
+        MDI4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTY6NTcuNTcx
+        NzcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZDAyMmQ0
+        ZWYtMGU1ZC00MGQwLTg5YzgtNGEyNjI4MWJmZmJlLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMGQ2
+        ZGI1MzctMzcyMS00MzM2LWFlNzYtMDgxM2FkNjQ1OTVhLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/86baa86f-2b96-4cd4-8476-3f920503b151/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2QwMjJkNGVmLTBlNWQtNDBkMC04OWM4LTRhMjYyODFiZmZi
+        ZS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 9466601f9c434b51913baeb89869ddab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyYzk1ZDNkLWE4M2UtNDFj
+        Ni05NTBhLWQ5ZDE4ZjBjZjcyYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/02c95d3d-a83e-41c6-950a-d9d18f0cf72b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:16:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7049884224ff4ee9a87de129e0345311
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDJjOTVkM2QtYTgz
+        ZS00MWM2LTk1MGEtZDlkMThmMGNmNzJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTY6NTcuNzIyMjA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5NDY2NjAxZjljNDM0YjUxOTEz
+        YmFlYjg5ODY5ZGRhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE2
+        OjU3Ljc2Nzk5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTY6
+        NTcuODY0NDUzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzg2YmFhODZmLTJiOTYtNGNkNC04NDc2LTNmOTIwNTAzYjE1MS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzg2YmFhODZmLTJiOTYt
+        NGNkNC04NDc2LTNmOTIwNTAzYjE1MS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:16:57 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/1ee23dab-9805-448f-a07c-997d15ec8ca4/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJmODQ3YWI5NTc3NGRi
+        ODcxZDM1MWFiNThjZGYxZGEzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODk3NC0xcDQyb2ExIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJmODQ3YWI5NTc3
+        NGRiODcxZDM1MWFiNThjZGYxZGEzLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-2f847ab95774db871d351ab58cdf1da3
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7ba41d5c7cca4770808db84b3d5e8452
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8xZWUyM2RhYi05
+        ODA1LTQ0OGYtYTA3Yy05OTdkMTVlYzhjYTQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxODo1OS43NTQ5MzBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:59 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/1ee23dab-9805-448f-a07c-997d15ec8ca4/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a74d8dd0071343faba56f37eed1df5e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2Yzc1NDEyLThmZGItNDYw
+        My05OTk5LTI0YWQzNDlmZDE5MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b6c75412-8fdb-4603-9999-24ad349fd191/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:18:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - fd1460e195b24f9586051e9cd6e03bfa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjZjNzU0MTItOGZk
+        Yi00NjAzLTk5OTktMjRhZDM0OWZkMTkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTg6NTkuODQ1OTYzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJhNzRkOGRkMDA3MTM0M2ZhYmE1NmYzN2VlZDFkZjVl
+        MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE4OjU5Ljg4NTY3NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTg6NTkuOTQ0MTk1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNWY4N2MwOTEtMTc4Yy00YjlhLTlk
+        MjMtZDNkZmMwZWNiMmQ4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzFlZTIzZGFiLTk4MDUtNDQ4Zi1h
+        MDdjLTk5N2QxNWVjOGNhNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:18:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ee0db692-0158-49aa-8d9b-b68bbec26d77/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:19:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 12033f44f3554ce4bb9ab0cf01264dff
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWUwZGI2OTItMDE1
+        OC00OWFhLThkOWItYjY4YmJlYzI2ZDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTk6MDAuMDY4NzAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyNzQxMzBkOTE3ZmM0NTQwYjAzNGZkMWU2
+        MTRhYjI4ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE5OjAwLjEw
+        OTk0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTk6MDAuMjIz
+        MTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMzg2Mzk1
+        ODktMWVkNi00ZjMwLTgxYjMtODhjOWQ2MjFlYWI0LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvNWY4
+        N2MwOTEtMTc4Yy00YjlhLTlkMjMtZDNkZmMwZWNiMmQ4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:19:00 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/fabafe21-da4a-45fa-88dd-27a228ae2a86/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzM4NjM5NTg5LTFlZDYtNGYzMC04MWIzLTg4YzlkNjIxZWFi
+        NC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:19:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 298914cf3e2f4bf1884311a7fa18c657
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4OGEyZjJmLTc3ZWQtNDky
+        OS05YjgyLTAzZDhiY2NmNzEzOC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:19:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/888a2f2f-77ed-4929-9b82-03d8bccf7138/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:19:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8651fc4e9e88442c9e04905dbf30a32f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODg4YTJmMmYtNzdl
+        ZC00OTI5LTliODItMDNkOGJjY2Y3MTM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTk6MDAuMzYzMDEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyOTg5MTRjZjNlMmY0YmYxODg0
+        MzExYTdmYTE4YzY1NyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjE5
+        OjAwLjQxODA0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTk6
+        MDAuNTIxNzkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2ZhYmFmZTIxLWRhNGEtNDVmYS04OGRkLTI3YTIyOGFlMmE4Ni92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ZhYmFmZTIxLWRhNGEt
+        NDVmYS04OGRkLTI3YTIyOGFlMmE4Ni8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:19:00 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b7329452-50db-42dd-ad3d-b0a53f4b70ab/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdkNzRkN2U3NzMwNjRi
+        ZWU1NjBjMDVlNjhiMTY0NmNkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtOTIzNS0xYjJ1OGF5Ig0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdkNzRkN2U3NzMw
+        NjRiZWU1NjBjMDVlNjhiMTY0NmNkLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-7d74d7e773064bee560c05e68b1646cd
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1ffbafb22bd945268326e79f0a544969
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9iNzMyOTQ1Mi01
+        MGRiLTQyZGQtYWQzZC1iMGE1M2Y0YjcwYWIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToyMjowMy41MjkwMzdaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:03 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b7329452-50db-42dd-ad3d-b0a53f4b70ab/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - e6af9db2e9e740b9a01bf29be9f75853
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3Yzg5ZTk0LTExNzAtNGYz
+        OS05NzNiLWJiZTE2ODFkNjA0MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:03 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/17c89e94-1170-4f39-973b-bbe1681d6041/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a1fd07cfd2f244d4ad93a46661e8ee58
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdjODllOTQtMTE3
+        MC00ZjM5LTk3M2ItYmJlMTY4MWQ2MDQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDMuNjE3NTcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJlNmFmOWRiMmU5ZTc0MGI5YTAxYmYyOWJlOWY3NTg1
+        MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIyOjAzLjY2MTMzM1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6MDMuNzIxMDM4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODAyODgxNDMtYTUxMy00NTE4LWJm
+        NDUtNjkxMTcyOWE5OWFhLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2I3MzI5NDUyLTUwZGItNDJkZC1h
+        ZDNkLWIwYTUzZjRiNzBhYi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:03 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/13e6bd81-91bd-4652-abc6-6761ff89632c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 210088af47054caba47792195507b2a8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTNlNmJkODEtOTFi
+        ZC00NjUyLWFiYzYtNjc2MWZmODk2MzJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDMuODQ3MDAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzZjcyNmJjYjNmZWQ0MzdmYjczOWM3MDE2
+        ODUyMGRkMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIyOjAzLjg4
+        OTQ5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6MDMuOTk1
+        NzM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNzA2YWM3
+        NTItODgwYy00YzJjLTk1MTgtMWEzYTFmYWNhNDkyLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvODAy
+        ODgxNDMtYTUxMy00NTE4LWJmNDUtNjkxMTcyOWE5OWFhLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/afdfba39-6c86-42d9-992a-79efd671a3e9/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzcwNmFjNzUyLTg4MGMtNGMyYy05NTE4LTFhM2ExZmFjYTQ5
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - a469de0f0a8a4ababcf6ae3205694842
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwN2JiOWZmLTVlMzMtNDcw
+        My1hY2IzLWM1OGFiN2NkNDZhMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:04 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/307bb9ff-5e33-4703-acb3-c58ab7cd46a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:22:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 7a6173f5c7554821972b385890c77674
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzA3YmI5ZmYtNWUz
+        My00NzAzLWFjYjMtYzU4YWI3Y2Q0NmEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MjI6MDQuMTE2OTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJhNDY5ZGUwZjBhOGE0YWJhYmNm
+        NmFlMzIwNTY5NDg0MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjIy
+        OjA0LjE2OTY5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MjI6
+        MDQuMzU0MzI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2FmZGZiYTM5LTZjODYtNDJkOS05OTJhLTc5ZWZkNjcxYTNlOS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2FmZGZiYTM5LTZjODYt
+        NDJkOS05OTJhLTc5ZWZkNjcxYTNlOS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:22:04 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b8b08b71-a396-4e08-b67c-3afda52cae50/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWIxN2MzOWUyYmVlOTE5
+        NDczZThlZDQxMjdkNGUyNTY1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtOTg1Mi0xbnpjcWF3Ig0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWIxN2MzOWUyYmVl
+        OTE5NDczZThlZDQxMjdkNGUyNTY1LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-b17c39e2bee919473e8ed4127d4e2565
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - dcfefdaf8f6c4352abc16c4fcfea22b0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9iOGIwOGI3MS1h
+        Mzk2LTRlMDgtYjY3Yy0zYWZkYTUyY2FlNTAvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMDowMC42NjI5MjBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:00 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b8b08b71-a396-4e08-b67c-3afda52cae50/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 672aa31e86384b259546ffb53f074049
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViODU1MTcwLWU3YjMtNGQ1
+        MS04ZTlhLTk1MTIyNDllMGQ4OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/eb855170-e7b3-4d51-8e9a-9512249e0d89/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 604adf4907f44afc9b4dbb0485c22193
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI4NTUxNzAtZTdi
+        My00ZDUxLThlOWEtOTUxMjI0OWUwZDg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDAuNzU3ODU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI2NzJhYTMxZTg2Mzg0YjI1OTU0NmZmYjUzZjA3NDA0
+        OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMwOjAwLjgwMDQ0MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6MDAuODU1NzcxWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjU2Y2Q5ZmItYTJlNi00NTAyLTg0
+        YWQtMWU5YTAxYWQ0OWVhLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2I4YjA4YjcxLWEzOTYtNGUwOC1i
+        NjdjLTNhZmRhNTJjYWU1MC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/788bed44-c53e-4d71-9717-2b3ffc604611/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - a62e315a9eac4c06a2ece5f29e85cbab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzg4YmVkNDQtYzUz
+        ZS00ZDcxLTk3MTctMmIzZmZjNjA0NjExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDEuMDIyNTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzZmM2MWZiOWU4ODE0YWIyYmJhOGNmMmQ0
+        ZjgwZWZiZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMwOjAxLjA4
+        NDY1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6MDEuMjA3
+        MzMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvYWU2NzAx
+        N2EtNTAyYi00YzYwLThlNjktODU5ZWNjNWQyMmUyLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjU2
+        Y2Q5ZmItYTJlNi00NTAyLTg0YWQtMWU5YTAxYWQ0OWVhLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:01 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/60d80606-2c28-40be-beba-bfcf79470790/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2FlNjcwMTdhLTUwMmItNGM2MC04ZTY5LTg1OWVjYzVkMjJl
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8678f3fba7364116aa00469a35a0e42b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxNTA1YWE2LThjNmMtNGZh
+        MS04ZWU3LTFiOTQ2OTY1YWVmNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:01 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/91505aa6-8c6c-4fa1-8ee7-1b946965aef4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:30:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8336d3b4c0ba4ad082fa1de0572e0895
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTE1MDVhYTYtOGM2
+        Yy00ZmExLThlZTctMWI5NDY5NjVhZWY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzA6MDEuMzI0MTMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4Njc4ZjNmYmE3MzY0MTE2YWEw
+        MDQ2OWEzNWEwZTQyYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMw
+        OjAxLjQwNTYyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzA6
+        MDEuNTA0MDA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzYwZDgwNjA2LTJjMjgtNDBiZS1iZWJhLWJmY2Y3OTQ3MDc5MC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzYwZDgwNjA2LTJjMjgt
+        NDBiZS1iZWJhLWJmY2Y3OTQ3MDc5MC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:30:01 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/6a076608-33d3-4bd8-9f1f-13e1d4a49b96/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWFjNzhmM2IxNjYwZDhj
+        ZTI0MzJmZDhkNmMwMjdlZDI3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTAxMzAtMWlldGdpdCINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1hYzc4ZjNiMTY2
+        MGQ4Y2UyNDMyZmQ4ZDZjMDI3ZWQyNy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-ac78f3b1660d8ce2432fd8d6c027ed27
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c4745cc9825c44caad06f5a3fc8027e1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy82YTA3NjYwOC0z
+        M2QzLTRiZDgtOWYxZi0xM2UxZDRhNDliOTYvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMjoxNS4wNDA1NDNaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/6a076608-33d3-4bd8-9f1f-13e1d4a49b96/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3c2dc7a591be4782bbe8d27c58902124
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjYjAwMjI4LTczMWEtNDk0
+        Ni04MzAxLTkwYTcwODU2Y2VkZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/4cb00228-731a-4946-8301-90a70856cedf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - fef6a77d57fa4c3ba0b5d0d32f5b73bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGNiMDAyMjgtNzMx
+        YS00OTQ2LTgzMDEtOTBhNzA4NTZjZWRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTUuMTQ5NTYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIzYzJkYzdhNTkxYmU0NzgyYmJlOGQyN2M1ODkwMjEy
+        NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMyOjE1LjE4OTE0M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6MTUuMjQ0MTg4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTVjODYxYWQtNzk4NS00ZmVjLTgz
+        NTItMGI5OGUxNWUxYWI0LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzZhMDc2NjA4LTMzZDMtNGJkOC05
+        ZjFmLTEzZTFkNGE0OWI5Ni8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b57d554c-c58b-481a-a98c-57b109bcc4bb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - d96be4a11b5c4ed0bb82ccf75d812fd3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '401'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjU3ZDU1NGMtYzU4
+        Yi00ODFhLWE5OGMtNTdiMTA5YmNjNGJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTUuMzU3NTA4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmZTE4YTgxZGE5YTU0MGM0OTNjNWEyYTRm
+        MTQ1ZmEzNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMyOjE1LjM5
+        NzgxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6MTUuNTA1
+        ODEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvN2FlYzI5
+        YjctOGE5NS00NzE1LTkwZTgtNDk3ZjI3OGY3ZGY3LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZTVj
+        ODYxYWQtNzk4NS00ZmVjLTgzNTItMGI5OGUxNWUxYWI0LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/a6edaa70-dfe7-445e-86a7-b20496a5de3c/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzdhZWMyOWI3LThhOTUtNDcxNS05MGU4LTQ5N2YyNzhmN2Rm
+        Ny8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 0755a983908d43ff93602180700211fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliOTU1ZGMwLTZkMDEtNDZl
+        Ni1iYmYxLWEzZjlkMWMxNDI3Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9b955dc0-6d01-46e6-bbf1-a3f9d1c14277/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:32:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 44434670484a47838708effb023d495a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWI5NTVkYzAtNmQw
+        MS00NmU2LWJiZjEtYTNmOWQxYzE0Mjc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzI6MTUuNjQ3OTM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNzU1YTk4MzkwOGQ0M2ZmOTM2
+        MDIxODA3MDAyMTFmYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMy
+        OjE1LjcxOTIxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzI6
+        MTUuODY5MDIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2E2ZWRhYTcwLWRmZTctNDQ1ZS04NmE3LWIyMDQ5NmE1ZGUzYy92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2E2ZWRhYTcwLWRmZTct
+        NDQ1ZS04NmE3LWIyMDQ5NmE1ZGUzYy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:32:15 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/9ca8f8ea-245e-4dc7-8a6b-593f68cc69c8/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWU1Y2UzNDI2MDY3MjU2
+        MmNlODUwNTFkNmQ5NTIyZWI3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTAzOTMtMTByYzZlYSINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1lNWNlMzQyNjA2
+        NzI1NjJjZTg1MDUxZDZkOTUyMmViNy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-e5ce34260672562ce85051d6d9522eb7
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 55afba432c30482da31536b81a623162
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy85Y2E4ZjhlYS0y
+        NDVlLTRkYzctOGE2Yi01OTNmNjhjYzY5YzgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMTozMzoyNy4wMzQxOTRaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/9ca8f8ea-245e-4dc7-8a6b-593f68cc69c8/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d7f691bd2bec497d98440892cba0ce49
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhZmNhNmE1LTJkYzgtNDk5
+        OS04NDk3LTlmZjc5YjhmM2NmYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5afca6a5-2dc8-4999-8497-9ff79b8f3cfa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - adfb5ff3886a424384b2b0c67456ddc4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWFmY2E2YTUtMmRj
+        OC00OTk5LTg0OTctOWZmNzliOGYzY2ZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MjcuMTM1OTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJkN2Y2OTFiZDJiZWM0OTdkOTg0NDA4OTJjYmEwY2U0
+        OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMzOjI3LjE3OTMwOFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6MjcuMjQ0MTU5WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODM2ZjVlYWUtMGM0MS00NzJjLTll
+        ZjQtMTJkNmNmY2U5ZDUxLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzljYThmOGVhLTI0NWUtNGRjNy04
+        YTZiLTU5M2Y2OGNjNjljOC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/7f4b32d0-f5ac-494c-bafd-ea3f6eea735e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e25241ed0c5d4f5b97fa1d2acd2f441b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y0YjMyZDAtZjVh
+        Yy00OTRjLWJhZmQtZWEzZjZlZWE3MzVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MjcuMzU3MDMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5MDA5MWYwMTYzM2E0ZmFhOTQyZWVhMjJi
+        NTI0YjU5YSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMzOjI3LjQw
+        MzMwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6MjcuNTE5
+        NTA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNjI2MWNl
+        NTAtYzFmYy00N2JmLTk3OWUtMWYwM2U3MDBmYjYwLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvODM2
+        ZjVlYWUtMGM0MS00NzJjLTllZjQtMTJkNmNmY2U5ZDUxLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/d44fa65c-9c62-4e1a-b6e6-bd592cb76c55/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzYyNjFjZTUwLWMxZmMtNDdiZi05NzllLTFmMDNlNzAwZmI2
+        MC8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3fe2fbd1982b4f18b720be3cae2d6314
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1ZTcwNDc1LWJiNDMtNDk4
+        Ni04ZTE4LWNjZjViZjdjM2UxZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/75e70475-bb43-4986-8e18-ccf5bf7c3e1d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:33:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 5e4259e8c0af429f8e20c7a323e1f652
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzVlNzA0NzUtYmI0
+        My00OTg2LThlMTgtY2NmNWJmN2MzZTFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MzM6MjcuNjMwNjgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzZmUyZmJkMTk4MmI0ZjE4Yjcy
+        MGJlM2NhZTJkNjMxNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjMz
+        OjI3LjY3NTE5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MzM6
+        MjcuODQ2NDU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2Q0NGZhNjVjLTljNjItNGUxYS1iNmU2LWJkNTkyY2I3NmM1NS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2Q0NGZhNjVjLTljNjIt
+        NGUxYS1iNmU2LWJkNTkyY2I3NmM1NS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:33:27 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/81ada72b-c0eb-4fd1-b87b-baef4e9d3d5f/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI2ODM5OTliMThiNmFj
+        YTcxMDI2MjA2OGIzYjFkNGI3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTI1NDYtMWFiMzAwYSINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC0yNjgzOTk5YjE4
+        YjZhY2E3MTAyNjIwNjhiM2IxZDRiNy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-2683999b18b6aca710262068b3b1d4b7
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 55fa2a2b4ae24274887bb8025b9e5494
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84MWFkYTcyYi1j
+        MGViLTRmZDEtYjg3Yi1iYWVmNGU5ZDNkNWYvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMzo1ODoxMS45MTc5ODBaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/81ada72b-c0eb-4fd1-b87b-baef4e9d3d5f/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - '0080903c0194407fb9b47d4f934a9c8f'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5YmNjODMzLTgzMWMtNGQy
+        ZS1hOWQzLTM3NGMyMzdiOGZhNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/49bcc833-831c-4d2e-a9d3-374c237b8fa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b4c5e7b71f8049f18419795effe4a614
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDliY2M4MzMtODMx
+        Yy00ZDJlLWE5ZDMtMzc0YzIzN2I4ZmE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTIuMDIxMTMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIwMDgwOTAzYzAxOTQ0MDdmYjliNDdkNGY5MzRhOWM4
+        ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4OjEyLjA2MTI4Mloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6MTIuMTE5NTM1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjA4NGY3OWYtZGE3NC00NGQ1LTk4
+        MTctY2QyM2FmNzA5YWExLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzgxYWRhNzJiLWMwZWItNGZkMS1i
+        ODdiLWJhZWY0ZTlkM2Q1Zi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/df1c68d4-1451-469f-a9d2-f3ebb815eb0d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - cc50ba55c00e4cb8a6e653cb5df1099a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGYxYzY4ZDQtMTQ1
+        MS00NjlmLWE5ZDItZjNlYmI4MTVlYjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTIuMjM5MDMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0NDgyNDcyMTk5ZDU0ZjIzYjc4OWVlYzFi
+        Y2JlOWJmNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4OjEyLjI3
+        ODE4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6MTIuMzg4
+        NTI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZTVjMjU5
+        ZGQtNzM1ZC00N2QxLThiNTUtMDRlNjcxY2YwNjBiLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjA4
+        NGY3OWYtZGE3NC00NGQ1LTk4MTctY2QyM2FmNzA5YWExLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:12 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/d8044338-34e9-47fe-8747-a5331cb83937/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U1YzI1OWRkLTczNWQtNDdkMS04YjU1LTA0ZTY3MWNmMDYw
+        Yi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - e5db7fd768f3460babbe99e640c2844b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmZjRiMjJlLTgxN2UtNGU3
+        My1hOTFkLTJiYzM0MjQyY2U5NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/1ff4b22e-817e-4e73-a91d-2bc34242ce94/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:58:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b9c4199ea48544888ee1d2ecb27b41f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWZmNGIyMmUtODE3
+        ZS00ZTczLWE5MWQtMmJjMzQyNDJjZTk0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTg6MTIuNTI3NjI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNWRiN2ZkNzY4ZjM0NjBiYWJi
+        ZTk5ZTY0MGMyODQ0YiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU4
+        OjEyLjU2Nzg3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTg6
+        MTIuNjYzOTA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2Q4MDQ0MzM4LTM0ZTktNDdmZS04NzQ3LWE1MzMxY2I4MzkzNy92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2Q4MDQ0MzM4LTM0ZTkt
+        NDdmZS04NzQ3LWE1MzMxY2I4MzkzNy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:58:12 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/d38f317a-6c5b-4f02-82a0-0870d01176cc/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU5YjU2NGEwM2M1NjJh
+        NDAyNTk3N2QxZGMyYTA3ODY5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTItMTI5MDQtdHVvNGgwIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU5YjU2NGEwM2M1
+        NjJhNDAyNTk3N2QxZGMyYTA3ODY5LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-59b564a03c562a4025977d1dc2a07869
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - '08d86377778642849ac9105b1298c75a'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '131'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9kMzhmMzE3YS02
+        YzViLTRmMDItODJhMC0wODcwZDAxMTc2Y2MvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMlQwMDowMDo0OC41NTgxMzNaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:48 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/d38f317a-6c5b-4f02-82a0-0870d01176cc/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 178987f59e594fb6a1f6bd5632a1a3db
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwOTNhZjhhLTg1OGEtNGM3
+        Yy1hOWU2LTAwMmE2MzZhMGU0OC8ifQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:48 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b093af8a-858a-4c7c-a9e6-002a636a0e48/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c986ddfe88814722b90b77fd101c7146
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjA5M2FmOGEtODU4
+        YS00YzdjLWE5ZTYtMDAyYTYzNmEwZTQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDguNjYxMTE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIxNzg5ODdmNTllNTk0ZmI2YTFmNmJkNTYzMmExYTNk
+        YiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAwOjQ4LjcwMjg5Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6NDguNzYwNTA1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvY2FjYTA4MmMtYzc2Ny00ODE0LThj
+        MjctMjFiNGI1YWE0ODIxLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2QzOGYzMTdhLTZjNWItNGYwMi04
+        MmEwLTA4NzBkMDExNzZjYy8iXX0=
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:48 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/c20efd17-f226-42d3-812e-da5704143110/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - af5b7346b2b149fc958474e053a4b9ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzIwZWZkMTctZjIy
+        Ni00MmQzLTgxMmUtZGE1NzA0MTQzMTEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDguODYxMTI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2YjU3OTg0NmEwMjg0ZTUzYWIyMTA0NzAw
+        MjYxNzYyNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAwOjQ4Ljkw
+        MDY4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6NDkuMDEy
+        Mjk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvZTJhZTk3
+        Y2MtMGIxNy00ZjcwLWFkYTEtNjhlMWY2Mjg1YThjLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvY2Fj
+        YTA4MmMtYzc2Ny00ODE0LThjMjctMjFiNGI1YWE0ODIxLyJdfQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:49 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/5c2b4e11-4bfd-42ca-9cb2-b3e69eee604f/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2UyYWU5N2NjLTBiMTctNGY3MC1hZGExLTY4ZTFmNjI4NWE4
+        Yy8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5d4622c2269945a5b04f5db45b78d5a1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliNGZhMmZmLWI4NGQtNDJl
+        OC1hMzE5LTY4ZWZkYjQ0YThlYi8ifQ==
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:49 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9b4fa2ff-b84d-42e8-a319-68efdb44a8eb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Aug 2021 00:00:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1633d54553e8426a93f6ac4577548691
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWI0ZmEyZmYtYjg0
+        ZC00MmU4LWEzMTktNjhlZmRiNDRhOGViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTJUMDA6MDA6NDkuMTI3NjQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1ZDQ2MjJjMjI2OTk0NWE1YjA0
+        ZjVkYjQ1Yjc4ZDVhMSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTEyVDAwOjAw
+        OjQ5LjE3MjE4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTJUMDA6MDA6
+        NDkuMjY3MDY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzVjMmI0ZTExLTRiZmQtNDJjYS05Y2IyLWIzZTY5ZWVlNjA0Zi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzVjMmI0ZTExLTRiZmQt
+        NDJjYS05Y2IyLWIzZTY5ZWVlNjA0Zi8iXX0=
+    http_version: 
+  recorded_at: Thu, 12 Aug 2021 00:00:49 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 55b560ac41734104abbaba8b412ac19b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - b11206c3423b483caaabef73929da794
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/e23fffb5-aa8a-452b-a9db-727f5b65025d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '130'
+      Correlation-Id:
+      - 7d945fe6cc8b4abdb1a72d57f62327fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9lMjNmZmZiNS1h
+        YThhLTQ1MmItYTlkYi03MjdmNWI2NTAyNWQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xN1QxNToyODozMy42OTU3MDNaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/e23fffb5-aa8a-452b-a9db-727f5b65025d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdkYjU3NGM2ZGQ0OWFl
+        NWIwZDg0NzNlZDIyNTgwZDg2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTctMTE5MTQtaWg4YWRlIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdkYjU3NGM2ZGQ0
+        OWFlNWIwZDg0NzNlZDIyNTgwZDg2LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-7db574c6dd49ae5b0d8473ed22580d86
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ecdf80826ef74716b17d56238d188fda
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9lMjNmZmZiNS1h
+        YThhLTQ1MmItYTlkYi03MjdmNWI2NTAyNWQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xN1QxNToyODozMy42OTU3MDNaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - ea53614cf5954589819f1bdb11f7a78c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/e23fffb5-aa8a-452b-a9db-727f5b65025d/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 5582e648640e4533a88a34c878a7946f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMTk2N2M0LWUwZTUtNGY4
+        Ny1hODk2LWMxYzlhMWFkMGMzYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6e1967c4-e0e5-4f87-a896-c1c9a1ad0c3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - af683593848b4c1f9fa533a78b6d3c58
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmUxOTY3YzQtZTBl
+        NS00Zjg3LWE4OTYtYzFjOWExYWQwYzNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzMuNzg4MDIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI1NTgyZTY0ODY0MGU0NTMzYTg4YTM0Yzg3OGE3OTQ2
+        ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjMzLjgzODEwMVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzMuODkyMTY4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3ZDMvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmU4MzA2YjItZmU2NC00N2NiLWI2
+        MzUtZTg0YmExZjAxOGFiLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2UyM2ZmZmI1LWFhOGEtNDUyYi1h
+        OWRiLTcyN2Y1YjY1MDI1ZC8iXX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1d8c7c6b41e34eb39a672c9e79de2d23
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '442'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmU4
+        MzA2YjItZmU2NC00N2NiLWI2MzUtZTg0YmExZjAxOGFiLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzMuODYzNjI5WiIsImZpbGUiOiJh
+        cnRpZmFjdC9lZi8wYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
+        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNpemUiOjc0MCwibWQ1
+        IjpudWxsLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFi
+        OGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2
+        YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwic2hhMjU2Ijoi
+        ZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJk
+        NWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUyOGQyMTEwZDgw
+        NjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNh
+        OGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUx
+        MiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3
+        ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIy
+        ZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1d
+        fQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:33 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTMzYzI5YWVhYjM2YmUz
+        N2ZhNjEzMWMwNzQ5NGMyZTA5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMzNjMjlhZWFi
+        MzZiZTM3ZmE2MTMxYzA3NDk0YzJlMDkNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvZmU4MzA2YjItZmU2NC00N2NiLWI2MzUtZTg0YmExZjAxOGFi
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTMzYzI5YWVhYjM2
+        YmUzN2ZhNjEzMWMwNzQ5NGMyZTA5LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-33c29aeab36be37fa6131c07494c2e09
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - edc40863f8104c1a8774462bb813b322
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwNTIwMjhjLWVjYzUtNDky
+        ZC1iZDIzLTYyNzY0ZWZkZDgwYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:34 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5052028c-ecc5-492d-bd23-62764efdd80b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - ea4f3466627640fbbf913c8e43228216
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA1MjAyOGMtZWNj
+        NS00OTJkLWJkMjMtNjI3NjRlZmRkODBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzMuOTk0NjM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlZGM0MDg2M2Y4MTA0YzFhODc3NDQ2MmJi
+        ODEzYjMyMiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4OjM0LjA0
+        NTcyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6MzQuMTc1
+        MDA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjNjNzZhNS04ZjdlLTQwMTUtYjI3Ni1kNTEyMjZlNDVlMWQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvNjYxZDk1
+        NWEtNGVhOS00MmVlLTk0YzYtMzhjYTI4NmNkOGVhLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmU4
+        MzA2YjItZmU2NC00N2NiLWI2MzUtZTg0YmExZjAxOGFiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:34 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/84af8ee1-aada-4cb4-a0a4-97d2384bd92b/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzY2MWQ5NTVhLTRlYTktNDJlZS05NGM2LTM4Y2EyODZjZDhl
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - dacecb96870344a49abc1f73c1784af7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0NWJjMTZlLWVkODMtNDJi
+        Ni04ZDhmLTA0MGY4ZDBiODFkNC8ifQ==
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:34 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/345bc16e-ed83-42b6-8d8f-040f8d0b81d4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Aug 2021 15:28:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 51ff8432169d4ec78b3cbda8f8240e3e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ1YmMxNmUtZWQ4
+        My00MmI2LThkOGYtMDQwZjhkMGI4MWQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTdUMTU6Mjg6MzQuMjk4Mjk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYWNlY2I5Njg3MDM0NGE0OWFi
+        YzFmNzNjMTc4NGFmNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTE3VDE1OjI4
+        OjM0LjM0MjI0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTdUMTU6Mjg6
+        MzQuNDQ2NTYwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8wMjlhMTJkYi03ZmIxLTRmYWEtOTNhZi0wZWY5OTE5Nzc3
+        ZDMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzg0YWY4ZWUxLWFhZGEtNGNiNC1hMGE0LTk3ZDIzODRiZDkyYi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzg0YWY4ZWUxLWFhZGEt
+        NGNiNC1hMGE0LTk3ZDIzODRiZDkyYi8iXX0=
+    http_version: 
+  recorded_at: Tue, 17 Aug 2021 15:28:34 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:00 GMT
+      - Wed, 11 Aug 2021 21:11:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 8ca0bc5271234f67a9f6943dec9250df
+      - 80f3bf9bb7084004bc07df6d519bbfc4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:00 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:00 GMT
+      - Wed, 11 Aug 2021 21:11:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - d5cfd5fdbb4d41ee9d59a1142b5fa027
+      - eab56d28f693418fb8060d151b58a1bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:00 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:00 GMT
+      - Wed, 11 Aug 2021 21:11:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 95a4dee913ca48328d94f2e4c5a69f96
+      - 6d443be25c6c4f92ad6cbf618f153aa9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:00 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:44 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:00 GMT
+      - Wed, 11 Aug 2021 21:11:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,86 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 805210a8f354414faee15731037e14b7
+      - bd8c24ba811e431e8360bf63f99a38c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:00 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:44 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
-        OjB9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/4f11b885-e54a-42e2-baf4-ff6aa050b76f/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '626'
-      Correlation-Id:
-      - 362a63c8780743d9bd1af5950719a9ab
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNGYxMWI4ODUtZTU0YS00MmUyLWJhZjQtZmY2YWEwNTBiNzZmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NTA6MDEuMTUzNjU4WiIsInZl
-        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNGYxMWI4ODUtZTU0YS00MmUyLWJhZjQtZmY2YWEwNTBiNzZmL3ZlcnNp
-        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80ZjExYjg4NS1l
-        NTRhLTQyZTItYmFmNC1mZjZhYTA1MGI3NmYvdmVyc2lvbnMvMC8iLCJuYW1l
-        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:01 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -289,13 +224,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:01 GMT
+      - Wed, 11 Aug 2021 21:11:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0fd59070-7b6e-4d2a-bdbd-74533a9941a8/"
+      - "/pulp/api/v3/remotes/rpm/rpm/b3bdb17f-2cac-4c02-91b1-5634a5673f02/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -305,31 +240,96 @@ http_interactions:
       Content-Length:
       - '534'
       Correlation-Id:
-      - 0ab384bd316442c5b037b1f9ce6c01ea
+      - 9d53815c8edf4c1da3c2e59798c6b6af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBm
-        ZDU5MDcwLTdiNmUtNGQyYS1iZGJkLTc0NTMzYTk5NDFhOC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUwOjAxLjQwMjI1N1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Iz
+        YmRiMTdmLTJjYWMtNGMwMi05MWIxLTU2MzRhNTY3M2YwMi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTA4LTExVDIxOjExOjQ0Ljc5Njk5NVoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMDctMjFUMTM6NTA6MDEuNDAyMjg5WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTE6NDQuNzk3MDI2WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:01 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:44 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
+        OjB9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/5862dc2f-5f83-496d-8cc4-8f8a17f4e774/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '626'
+      Correlation-Id:
+      - 6f9246816f1f4b5792399542052aa939
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTg2MmRjMmYtNWY4My00OTZkLThjYzQtOGY4YTE3ZjRlNzc0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTE6NDUuMjY5Njg1WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNTg2MmRjMmYtNWY4My00OTZkLThjYzQtOGY4YTE3ZjRlNzc0L3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ODYyZGMyZi01
+        ZjgzLTQ5NmQtOGNjNC04ZjhhMTdmNGU3NzQvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
+        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
+        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
+        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:45 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/0fd59070-7b6e-4d2a-bdbd-74533a9941a8/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/b3bdb17f-2cac-4c02-91b1-5634a5673f02/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -350,7 +350,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:04 GMT
+      - Wed, 11 Aug 2021 21:11:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -364,21 +364,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 867083f8897941199ce7883858f9b999
+      - 3e906e8260eb4d8893aa7d51432f7a86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiZDU2MTdiLThjOTAtNDk4
-        MC1iYTk4LTAxNTk0YzMyYTJhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkNjNmNWI5LWQ5M2QtNDgx
+        ZS1iZjg2LTg0MzIwZGM4YTBkMS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:04 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:52 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/abd5617b-8c90-4980-ba98-01594c32a2af/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/bd63f5b9-d93d-481e-bf86-84320dc8a0d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -399,7 +399,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:04 GMT
+      - Wed, 11 Aug 2021 21:11:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -411,910 +411,145 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - f6e0af71cfbe49319a8779faedb4a863
+      - e005a4a5a7a147218905c19fec1280b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmQ2M2Y1YjktZDkz
+        ZC00ODFlLWJmODYtODQzMjBkYzhhMGQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NTIuNDYxMzAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZTkwNmU4MjYwZWI0ZDg4OTNhYTdkNTE0
+        MzJmN2E4NiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjUyLjY0
+        ODE0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6NTIuNzk5
+        MjAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2IzYmRiMTdmLTJjYWMtNGMwMi05MWIx
+        LTU2MzRhNTY3M2YwMi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:52 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5862dc2f-5f83-496d-8cc4-8f8a17f4e774/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 6ac033945f174d0da80ab1398dbe59e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzMWM4N2Y1LWQwNzctNDNi
+        ZC1iOTBiLTA1NWRmMGM1MGE3MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:53 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/631c87f5-d077-43bd-b90b-055df0c50a71/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 34f85a19362241aaa7fe09337c3ce70c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWJkNTYxN2ItOGM5
-        MC00OTgwLWJhOTgtMDE1OTRjMzJhMmFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MDQuMzkzNjY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjMxYzg3ZjUtZDA3
+        Ny00M2JkLWI5MGItMDU1ZGYwYzUwYTcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NTMuMzEwNzQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NjcwODNmODg5Nzk0MTE5OWNlNzg4Mzg1
-        OGY5Yjk5OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUwOjA0LjQ4
-        MjgzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MDQuNTgw
-        NjQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YWMwMzM5NDVmMTc0ZDBkYTgwYWIxMzk4
+        ZGJlNTllNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjUzLjQ2
+        OTM5M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6NTMuNjQy
+        MjMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBmZDU5MDcwLTdiNmUtNGQyYS1iZGJk
-        LTc0NTMzYTk5NDFhOC8iXX0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg2MmRjMmYtNWY4My00OTZk
+        LThjYzQtOGY4YTE3ZjRlNzc0LyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:04 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/4f11b885-e54a-42e2-baf4-ff6aa050b76f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:04 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 849d78dd0b444f4aa0b6ee838ca7ad64
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhMWUwOTgyLTMzMWMtNDRm
-        Yy05YTFiLTgxODJjMjdhNTcwMy8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:04 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:53 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3a1e0982-331c-44fc-9a1b-8182c27a5703/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - ac65e8d587f047cd837544422c7b6c01
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '375'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2ExZTA5ODItMzMx
-        Yy00NGZjLTlhMWItODE4MmMyN2E1NzAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MDQuNzg3MjA0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NDlkNzhkZDBiNDQ0ZjRhYTBiNmVlODM4
-        Y2E3YWQ2NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUwOjA0Ljg3
-        ODY3M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MDUuMDEz
-        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGYxMWI4ODUtZTU0YS00MmUy
-        LWJhZjQtZmY2YWEwNTBiNzZmLyJdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:05 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - f707541614db46f1988df9b624ea64a4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '301'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5OjQ2LjE5MTI1
-        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMjNjNzE2MjktNjMxNC00ODhjLTlmNGUtZmFlNTNkNjY1
-        MzQxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0MS92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
-        X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFu
-        aWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:05 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/23c71629-6314-488c-9f4e-fae53d665341/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 49f9f8dab7354274a90cf2179d4bca9b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0
-        MS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6
-        NDk6NDYuMjAxOTY3WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQt
-        NDg4Yy05ZjRlLWZhZTUzZDY2NTM0MS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
-        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
-        cmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:05 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - a1fe2dbed81848559f3c2baadfe4a293
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '499'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0OToxNy43OTkwOTVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyMGMw
-        NGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8yLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2Fn
-        ZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwi
-        cGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVw
-        b19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVh
-        NmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMDctMjFUMTM6NDk6MTUuMTg0ODQxWiIsInZlcnNpb25z
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVh
-        NmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlL3ZlcnNpb25zLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQz
-        ZGEtYjA2ZS02MzE4NDY4ZDljNmUvdmVyc2lvbnMvMS8iLCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluZWRfdmVyc2lv
-        bnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJt
-        ZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdl
-        X3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJw
-        YWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBv
-        X2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMS0wNy0yMFQxOToyMjoxNy45OTgwNThaIiwidmVyc2lvbnNf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvdmVyc2lvbnMvIiwi
-        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwZmEzMWJlLTdlMmQtNGNk
-        NS04MjVmLTNjYWE4MGJiZDRkMy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJmb28z
-        LTM2NzMwIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0
-        YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92
-        ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFj
-        a2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19n
-        cGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxLyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjEtMDctMjBUMTk6MTM6MjQuODUyNjYzWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxL3ZlcnNpb25zLyIsInB1
-        bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMt
-        OGNiZi02YjRmZDJiYTQzZDEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZm9vLTE4
-        MjcyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpu
-        dWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRh
-        dGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJz
-        aW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2Fn
-        ZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdj
-        aGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:05 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/320c04e4-15e7-430b-8c72-b821dddc3c6d/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:05 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - c68581ea616145b9b40d446b5ff94cc6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '445'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5
-        OjI1LjY3MTY1N1oiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00MzBi
-        LThjNzItYjgyMWRkZGMzYzZkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlZW52aXJvbm1l
-        bnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWVudmlyb25tZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2Fk
-        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMjBjMDRl
-        NC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQvdmVyc2lvbnMvMi8ifX0s
-        InJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7InJwbS5kaXN0cmlidXRpb25fdHJl
-        ZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3Jw
-        bS9kaXN0cmlidXRpb25fdHJlZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00
-        MzBiLThjNzItYjgyMWRkZGMzYzZkL3ZlcnNpb25zLzIvIn0sInJwbS5wYWNr
-        YWdlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04Yzcy
-        LWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2FnZWVudmly
-        b25tZW50Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
-        bnQvcnBtL3BhY2thZ2VlbnZpcm9ubWVudHMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQt
-        MTVlNy00MzBiLThjNzItYjgyMWRkZGMzYzZkL3ZlcnNpb25zLzIvIn0sInJw
-        bS5wYWNrYWdlZ3JvdXAiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMjBjMDRl
-        NC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQvdmVyc2lvbnMvMi8ifSwi
-        cnBtLnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRhX2ZpbGVzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92
-        ZXJzaW9ucy8yLyJ9fX19LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4
-        MjFkZGRjM2M2ZC92ZXJzaW9ucy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEt
-        MDctMjFUMTM6NDk6MjUuMjQ1NTAyWiIsIm51bWJlciI6MSwicmVwb3NpdG9y
-        eSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMjBjMDRl
-        NC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQvIiwiYmFzZV92ZXJzaW9u
-        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyMGMwNGU0
-        LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8wLyIsImNv
-        bnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyMGMwNGU0
-        LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ucGFja2FnZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVk
-        PS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMjBjMDRlNC0x
-        NWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQvdmVyc2lvbnMvMS8ifSwicnBt
-        LnBhY2thZ2Vncm91cCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMy
-        MGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8x
-        LyJ9LCJycG0ucmVwb19tZXRhZGF0YV9maWxlIjp7ImNvdW50IjoxLCJocmVm
-        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRhdGFfZmls
-        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00MzBiLThjNzItYjgy
-        MWRkZGMzYzZkL3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
-        dCI6eyJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQiOjEsImhyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0aW9uX3RyZWVz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2
-        ZC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MywiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQvdmVyc2lv
-        bnMvMS8ifSwicnBtLnBhY2thZ2Vncm91cCI6eyJjb3VudCI6MSwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZ3JvdXBzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJz
-        aW9ucy8xLyJ9LCJycG0ucmVwb19tZXRhZGF0YV9maWxlIjp7ImNvdW50Ijox
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3JlcG9fbWV0YWRh
-        dGFfZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00MzBiLThjNzItYjgy
-        MWRkZGMzYzZkL3ZlcnNpb25zLzEvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00
-        MzBiLThjNzItYjgyMWRkZGMzYzZkL3ZlcnNpb25zLzAvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMS0wNy0yMVQxMzo0OToxNy44MTA5NDNaIiwibnVtYmVyIjow
-        LCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
-        cnBtLzMyMGMwNGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC8iLCJi
-        YXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6
-        e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:05 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/0ea6f82a-b0fe-43da-b06e-6318468d9c6e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 373cc1643fdd4cf8829ac459fb97101c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '462'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4NDY4ZDljNmUv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5
-        OjE4Ljg5ODMzNVoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVhNmY4MmEtYjBmZS00M2Rh
-        LWIwNmUtNjMxODQ2OGQ5YzZlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6NiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzBlYTZmODJhLWIwZmUtNDNkYS1iMDZlLTYz
-        MTg0NjhkOWM2ZS92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBlYTZmODJh
-        LWIwZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBlYTZmODJh
-        LWIwZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQiOjMsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vMGVhNmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZl
-        L3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoxOSwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4NDY4ZDljNmUv
-        dmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3VudCI6
-        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlY2F0
-        ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2
-        ZS02MzE4NDY4ZDljNmUvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZp
-        cm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBl
-        YTZmODJhLWIwZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92ZXJzaW9ucy8x
-        LyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3Jw
-        bS9ycG0vMGVhNmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlL3Zl
-        cnNpb25zLzEvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRh
-        ZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEt
-        YjA2ZS02MzE4NDY4ZDljNmUvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6NiwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzBlYTZmODJhLWIwZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92ZXJzaW9u
-        cy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0aW9uX3Ry
-        ZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzBlYTZmODJhLWIwZmUtNDNkYS1iMDZlLTYzMTg0Njhk
-        OWM2ZS92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYs
-        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzBlYTZmODJhLWIwZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92
-        ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQi
-        OjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRf
-        ZGVmYXVsdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vMGVhNmY4MmEtYjBmZS00M2RhLWIwNmUtNjMx
-        ODQ2OGQ5YzZlL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50
-        IjoxOSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4NDY4ZDlj
-        NmUvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3Vu
-        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        Y2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02
-        MzE4NDY4ZDljNmUvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZpcm9u
-        bWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzBlYTZmODJhLWIw
-        ZmUtNDNkYS1iMDZlLTYzMTg0NjhkOWM2ZS92ZXJzaW9ucy8xLyJ9LCJycG0u
-        cGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVhNmY4MmEt
-        YjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlL3ZlcnNpb25zLzEvIn0sInJw
-        bS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4NDY4ZDljNmUvdmVy
-        c2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4
-        NDY4ZDljNmUvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3
-        LTIxVDEzOjQ5OjE1LjIwNDg5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnki
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVhNmY4MmEt
-        YjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlLyIsImJhc2VfdmVyc2lvbiI6
-        bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6
-        e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e0fa31be-7e2d-4cd5-825f-3caa80bbd4d3/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - d238f34bffe24dd18e8c48cf7368b36b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjIy
-        OjE4LjAwNzc5OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBmYTMxYmUtN2UyZC00Y2Q1
-        LTgyNWYtM2NhYTgwYmJkNGQzLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/30143471-8eac-4e83-8cbf-6b4fd2ba43d1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 8b57c5f6eeb4455f8c844e9cd9b0d098
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMtOGNiZi02YjRmZDJiYTQzZDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjEz
-        OjI0Ljg1ODUzOVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 4bafaacfc89f49c1b00e948cfbc7ec15
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '275'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzoyOTo0NS42
-        MzExMjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00
-        YWIyNTAxOGM3NTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzEwMTNlOGRiLTdjNWItNDNjMy05M2ZjLTRhYjI1MDE4
-        Yzc1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
-        dWJsaXNoIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - defdc93be685485886d9bd70ffbe3fe0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '233'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIx
-        VDEzOjI5OjQ1LjYzOTQ1OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMTAxM2U4
-        ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUxLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.8.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 86b023951db14bb783b31e33e364e11d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1335,7 +570,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
+      - Wed, 11 Aug 2021 21:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1349,21 +584,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - ff05711a3c39413095cd97657b341941
+      - 68f8279aeb77452492fcd6184472c8b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1384,46 +619,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:06 GMT
+      - Wed, 11 Aug 2021 21:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Correlation-Id:
-      - 416e1f2e6a5442a6ba58bd464b37d1b9
+      - c94e3c59bf3a4074852e2a85814959d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '262'
+      - 1.1 centos7-devel4.samir.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMFQyMTow
-        Mjo0OC41MjE4MjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFi
-        LTQ1NzUtODQ4Ny1jMTA2M2ZiNGU0MDgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2FmZjc1NDdmLTU3MWIt
-        NDU3NS04NDg3LWMxMDYzZmI0ZTQwOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUi
-        Om51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:06 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/aff7547f-571b-4575-8487-c1063fb4e408/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1431,7 +655,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1444,42 +668,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:07 GMT
+      - Wed, 11 Aug 2021 21:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Correlation-Id:
-      - 272c069f3f9946ee81d936ada533c05d
+      - '0071751911034b199b9857194769b57a'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '235'
+      - 1.1 centos7-devel4.samir.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIwVDIxOjAyOjQ4LjU3MDA5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvYWZmNzU0N2YtNTcxYi00NTc1LTg0ODctYzEwNjNmYjRlNDA4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:07 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/320c04e4-15e7-430b-8c72-b821dddc3c6d/versions/2/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1496,11 +713,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:07 GMT
+      - Wed, 11 Aug 2021 21:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1508,27 +725,27 @@ http_interactions:
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '52'
       Correlation-Id:
-      - ed30400a388d42ffb759e55959716e6c
+      - 9ba520891e82482f913cb65336685412
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3MjYwY2NmLWFjZDYtNDNi
-        Yi04MGNlLTI2MjIzZTZhYTJjNi8ifQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:07 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/320c04e4-15e7-430b-8c72-b821dddc3c6d/versions/1/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1536,7 +753,105 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 04b62aafee1d415694ffc78c62adf498
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 1fd3c64ef642490db941e25e97d4c576
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1549,105 +864,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:07 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 66c3a6a0300345bdaa2f0066e722a2de
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4YjAwOWU2LWY1NjktNGZk
-        NS1iOWNkLTU2ZTE4NGQ2YzVmOC8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:07 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/0ea6f82a-b0fe-43da-b06e-6318468d9c6e/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:07 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 645b70374d524a9db3f8e24b4c7cc5e9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1M2M3OWNkLWFlOTMtNGY3
-        Zi1iNGIxLWNhZjkxMTRlNjUzYS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:07 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:07 GMT
+      - Wed, 11 Aug 2021 21:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1661,21 +878,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - ede384f26bfa40159f6290f44142b9a1
+      - 44e957af76b349ea943772555ee7270b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxMDAyM2IxLWZlOTctNDQ5
-        ZC1iMjlkLTY1NzUzMmVhMzczMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VjZmU2ODk0LTUxY2YtNGFk
+        Yi1iMjYxLTk1NzFlZDRkNmU0NC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:07 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:54 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/010023b1-fe97-449d-b29d-657532ea3732/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ecfe6894-51cf-4adb-b261-9571ed4d6e44/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1683,7 +900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1696,7 +913,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:10 GMT
+      - Wed, 11 Aug 2021 21:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1708,34 +925,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - b2b7a8053a044898a71c3fd0d61633ad
+      - 4b65749ec2af4562babb2c543164df14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '423'
+      - '411'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDEwMDIzYjEtZmU5
-        Ny00NDlkLWIyOWQtNjU3NTMyZWEzNzMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MDcuNjk0NTU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWNmZTY4OTQtNTFj
+        Zi00YWRiLWIyNjEtOTU3MWVkNGQ2ZTQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NTQuOTE4NjUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImVkZTM4NGYyNmJmYTQwMTU5ZjYyOTBm
-        NDQxNDJiOWExIiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MDgu
-        MDE0NzE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxMzo1MDoxMC42
-        MDcxMjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzc0ZjQ1YTlhLWEyOGItNDg2Ni1iNmIzLTM4YTJlNTY0MmRmOS8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjQ0ZTk1N2FmNzZiMzQ5ZWE5NDM3NzI1
+        NTVlZTcyNzBiIiwic3RhcnRlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6NTUu
+        MDkwMDAxWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wOC0xMVQyMToxMTo1NS42
+        Nzk1MDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2MwNjM0YmI4LWQwOWEtNDc4ZS04NGVmLTVjMDEwYWM2MTE3MC8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEwMywiZG9uZSI6MTAz
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBB
-        cnRpZmFjdHMiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOjExMiwiZG9uZSI6MTEyLCJzdWZmaXgiOm51
-        bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
-        ZXNfcmVjb3JkIjpbXX0=
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
+        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNy
+        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6W119
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:10 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
@@ -12507,60 +12507,6 @@ http_interactions:
     http_version: 
   recorded_at: Mon, 12 Jul 2021 16:13:10 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo2NTQwfQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 12 Jul 2021 21:44:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/37cbd6f4-f2d8-47be-a043-94cf3a51d962/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Correlation-Id:
-      - 5a4aa5dcac4f4ba0977331772ab8f44d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8zN2NiZDZmNC1m
-        MmQ4LTQ3YmUtYTA0My05NGNmM2E1MWQ5NjIvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0xMlQyMTo0NDozNS4wNDY0MTZaIiwic2l6ZSI6NjU0MH0=
-    http_version: 
-  recorded_at: Mon, 12 Jul 2021 21:44:35 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/37cbd6f4-f2d8-47be-a043-94cf3a51d962/
     body:
@@ -12881,66 +12827,6 @@ http_interactions:
     http_version: 
   recorded_at: Mon, 12 Jul 2021 21:44:35 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRjZDk0OTEzMmM5ZDYx
-        NWQ4OGJlNmY1YTBhZTkyNTJhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
-        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWRjZDk0
-        OTEzMmM5ZDYxNWQ4OGJlNmY1YTBhZTkyNTJhDQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
-        djMvYXJ0aWZhY3RzL2Q1MjhmMWRhLWQ5YzctNGZkNS05Zjc0LTQ4Y2EwYjRl
-        NTFlYS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1kY2Q5NDkx
-        MzJjOWQ2MTVkODhiZTZmNWEwYWU5MjUyYS0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-dcd949132c9d615d88be6f5a0ae9252a
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '389'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 12 Jul 2021 21:44:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 2dfba80c6d414836a595144ad48a1b59
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwOWEwMTM3LTFlNDMtNGZh
-        NS05MmEzLTRjOWQ3Yzk4Njg2Ny8ifQ==
-    http_version: 
-  recorded_at: Mon, 12 Jul 2021 21:44:35 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/509a0137-1e43-4fa5-92a3-4c9d7c986867/
     body:
@@ -13233,89 +13119,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 14 Jul 2021 13:46:30 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - ec0620a8979c44de9d918b9c31341cf5
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '914'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9kY2E1YTRiZS0zNmEzLTRhOTktYTY1My02MTA5OGM4MTliNmEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MjozNS44MjEyMTZa
-        IiwibWQ1IjoiODgzYmNlYzQ2NWJhMDRmMzJmYzgzMjk2MTU0MWVjMTMiLCJz
-        aGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0OGI1NTdjNTdmYjY1YWM5
-        YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3Y2FjMDlkMGU3YjExNmQ5
-        ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hhMjU2IjoiNWJkMzYzYjg2
-        MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhl
-        M2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4ZjI5ODI1MzIwYzYwY2Rh
-        M2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJiOGFkZTYwNmNhZDgwNDU0
-        N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIsInNoYTUxMiI6Ijc0ZjBh
-        ZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2FjMjgwMmVhODZmZDg0ZGZh
-        ODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgwMmY5NzA1OTRmMGU4ZjZk
-        MmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNiYmUyIiwiYXJ0aWZhY3Qi
-        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzMzNTJmYTBkLTdiZjQtNDc4Ni1h
-        Zjk1LTkxMWM3NDg5ZGEyZC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIs
-        InZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5
-        OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJjaGVja3N1bV90eXBl
-        Ijoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRo
-        ZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0dXJlIFJQTSBmb3IgdGVz
-        dGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6
-        W10sInJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAi
-        LCIwLjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMi
-        OltdLCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6
-        W10sInN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0
-        aW9uX2hyZWYiOiJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRo
-        b3N0IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5z
-        cGVjaWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1f
-        cGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMu
-        cnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQs
-        InJwbV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjp0cnVlLCJzaXpl
-        X2FyY2hpdmUiOjI2NCwic2l6ZV9pbnN0YWxsZWQiOjUsInNpemVfcGFja2Fn
-        ZSI6NjU0MCwidGltZV9idWlsZCI6MTUzMzA2NjAxNywidGltZV9maWxlIjox
-        NTg0MTAxODY0fV19
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:01 GMT
-- request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/4f11b885-e54a-42e2-baf4-ff6aa050b76f/modify/
     body:
@@ -13430,4 +13233,2165 @@ http_interactions:
         LWJhZjQtZmY2YWEwNTBiNzZmLyJdfQ==
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:50:02 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/c7019cd6-d9f9-4e9d-ad8a-0247c4ca4888/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA4YmY0ZWU0NTA3Zjlh
+        ZjhiMTYzN2I3NDRlMTc0ZGNjDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTA1MC0xZnhkMTk3Ig0KQ29udGVudC1MZW5ndGg6IDY1NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0K7avu2wMAAAAAAWR1Y2stMC43
+        LTEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAABAAUAAAAAAAAAAAAAAAAAAAAAjq3oAQAAAAAAAAAH
+        AAAQtAAAAD4AAAAHAAAQpAAAABAAAAENAAAABgAAAAAAAAABAAABEQAAAAYA
+        AAApAAAAAQAAA+gAAAAEAAAAbAAAAAEAAAPsAAAABwAAAHAAAAAQAAAD7wAA
+        AAQAAACAAAAAAQAAA/AAAAAHAAAAhAAAECBlNTA2NTRlYjEyNGU0NDMwOWJj
+        MjIxYTgwZjBlMjg3YTNhNzFhMDgzADkxMzk3N2NjZDJhZDNhNTEwNjI0OGVi
+        MDFjZWZiY2EzNmUzNTQzZmVhOGE4YjMyOWFjZjIyOTU5ZDkyYzg3YTYAAAAA
+        AAf0pjdCLRnnqudft0VbIKrAsgAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAA+AAAAB////5AAAAAQAAAAAI6t6AEAAAAAAAAANAAA
+        A/QAAAA/AAAABwAAA+QAAAAQAAAAZAAAAAgAAAAAAAAAAQAAA+gAAAAGAAAA
+        AgAAAAEAAAPpAAAABgAAAAcAAAABAAAD6gAAAAYAAAALAAAAAQAAA+wAAAAJ
+        AAAADQAAAAEAAAPtAAAACQAAACwAAAABAAAD7gAAAAQAAABMAAAAAQAAA+8A
+        AAAGAAAAUAAAAAEAAAPxAAAABAAAAGgAAAABAAAD9gAAAAYAAABsAAAAAQAA
+        A/gAAAAJAAAAegAAAAEAAAP9AAAABgAAAIYAAAABAAAD/gAAAAYAAACMAAAA
+        AQAABAQAAAAEAAAAlAAAAAEAAAQGAAAAAwAAAJgAAAABAAAECQAAAAMAAACa
+        AAAAAQAABAoAAAAEAAAAnAAAAAEAAAQLAAAACAAAAKAAAAABAAAEDAAAAAgA
+        AADhAAAAAQAABA0AAAAEAAAA5AAAAAEAAAQPAAAACAAAAOgAAAABAAAEEAAA
+        AAgAAADtAAAAAQAABBQAAAAGAAAA8gAAAAEAAAQVAAAABAAAAQgAAAABAAAE
+        FwAAAAgAAAEMAAAAAQAABBgAAAAEAAABFAAAAAQAAAQZAAAACAAAASQAAAAE
+        AAAEGgAAAAgAAAGHAAAABAAABCgAAAAGAAABowAAAAEAAARGAAAABgAAAaoA
+        AAABAAAERwAAAAQAAAHMAAAAAQAABEgAAAAEAAAB0AAAAAEAAARJAAAACAAA
+        AdQAAAABAAAEWAAAAAQAAAHYAAAAAQAABFkAAAAIAAAB3AAAAAEAAARcAAAA
+        BAAAAeQAAAABAAAEXQAAAAgAAAHoAAAAAQAABF4AAAAIAAAB8QAAAAEAAARi
+        AAAABgAAAfsAAAABAAAEZAAAAAYAAANLAAAAAQAABGUAAAAGAAADUAAAAAEA
+        AARmAAAABgAAA1MAAAABAAAEbAAAAAYAAANVAAAAAQAABHQAAAAEAAADcAAA
+        AAEAAAR1AAAABAAAA3QAAAABAAAEdgAAAAgAAAN4AAAAAQAABHoAAAAHAAAD
+        gwAAABAAABOTAAAABAAAA5QAAAABAAATxgAAAAYAAAOYAAAAAQAAE+QAAAAI
+        AAADngAAAAEAABPlAAAABAAAA+AAAAABQwBkdWNrADAuNwAxAFF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLgBBIGZpeHR1cmUgUlBNIGZvciB0ZXN0
+        aW5nIFB1bHAuAFtguyFsb2NhbGhvc3QubG9jYWxkb21haW4AAAAAAAAFUHVi
+        bGljIERvbWFpbgBVbnNwZWNpZmllZABsaW51eABub2FyY2gAAAAAAAWBpAAA
+        W190pjUxODkxNDhiZWY2NmY0NzQzYTgyMTRmMGM5OTBhZGIyZmQ3NjYxYTE5
+        OTBjNzRjODJiZWNlNGY4NDIxYjE2MzEAAAAAAAAAAHJvb3QAcm9vdABkdWNr
+        LTAuNy0xLnNyYy5ycG0AAAAA/////2R1Y2sAAAAAAQAACgEAAAoBAAAKAQAA
+        CnJwbWxpYihDb21wcmVzc2VkRmlsZU5hbWVzKQBycG1saWIoRmlsZURpZ2Vz
+        dHMpAHJwbWxpYihQYXlsb2FkRmlsZXNIYXZlUHJlZml4KQBycG1saWIoUGF5
+        bG9hZElzWHopADMuMC40LTEANC42LjAtMQA0LjAtMQA1LjItMQA0LjE0LjEA
+        bG9jYWxob3N0LmxvY2FsZG9tYWluIDE1MzMwNjYwMTcAAAAAAAEAAAABAAAA
+        AAAAAAgwLjctMQAAAAAAAABkdWNrLnR4dAAvdXNyL2Jpbi8ALU8yIC1nIC1w
+        aXBlIC1XYWxsIC1XZXJyb3I9Zm9ybWF0LXNlY3VyaXR5IC1XcCwtRF9GT1JU
+        SUZZX1NPVVJDRT0yIC1XcCwtRF9HTElCQ1hYX0FTU0VSVElPTlMgLWZleGNl
+        cHRpb25zIC1mc3RhY2stcHJvdGVjdG9yLXN0cm9uZyAtZ3JlY29yZC1nY2Mt
+        c3dpdGNoZXMgLXNwZWNzPS91c3IvbGliL3JwbS9yZWRoYXQvcmVkaGF0LWhh
+        cmRlbmVkLWNjMSAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQt
+        YW5ub2Jpbi1jYzEgLW02NCAtbXR1bmU9Z2VuZXJpYyAtZmFzeW5jaHJvbm91
+        cy11bndpbmQtdGFibGVzIC1mc3RhY2stY2xhc2gtcHJvdGVjdGlvbiAtZmNm
+        LXByb3RlY3Rpb24AY3BpbwB4egAyAG5vYXJjaC1yZWRoYXQtbGludXgtZ251
+        AAAAAAAAAAAAAAAAQVNDSUkgdGV4dAAfW4m2YByqQ87omgFRndWsAAAAAAh1
+        dGYtOAA4NGUzNzY3MzAxYTk0NTE1NWQ0OTA4ZTc0MjI5MDlkNDA5MzEyMTFk
+        MmExNTEyN2E1MTEzNjA1ZTJmMjZhZWM5AAAAAAAIAAAAPwAAAAf///zAAAAA
+        EP03elhaAAAK4fsMoQIAIQESAAAAI7iHLOABBwBVXQAYDd0EYjL5dQuAor0P
+        UQZ7xEsXgbjOcqNnJvefbj6pFydmLWoJ0g/Gg1qEDA3rFaXoiMfY5sOWRK8j
+        AnaIGc+9bHY2Oe7WiYYa8SWojB4WoN7cOq30AAAAAN9f01VaHsmIaVr8EpSQ
+        RS2bxglrE1BK3ZpZ4G1tq6d8AAGJAYgCAADH8uPstunfHAIAAAAACllaDQot
+        LS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMDhiZjRlZTQ1MDdmOWFm
+        OGIxNjM3Yjc0NGUxNzRkY2MtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-08bf4ee4507f9af8b1637b744e174dcc
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6861'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - cf41289c61f54fd0ad7c16551e0e7f73
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9jNzAxOWNkNi1k
+        OWY5LTRlOWQtYWQ4YS0wMjQ3YzRjYTQ4ODgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMDoxMjo1NS44MTU0NTBaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:55 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/c7019cd6-d9f9-4e9d-ad8a-0247c4ca4888/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 4ca5aaee8e574d4d89bfb29122d17466
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllNTM2YzJlLTFjZGYtNGI3
+        MC1iMTZiLWUwNmVjNTQxNTg1NS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9e536c2e-1cdf-4b70-b16b-e06ec5415855/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 10ae84ba21cc4f569acd789059e0d56d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWU1MzZjMmUtMWNk
+        Zi00YjcwLWIxNmItZTA2ZWM1NDE1ODU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTI6NTUuOTA0Mzk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI0Y2E1YWFlZThlNTc0ZDRkODliZmIyOTEyMmQxNzQ2
+        NiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjEyOjU1Ljk0NjI1M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTI6NTYuMDAxNzI3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80
+        OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlmYzcvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYzNjNTBmNTgtMzVhNC00NGY3LTg5
+        Y2EtZjIzMzg4MTQ1ZTVlLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2M3MDE5Y2Q2LWQ5ZjktNGU5ZC1h
+        ZDhhLTAyNDdjNGNhNDg4OC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5a13305e-f2e5-43fe-b9f3-5ce0cd05191b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4bdf88efe5dd425c84c5a18f0b719439
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWExMzMwNWUtZjJl
+        NS00M2ZlLWI5ZjMtNWNlMGNkMDUxOTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTI6NTYuMTE2NTUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkODgzMWM1NWI1NTA0NDFjODhkOTMyOTU3
+        MGEwMjI0MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjEyOjU2LjE2
+        MDA5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTI6NTYuMjc1
+        NzgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlmYzcvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jMWM5
+        ZjVmOC05YThiLTQ4NTktYWM4NC1jOGI2MDNkY2Q5ZmYvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        M2M1MGY1OC0zNWE0LTQ0ZjctODljYS1mMjMzODgxNDVlNWUvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/2d2bdcc9-8ff9-4270-8c0a-6cdd3040f737/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - bc44f7a2367240018e1e21f47b8ae96e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmYjM0YThhLWNmNmMtNGNh
+        MC04MTAxLTJmNjY5NDc4MTBkZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ffb34a8a-cf6c-4ca0-8101-2f66947810df/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 43b7d736f0a74759b26696495ef55c20
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmZiMzRhOGEtY2Y2
+        Yy00Y2EwLTgxMDEtMmY2Njk0NzgxMGRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTI6NTYuMzk0OTAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiYzQ0ZjdhMjM2NzI0MDAxOGUx
+        ZTIxZjQ3YjhhZTk2ZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjEy
+        OjU2LjQ2MDI5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTI6
+        NTYuNjEyODA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82NzIzYTI3My1hN2ZmLTRkYTQtODUwMC03MDZhYjRmMTQ2
+        YWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8yZDJiZGNjOS04ZmY5LTQyNzAtOGMwYS02Y2RkMzA0MGY3MzcvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmQyYmRjYzktOGZmOS00Mjcw
+        LThjMGEtNmNkZDMwNDBmNzM3LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/13318479-b715-4320-8155-166af00b2293/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 0d8ebcb4f65b4297b08494bb1aa3b2d6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyNzdjZWY0LTMxOTktNGMz
+        Ni1iNmE4LTE1NDQxY2E4MWZmZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5277cef4-3199-4c36-b6a8-15441ca81ffe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 89fb83943caf47098b5f4c5c9137cc07
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTI3N2NlZjQtMzE5
+        OS00YzM2LWI2YTgtMTU0NDFjYTgxZmZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTc6NDEuNzE0OTU5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwZDhlYmNiNGY2NWI0Mjk3YjA4
+        NDk0YmIxYWEzYjJkNiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE3
+        OjQxLjc5MzU2NloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTc6
+        NDEuOTU4NDIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8xMzMxODQ3OS1iNzE1LTQzMjAtODE1NS0xNjZhZjAwYjIyOTMvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTMzMTg0NzktYjcxNS00MzIw
+        LTgxNTUtMTY2YWYwMGIyMjkzLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:42 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/d02e41a7-9b55-4fc7-9c23-c8d964178a58/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 16bb71235c3d4742b4e2d4115c62b109
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmNzhhYjNiLTNlZmItNDg3
+        NS1hMjJjLTcxYzY5YzYwZThhYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:31 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ff78ab3b-3efb-4875-a22c-71c69c60e8ab/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1e57a58164194996ad1684bc7bcf8a3c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmY3OGFiM2ItM2Vm
+        Yi00ODc1LWEyMmMtNzFjNjljNjBlOGFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTk6MzEuNjc0MzM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxNmJiNzEyMzVjM2Q0NzQyYjRl
+        MmQ0MTE1YzYyYjEwOSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE5
+        OjMxLjcyNjE4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTk6
+        MzEuODk0NTQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82NzIzYTI3My1hN2ZmLTRkYTQtODUwMC03MDZhYjRmMTQ2
+        YWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kMDJlNDFhNy05YjU1LTRmYzctOWMyMy1jOGQ5NjQxNzhhNTgvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDAyZTQxYTctOWI1NS00ZmM3
+        LTljMjMtYzhkOTY0MTc4YTU4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:32 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/e7de9b2e-e1ce-4f2c-a43b-de7009ffd628/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:20:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 217f7d28298d4736b9fc02304e891bd2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5YjQ2MjA4LTQ3MjAtNGM3
+        OS1iZWYyLTY1ODc4YmU5YTcyZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:20:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e9b46208-4720-4c79-bef2-65878be9a72e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:20:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 308531c56b2d4b7988b03f6122f9ea00
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTliNDYyMDgtNDcy
+        MC00Yzc5LWJlZjItNjU4NzhiZTlhNzJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MjA6NTUuMzk4MTIxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMTdmN2QyODI5OGQ0NzM2Yjlm
+        YzAyMzA0ZTg5MWJkMiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjIw
+        OjU1LjQ2MDIxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MjA6
+        NTUuNzUzNDM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82NzIzYTI3My1hN2ZmLTRkYTQtODUwMC03MDZhYjRmMTQ2
+        YWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9lN2RlOWIyZS1lMWNlLTRmMmMtYTQzYi1kZTcwMDlmZmQ2MjgvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTdkZTliMmUtZTFjZS00ZjJj
+        LWE0M2ItZGU3MDA5ZmZkNjI4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:20:55 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b57b11fb-d06a-4195-8871-10ff8dff8352/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYwMDY1ZDNkYjIzYzEx
+        NzBhMzViYzJiNDU5ODc2NTQzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtNjIyNC0xb2FuN3VxIg0KQ29udGVudC1MZW5ndGg6IDY1NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0K7avu2wMAAAAAAWR1Y2stMC43
+        LTEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAABAAUAAAAAAAAAAAAAAAAAAAAAjq3oAQAAAAAAAAAH
+        AAAQtAAAAD4AAAAHAAAQpAAAABAAAAENAAAABgAAAAAAAAABAAABEQAAAAYA
+        AAApAAAAAQAAA+gAAAAEAAAAbAAAAAEAAAPsAAAABwAAAHAAAAAQAAAD7wAA
+        AAQAAACAAAAAAQAAA/AAAAAHAAAAhAAAECBlNTA2NTRlYjEyNGU0NDMwOWJj
+        MjIxYTgwZjBlMjg3YTNhNzFhMDgzADkxMzk3N2NjZDJhZDNhNTEwNjI0OGVi
+        MDFjZWZiY2EzNmUzNTQzZmVhOGE4YjMyOWFjZjIyOTU5ZDkyYzg3YTYAAAAA
+        AAf0pjdCLRnnqudft0VbIKrAsgAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAA+AAAAB////5AAAAAQAAAAAI6t6AEAAAAAAAAANAAA
+        A/QAAAA/AAAABwAAA+QAAAAQAAAAZAAAAAgAAAAAAAAAAQAAA+gAAAAGAAAA
+        AgAAAAEAAAPpAAAABgAAAAcAAAABAAAD6gAAAAYAAAALAAAAAQAAA+wAAAAJ
+        AAAADQAAAAEAAAPtAAAACQAAACwAAAABAAAD7gAAAAQAAABMAAAAAQAAA+8A
+        AAAGAAAAUAAAAAEAAAPxAAAABAAAAGgAAAABAAAD9gAAAAYAAABsAAAAAQAA
+        A/gAAAAJAAAAegAAAAEAAAP9AAAABgAAAIYAAAABAAAD/gAAAAYAAACMAAAA
+        AQAABAQAAAAEAAAAlAAAAAEAAAQGAAAAAwAAAJgAAAABAAAECQAAAAMAAACa
+        AAAAAQAABAoAAAAEAAAAnAAAAAEAAAQLAAAACAAAAKAAAAABAAAEDAAAAAgA
+        AADhAAAAAQAABA0AAAAEAAAA5AAAAAEAAAQPAAAACAAAAOgAAAABAAAEEAAA
+        AAgAAADtAAAAAQAABBQAAAAGAAAA8gAAAAEAAAQVAAAABAAAAQgAAAABAAAE
+        FwAAAAgAAAEMAAAAAQAABBgAAAAEAAABFAAAAAQAAAQZAAAACAAAASQAAAAE
+        AAAEGgAAAAgAAAGHAAAABAAABCgAAAAGAAABowAAAAEAAARGAAAABgAAAaoA
+        AAABAAAERwAAAAQAAAHMAAAAAQAABEgAAAAEAAAB0AAAAAEAAARJAAAACAAA
+        AdQAAAABAAAEWAAAAAQAAAHYAAAAAQAABFkAAAAIAAAB3AAAAAEAAARcAAAA
+        BAAAAeQAAAABAAAEXQAAAAgAAAHoAAAAAQAABF4AAAAIAAAB8QAAAAEAAARi
+        AAAABgAAAfsAAAABAAAEZAAAAAYAAANLAAAAAQAABGUAAAAGAAADUAAAAAEA
+        AARmAAAABgAAA1MAAAABAAAEbAAAAAYAAANVAAAAAQAABHQAAAAEAAADcAAA
+        AAEAAAR1AAAABAAAA3QAAAABAAAEdgAAAAgAAAN4AAAAAQAABHoAAAAHAAAD
+        gwAAABAAABOTAAAABAAAA5QAAAABAAATxgAAAAYAAAOYAAAAAQAAE+QAAAAI
+        AAADngAAAAEAABPlAAAABAAAA+AAAAABQwBkdWNrADAuNwAxAFF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLgBBIGZpeHR1cmUgUlBNIGZvciB0ZXN0
+        aW5nIFB1bHAuAFtguyFsb2NhbGhvc3QubG9jYWxkb21haW4AAAAAAAAFUHVi
+        bGljIERvbWFpbgBVbnNwZWNpZmllZABsaW51eABub2FyY2gAAAAAAAWBpAAA
+        W190pjUxODkxNDhiZWY2NmY0NzQzYTgyMTRmMGM5OTBhZGIyZmQ3NjYxYTE5
+        OTBjNzRjODJiZWNlNGY4NDIxYjE2MzEAAAAAAAAAAHJvb3QAcm9vdABkdWNr
+        LTAuNy0xLnNyYy5ycG0AAAAA/////2R1Y2sAAAAAAQAACgEAAAoBAAAKAQAA
+        CnJwbWxpYihDb21wcmVzc2VkRmlsZU5hbWVzKQBycG1saWIoRmlsZURpZ2Vz
+        dHMpAHJwbWxpYihQYXlsb2FkRmlsZXNIYXZlUHJlZml4KQBycG1saWIoUGF5
+        bG9hZElzWHopADMuMC40LTEANC42LjAtMQA0LjAtMQA1LjItMQA0LjE0LjEA
+        bG9jYWxob3N0LmxvY2FsZG9tYWluIDE1MzMwNjYwMTcAAAAAAAEAAAABAAAA
+        AAAAAAgwLjctMQAAAAAAAABkdWNrLnR4dAAvdXNyL2Jpbi8ALU8yIC1nIC1w
+        aXBlIC1XYWxsIC1XZXJyb3I9Zm9ybWF0LXNlY3VyaXR5IC1XcCwtRF9GT1JU
+        SUZZX1NPVVJDRT0yIC1XcCwtRF9HTElCQ1hYX0FTU0VSVElPTlMgLWZleGNl
+        cHRpb25zIC1mc3RhY2stcHJvdGVjdG9yLXN0cm9uZyAtZ3JlY29yZC1nY2Mt
+        c3dpdGNoZXMgLXNwZWNzPS91c3IvbGliL3JwbS9yZWRoYXQvcmVkaGF0LWhh
+        cmRlbmVkLWNjMSAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQt
+        YW5ub2Jpbi1jYzEgLW02NCAtbXR1bmU9Z2VuZXJpYyAtZmFzeW5jaHJvbm91
+        cy11bndpbmQtdGFibGVzIC1mc3RhY2stY2xhc2gtcHJvdGVjdGlvbiAtZmNm
+        LXByb3RlY3Rpb24AY3BpbwB4egAyAG5vYXJjaC1yZWRoYXQtbGludXgtZ251
+        AAAAAAAAAAAAAAAAQVNDSUkgdGV4dAAfW4m2YByqQ87omgFRndWsAAAAAAh1
+        dGYtOAA4NGUzNzY3MzAxYTk0NTE1NWQ0OTA4ZTc0MjI5MDlkNDA5MzEyMTFk
+        MmExNTEyN2E1MTEzNjA1ZTJmMjZhZWM5AAAAAAAIAAAAPwAAAAf///zAAAAA
+        EP03elhaAAAK4fsMoQIAIQESAAAAI7iHLOABBwBVXQAYDd0EYjL5dQuAor0P
+        UQZ7xEsXgbjOcqNnJvefbj6pFydmLWoJ0g/Gg1qEDA3rFaXoiMfY5sOWRK8j
+        AnaIGc+9bHY2Oe7WiYYa8SWojB4WoN7cOq30AAAAAN9f01VaHsmIaVr8EpSQ
+        RS2bxglrE1BK3ZpZ4G1tq6d8AAGJAYgCAADH8uPstunfHAIAAAAACllaDQot
+        LS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNjAwNjVkM2RiMjNjMTE3
+        MGEzNWJjMmI0NTk4NzY1NDMtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-60065d3db23c1170a35bc2b459876543
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6861'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 59048ff4ca0f471195f5e13e1748a2ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9iNTdiMTFmYi1k
+        MDZhLTQxOTUtODg3MS0xMGZmOGRmZjgzNTIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMDo0ODoxMC4wMDUxMjJaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/b57b11fb-d06a-4195-8871-10ff8dff8352/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3aa50c53a1e64c40bb94f02f2dee3a6e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliZTdmZDc2LTNmZTUtNGNj
+        MC05NTFiLWRhZTBlZjQzYjBmMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9be7fd76-3fe5-4cc0-951b-dae0ef43b0f2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f58352534bfb405ba3d530f8cebab091
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWJlN2ZkNzYtM2Zl
+        NS00Y2MwLTk1MWItZGFlMGVmNDNiMGYyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTAuMTAyNzIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIzYWE1MGM1M2ExZTY0YzQwYmI5NGYwMmYyZGVlM2E2
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4OjEwLjE0Nzg0MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6MTAuMjA0NDY3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOWY4OWZhYjMtZDRjNy00ODUxLWFl
+        OGYtNjY4MzQ5NmQxNDc1LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2I1N2IxMWZiLWQwNmEtNDE5NS04
+        ODcxLTEwZmY4ZGZmODM1Mi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/92047f45-8d21-47e8-adbb-c26e6e1396c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9172bc9f3e7f4d7591d92058ac1a8e71
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTIwNDdmNDUtOGQy
+        MS00N2U4LWFkYmItYzI2ZTZlMTM5NmM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTAuMzIzMjQyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzOGFmYWVlYzAzNDU0N2ZiODc2YzQ2YTA0
+        MGQ5NmI4MCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4OjEwLjM2
+        MzAyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6MTAuNDgx
+        NjY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wYTk0
+        ZWY2OC1kYWM4LTQwYmItYTFjNS1hZmZkYmI1Zjk4MGUvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        Zjg5ZmFiMy1kNGM3LTQ4NTEtYWU4Zi02NjgzNDk2ZDE0NzUvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fff10780-d5b0-41a8-b487-4fd0b72f62dd/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGE5NGVmNjgtZGFjOC00MGJiLWExYzUtYWZmZGJiNWY5
+        ODBlLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - b0de5f7698914bae823ffa184d003cc5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkYTJhYTM0LTZjZDktNDY1
+        Yi1iMWJiLTA4ODhiMjJiYzM2OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/cda2aa34-6cd9-465b-b1bb-0888b22bc368/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 379c176617b34c5aad11ee8d9b0a0747
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2RhMmFhMzQtNmNk
+        OS00NjViLWIxYmItMDg4OGIyMmJjMzY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTAuNTk4MTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiMGRlNWY3Njk4OTE0YmFlODIz
+        ZmZhMTg0ZDAwM2NjNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4
+        OjEwLjYzNzg1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6
+        MTAuNzkzNDA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9mZmYxMDc4MC1kNWIwLTQxYTgtYjQ4Ny00ZmQwYjcyZjYyZGQvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmZmMTA3ODAtZDViMC00MWE4
+        LWI0ODctNGZkMGI3MmY2MmRkLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - ec26550195c74ed3a2520ed654d46358
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:45 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - b47e23a8e16a48898a342af41f225f31
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:45 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo2NTQwfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/0439340c-055f-4a60-ac74-1e938c511a5c/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Correlation-Id:
+      - 5102cd4ee16c401dae171d9c3e18ee1e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wNDM5MzQwYy0w
+        NTVmLTRhNjAtYWM3NC0xZTkzOGM1MTFhNWMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMTo0Ni42OTg4MThaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:46 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/0439340c-055f-4a60-ac74-1e938c511a5c/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNkOTE5MjMyZmEwODEx
+        ZmU3ODE1MDI1YTBlNThjMzY5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODAxMy0xcmpxM3ZoIg0KQ29udGVudC1MZW5ndGg6IDY1NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0K7avu2wMAAAAAAWR1Y2stMC43
+        LTEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAABAAUAAAAAAAAAAAAAAAAAAAAAjq3oAQAAAAAAAAAH
+        AAAQtAAAAD4AAAAHAAAQpAAAABAAAAENAAAABgAAAAAAAAABAAABEQAAAAYA
+        AAApAAAAAQAAA+gAAAAEAAAAbAAAAAEAAAPsAAAABwAAAHAAAAAQAAAD7wAA
+        AAQAAACAAAAAAQAAA/AAAAAHAAAAhAAAECBlNTA2NTRlYjEyNGU0NDMwOWJj
+        MjIxYTgwZjBlMjg3YTNhNzFhMDgzADkxMzk3N2NjZDJhZDNhNTEwNjI0OGVi
+        MDFjZWZiY2EzNmUzNTQzZmVhOGE4YjMyOWFjZjIyOTU5ZDkyYzg3YTYAAAAA
+        AAf0pjdCLRnnqudft0VbIKrAsgAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAA+AAAAB////5AAAAAQAAAAAI6t6AEAAAAAAAAANAAA
+        A/QAAAA/AAAABwAAA+QAAAAQAAAAZAAAAAgAAAAAAAAAAQAAA+gAAAAGAAAA
+        AgAAAAEAAAPpAAAABgAAAAcAAAABAAAD6gAAAAYAAAALAAAAAQAAA+wAAAAJ
+        AAAADQAAAAEAAAPtAAAACQAAACwAAAABAAAD7gAAAAQAAABMAAAAAQAAA+8A
+        AAAGAAAAUAAAAAEAAAPxAAAABAAAAGgAAAABAAAD9gAAAAYAAABsAAAAAQAA
+        A/gAAAAJAAAAegAAAAEAAAP9AAAABgAAAIYAAAABAAAD/gAAAAYAAACMAAAA
+        AQAABAQAAAAEAAAAlAAAAAEAAAQGAAAAAwAAAJgAAAABAAAECQAAAAMAAACa
+        AAAAAQAABAoAAAAEAAAAnAAAAAEAAAQLAAAACAAAAKAAAAABAAAEDAAAAAgA
+        AADhAAAAAQAABA0AAAAEAAAA5AAAAAEAAAQPAAAACAAAAOgAAAABAAAEEAAA
+        AAgAAADtAAAAAQAABBQAAAAGAAAA8gAAAAEAAAQVAAAABAAAAQgAAAABAAAE
+        FwAAAAgAAAEMAAAAAQAABBgAAAAEAAABFAAAAAQAAAQZAAAACAAAASQAAAAE
+        AAAEGgAAAAgAAAGHAAAABAAABCgAAAAGAAABowAAAAEAAARGAAAABgAAAaoA
+        AAABAAAERwAAAAQAAAHMAAAAAQAABEgAAAAEAAAB0AAAAAEAAARJAAAACAAA
+        AdQAAAABAAAEWAAAAAQAAAHYAAAAAQAABFkAAAAIAAAB3AAAAAEAAARcAAAA
+        BAAAAeQAAAABAAAEXQAAAAgAAAHoAAAAAQAABF4AAAAIAAAB8QAAAAEAAARi
+        AAAABgAAAfsAAAABAAAEZAAAAAYAAANLAAAAAQAABGUAAAAGAAADUAAAAAEA
+        AARmAAAABgAAA1MAAAABAAAEbAAAAAYAAANVAAAAAQAABHQAAAAEAAADcAAA
+        AAEAAAR1AAAABAAAA3QAAAABAAAEdgAAAAgAAAN4AAAAAQAABHoAAAAHAAAD
+        gwAAABAAABOTAAAABAAAA5QAAAABAAATxgAAAAYAAAOYAAAAAQAAE+QAAAAI
+        AAADngAAAAEAABPlAAAABAAAA+AAAAABQwBkdWNrADAuNwAxAFF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLgBBIGZpeHR1cmUgUlBNIGZvciB0ZXN0
+        aW5nIFB1bHAuAFtguyFsb2NhbGhvc3QubG9jYWxkb21haW4AAAAAAAAFUHVi
+        bGljIERvbWFpbgBVbnNwZWNpZmllZABsaW51eABub2FyY2gAAAAAAAWBpAAA
+        W190pjUxODkxNDhiZWY2NmY0NzQzYTgyMTRmMGM5OTBhZGIyZmQ3NjYxYTE5
+        OTBjNzRjODJiZWNlNGY4NDIxYjE2MzEAAAAAAAAAAHJvb3QAcm9vdABkdWNr
+        LTAuNy0xLnNyYy5ycG0AAAAA/////2R1Y2sAAAAAAQAACgEAAAoBAAAKAQAA
+        CnJwbWxpYihDb21wcmVzc2VkRmlsZU5hbWVzKQBycG1saWIoRmlsZURpZ2Vz
+        dHMpAHJwbWxpYihQYXlsb2FkRmlsZXNIYXZlUHJlZml4KQBycG1saWIoUGF5
+        bG9hZElzWHopADMuMC40LTEANC42LjAtMQA0LjAtMQA1LjItMQA0LjE0LjEA
+        bG9jYWxob3N0LmxvY2FsZG9tYWluIDE1MzMwNjYwMTcAAAAAAAEAAAABAAAA
+        AAAAAAgwLjctMQAAAAAAAABkdWNrLnR4dAAvdXNyL2Jpbi8ALU8yIC1nIC1w
+        aXBlIC1XYWxsIC1XZXJyb3I9Zm9ybWF0LXNlY3VyaXR5IC1XcCwtRF9GT1JU
+        SUZZX1NPVVJDRT0yIC1XcCwtRF9HTElCQ1hYX0FTU0VSVElPTlMgLWZleGNl
+        cHRpb25zIC1mc3RhY2stcHJvdGVjdG9yLXN0cm9uZyAtZ3JlY29yZC1nY2Mt
+        c3dpdGNoZXMgLXNwZWNzPS91c3IvbGliL3JwbS9yZWRoYXQvcmVkaGF0LWhh
+        cmRlbmVkLWNjMSAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQt
+        YW5ub2Jpbi1jYzEgLW02NCAtbXR1bmU9Z2VuZXJpYyAtZmFzeW5jaHJvbm91
+        cy11bndpbmQtdGFibGVzIC1mc3RhY2stY2xhc2gtcHJvdGVjdGlvbiAtZmNm
+        LXByb3RlY3Rpb24AY3BpbwB4egAyAG5vYXJjaC1yZWRoYXQtbGludXgtZ251
+        AAAAAAAAAAAAAAAAQVNDSUkgdGV4dAAfW4m2YByqQ87omgFRndWsAAAAAAh1
+        dGYtOAA4NGUzNzY3MzAxYTk0NTE1NWQ0OTA4ZTc0MjI5MDlkNDA5MzEyMTFk
+        MmExNTEyN2E1MTEzNjA1ZTJmMjZhZWM5AAAAAAAIAAAAPwAAAAf///zAAAAA
+        EP03elhaAAAK4fsMoQIAIQESAAAAI7iHLOABBwBVXQAYDd0EYjL5dQuAor0P
+        UQZ7xEsXgbjOcqNnJvefbj6pFydmLWoJ0g/Gg1qEDA3rFaXoiMfY5sOWRK8j
+        AnaIGc+9bHY2Oe7WiYYa8SWojB4WoN7cOq30AAAAAN9f01VaHsmIaVr8EpSQ
+        RS2bxglrE1BK3ZpZ4G1tq6d8AAGJAYgCAADH8uPstunfHAIAAAAACllaDQot
+        LS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtM2Q5MTkyMzJmYTA4MTFm
+        ZTc4MTUwMjVhMGU1OGMzNjktLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-3d919232fa0811fe7815025a0e58c369
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6861'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 1e79366e45d94564887795bab303dc66
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wNDM5MzQwYy0w
+        NTVmLTRhNjAtYWM3NC0xZTkzOGM1MTFhNWMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMTo0Ni42OTg4MThaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:46 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - f9bc2e7cf4c449a2bd64bc964e91bd0e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:46 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/0439340c-055f-4a60-ac74-1e938c511a5c/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - c8edea5d51bc41e680448159280db0e9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwNGQ0OWYzLWJkMjQtNDA0
+        OC1hZDM4LTBkODgxOWM1NDAzMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a04d49f3-bd24-4048-ad38-0d8819c54033/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 90b0c8d4d32f471b99389d2139e63e80
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTA0ZDQ5ZjMtYmQy
+        NC00MDQ4LWFkMzgtMGQ4ODE5YzU0MDMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NDYuOTQ3MTQ1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJjOGVkZWE1ZDUxYmM0MWU2ODA0NDgxNTkyODBkYjBl
+        OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjQ3LjExOTkyOFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6NDcuMjgzMzIxWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTEwZDYzODEtNmY1Mi00NjI3LTg2
+        NzUtNzljZmIyNTMzYmVhLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzA0MzkzNDBjLTA1NWYtNGE2MC1h
+        Yzc0LTFlOTM4YzUxMWE1Yy8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 10a4f9467fff4783bd72a4f3019df193
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTEw
+        ZDYzODEtNmY1Mi00NjI3LTg2NzUtNzljZmIyNTMzYmVhLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTFUMjE6MTE6NDcuMTg0MDQ2WiIsImZpbGUiOiJh
+        cnRpZmFjdC81Yi9kMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4
+        ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNpemUiOjY1NDAsIm1k
+        NSI6bnVsbCwic2hhMSI6ImM5MThiZDkxYTA0MjE4NTVmOTIyOThlNDhiNTU3
+        YzU3ZmI2NWFjOWEiLCJzaGEyMjQiOiJhN2Y1NTQyZDUyOTY1NzI5N2NhYzA5
+        ZDBlN2IxMTZkOTgzNTUxMjEzYjE0NDNkMzFiMjg2Nzg1ZCIsInNoYTI1NiI6
+        IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIx
+        MjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJzaGEzODQiOiJmY2VhYWQ5OGYyOTgy
+        NTMyMGM2MGNkYTNhOGQyYmM3ZmU3NmFhM2Y3YjJkYjllNmIyNjFiYjhhZGU2
+        MDZjYWQ4MDQ1NDdjN2MzNWIxMWJlOTQ5ZTZjNGQ3YjMzN2UzM2QiLCJzaGE1
+        MTIiOiI3NGYwYWUwYjhiYTNkN2YyYjhmMTY3NzRhNWY0MDk3OWNhYzI4MDJl
+        YTg2ZmQ4NGRmYTgzOTAyM2IzODY3MTVmOGU0OWE5ZTJlYzE4OTk4MDJmOTcw
+        NTk0ZjBlOGY2ZDJhNDA2NmIyNTk0MDZkMjIzN2JhOGJiOTIyZTEzYmJlMiJ9
+        XX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:47 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWZmNjhmNjU4NzY2MzE3
+        MTE1NmE5NDNiNmE3MGYyZThlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
+        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWZmNjhm
+        NjU4NzY2MzE3MTE1NmE5NDNiNmE3MGYyZThlDQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzkxMGQ2MzgxLTZmNTItNDYyNy04Njc1LTc5Y2ZiMjUz
+        M2JlYS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1mZjY4ZjY1
+        ODc2NjMxNzExNTZhOTQzYjZhNzBmMmU4ZS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-ff68f6587663171156a943b6a70f2e8e
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '389'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - be3a3cdfe4d64f5a85d9895b3951b299
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2Y2U0Mjg4LThiYWUtNDQ2
+        My04OGYzLWY2NzQwYzRjMDY0MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/16ce4288-8bae-4463-88f3-f6740c4c0641/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 82c1f6d2222e419f86835ec7728b6fd7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '407'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTZjZTQyODgtOGJh
+        ZS00NDYzLTg4ZjMtZjY3NDBjNGMwNjQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NDcuNzIyNDk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiZTNhM2NkZmU0ZDY0ZjVhODVkOTg5NWIz
+        OTUxYjI5OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjExOjQ3Ljgz
+        ODUzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6NDguMTM1
+        NzIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9kMjgw
+        ZDdiNC00YTNmLTRlNGYtOGJjMy0zNzQ4YzFhOGIwODkvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85
+        MTBkNjM4MS02ZjUyLTQ2MjctODY3NS03OWNmYjI1MzNiZWEvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:48 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5862dc2f-5f83-496d-8cc4-8f8a17f4e774/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZDI4MGQ3YjQtNGEzZi00ZTRmLThiYzMtMzc0OGMxYThi
+        MDg5LyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - e83c6263c91f485e9cbb839ba264c4e0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyOTdkOTZlLWUzZTMtNDU1
+        ZS04ZGNkLThjYmZmM2E4NDgwYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:48 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2297d96e-e3e3-455e-8dcd-8cbff3a8480c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 99f636a451a049e3b3d72ca556aaa828
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI5N2Q5NmUtZTNl
+        My00NTVlLThkY2QtOGNiZmYzYTg0ODBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NDguNDA5NzgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlODNjNjI2M2M5MWY0ODVlOWNi
+        YjgzOWJhMjY0YzRlMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEx
+        OjQ4LjU0Nzk4MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6
+        NDkuMDgzMzYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81ODYyZGMyZi01ZjgzLTQ5NmQtOGNjNC04ZjhhMTdmNGU3NzQvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg2MmRjMmYtNWY4My00OTZk
+        LThjYzQtOGY4YTE3ZjRlNzc0LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:49 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
@@ -2858,89 +2858,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 14 Jul 2021 13:46:31 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 1202e995f2fe4e8584e4b69e544bf4d3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '914'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9kY2E1YTRiZS0zNmEzLTRhOTktYTY1My02MTA5OGM4MTliNmEv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0MjozNS44MjEyMTZa
-        IiwibWQ1IjoiODgzYmNlYzQ2NWJhMDRmMzJmYzgzMjk2MTU0MWVjMTMiLCJz
-        aGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0OGI1NTdjNTdmYjY1YWM5
-        YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3Y2FjMDlkMGU3YjExNmQ5
-        ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hhMjU2IjoiNWJkMzYzYjg2
-        MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhl
-        M2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4ZjI5ODI1MzIwYzYwY2Rh
-        M2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJiOGFkZTYwNmNhZDgwNDU0
-        N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIsInNoYTUxMiI6Ijc0ZjBh
-        ZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2FjMjgwMmVhODZmZDg0ZGZh
-        ODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgwMmY5NzA1OTRmMGU4ZjZk
-        MmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNiYmUyIiwiYXJ0aWZhY3Qi
-        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzMzNTJmYTBkLTdiZjQtNDc4Ni1h
-        Zjk1LTkxMWM3NDg5ZGEyZC8iLCJuYW1lIjoiZHVjayIsImVwb2NoIjoiMCIs
-        InZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2gi
-        LCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5
-        OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJjaGVja3N1bV90eXBl
-        Ijoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRo
-        ZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0dXJlIFJQTSBmb3IgdGVz
-        dGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6
-        W10sInJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAi
-        LCIwLjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMi
-        OltdLCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6
-        W10sInN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0
-        aW9uX2hyZWYiOiJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRo
-        b3N0IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5z
-        cGVjaWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1f
-        cGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMu
-        cnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQs
-        InJwbV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjp0cnVlLCJzaXpl
-        X2FyY2hpdmUiOjI2NCwic2l6ZV9pbnN0YWxsZWQiOjUsInNpemVfcGFja2Fn
-        ZSI6NjU0MCwidGltZV9idWlsZCI6MTUzMzA2NjAxNywidGltZV9maWxlIjox
-        NTg0MTAxODY0fV19
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:03 GMT
-- request:
     method: post
     uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/4f11b885-e54a-42e2-baf4-ff6aa050b76f/modify/
     body:
@@ -3053,4 +2970,765 @@ http_interactions:
         YS00MmUyLWJhZjQtZmY2YWEwNTBiNzZmLyJdfQ==
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:50:03 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/2d2bdcc9-8ff9-4270-8c0a-6cdd3040f737/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 3225d01d67db43798928ec77185b92f7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxYmUzODI4LTg3ZWEtNDJl
+        Mi1hOTk2LTkxMzAwYmI0ODc0Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:57 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/01be3828-87ea-42e2-a996-91300bb48747/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:12:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 02c3a47d7ccd476bb405df080386d636
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDFiZTM4MjgtODdl
+        YS00MmUyLWE5OTYtOTEzMDBiYjQ4NzQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTI6NTcuMjUwNjI0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMjI1ZDAxZDY3ZGI0Mzc5ODky
+        OGVjNzcxODViOTJmNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjEy
+        OjU3LjI5MzIxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTI6
+        NTcuNDQ1NDkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMmQyYmRjYzktOGZm
+        OS00MjcwLThjMGEtNmNkZDMwNDBmNzM3LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:12:57 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/13318479-b715-4320-8155-166af00b2293/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - d819409b020c45208a6f5ead2d40469f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyNGVhMDIyLTVhN2EtNGMw
+        YS1hYmFmLTM4ODc1MjZiOGM1Ni8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:42 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f24ea022-5a7a-4c0a-abaf-3887526b8c56/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4351eec16d094c1e8a52e28e6301d1e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjI0ZWEwMjItNWE3
+        YS00YzBhLWFiYWYtMzg4NzUyNmI4YzU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTc6NDIuNTMzMjM4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkODE5NDA5YjAyMGM0NTIwOGE2
+        ZjVlYWQyZDQwNDY5ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE3
+        OjQyLjU3MzI4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTc6
+        NDIuNzMxMjUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTMzMTg0NzktYjcx
+        NS00MzIwLTgxNTUtMTY2YWYwMGIyMjkzLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:42 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/d02e41a7-9b55-4fc7-9c23-c8d964178a58/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 11d28cfa1d284883b14031c2f2c7e4af
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNzA3NzE2LTIzMzItNDZi
+        MS1hZjZmLTQwY2Q2YzFiMWRkZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:32 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e2707716-2332-46b1-af6f-40cd6c1b1ddf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 518ef54d434a4d649cd844c9b94add02
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTI3MDc3MTYtMjMz
+        Mi00NmIxLWFmNmYtNDBjZDZjMWIxZGRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTk6MzIuNDg4ODg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMWQyOGNmYTFkMjg0ODgzYjE0
+        MDMxYzJmMmM3ZTRhZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE5
+        OjMyLjUyNjYxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTk6
+        MzIuNjcxNjI4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDAyZTQxYTctOWI1
+        NS00ZmM3LTljMjMtYzhkOTY0MTc4YTU4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:32 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/e7de9b2e-e1ce-4f2c-a43b-de7009ffd628/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:20:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 131e26b7140e420fa22d103ba8e9144c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJlZDExMGI0LWZlMjgtNGU3
+        Ny1hOTRlLWJhNTM3OTFkOTY0ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:20:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/2ed110b4-fe28-4e77-a94e-ba53791d964d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:20:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - c26afa868c944e26b7221a429e5aee05
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmVkMTEwYjQtZmUy
+        OC00ZTc3LWE5NGUtYmE1Mzc5MWQ5NjRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MjA6NTYuMzMxMDY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMzFlMjZiNzE0MGU0MjBmYTIy
+        ZDEwM2JhOGU5MTQ0YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjIw
+        OjU2LjM5MTA3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MjA6
+        NTYuNTg3OTIzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTdkZTliMmUtZTFj
+        ZS00ZjJjLWE0M2ItZGU3MDA5ZmZkNjI4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:20:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fff10780-d5b0-41a8-b487-4fd0b72f62dd/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMGE5NGVmNjgtZGFjOC00MGJiLWExYzUtYWZmZGJiNWY5
+        ODBlLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - c6cb3de19fa54b38ab14995267201b3c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzZjQ3NDk5LTAzZjgtNDdk
+        MS05MjVjLTFiMzlhYmU2NGVhMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/23f47499-03f8-47d1-925c-1b39abe64ea1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:11 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8fac8424c827407b87353ae613c80baf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjNmNDc0OTktMDNm
+        OC00N2QxLTkyNWMtMWIzOWFiZTY0ZWExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTEuNDI3NTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNmNiM2RlMTlmYTU0YjM4YWIx
+        NDk5NTI2NzIwMWIzYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4
+        OjExLjQ3NTgxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6
+        MTEuNjQwNDQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmZmMTA3ODAtZDVi
+        MC00MWE4LWI0ODctNGZkMGI3MmY2MmRkLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:11 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f06b2884ddeb46549f459df612a132f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '916'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9kMjgwZDdiNC00YTNmLTRlNGYtOGJjMy0zNzQ4YzFhOGIwODkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMTo0OC4wODc3ODNa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
+        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
+        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
+        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
+        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
+        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
+        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
+        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
+        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
+        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzkxMGQ2
+        MzgxLTZmNTItNDYyNy04Njc1LTc5Y2ZiMjUzM2JlYS8iLCJuYW1lIjoiZHVj
+        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
+        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
+        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
+        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
+        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
+        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
+        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
+        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
+        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
+        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
+        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
+        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
+        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
+        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
+        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTYy
+        ODcxNjMwOH1dfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:50 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5862dc2f-5f83-496d-8cc4-8f8a17f4e774/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZDI4MGQ3YjQtNGEzZi00ZTRmLThiYzMtMzc0OGMxYThi
+        MDg5LyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 2f7ff7a916ce45c7b5de7e494773f60b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxOGI2ZTA5LTg5OWItNDhl
+        Ni05ZTZjLWZmMjY2ZjU0ZTZkMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:50 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/718b6e09-899b-48e6-9e6c-ff266f54e6d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f963e209fb804fb5a806e6b6e44ee237
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzE4YjZlMDktODk5
+        Yi00OGU2LTllNmMtZmYyNjZmNTRlNmQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTE6NTAuNjI4MTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZjdmZjdhOTE2Y2U0NWM3YjVk
+        ZTdlNDk0NzczZjYwYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEx
+        OjUwLjc2OTQ1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTE6
+        NTEuMjE3ODA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTg2MmRjMmYtNWY4
+        My00OTZkLThjYzQtOGY4YTE3ZjRlNzc0LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:51 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:12 GMT
+      - Wed, 11 Aug 2021 21:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 1e855c411f98441d952f1f9193fac3f3
+      - 4cca1b958772484e98858d337089221d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:12 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:57 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:12 GMT
+      - Wed, 11 Aug 2021 21:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 75e0494311454569b7e57b447365152f
+      - e55f5782bf3e4a0e9cf62b851d7fa18a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:12 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:57 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:12 GMT
+      - Wed, 11 Aug 2021 21:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - e25eb3e62e34406d9cc6a590226e0ebb
+      - 56d3ca6bc551444288c945bf07ba8fc4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:12 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:57 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:12 GMT
+      - Wed, 11 Aug 2021 21:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,86 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - e1841621937744fcbe146348ab305f3d
+      - c00f9f86c904422aa181b51818ad9c5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:12 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:57 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
-        OjB9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/87a1b0d8-9ad4-49af-88ee-e2d7a811d5ba/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '626'
-      Correlation-Id:
-      - 7dd1b2dbc2694f329a1ef0f7918e9a48
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODdhMWIwZDgtOWFkNC00OWFmLTg4ZWUtZTJkN2E4MTFkNWJhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NTA6MTMuMDg3ODIxWiIsInZl
-        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vODdhMWIwZDgtOWFkNC00OWFmLTg4ZWUtZTJkN2E4MTFkNWJhL3ZlcnNp
-        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84N2ExYjBkOC05
-        YWQ0LTQ5YWYtODhlZS1lMmQ3YTgxMWQ1YmEvdmVyc2lvbnMvMC8iLCJuYW1l
-        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:13 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -289,13 +224,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:13 GMT
+      - Wed, 11 Aug 2021 21:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/7a948951-d314-4574-8942-e3326baea52b/"
+      - "/pulp/api/v3/remotes/rpm/rpm/95d87b8f-c8e7-4ea6-b6eb-f683770e3114/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -305,31 +240,96 @@ http_interactions:
       Content-Length:
       - '534'
       Correlation-Id:
-      - df34679682224ee881e49310dac0c1cb
+      - b297f00d4c534b358bdf83ea4443ecea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdh
-        OTQ4OTUxLWQzMTQtNDU3NC04OTQyLWUzMzI2YmFlYTUyYi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUwOjEzLjMxNTk3M1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk1
+        ZDg3YjhmLWM4ZTctNGVhNi1iNmViLWY2ODM3NzBlMzExNC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTA4LTExVDIxOjExOjU3LjgwNTU5MloiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMDctMjFUMTM6NTA6MTMuMzE2MDMxWiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTE6NTcuODA1NjEzWiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:13 GMT
+  recorded_at: Wed, 11 Aug 2021 21:11:57 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
+        OjB9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/fbb93392-7cf1-47d7-b4e2-617aa81ee768/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '626'
+      Correlation-Id:
+      - ae1930097b3649cabceb5ba08916b56a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vZmJiOTMzOTItN2NmMS00N2Q3LWI0ZTItNjE3YWE4MWVlNzY4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTE6NTguNTI3Njc1WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vZmJiOTMzOTItN2NmMS00N2Q3LWI0ZTItNjE3YWE4MWVlNzY4L3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYmI5MzM5Mi03
+        Y2YxLTQ3ZDctYjRlMi02MTdhYTgxZWU3NjgvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
+        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
+        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
+        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:58 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/7a948951-d314-4574-8942-e3326baea52b/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/95d87b8f-c8e7-4ea6-b6eb-f683770e3114/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -350,7 +350,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:17 GMT
+      - Wed, 11 Aug 2021 21:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -364,21 +364,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - af9ca04a02de4eba88605aef50247f43
+      - 8c84cbf7e93a4639bfa27d936c18646d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmMDY5ZTJmLWFjNmUtNDMw
-        ZS04NTU4LWI5OTY4OTY3NmNjYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyYThjNjMyLTc0NmUtNDE5
+        YS04MDIwLTU3YWY0Zjk3MTc5Mi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:17 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:05 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/3f069e2f-ac6e-430e-8558-b99689676ccb/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/12a8c632-746e-419a-8020-57af4f971792/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -399,7 +399,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:17 GMT
+      - Wed, 11 Aug 2021 21:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -411,35 +411,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - f62c914607754f47a11192c809ca2012
+      - 06fa3dccfa264dfa9737abb55f9eafa2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '373'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2YwNjllMmYtYWM2
-        ZS00MzBlLTg1NTgtYjk5Njg5Njc2Y2NiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MTcuMDYzNzQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTJhOGM2MzItNzQ2
+        ZS00MTlhLTgwMjAtNTdhZjRmOTcxNzkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDUuMzA0NjU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZjljYTA0YTAyZGU0ZWJhODg2MDVhZWY1
-        MDI0N2Y0MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUwOjE3LjE1
-        MjYzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MTcuMjQw
-        NTMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4Yzg0Y2JmN2U5M2E0NjM5YmZhMjdkOTM2
+        YzE4NjQ2ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEyOjA1LjQ1
+        NDg0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6MDUuNTc0
+        MDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzdhOTQ4OTUxLWQzMTQtNDU3NC04OTQy
-        LWUzMzI2YmFlYTUyYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk1ZDg3YjhmLWM4ZTctNGVhNi1iNmVi
+        LWY2ODM3NzBlMzExNC8iXX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:17 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:05 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/87a1b0d8-9ad4-49af-88ee-e2d7a811d5ba/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fbb93392-7cf1-47d7-b4e2-617aa81ee768/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +460,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:17 GMT
+      - Wed, 11 Aug 2021 21:12:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -474,21 +474,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 8d4f84e1dc5d4a5f9b5e87b08b0a3061
+      - 9eb3f39809474df08e196b650839da37
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3MWEyOTQxLWMwYmEtNDE5
-        Zi05NjkwLWY4OWJkY2ZkZjFjNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRiZmU0YzZiLTY5M2EtNGY1
+        Zi05MjIxLTFjYjk3ZjJkMTY1OC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:17 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/b71a2941-c0ba-419f-9690-f89bdcfdf1c4/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/4bfe4c6b-693a-4f5f-9221-1cb97f2d1658/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -496,7 +496,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -509,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:17 GMT
+      - Wed, 11 Aug 2021 21:12:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -521,644 +521,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 6e7d5877752e42218c12adef89e4e19a
+      - 8ffecaccb2074ad69c8a7924fa038a68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '375'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjcxYTI5NDEtYzBi
-        YS00MTlmLTk2OTAtZjg5YmRjZmRmMWM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MTcuNDgwOTY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGJmZTRjNmItNjkz
+        YS00ZjVmLTkyMjEtMWNiOTdmMmQxNjU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDYuMDk0NjkyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4ZDRmODRlMWRjNWQ0YTVmOWI1ZTg3YjA4
-        YjBhMzA2MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUwOjE3LjU2
-        NjQ2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MTcuNjc5
-        MTA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5ZWIzZjM5ODA5NDc0ZGYwOGUxOTZiNjUw
+        ODM5ZGEzNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEyOjA2LjIw
+        NDc2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6MDYuMzQ1
+        NzI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vODdhMWIwZDgtOWFkNC00OWFm
-        LTg4ZWUtZTJkN2E4MTFkNWJhLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJiOTMzOTItN2NmMS00N2Q3
+        LWI0ZTItNjE3YWE4MWVlNzY4LyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:17 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 0400b47ff2ef42e68038151b5d53614b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '301'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5OjQ2LjE5MTI1
-        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMjNjNzE2MjktNjMxNC00ODhjLTlmNGUtZmFlNTNkNjY1
-        MzQxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0MS92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
-        X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFu
-        aWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/23c71629-6314-488c-9f4e-fae53d665341/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - e62b87c10bb345c7b081e64742cb3ffe
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0
-        MS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6
-        NDk6NDYuMjAxOTY3WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQt
-        NDg4Yy05ZjRlLWZhZTUzZDY2NTM0MS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
-        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
-        cmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - c0b9ad8d71df45919797a79a4fbf055f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '498'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6NCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0OToxNy43OTkwOTVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMyMGMw
-        NGU0LTE1ZTctNDMwYi04YzcyLWI4MjFkZGRjM2M2ZC92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2Fn
-        ZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwi
-        cGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVw
-        b19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVh
-        NmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMDctMjFUMTM6NDk6MTUuMTg0ODQxWiIsInZlcnNpb25z
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVh
-        NmY4MmEtYjBmZS00M2RhLWIwNmUtNjMxODQ2OGQ5YzZlL3ZlcnNpb25zLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQz
-        ZGEtYjA2ZS02MzE4NDY4ZDljNmUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluZWRfdmVyc2lv
-        bnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJt
-        ZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdl
-        X3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJw
-        YWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBv
-        X2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvIiwicHVscF9jcmVh
-        dGVkIjoiMjAyMS0wNy0yMFQxOToyMjoxNy45OTgwNThaIiwidmVyc2lvbnNf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZh
-        MzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMvdmVyc2lvbnMvIiwi
-        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2UwZmEzMWJlLTdlMmQtNGNk
-        NS04MjVmLTNjYWE4MGJiZDRkMy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJmb28z
-        LTM2NzMwIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0
-        YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92
-        ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFj
-        a2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19n
-        cGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxLyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjEtMDctMjBUMTk6MTM6MjQuODUyNjYzWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0
-        NzEtOGVhYy00ZTgzLThjYmYtNmI0ZmQyYmE0M2QxL3ZlcnNpb25zLyIsInB1
-        bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMt
-        OGNiZi02YjRmZDJiYTQzZDEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZm9vLTE4
-        MjcyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpu
-        dWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRh
-        dGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJz
-        aW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2Fn
-        ZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdj
-        aGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/320c04e4-15e7-430b-8c72-b821dddc3c6d/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 8a0df0e66daa4068b749180d26a8b454
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMjBjMDRlNC0xNWU3LTQzMGItOGM3Mi1iODIxZGRkYzNjNmQv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5
-        OjE3LjgxMDk0M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzIwYzA0ZTQtMTVlNy00MzBi
-        LThjNzItYjgyMWRkZGMzYzZkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/0ea6f82a-b0fe-43da-b06e-6318468d9c6e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 998c403c5b734beda9abfa03b9b95403
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '229'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wZWE2ZjgyYS1iMGZlLTQzZGEtYjA2ZS02MzE4NDY4ZDljNmUv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5
-        OjE1LjIwNDg5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMGVhNmY4MmEtYjBmZS00M2Rh
-        LWIwNmUtNjMxODQ2OGQ5YzZlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e0fa31be-7e2d-4cd5-825f-3caa80bbd4d3/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - cda0849b01fe4faaa1f23fa6e564781f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjIy
-        OjE4LjAwNzc5OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBmYTMxYmUtN2UyZC00Y2Q1
-        LTgyNWYtM2NhYTgwYmJkNGQzLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/30143471-8eac-4e83-8cbf-6b4fd2ba43d1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 6b98f1b379944cfd909969cb9a9b2dd7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMtOGNiZi02YjRmZDJiYTQzZDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjEz
-        OjI0Ljg1ODUzOVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - dbbbafddde124542b963f7935b27b42e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '275'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzoyOTo0NS42
-        MzExMjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00
-        YWIyNTAxOGM3NTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzEwMTNlOGRiLTdjNWItNDNjMy05M2ZjLTRhYjI1MDE4
-        Yzc1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
-        dWJsaXNoIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 0d88c02fe537428d8d9b708dfa468e68
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '233'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIx
-        VDEzOjI5OjQ1LjYzOTQ1OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMTAxM2U4
-        ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUxLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.8.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 25035d47732a4f4fa547732af308be85
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1179,7 +570,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
+      - Wed, 11 Aug 2021 21:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1193,21 +584,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - e29445cd31cd40c289a062e8bd7a18ca
+      - 70d129451f644441a24f8678355fd863
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1228,46 +619,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
+      - Wed, 11 Aug 2021 21:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Correlation-Id:
-      - 650f39497c074a9fa708d46fe930c906
+      - fa5c039f8be34211b34654a4675126fc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '262'
+      - 1.1 centos7-devel4.samir.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMFQyMTow
-        Mjo0OC41MjE4MjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFi
-        LTQ1NzUtODQ4Ny1jMTA2M2ZiNGU0MDgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyL2FmZjc1NDdmLTU3MWIt
-        NDU3NS04NDg3LWMxMDYzZmI0ZTQwOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUi
-        Om51bGx9XX0=
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/aff7547f-571b-4575-8487-c1063fb4e408/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1275,7 +655,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1288,42 +668,35 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:18 GMT
+      - Wed, 11 Aug 2021 21:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Correlation-Id:
-      - 2d574f7c063647eaaac1096183a9a280
+      - eee5a1d23c3a403faad09b4504bdaf50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '235'
+      - 1.1 centos7-devel4.samir.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci9hZmY3NTQ3Zi01NzFiLTQ1NzUtODQ4Ny1j
-        MTA2M2ZiNGU0MDgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIwVDIxOjAyOjQ4LjU3MDA5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvYWZmNzU0N2YtNTcxYi00NTc1LTg0ODctYzEwNjNmYjRlNDA4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:18 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
 - request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1331,7 +704,154 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 026747d7fcee45c587e48ab89ab07e99
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 3669afa370cb4e37adf59f1fdeb33a45
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 925f425d1f0e40738ea96bd312cc60f0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1344,7 +864,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:19 GMT
+      - Wed, 11 Aug 2021 21:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1358,21 +878,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - dff82f7323814f51af68b630231268ac
+      - bd5e7a540a6f4bbd900dd85a367d6ebd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3MTI0NmFhLWVlMzYtNGJi
-        NC1iYjhhLTdhZTcxMmU3ZTQ4ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzZmY5Y2VmLTZlMzgtNGNl
+        ZS05OWI5LTIxZmRmODRlZDE1NS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/c71246aa-ee36-4bb4-bb8a-7ae712e7e48e/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e3ff9cef-6e38-4cee-99b9-21fdf84ed155/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1380,7 +900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1393,7 +913,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:50:19 GMT
+      - Wed, 11 Aug 2021 21:12:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1405,25 +925,25 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - e35bca1964f74328908705d015070912
+      - 284377070a9c4941a8f4656a8ed350f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '410'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzcxMjQ2YWEtZWUz
-        Ni00YmI0LWJiOGEtN2FlNzEyZTdlNDhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTA6MTkuMDUwNDMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTNmZjljZWYtNmUz
+        OC00Y2VlLTk5YjktMjFmZGY4NGVkMTU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDcuNjgxODIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImRmZjgyZjczMjM4MTRmNTFhZjY4YjYz
-        MDIzMTI2OGFjIiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTA6MTku
-        MTU0NzY3WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxMzo1MDoxOS43
-        MDY4MzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzL2I4ZDU5N2E0LTdkYTktNGZhYS1hZjg4LTViZGFkMmMxYTllMC8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImJkNWU3YTU0MGE2ZjRiYmQ5MDBkZDg1
+        YTM2N2Q2ZWJkIiwic3RhcnRlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6MDcu
+        ODA0OTQ1WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wOC0xMVQyMToxMjowOC4y
+        ODExMTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2MwNjM0YmI4LWQwOWEtNDc4ZS04NGVmLTVjMDEwYWM2MTE3MC8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
@@ -1434,5 +954,5 @@ http_interactions:
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:12:08 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
@@ -13690,109 +13690,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 14 Jul 2021 13:46:51 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 6a1a5a1ce883439480cb287a1562810a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:13 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo2NTQwfQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/dc9a9d6b-5a25-45f5-8d40-c78b6ddbffbd/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Correlation-Id:
-      - d2a860cc54634ed09f61930a71f6fefa
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9kYzlhOWQ2Yi01
-        YTI1LTQ1ZjUtOGQ0MC1jNzhiNmRkYmZmYmQvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo1MDoxMy43ODUyNDNaIiwic2l6ZSI6NjU0MH0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:13 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/dc9a9d6b-5a25-45f5-8d40-c78b6ddbffbd/
     body:
@@ -14113,66 +14010,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:50:14 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWViOGE1NDg0OGJlYTEx
-        MGQ3NjA0YmQ2MmFiMDkxNTM1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
-        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWViOGE1
-        NDg0OGJlYTExMGQ3NjA0YmQ2MmFiMDkxNTM1DQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
-        djMvYXJ0aWZhY3RzL2NkYzdjZDZmLTQzZDgtNDc5MS05YmU5LTFjOWU5NGI4
-        ZjI0YS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1lYjhhNTQ4
-        NDhiZWExMTBkNzYwNGJkNjJhYjA5MTUzNS0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-eb8a54848bea110d7604bd62ab091535
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '389'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:50:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 7203ff8e96ff4b859093802bbf381ab6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3NzNkZmI5LWRiOGEtNGI0
-        Mi05ZmUwLTRiM2Q3NjJlZDU4NS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:50:14 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/7773dfb9-db8a-4b42-9fe0-4b3d762ed585/
     body:
@@ -14349,4 +14186,1783 @@ http_interactions:
         LTg4ZWUtZTJkN2E4MTFkNWJhLyJdfQ==
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:50:16 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/069b7f9e-5c2c-4947-802d-dbf9828b33b6/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:13:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 8ff0f40d54db4862904f7b17c0808f5d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlYTgyNDQwLWU0YTgtNDEy
+        Zi04ZTZlLTVhYzM1MTg3YTNiNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:13:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/5ea82440-e4a8-412f-8e6e-5ac35187a3b4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:13:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f9b6bf1e7ece4227ab3b8f922770d236
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWVhODI0NDAtZTRh
+        OC00MTJmLThlNmUtNWFjMzUxODdhM2I0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTM6MDAuMjk1MjcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4ZmYwZjQwZDU0ZGI0ODYyOTA0
+        ZjdiMTdjMDgwOGY1ZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjEz
+        OjAwLjM0MjIxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTM6
+        MDAuNTAwMTUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8wNjliN2Y5ZS01YzJjLTQ5NDctODAyZC1kYmY5ODI4YjMzYjYvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDY5YjdmOWUtNWMyYy00OTQ3
+        LTgwMmQtZGJmOTgyOGIzM2I2LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:13:00 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/58f4e27b-7750-4610-8768-4654a7b9afde/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 043f05f94849470bad9d972865ce6610
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5OWVkNzZmLTk2NmQtNDcw
+        YS1hMjI5LWFhNzkwZjc3NjBkMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:45 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f99ed76f-966d-470a-a229-aa790f7760d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:17:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 96dd7a2d167046cea3e96ff8d13bc62c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjk5ZWQ3NmYtOTY2
+        ZC00NzBhLWEyMjktYWE3OTBmNzc2MGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTc6NDUuNjk5OTkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNDNmMDVmOTQ4NDk0NzBiYWQ5
+        ZDk3Mjg2NWNlNjYxMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE3
+        OjQ1Ljc0MDQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTc6
+        NDUuOTE0MjA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OGU4OGJjYy00ZmVkLTQyYmYtYjdmNy0xZjI5Zjk4MTlm
+        YzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81OGY0ZTI3Yi03NzUwLTQ2MTAtODc2OC00NjU0YTdiOWFmZGUvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNThmNGUyN2ItNzc1MC00NjEw
+        LTg3NjgtNDY1NGE3YjlhZmRlLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:17:45 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/c8294c5d-c445-40ab-8c9e-87bf11b88f6e/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - e6a33e1acddd4064967cca9c5badf338
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiMDIyYzc5LWZkMGUtNDll
+        OC04YzI0LTA5YjRiMmY4YTQ1OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:34 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/bb022c79-fd0e-49e8-8c24-09b4b2f8a458/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:19:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 697c15c7c3d8421aad021bf23ced010b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmIwMjJjNzktZmQw
+        ZS00OWU4LThjMjQtMDliNGIyZjhhNDU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MTk6MzQuNjU2MDQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJlNmEzM2UxYWNkZGQ0MDY0OTY3
+        Y2NhOWM1YmFkZjMzOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjE5
+        OjM0LjY5Nzc4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MTk6
+        MzQuODYwMTIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82NzIzYTI3My1hN2ZmLTRkYTQtODUwMC03MDZhYjRmMTQ2
+        YWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9jODI5NGM1ZC1jNDQ1LTQwYWItOGM5ZS04N2JmMTFiODhmNmUvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzgyOTRjNWQtYzQ0NS00MGFi
+        LThjOWUtODdiZjExYjg4ZjZlLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:19:34 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/590a45f2-941b-425e-85cf-730f9203d478/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYzFjOWY1ZjgtOWE4Yi00ODU5LWFjODQtYzhiNjAzZGNk
+        OWZmLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:21:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 396cd01822b14deba2afc5a446a50f42
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzYmE5MmE5LWM0ZTQtNDlk
+        Yy04MTJmLTIyNTE2MGE2NzdkMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:21:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/53ba92a9-c4e4-49dc-812f-225160a677d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:21:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 9f49af7e9f764b8792945d2a68b23efd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTNiYTkyYTktYzRl
+        NC00OWRjLTgxMmYtMjI1MTYwYTY3N2QyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6MjE6MDAuMjA2NzgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzOTZjZDAxODIyYjE0ZGViYTJh
+        ZmM1YTQ0NmE1MGY0MiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjIx
+        OjAwLjI0OTI4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6MjE6
+        MDAuNDQwMzM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82NzIzYTI3My1hN2ZmLTRkYTQtODUwMC03MDZhYjRmMTQ2
+        YWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81OTBhNDVmMi05NDFiLTQyNWUtODVjZi03MzBmOTIwM2Q0NzgvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTkwYTQ1ZjItOTQxYi00MjVl
+        LTg1Y2YtNzMwZjkyMDNkNDc4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:21:00 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5a0e2f09-ac16-490c-8549-70d74302de1b/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTViYjQwYjM3ZWY1N2Rl
+        OTdkNzY1ZDZlYTE1ZmI4NmZjDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtNjIyNC1hcnV2MDkiDQpDb250ZW50LUxlbmd0aDogNjU0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQrtq+7bAwAAAAABZHVjay0wLjct
+        MQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAEABQAAAAAAAAAAAAAAAAAAAACOregBAAAAAAAAAAcA
+        ABC0AAAAPgAAAAcAABCkAAAAEAAAAQ0AAAAGAAAAAAAAAAEAAAERAAAABgAA
+        ACkAAAABAAAD6AAAAAQAAABsAAAAAQAAA+wAAAAHAAAAcAAAABAAAAPvAAAA
+        BAAAAIAAAAABAAAD8AAAAAcAAACEAAAQIGU1MDY1NGViMTI0ZTQ0MzA5YmMy
+        MjFhODBmMGUyODdhM2E3MWEwODMAOTEzOTc3Y2NkMmFkM2E1MTA2MjQ4ZWIw
+        MWNlZmJjYTM2ZTM1NDNmZWE4YThiMzI5YWNmMjI5NTlkOTJjODdhNgAAAAAA
+        B/SmN0ItGeeq51+3RVsgqsCyAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAD4AAAAH////kAAAABAAAAAAjq3oAQAAAAAAAAA0AAAD
+        9AAAAD8AAAAHAAAD5AAAABAAAABkAAAACAAAAAAAAAABAAAD6AAAAAYAAAAC
+        AAAAAQAAA+kAAAAGAAAABwAAAAEAAAPqAAAABgAAAAsAAAABAAAD7AAAAAkA
+        AAANAAAAAQAAA+0AAAAJAAAALAAAAAEAAAPuAAAABAAAAEwAAAABAAAD7wAA
+        AAYAAABQAAAAAQAAA/EAAAAEAAAAaAAAAAEAAAP2AAAABgAAAGwAAAABAAAD
+        +AAAAAkAAAB6AAAAAQAAA/0AAAAGAAAAhgAAAAEAAAP+AAAABgAAAIwAAAAB
+        AAAEBAAAAAQAAACUAAAAAQAABAYAAAADAAAAmAAAAAEAAAQJAAAAAwAAAJoA
+        AAABAAAECgAAAAQAAACcAAAAAQAABAsAAAAIAAAAoAAAAAEAAAQMAAAACAAA
+        AOEAAAABAAAEDQAAAAQAAADkAAAAAQAABA8AAAAIAAAA6AAAAAEAAAQQAAAA
+        CAAAAO0AAAABAAAEFAAAAAYAAADyAAAAAQAABBUAAAAEAAABCAAAAAEAAAQX
+        AAAACAAAAQwAAAABAAAEGAAAAAQAAAEUAAAABAAABBkAAAAIAAABJAAAAAQA
+        AAQaAAAACAAAAYcAAAAEAAAEKAAAAAYAAAGjAAAAAQAABEYAAAAGAAABqgAA
+        AAEAAARHAAAABAAAAcwAAAABAAAESAAAAAQAAAHQAAAAAQAABEkAAAAIAAAB
+        1AAAAAEAAARYAAAABAAAAdgAAAABAAAEWQAAAAgAAAHcAAAAAQAABFwAAAAE
+        AAAB5AAAAAEAAARdAAAACAAAAegAAAABAAAEXgAAAAgAAAHxAAAAAQAABGIA
+        AAAGAAAB+wAAAAEAAARkAAAABgAAA0sAAAABAAAEZQAAAAYAAANQAAAAAQAA
+        BGYAAAAGAAADUwAAAAEAAARsAAAABgAAA1UAAAABAAAEdAAAAAQAAANwAAAA
+        AQAABHUAAAAEAAADdAAAAAEAAAR2AAAACAAAA3gAAAABAAAEegAAAAcAAAOD
+        AAAAEAAAE5MAAAAEAAADlAAAAAEAABPGAAAABgAAA5gAAAABAAAT5AAAAAgA
+        AAOeAAAAAQAAE+UAAAAEAAAD4AAAAAFDAGR1Y2sAMC43ADEAUXVhY2sgbGlr
+        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuAEEgZml4dHVyZSBSUE0gZm9yIHRlc3Rp
+        bmcgUHVscC4AW2C7IWxvY2FsaG9zdC5sb2NhbGRvbWFpbgAAAAAAAAVQdWJs
+        aWMgRG9tYWluAFVuc3BlY2lmaWVkAGxpbnV4AG5vYXJjaAAAAAAABYGkAABb
+        X3SmNTE4OTE0OGJlZjY2ZjQ3NDNhODIxNGYwYzk5MGFkYjJmZDc2NjFhMTk5
+        MGM3NGM4MmJlY2U0Zjg0MjFiMTYzMQAAAAAAAAAAcm9vdAByb290AGR1Y2st
+        MC43LTEuc3JjLnJwbQAAAAD/////ZHVjawAAAAABAAAKAQAACgEAAAoBAAAK
+        cnBtbGliKENvbXByZXNzZWRGaWxlTmFtZXMpAHJwbWxpYihGaWxlRGlnZXN0
+        cykAcnBtbGliKFBheWxvYWRGaWxlc0hhdmVQcmVmaXgpAHJwbWxpYihQYXls
+        b2FkSXNYeikAMy4wLjQtMQA0LjYuMC0xADQuMC0xADUuMi0xADQuMTQuMQBs
+        b2NhbGhvc3QubG9jYWxkb21haW4gMTUzMzA2NjAxNwAAAAAAAQAAAAEAAAAA
+        AAAACDAuNy0xAAAAAAAAAGR1Y2sudHh0AC91c3IvYmluLwAtTzIgLWcgLXBp
+        cGUgLVdhbGwgLVdlcnJvcj1mb3JtYXQtc2VjdXJpdHkgLVdwLC1EX0ZPUlRJ
+        RllfU09VUkNFPTIgLVdwLC1EX0dMSUJDWFhfQVNTRVJUSU9OUyAtZmV4Y2Vw
+        dGlvbnMgLWZzdGFjay1wcm90ZWN0b3Itc3Ryb25nIC1ncmVjb3JkLWdjYy1z
+        d2l0Y2hlcyAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQtaGFy
+        ZGVuZWQtY2MxIC1zcGVjcz0vdXNyL2xpYi9ycG0vcmVkaGF0L3JlZGhhdC1h
+        bm5vYmluLWNjMSAtbTY0IC1tdHVuZT1nZW5lcmljIC1mYXN5bmNocm9ub3Vz
+        LXVud2luZC10YWJsZXMgLWZzdGFjay1jbGFzaC1wcm90ZWN0aW9uIC1mY2Yt
+        cHJvdGVjdGlvbgBjcGlvAHh6ADIAbm9hcmNoLXJlZGhhdC1saW51eC1nbnUA
+        AAAAAAAAAAAAAABBU0NJSSB0ZXh0AB9bibZgHKpDzuiaAVGd1awAAAAACHV0
+        Zi04ADg0ZTM3NjczMDFhOTQ1MTU1ZDQ5MDhlNzQyMjkwOWQ0MDkzMTIxMWQy
+        YTE1MTI3YTUxMTM2MDVlMmYyNmFlYzkAAAAAAAgAAAA/AAAAB////MAAAAAQ
+        /Td6WFoAAArh+wyhAgAhARIAAAAjuIcs4AEHAFVdABgN3QRiMvl1C4CivQ9R
+        BnvESxeBuM5yo2cm959uPqkXJ2YtagnSD8aDWoQMDesVpeiIx9jmw5ZEryMC
+        dogZz71sdjY57taJhhrxJaiMHhag3tw6rfQAAAAA31/TVVoeyYhpWvwSlJBF
+        LZvGCWsTUErdmlngbW2rp3wAAYkBiAIAAMfy4+y26d8cAgAAAAAKWVoNCi0t
+        LS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC01YmI0MGIzN2VmNTdkZTk3
+        ZDc2NWQ2ZWExNWZiODZmYy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-5bb40b37ef57de97d765d6ea15fb86fc
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6860'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 566382f49a9949b19c6bfdee6e55942c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81YTBlMmYwOS1h
+        YzE2LTQ5MGMtODU0OS03MGQ3NDMwMmRlMWIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMDo0ODoxNC42ODc5NzRaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:14 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/5a0e2f09-ac16-490c-8549-70d74302de1b/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 0cebc27ea4014705b3e0cd4e2382e427
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmMWE0MWMyLWViYTQtNDlh
+        Yi05NTA5LThjZDc1Y2UyZDljZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:14 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ff1a41c2-eba4-49ab-9509-8cd75ce2d9ce/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:14 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - e83a58f9ca5d4086bd4cbc72378fc0d5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmYxYTQxYzItZWJh
+        NC00OWFiLTk1MDktOGNkNzVjZTJkOWNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTQuNzc3MDc0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIwY2ViYzI3ZWE0MDE0NzA1YjNlMGNkNGUyMzgyZTQy
+        NyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4OjE0LjgxNzc0MFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6MTQuODk2NDQ0WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        MDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMTk3YWNmYzgtNzM0Ni00YjZlLTk4
+        YTMtOTc4YjQxZDQ3ZDFhLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzVhMGUyZjA5LWFjMTYtNDkwYy04
+        NTQ5LTcwZDc0MzAyZGUxYi8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:14 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/c880684c-a542-438d-9272-ba9b074904a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 544c0a346aa04ffdb45ae73ff4a98bcd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzg4MDY4NGMtYTU0
+        Mi00MzhkLTkyNzItYmE5YjA3NDkwNGEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTUuMDYzNjQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwYzBmNmM5ZGZmMTg0MzE1OGZiZDRiMTMy
+        MzJhZTFlYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4OjE1LjEy
+        NjYxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6MTUuMjM5
+        OTExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8wMGIz
+        NzQzZi1hZDQ2LTQ3MjctODM3NS1lZDQ2ODYyM2MyZjMvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        OTdhY2ZjOC03MzQ2LTRiNmUtOThhMy05NzhiNDFkNDdkMWEvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:15 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/4c2c0f50-b843-408c-b46f-f84e27533748/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMDBiMzc0M2YtYWQ0Ni00NzI3LTgzNzUtZWQ0Njg2MjNj
+        MmYzLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 79dbd3a599014c14a4c2e070e87fe320
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE0NWJiNGZkLWUyMjktNDQx
+        ZS05ODllLTZmYmQzNmQ5ZjE1NS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/145bb4fd-e229-441e-989e-6fbd36d9f155/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 20:48:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 91c5b7c4b9db4165a5cd9e9671a189a3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTQ1YmI0ZmQtZTIy
+        OS00NDFlLTk4OWUtNmZiZDM2ZDlmMTU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjA6NDg6MTUuMzM4MDg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OWRiZDNhNTk5MDE0YzE0YTRj
+        MmUwNzBlODdmZTMyMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIwOjQ4
+        OjE1LjM4MDkyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjA6NDg6
+        MTUuNTQyNjE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS80YzJjMGY1MC1iODQzLTQwOGMtYjQ2Zi1mODRlMjc1MzM3NDgvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGMyYzBmNTAtYjg0My00MDhj
+        LWI0NmYtZjg0ZTI3NTMzNzQ4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 20:48:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - ebdd08e18c6e4994883bd04d77a699a1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 2e6ce55569bf407186a82f77abbdcdaf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:11:59 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo2NTQwfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/8db623f5-086c-43dc-ab56-c092bf119225/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Correlation-Id:
+      - e292c2184fc54908807f82f2f2b29e7b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84ZGI2MjNmNS0w
+        ODZjLTQzZGMtYWI1Ni1jMDkyYmYxMTkyMjUvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMjowMC41NDkyODZaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:00 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/8db623f5-086c-43dc-ab56-c092bf119225/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTQ5NDRjNGMxNjNhNGI0
+        NzlkNWQ5ODE2MWIwY2ExNDM5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtODAxMy1zMjB3cWgiDQpDb250ZW50LUxlbmd0aDogNjU0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQrtq+7bAwAAAAABZHVjay0wLjct
+        MQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAEABQAAAAAAAAAAAAAAAAAAAACOregBAAAAAAAAAAcA
+        ABC0AAAAPgAAAAcAABCkAAAAEAAAAQ0AAAAGAAAAAAAAAAEAAAERAAAABgAA
+        ACkAAAABAAAD6AAAAAQAAABsAAAAAQAAA+wAAAAHAAAAcAAAABAAAAPvAAAA
+        BAAAAIAAAAABAAAD8AAAAAcAAACEAAAQIGU1MDY1NGViMTI0ZTQ0MzA5YmMy
+        MjFhODBmMGUyODdhM2E3MWEwODMAOTEzOTc3Y2NkMmFkM2E1MTA2MjQ4ZWIw
+        MWNlZmJjYTM2ZTM1NDNmZWE4YThiMzI5YWNmMjI5NTlkOTJjODdhNgAAAAAA
+        B/SmN0ItGeeq51+3RVsgqsCyAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAD4AAAAH////kAAAABAAAAAAjq3oAQAAAAAAAAA0AAAD
+        9AAAAD8AAAAHAAAD5AAAABAAAABkAAAACAAAAAAAAAABAAAD6AAAAAYAAAAC
+        AAAAAQAAA+kAAAAGAAAABwAAAAEAAAPqAAAABgAAAAsAAAABAAAD7AAAAAkA
+        AAANAAAAAQAAA+0AAAAJAAAALAAAAAEAAAPuAAAABAAAAEwAAAABAAAD7wAA
+        AAYAAABQAAAAAQAAA/EAAAAEAAAAaAAAAAEAAAP2AAAABgAAAGwAAAABAAAD
+        +AAAAAkAAAB6AAAAAQAAA/0AAAAGAAAAhgAAAAEAAAP+AAAABgAAAIwAAAAB
+        AAAEBAAAAAQAAACUAAAAAQAABAYAAAADAAAAmAAAAAEAAAQJAAAAAwAAAJoA
+        AAABAAAECgAAAAQAAACcAAAAAQAABAsAAAAIAAAAoAAAAAEAAAQMAAAACAAA
+        AOEAAAABAAAEDQAAAAQAAADkAAAAAQAABA8AAAAIAAAA6AAAAAEAAAQQAAAA
+        CAAAAO0AAAABAAAEFAAAAAYAAADyAAAAAQAABBUAAAAEAAABCAAAAAEAAAQX
+        AAAACAAAAQwAAAABAAAEGAAAAAQAAAEUAAAABAAABBkAAAAIAAABJAAAAAQA
+        AAQaAAAACAAAAYcAAAAEAAAEKAAAAAYAAAGjAAAAAQAABEYAAAAGAAABqgAA
+        AAEAAARHAAAABAAAAcwAAAABAAAESAAAAAQAAAHQAAAAAQAABEkAAAAIAAAB
+        1AAAAAEAAARYAAAABAAAAdgAAAABAAAEWQAAAAgAAAHcAAAAAQAABFwAAAAE
+        AAAB5AAAAAEAAARdAAAACAAAAegAAAABAAAEXgAAAAgAAAHxAAAAAQAABGIA
+        AAAGAAAB+wAAAAEAAARkAAAABgAAA0sAAAABAAAEZQAAAAYAAANQAAAAAQAA
+        BGYAAAAGAAADUwAAAAEAAARsAAAABgAAA1UAAAABAAAEdAAAAAQAAANwAAAA
+        AQAABHUAAAAEAAADdAAAAAEAAAR2AAAACAAAA3gAAAABAAAEegAAAAcAAAOD
+        AAAAEAAAE5MAAAAEAAADlAAAAAEAABPGAAAABgAAA5gAAAABAAAT5AAAAAgA
+        AAOeAAAAAQAAE+UAAAAEAAAD4AAAAAFDAGR1Y2sAMC43ADEAUXVhY2sgbGlr
+        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuAEEgZml4dHVyZSBSUE0gZm9yIHRlc3Rp
+        bmcgUHVscC4AW2C7IWxvY2FsaG9zdC5sb2NhbGRvbWFpbgAAAAAAAAVQdWJs
+        aWMgRG9tYWluAFVuc3BlY2lmaWVkAGxpbnV4AG5vYXJjaAAAAAAABYGkAABb
+        X3SmNTE4OTE0OGJlZjY2ZjQ3NDNhODIxNGYwYzk5MGFkYjJmZDc2NjFhMTk5
+        MGM3NGM4MmJlY2U0Zjg0MjFiMTYzMQAAAAAAAAAAcm9vdAByb290AGR1Y2st
+        MC43LTEuc3JjLnJwbQAAAAD/////ZHVjawAAAAABAAAKAQAACgEAAAoBAAAK
+        cnBtbGliKENvbXByZXNzZWRGaWxlTmFtZXMpAHJwbWxpYihGaWxlRGlnZXN0
+        cykAcnBtbGliKFBheWxvYWRGaWxlc0hhdmVQcmVmaXgpAHJwbWxpYihQYXls
+        b2FkSXNYeikAMy4wLjQtMQA0LjYuMC0xADQuMC0xADUuMi0xADQuMTQuMQBs
+        b2NhbGhvc3QubG9jYWxkb21haW4gMTUzMzA2NjAxNwAAAAAAAQAAAAEAAAAA
+        AAAACDAuNy0xAAAAAAAAAGR1Y2sudHh0AC91c3IvYmluLwAtTzIgLWcgLXBp
+        cGUgLVdhbGwgLVdlcnJvcj1mb3JtYXQtc2VjdXJpdHkgLVdwLC1EX0ZPUlRJ
+        RllfU09VUkNFPTIgLVdwLC1EX0dMSUJDWFhfQVNTRVJUSU9OUyAtZmV4Y2Vw
+        dGlvbnMgLWZzdGFjay1wcm90ZWN0b3Itc3Ryb25nIC1ncmVjb3JkLWdjYy1z
+        d2l0Y2hlcyAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQtaGFy
+        ZGVuZWQtY2MxIC1zcGVjcz0vdXNyL2xpYi9ycG0vcmVkaGF0L3JlZGhhdC1h
+        bm5vYmluLWNjMSAtbTY0IC1tdHVuZT1nZW5lcmljIC1mYXN5bmNocm9ub3Vz
+        LXVud2luZC10YWJsZXMgLWZzdGFjay1jbGFzaC1wcm90ZWN0aW9uIC1mY2Yt
+        cHJvdGVjdGlvbgBjcGlvAHh6ADIAbm9hcmNoLXJlZGhhdC1saW51eC1nbnUA
+        AAAAAAAAAAAAAABBU0NJSSB0ZXh0AB9bibZgHKpDzuiaAVGd1awAAAAACHV0
+        Zi04ADg0ZTM3NjczMDFhOTQ1MTU1ZDQ5MDhlNzQyMjkwOWQ0MDkzMTIxMWQy
+        YTE1MTI3YTUxMTM2MDVlMmYyNmFlYzkAAAAAAAgAAAA/AAAAB////MAAAAAQ
+        /Td6WFoAAArh+wyhAgAhARIAAAAjuIcs4AEHAFVdABgN3QRiMvl1C4CivQ9R
+        BnvESxeBuM5yo2cm959uPqkXJ2YtagnSD8aDWoQMDesVpeiIx9jmw5ZEryMC
+        dogZz71sdjY57taJhhrxJaiMHhag3tw6rfQAAAAA31/TVVoeyYhpWvwSlJBF
+        LZvGCWsTUErdmlngbW2rp3wAAYkBiAIAAMfy4+y26d8cAgAAAAAKWVoNCi0t
+        LS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC00OTQ0YzRjMTYzYTRiNDc5
+        ZDVkOTgxNjFiMGNhMTQzOS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-4944c4c163a4b479d5d98161b0ca1439
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6860'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f3f86d70efce4b26b9b8264af2ce5f94
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '131'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84ZGI2MjNmNS0w
+        ODZjLTQzZGMtYWI1Ni1jMDkyYmYxMTkyMjUvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMjowMC41NDkyODZaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - b3bc8949cf0e4e9db2894bbcc75c3448
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:00 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/8db623f5-086c-43dc-ab56-c092bf119225/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 18bc80eb328f451e94582b6183fdaad3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2ZWVhYzZlLWY5NzgtNDMw
+        OS04ZTllLTdkYWY4NmIyYmQ3NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/76eeac6e-f978-4309-8e9e-7daf86b2bd74/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 830fe2c7547442eea9678342151caba1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '395'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzZlZWFjNmUtZjk3
+        OC00MzA5LThlOWUtN2RhZjg2YjJiZDc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDAuODU2MDY2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiIxOGJjODBlYjMyOGY0NTFlOTQ1ODJiNjE4M2ZkYWFk
+        MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEyOjAxLjA0OTUzOVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6MDEuMjQ5NDkwWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNmRjMWZjYWUtNTU4NC00YjVkLWFi
+        MTEtNzk4MzFlZTNiNDBlLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzhkYjYyM2Y1LTA4NmMtNDNkYy1h
+        YjU2LWMwOTJiZjExOTIyNS8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:01 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - de2650cb97674737bc83be49531724c9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNmRj
+        MWZjYWUtNTU4NC00YjVkLWFiMTEtNzk4MzFlZTNiNDBlLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTFUMjE6MTI6MDEuMTE1ODY0WiIsImZpbGUiOiJh
+        cnRpZmFjdC81Yi9kMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4
+        ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNpemUiOjY1NDAsIm1k
+        NSI6bnVsbCwic2hhMSI6ImM5MThiZDkxYTA0MjE4NTVmOTIyOThlNDhiNTU3
+        YzU3ZmI2NWFjOWEiLCJzaGEyMjQiOiJhN2Y1NTQyZDUyOTY1NzI5N2NhYzA5
+        ZDBlN2IxMTZkOTgzNTUxMjEzYjE0NDNkMzFiMjg2Nzg1ZCIsInNoYTI1NiI6
+        IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIx
+        MjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJzaGEzODQiOiJmY2VhYWQ5OGYyOTgy
+        NTMyMGM2MGNkYTNhOGQyYmM3ZmU3NmFhM2Y3YjJkYjllNmIyNjFiYjhhZGU2
+        MDZjYWQ4MDQ1NDdjN2MzNWIxMWJlOTQ5ZTZjNGQ3YjMzN2UzM2QiLCJzaGE1
+        MTIiOiI3NGYwYWUwYjhiYTNkN2YyYjhmMTY3NzRhNWY0MDk3OWNhYzI4MDJl
+        YTg2ZmQ4NGRmYTgzOTAyM2IzODY3MTVmOGU0OWE5ZTJlYzE4OTk4MDJmOTcw
+        NTk0ZjBlOGY2ZDJhNDA2NmIyNTk0MDZkMjIzN2JhOGJiOTIyZTEzYmJlMiJ9
+        XX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:01 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWUxOTdhOGMzZWQwZGFk
+        Y2I1Mjc3ZDBlNjMyOGIxMjUzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
+        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWUxOTdh
+        OGMzZWQwZGFkY2I1Mjc3ZDBlNjMyOGIxMjUzDQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzZkYzFmY2FlLTU1ODQtNGI1ZC1hYjExLTc5ODMxZWUz
+        YjQwZS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1lMTk3YThj
+        M2VkMGRhZGNiNTI3N2QwZTYzMjhiMTI1My0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-e197a8c3ed0dadcb5277d0e6328b1253
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '389'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 56c32670b389400b870315171e235565
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlMWMxZTkxLTgyNDAtNDU0
+        Ny05ZGY4LTA2OGFlMDA5M2UxYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:01 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/0e1c1e91-8240-4547-9df8-068ae0093e1a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 36b17058e89c4965a047e5573e57f804
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '404'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGUxYzFlOTEtODI0
+        MC00NTQ3LTlkZjgtMDY4YWUwMDkzZTFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDEuNTcwNDc1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1NmMzMjY3MGIzODk0MDBiODcwMzE1MTcx
+        ZTIzNTU2NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEyOjAxLjY4
+        NTQyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6MDIuMDA5
+        NDMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jYzJi
+        NDdlMy1kOGM3LTRmMGUtYjRjNi1jZDVmYzgwN2ViMmIvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy82
+        ZGMxZmNhZS01NTg0LTRiNWQtYWIxMS03OTgzMWVlM2I0MGUvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:02 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fbb93392-7cf1-47d7-b4e2-617aa81ee768/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvY2MyYjQ3ZTMtZDhjNy00ZjBlLWI0YzYtY2Q1ZmM4MDdl
+        YjJiLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - dc85c36da67a46f0a1a4cdb317f93449
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VhOWYxOWQ1LWQ4NjAtNDNk
+        OC1hZjFiLTA3MDc3ZjNhZWE4NC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/ea9f19d5-d860-43d8-af1b-07077f3aea84/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:12:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 8a2973f2a6da456894312c80aab3c393
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWE5ZjE5ZDUtZDg2
+        MC00M2Q4LWFmMWItMDcwNzdmM2FlYTg0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTI6MDIuNTMxOTU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJkYzg1YzM2ZGE2N2E0NmYwYTFh
+        NGNkYjMxN2Y5MzQ0OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEy
+        OjAyLjY1MTU5N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTI6
+        MDMuMTEyMzMxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjEx
+        NzAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9mYmI5MzM5Mi03Y2YxLTQ3ZDctYjRlMi02MTdhYTgxZWU3NjgvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJiOTMzOTItN2NmMS00N2Q3
+        LWI0ZTItNjE3YWE4MWVlNzY4LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:12:03 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:09 GMT
+      - Wed, 11 Aug 2021 23:54:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -37,21 +37,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - b3323c3f34cc407dafe1e1baddbf06b4
+      - 3f7cb73218ca460586d7df985217bf78
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:09 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -72,7 +72,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:09 GMT
+      - Wed, 11 Aug 2021 23:54:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -86,21 +86,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 4df053f33abc4be9abd39c50828b3106
+      - b02b549d043442feb5d9eb513a7c0f55
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:09 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:09 GMT
+      - Wed, 11 Aug 2021 23:54:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -135,21 +135,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - db9dd6cd69164f658ca37fd2d0bd31c9
+      - f0872af033f4429e901e1ecf24cb4b1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:09 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:10 GMT
+      - Wed, 11 Aug 2021 23:54:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -184,86 +184,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 4cbdbe93b8b246ec85dba25cb0dd3d3c
+      - aaa8d8acbd634984bb39cd8d99fd6130
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:10 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
-        OjB9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/e8a8b39d-7142-4c5d-81d9-4a0ac1c451e8/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '626'
-      Correlation-Id:
-      - a25d4beb973f44108a0122e693c122f6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZThhOGIzOWQtNzE0Mi00YzVkLTgxZDktNGEwYWMxYzQ1MWU4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NTk6MTAuNDM5ODI3WiIsInZl
-        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZThhOGIzOWQtNzE0Mi00YzVkLTgxZDktNGEwYWMxYzQ1MWU4L3ZlcnNp
-        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lOGE4YjM5ZC03
-        MTQyLTRjNWQtODFkOS00YTBhYzFjNDUxZTgvdmVyc2lvbnMvMC8iLCJuYW1l
-        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:10 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -289,13 +224,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:10 GMT
+      - Wed, 11 Aug 2021 23:54:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/dae3888d-67e2-4342-8dc0-1a9ee81ad84c/"
+      - "/pulp/api/v3/remotes/rpm/rpm/336e6bb7-c285-4436-a458-b6c9bae9b10e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -305,31 +240,96 @@ http_interactions:
       Content-Length:
       - '534'
       Correlation-Id:
-      - 957c26aec71749a2a90d2411bcf7e318
+      - c06423ba84de4c4193e4e29a7c18959a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Rh
-        ZTM4ODhkLTY3ZTItNDM0Mi04ZGMwLTFhOWVlODFhZDg0Yy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjU5OjEwLjcyMDA1M1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMz
+        NmU2YmI3LWMyODUtNDQzNi1hNDU4LWI2YzliYWU5YjEwZS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTA4LTExVDIzOjU0OjA0LjI4NzAxMloiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMDctMjFUMTM6NTk6MTAuNzIwMTA1WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDQuMjg3MDI2WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:10 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
+        OjB9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/34a38f72-702e-4b32-9ad8-d062f22c928a/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '626'
+      Correlation-Id:
+      - 9961f5528c004d368c7879e715a1aa49
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMzRhMzhmNzItNzAyZS00YjMyLTlhZDgtZDA2MmYyMmM5MjhhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDQuNTAyNTY3WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMzRhMzhmNzItNzAyZS00YjMyLTlhZDgtZDA2MmYyMmM5MjhhL3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNGEzOGY3Mi03
+        MDJlLTRiMzItOWFkOC1kMDYyZjIyYzkyOGEvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3Zl
+        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
+        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
+        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
+        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
+        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/dae3888d-67e2-4342-8dc0-1a9ee81ad84c/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/rpm/rpm/336e6bb7-c285-4436-a458-b6c9bae9b10e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -350,7 +350,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:14 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -364,21 +364,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 65721e0c847441d1b6215a2428fa23b5
+      - a537796a584641b19adc13e3228f33ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwODg5YjA0LWMxNjAtNDUw
-        Yi1iZGE0LTkwNmQ5ZWE3OGM1ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiNGZiZDMwLWI0MmQtNDQ1
+        OC05ZThmLWFjZWJmNGM0MTEzNC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:14 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/a0889b04-c160-450b-bda4-906d9ea78c5d/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/6b4fbd30-b42d-4458-9e8f-acebf4c41134/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -386,7 +386,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -399,7 +399,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:14 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -411,35 +411,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 402626946e274a20bd7ecec1ee10c486
+      - 69e33f8c798141cfa98f633764d68c60
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '371'
+      - '370'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTA4ODliMDQtYzE2
-        MC00NTBiLWJkYTQtOTA2ZDllYTc4YzVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTk6MTQuMDIyMTI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmI0ZmJkMzAtYjQy
+        ZC00NDU4LTllOGYtYWNlYmY0YzQxMTM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDYuMzk2MzA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NTcyMWUwYzg0NzQ0MWQxYjYyMTVhMjQy
-        OGZhMjNiNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjU5OjE0LjEw
-        ODAwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTk6MTQuMTgz
-        MDAwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNTM3Nzk2YTU4NDY0MWIxOWFkYzEzZTMy
+        MjhmMzNhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU0OjA2LjQz
+        NzM0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDYuNDc4
+        OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2RhZTM4ODhkLTY3ZTItNDM0Mi04ZGMw
-        LTFhOWVlODFhZDg0Yy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMzNmU2YmI3LWMyODUtNDQzNi1hNDU4
+        LWI2YzliYWU5YjEwZS8iXX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:14 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e8a8b39d-7142-4c5d-81d9-4a0ac1c451e8/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/34a38f72-702e-4b32-9ad8-d062f22c928a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -460,7 +460,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:14 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -474,21 +474,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 756b6eac2075429e8947b29b8fa34004
+      - a46386bbc5bd4ad5bbe1bc91c7e429d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxZTJhNWRhLTY1ZDAtNDIx
-        NS05MDhmLWYxYTY1NjRhN2M3OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllZTY0NDY2LTM1NzQtNDVi
+        NS04MThiLTU4YzI2MGEzNjM1NC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:14 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/c1e2a5da-65d0-4215-908f-f1a6564a7c79/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9ee64466-3574-45b5-818b-58c260a36354/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -496,7 +496,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -509,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:14 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -521,574 +521,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - daeced39c9f84ae6a2116b67bd9c9fcb
+      - 8fd4d244d684407e8b45441fb9aa4dca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '375'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzFlMmE1ZGEtNjVk
-        MC00MjE1LTkwOGYtZjFhNjU2NGE3Yzc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTk6MTQuMzc2ODAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWVlNjQ0NjYtMzU3
+        NC00NWI1LTgxOGItNThjMjYwYTM2MzU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDYuNTgyMjg0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3NTZiNmVhYzIwNzU0MjllODk0N2IyOWI4
-        ZmEzNDAwNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjU5OjE0LjQ3
-        MzQ0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTk6MTQuNTcy
-        MDAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNDYzODZiYmM1YmQ0YWQ1YmJlMWJjOTFj
+        N2U0MjlkOSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU0OjA2LjYy
+        NzM3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDYuNjgz
+        NTMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZThhOGIzOWQtNzE0Mi00YzVk
-        LTgxZDktNGEwYWMxYzQ1MWU4LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzRhMzhmNzItNzAyZS00YjMy
+        LTlhZDgtZDA2MmYyMmM5MjhhLyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:14 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - d5ff303fb8444a1483f518d1906f2038
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '300'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzE5OGZlNTQ2LTFkODgtNGZkOC05MjdlLTdlNDNiNDU2MzYz
-        NS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUzOjIxLjExNTc1
-        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMTk4ZmU1NDYtMWQ4OC00ZmQ4LTkyN2UtN2U0M2I0NTYz
-        NjM1L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzE5OGZlNTQ2LTFkODgtNGZkOC05MjdlLTdlNDNiNDU2MzYzNS92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
-        X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
-        IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFu
-        aWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:14 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/198fe546-1d88-4fd8-927e-7e43b4563635/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 4e66bbff9df34bdab835907a4d69fba8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzE5OGZlNTQ2LTFkODgtNGZkOC05MjdlLTdlNDNiNDU2MzYz
-        NS92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6
-        NTM6MjEuMTI1NTg3WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzE5OGZlNTQ2LTFkODgt
-        NGZkOC05MjdlLTdlNDNiNDU2MzYzNS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
-        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
-        cmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 5bc982f9fcba4aebb948ea67605e28a0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '443'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yOTg2YmZhNi01NDEwLTQ4N2EtOTBmNC00OWRmMTM2ZWRlMGMv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MToxNS4wMDA2MjJa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yOTg2YmZhNi01NDEwLTQ4N2EtOTBmNC00OWRmMTM2ZWRlMGMv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI5ODZi
-        ZmE2LTU0MTAtNDg3YS05MGY0LTQ5ZGYxMzZlZGUwYy92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2Fn
-        ZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwi
-        cGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVw
-        b19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxw
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBm
-        YTMxYmUtN2UyZC00Y2Q1LTgyNWYtM2NhYTgwYmJkNGQzLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMDctMjBUMTk6MjI6MTcuOTk4MDU4WiIsInZlcnNpb25z
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBm
-        YTMxYmUtN2UyZC00Y2Q1LTgyNWYtM2NhYTgwYmJkNGQzL3ZlcnNpb25zLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRj
-        ZDUtODI1Zi0zY2FhODBiYmQ0ZDMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZm9v
-        My0zNjczMCIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9u
-        cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1l
-        dGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2Vf
-        dmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGwsInBh
-        Y2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9f
-        Z3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9LHsicHVscF9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMwMTQz
-        NDcxLThlYWMtNGU4My04Y2JmLTZiNGZkMmJhNDNkMS8iLCJwdWxwX2NyZWF0
-        ZWQiOiIyMDIxLTA3LTIwVDE5OjEzOjI0Ljg1MjY2M1oiLCJ2ZXJzaW9uc19o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzMwMTQz
-        NDcxLThlYWMtNGU4My04Y2JmLTZiNGZkMmJhNDNkMS92ZXJzaW9ucy8iLCJw
-        dWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxL3ZlcnNpb25zLzAvIiwibmFtZSI6ImZvby0x
-        ODI3MiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6
-        bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1ldGFk
-        YXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2thZ2VfdmVy
-        c2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGwsInBhY2th
-        Z2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJlcG9fZ3Bn
-        Y2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/2986bfa6-5410-487a-90f4-49df136ede0c/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 15a47f007b9a4d45b851ac164a381786
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yOTg2YmZhNi01NDEwLTQ4N2EtOTBmNC00OWRmMTM2ZWRlMGMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUx
-        OjE1LjAwNzc5NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjk4NmJmYTYtNTQxMC00ODdh
-        LTkwZjQtNDlkZjEzNmVkZTBjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/e0fa31be-7e2d-4cd5-825f-3caa80bbd4d3/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 0b5cf4f0928543ae9326ac152f3ff408
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '230'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lMGZhMzFiZS03ZTJkLTRjZDUtODI1Zi0zY2FhODBiYmQ0ZDMv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjIy
-        OjE4LjAwNzc5OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTBmYTMxYmUtN2UyZC00Y2Q1
-        LTgyNWYtM2NhYTgwYmJkNGQzLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/30143471-8eac-4e83-8cbf-6b4fd2ba43d1/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 0a6c7ff2f7e744b490ebf040f93332ab
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '231'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zMDE0MzQ3MS04ZWFjLTRlODMtOGNiZi02YjRmZDJiYTQzZDEv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIwVDE5OjEz
-        OjI0Ljg1ODUzOVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzAxNDM0NzEtOGVhYy00ZTgz
-        LThjYmYtNmI0ZmQyYmE0M2QxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - e867852af6bf48ffacbe41b2a6a8cbec
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '275'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzoyOTo0NS42
-        MzExMjFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00
-        YWIyNTAxOGM3NTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzEwMTNlOGRiLTdjNWItNDNjMy05M2ZjLTRhYjI1MDE4
-        Yzc1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
-        dWJsaXNoIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/python/python/1013e8db-7c5b-43c3-93fc-4ab25018c751/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.4.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 4c8663a1ccd14ffd9299f23e5251c867
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '233'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8xMDEzZThkYi03YzViLTQzYzMtOTNmYy00YWIyNTAx
-        OGM3NTEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIx
-        VDEzOjI5OjQ1LjYzOTQ1OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMTAxM2U4
-        ZGItN2M1Yi00M2MzLTkzZmMtNGFiMjUwMThjNzUxLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.8.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - cd5705cf4a11457b8ca5d675b2b4d28b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1109,7 +570,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1123,21 +584,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 4d0112e6771c4ecb81d5d70fbfcf72a9
+      - e054464d315d4f87a41e4a0c754ca0b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1158,7 +619,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 32c3d1417ffd4899a27f399390bb00b4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1170,45 +680,33 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 9b1e0f02f3ff4ba68779ec027bf5eb7e
+      - e7f35452cf7d49e88a6dca1647d28604
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '322'
+      - '279'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zNzMwZjU0Ni0yYjljLTRiZjEtYTZlYy1h
-        ZjBmOTZkNDBiNGEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1
-        ODo0Ni43OTIyMzdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zNzMwZjU0Ni0yYjlj
-        LTRiZjEtYTZlYy1hZjBmOTZkNDBiNGEvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzM3MzBmNTQ2LTJiOWMt
-        NGJmMS1hNmVjLWFmMGY5NmQ0MGI0YS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVsbCwicmVt
-        b3RlIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zYjdlZWM3NS0yNjg5LTQ5YWYt
-        OTcxYy0wZjI0OTg4MDgxYzEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0y
-        MVQxMzo1Njo0NS4yMjI4MDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zYjdlZWM3
-        NS0yNjg5LTQ5YWYtOTcxYy0wZjI0OTg4MDgxYzEvdmVyc2lvbnMvIiwicHVs
-        cF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzNiN2VlYzc1
-        LTI2ODktNDlhZi05NzFjLTBmMjQ5ODgwODFjMS92ZXJzaW9ucy8wLyIsIm5h
-        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2Iiwi
-        ZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJy
-        ZW1vdGUiOm51bGx9XX0=
+        ZmlsZS9maWxlLzZlMzM3NmI2LWM4ZjktNDgwOS1iNmQ2LWEyYWJjYWEwNWMy
+        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTExVDIxOjI2OjMwLjk5NzM2
+        MVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNmUzMzc2YjYtYzhmOS00ODA5LWI2ZDYtYTJhYmNhYTA1
+        YzIyL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzZlMzM3NmI2LWM4ZjktNDgwOS1iNmQ2LWEyYWJjYWEwNWMyMi92ZXJzaW9u
+        cy8wLyIsIm5hbWUiOiJ0ZXN0LTE2MDYyIiwiZGVzY3JpcHRpb24iOm51bGws
+        InJldGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9w
+        dWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/3730f546-2b9c-4bf1-a6ec-af0f96d40b4a/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/6e3376b6-c8f9-4809-b6d6-a2abcaa05c22/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1216,7 +714,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/1.8.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1229,7 +727,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1241,30 +739,30 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - aa0245a7f8054dfe9a1431f526413de7
+      - b9c6310df0d547329ca8fee62743d8a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '236'
+      - '231'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zNzMwZjU0Ni0yYjljLTRiZjEtYTZlYy1h
-        ZjBmOTZkNDBiNGEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIxVDEzOjU4OjQ2Ljg5NDQzOFoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzczMGY1NDYtMmI5Yy00YmYxLWE2ZWMtYWYwZjk2ZDQwYjRhLyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        ZmlsZS9maWxlLzZlMzM3NmI2LWM4ZjktNDgwOS1iNmQ2LWEyYWJjYWEwNWMy
+        Mi92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6
+        MjY6MzEuMDA5OTM5WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzZlMzM3NmI2LWM4Zjkt
+        NDgwOS1iNmQ2LWEyYWJjYWEwNWMyMi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/container/container/3b7eec75-2689-49af-971c-0f24988081c1/versions/?limit=2000&offset=0
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1272,7 +770,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.7.0/ruby
+      - OpenAPI-Generator/3.13.3/ruby
       Accept:
       - application/json
       Authorization:
@@ -1285,42 +783,133 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:15 GMT
+      - Wed, 11 Aug 2021 23:54:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
+      Content-Length:
+      - '52'
       Correlation-Id:
-      - 8a5bb44bdfd6406a800068e26c2361ca
+      - 8f773976c85b4161b54b536e90de3f74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '234'
+      - 1.1 centos7-devel4.samir.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zYjdlZWM3NS0yNjg5LTQ5YWYtOTcxYy0w
-        ZjI0OTg4MDgxYzEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTA3LTIxVDEzOjU2OjQ1LjM1NDY2OVoiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvM2I3ZWVjNzUtMjY4OS00OWFmLTk3MWMtMGYyNDk4ODA4MWMxLyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:15 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.4.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 5effc66d144c4691b14d6e75111d4dbf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.8.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 7d66cba6b556471aa48f90166659e988
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:07 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1328,7 +917,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1341,7 +930,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:16 GMT
+      - Wed, 11 Aug 2021 23:54:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1355,21 +944,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 0f58b3c876eb4e8fbd468ecd509bd81f
+      - 9298920fabf949d5bff36b0d3183f405
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwMTIxMzE3LWRlOTItNDY1
-        Yi04OTZiLTljMzJmOTA4MThhNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwZDkwZmUyLTRkYjItNGQ3
+        My1iZDM3LTlkZjg5M2EwMWEyYS8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:16 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:07 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/90121317-de92-465b-896b-9c32f90818a5/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/00d90fe2-4db2-4d73-bd37-9df893a01a2a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1377,7 +966,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1390,7 +979,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:59:16 GMT
+      - Wed, 11 Aug 2021 23:54:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1402,34 +991,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 438eb03c0879430baf1813feac7ab4e5
+      - 2e3181d499c9496a8a02f83ea4cfd800
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '419'
+      - '409'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTAxMjEzMTctZGU5
-        Mi00NjViLTg5NmItOWMzMmY5MDgxOGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTk6MTYuMDM2MzQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDBkOTBmZTItNGRi
+        Mi00ZDczLWJkMzctOWRmODkzYTAxYTJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDcuMTE0OTI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjBmNThiM2M4NzZlYjRlOGZiZDQ2OGVj
-        ZDUwOWJkODFmIiwic3RhcnRlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTk6MTYu
-        MTIxNzkzWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wNy0yMVQxMzo1OToxNi44
-        OTk0NzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzL2I4ZDU5N2E0LTdkYTktNGZhYS1hZjg4LTViZGFkMmMxYTllMC8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjkyOTg5MjBmYWJmOTQ5ZDViZmYzNmIw
+        ZDMxODNmNDA1Iiwic3RhcnRlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDcu
+        MTYwNDQ0WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0wOC0xMVQyMzo1NDowNy4z
+        NjYxMTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2MwNjM0YmI4LWQwOWEtNDc4ZS04NGVmLTVjMDEwYWM2MTE3MC8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjE5LCJkb25lIjoxOSwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0
-        aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjoyMiwiZG9uZSI6MjIsInN1ZmZpeCI6bnVsbH1d
-        LCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19y
-        ZWNvcmQiOltdfQ==
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
+        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNy
+        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6W119
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:16 GMT
+  recorded_at: Wed, 11 Aug 2021 23:54:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
@@ -7434,109 +7434,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 14 Jul 2021 14:02:37 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 7f28ee1058fc453eafa0fe4cde6c5c3c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:11 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoxNjA3fQ==
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:11 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/b18ebf0f-0bf5-4fb3-a3e2-054198cc0421/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '131'
-      Correlation-Id:
-      - b9a14d4c567543449e90d782ca2d0088
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9iMThlYmYwZi0w
-        YmY1LTRmYjMtYTNlMi0wNTQxOThjYzA0MjEvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo1OToxMS4zNDQwMzhaIiwic2l6ZSI6MTYwN30=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:11 GMT
-- request:
     method: put
     uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/b18ebf0f-0bf5-4fb3-a3e2-054198cc0421/
     body:
@@ -7747,66 +7644,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:59:11 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/rpm/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM0MDg2ZGNmNTA3NDhk
-        MWZhMGNhYmNlYTViNjg4MmYwDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3Qtc3JwbTAxLTEu
-        MC0xLnNyYy5ycG0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1j
-        NDA4NmRjZjUwNzQ4ZDFmYTBjYWJjZWE1YjY4ODJmMA0KQ29udGVudC1EaXNw
-        b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJhcnRpZmFjdCINCg0KL3B1bHAv
-        YXBpL3YzL2FydGlmYWN0cy80MmMwNWZkZi1hZjEwLTQwZTMtYjJkZC02YWEx
-        MTE1ZjFmYzEvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzQw
-        ODZkY2Y1MDc0OGQxZmEwY2FiY2VhNWI2ODgyZjAtLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-c4086dcf50748d1fa0cabcea5b6882f0
-      User-Agent:
-      - OpenAPI-Generator/3.13.3/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '393'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:59:12 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - ce2670a9a8364683a01191f83b1f1f50
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3NmIxYTc5LWFmZTItNGIy
-        Mi1iMGIyLTU4NzNlNzQwYzg2ZC8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:59:12 GMT
-- request:
     method: get
     uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/276b1a79-afe2-4b22-b0b2-5873e740c86d/
     body:
@@ -7983,4 +7820,716 @@ http_interactions:
         LTgxZDktNGEwYWMxYzQ1MWU4LyJdfQ==
     http_version: 
   recorded_at: Wed, 21 Jul 2021 13:59:13 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - f6cad7671511419c99f93805d802202f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 3a44cfca93aa4cc7aed026b689e03d38
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoxNjA3fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/4d06ba22-1d63-43a6-9b34-d592c98940ad/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '131'
+      Correlation-Id:
+      - 246b8f6ee9154f44b11f21a73d3bb26f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy80ZDA2YmEyMi0x
+        ZDYzLTQzYTYtOWIzNC1kNTkyYzk4OTQwYWQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMzo1NDowNS4wMTUwMzdaIiwic2l6ZSI6MTYwN30=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: put
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/4d06ba22-1d63-43a6-9b34-d592c98940ad/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWQ1NWMwMWYyNGZmZTUz
+        M2E0YTFlMzJjZDJiYmQ4ZTcwDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMTA4
+        MTEtMTIyOTYtcWtnMDBiIg0KQ29udGVudC1MZW5ndGg6IDE2MDcNCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0K7avu2wMAAAEAAXRlc3Qtc3Jw
+        bTAxLTEuMC0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAABAAUAAAAAAAAAAAAAAAAAAAAAjq3oAQAAAAAAAAAF
+        AAAAVAAAAD4AAAAHAAAARAAAABAAAAENAAAABgAAAAAAAAABAAAD6AAAAAQA
+        AAAsAAAAAQAAA+wAAAAHAAAAMAAAABAAAAPvAAAABAAAAEAAAAABYzI5NzEz
+        ZDhhYmIyNjA0NTY5MzExODBhZjdhOTc2OWUyZjkyYjQwNgAAAAAAAAUvfxrR
+        ouhyc4oaTGdVw1z5HAAAAbwAAAA+AAAAB////7AAAAAQAAAAAI6t6AEAAAAA
+        AAAAKAAAAaQAAAA/AAAABwAAAZQAAAAQAAAAZAAAAAgAAAAAAAAAAQAAA+gA
+        AAAGAAAAAgAAAAEAAAPpAAAABgAAAA4AAAABAAAD6gAAAAYAAAASAAAAAQAA
+        A+wAAAAJAAAAFAAAAAEAAAPtAAAACQAAADUAAAABAAAD7gAAAAQAAABMAAAA
+        AQAAA+8AAAAGAAAAUAAAAAEAAAPxAAAABAAAAFwAAAABAAAD9gAAAAYAAABg
+        AAAAAQAAA/gAAAAJAAAAZgAAAAEAAAP9AAAABgAAAH4AAAABAAAD/gAAAAYA
+        AACEAAAAAQAABAQAAAAEAAAAjAAAAAEAAAQGAAAAAwAAAJAAAAABAAAECQAA
+        AAMAAACSAAAAAQAABAoAAAAEAAAAlAAAAAEAAAQLAAAACAAAAJgAAAABAAAE
+        DAAAAAgAAADZAAAAAQAABA0AAAAEAAAA3AAAAAEAAAQPAAAACAAAAOAAAAAB
+        AAAEEAAAAAgAAADpAAAAAQAABBUAAAAEAAAA9AAAAAEAAAQYAAAABAAAAPgA
+        AAACAAAEGQAAAAgAAAEAAAAAAgAABBoAAAAIAAABMAAAAAIAAAQoAAAABgAA
+        AUAAAAABAAAEQQAAAAgAAAFGAAAAAQAABEYAAAAGAAABTQAAAAEAAARHAAAA
+        BAAAAWQAAAABAAAESAAAAAQAAAFoAAAAAQAABEkAAAAIAAABbAAAAAEAAARc
+        AAAABAAAAXAAAAABAAAEXQAAAAgAAAF0AAAAAQAABF4AAAAIAAABgwAAAAEA
+        AARkAAAABgAAAYQAAAABAAAEZQAAAAYAAAGJAAAAAQAABGYAAAAGAAABjgAA
+        AAEAABOTAAAABAAAAZAAAAABQwB0ZXN0LXNycG0wMQAxLjAAMQBEdW1teSBQ
+        YWNrYWdlIHRvIHByb3ZpZGUgdG9tY2F0NQAKVGhpcyBpcyBhIHRlc3QgcnBt
+        AAAAAE9aDuNsb2NhbGhvc3QAAAAAAADAR1BMdjIAU3lzdGVtIEVudmlyb25t
+        ZW50L0Jhc2UAbGludXgAbm9hcmNoAAAAAADAgbQAAE9aDtU1MTI5YmFmY2M0
+        MGM2MTE0MmMzY2E1YmJkYzkzNDc5MWNlYjY1MGE0YWZiYmI0OTgyYTRkNGYx
+        YzFkZmE3NzliAAAAAAAAACBwa2lsYW1iaQBwa2lsYW1iaQAAAP////8BAAAK
+        AQAACnJwbWxpYihGaWxlRGlnZXN0cykAcnBtbGliKENvbXByZXNzZWRGaWxl
+        TmFtZXMpADQuNi4wLTEAMy4wLjQtMQA0LjkuMABub2FyY2gAbG9jYWxob3N0
+        IDEzMzEzMDIxMTUAAAAAAP0BAAg0DgAAAAAAAAAAdGVzdC1zcnBtLnNwZWMA
+        AGNwaW8AZ3ppcAA5AAAAAAgAAAA/AAAAB////YAAAAAQH4sIAAAAAAACA42Q
+        UUvDMBDHfb5PcX3w0XnRlo2+bTiGUGR0w/csvbpgk5QkLezbm6r1QRT2J5Bf
+        kl/u4GhJSxJEtHrMiWkCccrp74i8LSRxU3wd1fd128zv//xrZ4gc4l3wvVmE
+        ntVNymEwRvpLiU8JLriX6l2+MUaHvXejbiY0SsYCXqThEn8qkIBX9kE7W6JY
+        ENTcsQzJELDzbuhLPFxCZINbO2rvrGEb7zfJgEortpO521fjA2wG3TVrr84l
+        WifTDnDbcFBe9zFVBziedcC05GdzTL2T0eqOAwDQPL9rcq33O6cZjvX6udrW
+        WZZNs/sATYC6I7wBAAANCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9z
+        dC1kNTVjMDFmMjRmZmU1MzNhNGExZTMyY2QyYmJkOGU3MC0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-d55c01f24ffe533a4a1e32cd2bbd8e70
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-1606/1607
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1928'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 879ac3a6217646129b8239801c803644
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy80ZDA2YmEyMi0x
+        ZDYzLTQzYTYtOWIzNC1kNTkyYzk4OTQwYWQvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMzo1NDowNS4wMTUwMzdaIiwic2l6ZSI6MTYwN30=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - a561b2a6ed3c4eab85ab9327027f686d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/4d06ba22-1d63-43a6-9b34-d592c98940ad/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1NGNjNDcxM2ZlNzA0ZGZjN2E0ZmQ1YjM5OGY4MzRjZWI2
+        YTY5MmY1M2IwYzZhZWZhZjg5ZDg4NDE3YjRjNTFkIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 569d525c6bda49a280c6915f6af9a9e7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4NGRiNmUwLWFlZjItNDVk
+        Yy04ODJhLTI5ZTY2OTM1NTFlZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/184db6e0-aef2-45dc-882a-29e6693551ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 77042a49f7204d2eadeabe6746f33295
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTg0ZGI2ZTAtYWVm
+        Mi00NWRjLTg4MmEtMjllNjY5MzU1MWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDUuMTA0ODk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI1NjlkNTI1YzZiZGE0OWEyODBjNjkxNWY2YWY5YTll
+        NyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU0OjA1LjE1MDI1Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDUuMjM0MjIyWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy85
+        NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNDk3ZDRjZDctMjgyYi00YTEyLTlh
+        NDUtODVlNGU3MjI5YjBjLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzRkMDZiYTIyLTFkNjMtNDNhNi05
+        YjM0LWQ1OTJjOTg5NDBhZC8iXX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/artifacts/?sha256=54cc4713fe704dfc7a4fd5b398f834ceb6a692f53b0c6aefaf89d88417b4c51d
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - f126d4cd94244ad7b0d2a8a111cc83b5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '442'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNDk3
+        ZDRjZDctMjgyYi00YTEyLTlhNDUtODVlNGU3MjI5YjBjLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDUuMTkyMjExWiIsImZpbGUiOiJh
+        cnRpZmFjdC81NC9jYzQ3MTNmZTcwNGRmYzdhNGZkNWIzOThmODM0Y2ViNmE2
+        OTJmNTNiMGM2YWVmYWY4OWQ4ODQxN2I0YzUxZCIsInNpemUiOjE2MDcsIm1k
+        NSI6bnVsbCwic2hhMSI6ImQ5NjI5YzAzNGZlZDNhMmY0Nzg3MGZjNmZkYzc4
+        YTMwYzU1NTZlMWQiLCJzaGEyMjQiOiJkOWYxZWFhOTgwNzFlMjEzOTIxMGFm
+        YWY1N2RmYmIwNjQ4NzRmN2IxODFjZDljMjYxOTFjMTM4NiIsInNoYTI1NiI6
+        IjU0Y2M0NzEzZmU3MDRkZmM3YTRmZDViMzk4ZjgzNGNlYjZhNjkyZjUzYjBj
+        NmFlZmFmODlkODg0MTdiNGM1MWQiLCJzaGEzODQiOiI5NDA2MzU0MDdlYzIy
+        MzEzODcyN2FiNmQxODJlYzFiMmIxMTAxOWZkMmI5MTNiZDc0ZWM2NjEwYjRi
+        NTE4NzdjYjEwM2I1YWUzZGU5ZDkyMTFlZmUwNzlkYjQ5MGZkZjkiLCJzaGE1
+        MTIiOiI1MDEyMmUyNzZkOWUzNTkzMTdkMGI4NTE5YTJjNWQ2YWMxNzVjNTM4
+        OTBjODc1YmExMmE0NTc2ODkzZTFkNmFiNjU5ZmU3Y2MzYjkxMDAyZTc0MTRm
+        YjRkNzgzNDNlZGQ3MTdlZDY0NjI1ZDJjYmFlNWM3MzMxM2Q1N2MwNDM5OCJ9
+        XX0=
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTQ4NTE4YTM2YWM1MjJi
+        YWViYmU4NDVkZDY5MjRlOGVhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3Qtc3JwbTAxLTEu
+        MC0xLnNyYy5ycG0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC00
+        ODUxOGEzNmFjNTIyYmFlYmJlODQ1ZGQ2OTI0ZThlYQ0KQ29udGVudC1EaXNw
+        b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJhcnRpZmFjdCINCg0KL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy80OTdkNGNkNy0yODJiLTRhMTItOWE0NS04NWU0
+        ZTcyMjliMGMvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNDg1
+        MThhMzZhYzUyMmJhZWJiZTg0NWRkNjkyNGU4ZWEtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-48518a36ac522baebbe845dd6924e8ea
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '393'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - f4ee2ef0a67e45dcba7deda19caa0c10
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0NTVhYTYyLTNjMjUtNGUx
+        Yy04OThlLTk0OWNjMTcwMzAyZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/f455aa62-3c25-4e1c-898e-949cc170302d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2c830a09b77846e998753a1cfcce618a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '403'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjQ1NWFhNjItM2My
+        NS00ZTFjLTg5OGUtOTQ5Y2MxNzAzMDJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDUuMzMwNjc4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmNGVlMmVmMGE2N2U0NWRjYmE3ZGVkYTE5
+        Y2FhMGMxMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU0OjA1LjM3
+        MTk4OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6MDUuNDkw
+        MzE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9mYTY5
+        MDNjYi0zMWJiLTQ1OWItYjQzMC01MzMwNDg1MzhjZjIvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy80
+        OTdkNGNkNy0yODJiLTRhMTItOWE0NS04NWU0ZTcyMjliMGMvIl19
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/rpm/rpm/34a38f72-702e-4b32-9ad8-d062f22c928a/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvZmE2OTAzY2ItMzFiYi00NTliLWI0MzAtNTMzMDQ4NTM4
+        Y2YyLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.13.3/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 136ad3eaed224aafbd37d71f921de5d8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I3OGVlMjU2LTAxOGUtNGNh
+        NC1hNWY0LTUxYTkzNDQwMTI4ZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b78ee256-018e-4ca4-a5f4-51a93440128e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 23:54:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - b16eae5d06c640609bb70b9e2d9df628
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjc4ZWUyNTYtMDE4
+        ZS00Y2E0LWE1ZjQtNTFhOTM0NDAxMjhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjM6NTQ6MDUuNjEzMDM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxMzZhZDNlYWVkMjI0YWFmYmQz
+        N2Q3MWY5MjFkZTVkOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIzOjU0
+        OjA1LjY2MDM1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjM6NTQ6
+        MDUuODE0ODg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0
+        MTQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8zNGEzOGY3Mi03MDJlLTRiMzItOWFkOC1kMDYyZjIyYzkyOGEvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzRhMzhmNzItNzAyZS00YjMy
+        LTlhZDgtZDA2MmYyMmM5MjhhLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 23:54:05 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:13 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,11 +35,11 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - caa6dbef50794fb199a6f20634c955ae
+      - 53c86f79798349129e0da117473b53e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '301'
     body:
@@ -47,22 +47,22 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjQ5OjQ2LjE5MTI1
-        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMjNjNzE2MjktNjMxNC00ODhjLTlmNGUtZmFlNTNkNjY1
-        MzQxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS9maWxlLzA5NDdlZWYxLWY1MGEtNGJjOS04MTdkLWMyYjcyNWM1MWE0
+        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTExVDIwOjU2OjI0Ljc1MzI4
+        M1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMDk0N2VlZjEtZjUwYS00YmM5LTgxN2QtYzJiNzI1YzUx
+        YTQzL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzIzYzcxNjI5LTYzMTQtNDg4Yy05ZjRlLWZhZTUzZDY2NTM0MS92ZXJzaW9u
+        LzA5NDdlZWYxLWY1MGEtNGJjOS04MTdkLWMyYjcyNWM1MWE0My92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
         IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFu
         aWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:13 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/23c71629-6314-488c-9f4e-fae53d665341/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/0947eef1-f50a-4bc9-817d-c2b725c51a43/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -83,7 +83,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:14 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,21 +97,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 4434d18771374c93aa2ec5959eaf9ca8
+      - 9442d84d94e04f4ca82d8821b828f0ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzZjE1M2NmLWVkZWMtNDNk
-        My05NWI2LTBjZDcxY2M1M2Q3OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxZWI4ODQyLWU1ZWMtNDky
+        MS1iN2Y5LTVkOWIyNjEyY2U2Zi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:14 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -132,7 +132,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:14 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -144,36 +144,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 38dd3d993a93412ea3a4259ceedc84da
+      - 660cf3ec398a455cbe11260a9e0c0957
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '420'
+      - '376'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS85MDgzODUzMy1mMmU5LTQwMDYtYjgxMi0xNDBiNWI3ZWY5MDQvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0OTo0Ni40NTY4OTJaIiwi
+        ZmlsZS9kMGQ1MzdjNC0yZGEzLTRlY2QtOGI0My0yOTU5NjI1YzU2ZDgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMDo1NjoyNC41OTI5NzFaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
-        Y2VydCI6IktKTDpLREYqKERGJiooKiQmKCojJEpMS0pEKEQoKEQiLCJjbGll
-        bnRfY2VydCI6IktKTDpLREYqKERGJiooKiQmKCojJEpMS0pEKEQoKEQiLCJ0
-        bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
-        YmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxMzo0
-        OTo0OS44Njc1ODBaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1h
-        eF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90
-        aW1lb3V0IjozMDAuMCwiY29ubmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nv
-        bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19yZWFkX3RpbWVvdXQiOm51bGws
-        ImhlYWRlcnMiOm51bGwsInJhdGVfbGltaXQiOm51bGx9XX0=
+        Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
+        Ijp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDIxLTA4LTExVDIwOjU2OjI0LjU5Mjk4NVoi
+        LCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51
+        bGwsInBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjMwMC4w
+        LCJjb25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfY29ubmVjdF90aW1lb3V0
+        IjpudWxsLCJzb2NrX3JlYWRfdGltZW91dCI6bnVsbCwiaGVhZGVycyI6bnVs
+        bCwicmF0ZV9saW1pdCI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:14 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/90838533-f2e9-4006-b812-140b5b7ef904/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/d0d537c4-2da3-4ecd-8b43-2959625c56d8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -194,7 +193,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:14 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -208,21 +207,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 6f426b70974340db978d9093be1a1a7b
+      - 06c149eac5b7435c8ba1323659fb0d96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0NTc5ZGNhLWUzZjktNDAy
-        OC1hMzk3LWZjYTUwMTk5ZDRiMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjMmQwNzI4LTAyMjQtNGY1
+        NC04ZjNkLWJjYjIxYWVjN2I1Yy8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:14 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/93f153cf-edec-43d3-95b6-0cd71cc53d78/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/41eb8842-e5ec-4921-b7f9-5d9b2612ce6f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -230,7 +229,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -243,7 +242,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:14 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -255,96 +254,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 5d59fe12eba045c8a99993ae366d1214
+      - 0ea7151ac58d43ae921e630fb552b0e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '375'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTNmMTUzY2YtZWRl
-        Yy00M2QzLTk1YjYtMGNkNzFjYzUzZDc4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTI6MTQuMDM2NzI2WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI0NDM0ZDE4NzcxMzc0YzkzYWEyZWM1OTU5
-        ZWFmOWNhOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUyOjE0LjIw
-        NTI2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTI6MTQuNTk2
-        MDY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8yM2M3MTYyOS02MzE0LTQ4
-        OGMtOWY0ZS1mYWU1M2Q2NjUzNDEvIl19
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:14 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/24579dca-e3f9-4028-a397-fca50199d4b2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - a6a900c53e7b4b5a82ce8bc787d7ad0a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
       - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQ1NzlkY2EtZTNm
-        OS00MDI4LWEzOTctZmNhNTAxOTlkNGIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTI6MTQuMzQzNzQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDFlYjg4NDItZTVl
+        Yy00OTIxLWI3ZjktNWQ5YjI2MTJjZTZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTA6MDkuMTE2MTEwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZjQyNmI3MDk3NDM0MGRiOTc4ZDkwOTNi
-        ZTFhMWE3YiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUyOjE0LjUy
-        NjEwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTI6MTQuNjg3
-        Mjc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5NDQyZDg0ZDk0ZTA0ZjRjYTgyZDg4MjFi
+        ODI4ZjBhYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEwOjA5LjE2
+        MzM0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTA6MDkuMjI1
+        MTM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvOTA4Mzg1MzMtZjJlOS00MDA2LWI4
-        MTItMTQwYjViN2VmOTA0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wOTQ3ZWVmMS1mNTBhLTRi
+        YzktODE3ZC1jMmI3MjVjNTFhNDMvIl19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:14 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/4c2d0728-0224-4f54-8f3d-bcb21aec7b5c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -352,7 +290,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -365,221 +303,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 7d3f83893e59482ca6ba8b1304ac911c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '299'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS80YmRjZTNkMi02YmYwLTQ4MTEtYmU4MS1mODEyZDQzMzU4
-        Y2UvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0OTo0OC4zNjE3
-        MTVaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9kZXZlbDIuYmFsbW9y
-        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRp
-        b24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJw
-        dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
-        YWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRp
-        b24iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/4bdce3d2-6bf0-4811-be81-f812d43358ce/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '67'
-      Correlation-Id:
-      - 54f93bacab3b4cae975871be7b27bd3d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4Mjg0NGEzLTY3MjEtNDA1
-        Mi04YmM0LTVkNGQyNTFmMDE5ZS8ifQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - 8b15d21c9017429abc31e3fe93e16fff
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '299'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS80YmRjZTNkMi02YmYwLTQ4MTEtYmU4MS1mODEyZDQzMzU4
-        Y2UvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo0OTo0OC4zNjE3
-        MTVaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9kZXZlbDIuYmFsbW9y
-        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRp
-        b24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJw
-        dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
-        YWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRp
-        b24iOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
-- request:
-    method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/4bdce3d2-6bf0-4811-be81-f812d43358ce/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '23'
-      Correlation-Id:
-      - 65586a08768b400db1f62543202cbf46
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
-
-'
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/882844a3-6721-4052-8bc4-5d4d251f019e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -591,39 +315,38 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - '0097cd17e0de4a50963808774d887297'
+      - b352bf8280b94e0a84818a25828555fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '347'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODgyODQ0YTMtNjcy
-        MS00MDUyLThiYzQtNWQ0ZDI1MWYwMTllLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTI6MTUuMjA0ODkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGMyZDA3MjgtMDIy
+        NC00ZjU0LThmM2QtYmNiMjFhZWM3YjVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTA6MDkuMjM4ODYzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NGY5M2JhY2FiM2I0Y2FlOTc1ODcxYmU3
-        YjI3YmQzZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUyOjE1LjMy
-        NzcxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTI6MTUuNDk4
-        MDE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNmMxNDllYWM1Yjc0MzVjOGJhMTMyMzY1
+        OWZiMGQ5NiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEwOjA5LjI5
+        MzI3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTA6MDkuMzMy
+        MzkyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
-        L2Rpc3RyaWJ1dGlvbnMvIl19
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZDBkNTM3YzQtMmRhMy00ZWNkLThi
+        NDMtMjk1OTYyNWM1NmQ4LyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyJ9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
@@ -637,17 +360,15 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:15 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
-      Location:
-      - "/pulp/api/v3/repositories/file/file/6be112ae-609c-491f-837a-a600660dadba/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -655,33 +376,72 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '513'
+      - '52'
       Correlation-Id:
-      - 9cdbc0aa6a5749e4b9b7e7072982b5fa
+      - 05e4563f04f24677920b87fcaff952e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS82YmUxMTJhZS02MDljLTQ5MWYtODM3YS1hNjAwNjYwZGFkYmEvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MjoxNS45Njk2MTlaIiwi
-        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzZiZTExMmFlLTYwOWMtNDkxZi04MzdhLWE2MDA2NjBkYWRiYS92
-        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82YmUx
-        MTJhZS02MDljLTQ5MWYtODM3YS1hNjAwNjYwZGFkYmEvdmVyc2lvbnMvMC8i
-        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
-        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
-        IjoiUFVMUF9NQU5JRkVTVCJ9
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:15 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:10:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - d1f84123190745c0b6578e901c146e30
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -708,13 +468,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:16 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/7643516a-d944-4423-bf50-690bb80162bf/"
+      - "/pulp/api/v3/remotes/file/file/f1cf1f3f-4732-490e-808c-3c701c6b152e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -724,91 +484,42 @@ http_interactions:
       Content-Length:
       - '555'
       Correlation-Id:
-      - 7fa7f60ed5cf4ab9a3e6b7cfed09bbab
+      - 358bb56065004f8883872895236d1888
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        NzY0MzUxNmEtZDk0NC00NDIzLWJmNTAtNjkwYmI4MDE2MmJmLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NTI6MTYuMTg5NjE1WiIsIm5hbWUi
+        ZjFjZjFmM2YtNDczMi00OTBlLTgwOGMtM2M3MDFjNmIxNTJlLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTA6MDkuNTk0MTY2WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MjoxNi4xODk2NjRaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDowOS41OTQyMDNaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:16 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/
     body:
-      encoding: US-ASCII
-      base64_string: ''
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:52:16 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Correlation-Id:
-      - 3201478657e04aafaae2c9a347147ac3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:16 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -821,38 +532,47 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:52:16 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/uploads/2bbfddc6-cc13-4654-9c19-424b88c469a0/"
+      - "/pulp/api/v3/repositories/file/file/d24289c8-8286-4744-9ad1-5458fac0952a/"
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '130'
+      - '513'
       Correlation-Id:
-      - 72287e8cbf584a3cb75661d548ad6474
+      - 583faa5d0a064aceb47a813f8ae8f5c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8yYmJmZGRjNi1j
-        YzEzLTQ2NTQtOWMxOS00MjRiODhjNDY5YTAvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo1MjoxNi40ODA2NDNaIiwic2l6ZSI6NzQwfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS9kMjQyODljOC04Mjg2LTQ3NDQtOWFkMS01NDU4ZmFjMDk1MmEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDowOS43ODA2NTVaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlL2QyNDI4OWM4LTgyODYtNDc0NC05YWQxLTU0NThmYWMwOTUyYS92
+        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9kMjQy
+        ODljOC04Mjg2LTQ3NDQtOWFkMS01NDU4ZmFjMDk1MmEvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
+        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
+        IjoiUFVMUF9NQU5JRkVTVCJ9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:52:16 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/6be112ae-609c-491f-837a-a600660dadba/versions/0/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -873,7 +593,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:15 GMT
+      - Wed, 11 Aug 2021 21:10:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -887,16 +607,119 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 34a34bc0d2f14646929bacd4fa08c1a8
+      - d72e799715b342379c44168fa40ad844
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:15 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:10:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/87a2e76a-d526-4ee6-bf9c-69c905bf7523/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '130'
+      Correlation-Id:
+      - fd6de514e6be434bbc5bdf974b13bc0b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy84N2EyZTc2YS1k
+        NTI2LTRlZTYtYmY5Yy02OWM5MDViZjc1MjMvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMDowOS45NTY1MDFaIiwic2l6ZSI6NzQwfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:10:09 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/d24289c8-8286-4744-9ad1-5458fac0952a/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:10:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 0a7e904174a3445daae9ecafd0a8382c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:10:36 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/create_upload.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/create_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:19 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,34 +35,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 7ddf1898a621489ba8b4732517ac94cb
+      - a1911966bb9249818898a1e9aaaddbce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzZiZTExMmFlLTYwOWMtNDkxZi04MzdhLWE2MDA2NjBkYWRi
-        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUyOjE1Ljk2OTYx
-        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNmJlMTEyYWUtNjA5Yy00OTFmLTgzN2EtYTYwMDY2MGRh
-        ZGJhL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS9maWxlL2QyNDI4OWM4LTgyODYtNDc0NC05YWQxLTU0NThmYWMwOTUy
+        YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTA4LTExVDIxOjEwOjA5Ljc4MDY1
+        NVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvZDI0Mjg5YzgtODI4Ni00NzQ0LTlhZDEtNTQ1OGZhYzA5
+        NTJhL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzZiZTExMmFlLTYwOWMtNDkxZi04MzdhLWE2MDA2NjBkYWRiYS92ZXJzaW9u
+        L2QyNDI4OWM4LTgyODYtNDc0NC05YWQxLTU0NThmYWMwOTUyYS92ZXJzaW9u
         cy8xLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbmVkX3ZlcnNpb25z
         IjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFu
         aWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/6be112ae-609c-491f-837a-a600660dadba/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/d24289c8-8286-4744-9ad1-5458fac0952a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -83,7 +83,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:19 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,21 +97,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 93287ee4e36c4ff7a42a1945b5df532e
+      - 0215d55e9ae4484784bb147be503bbab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyNDUyNjMzLWE5OTgtNDUz
-        OS1hODEwLTAyYjcxMjdkYWRhZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE3ZjRmOGFiLWIzMDUtNDNj
+        Yy05MjFjLTM1MDgyOTYzYzBlOC8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -132,7 +132,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:19 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -144,35 +144,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 38ccc04c9faf46b8bcd137bc70f01ad3
+      - 78b04e95160144eab6abed6cfe60cc05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '377'
+      - '375'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS83NjQzNTE2YS1kOTQ0LTQ0MjMtYmY1MC02OTBiYjgwMTYyYmYvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MjoxNi4xODk2MTVaIiwi
+        ZmlsZS9mMWNmMWYzZi00NzMyLTQ5MGUtODA4Yy0zYzcwMWM2YjE1MmUvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDowOS41OTQxNjZaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
         Ijp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDIxLTA3LTIxVDEzOjUyOjE2LjE4OTY2NFoi
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDIxLTA4LTExVDIxOjEwOjA5LjU5NDIwM1oi
         LCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51
         bGwsInBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjMwMC4w
         LCJjb25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfY29ubmVjdF90aW1lb3V0
         IjpudWxsLCJzb2NrX3JlYWRfdGltZW91dCI6bnVsbCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6bnVsbH1dfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/7643516a-d944-4423-bf50-690bb80162bf/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/f1cf1f3f-4732-490e-808c-3c701c6b152e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -193,7 +193,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:19 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -207,21 +207,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 1e207dc2a5f54af4b92b49155521925a
+      - 6ceb0d312a3649228c3e3e9bf52d65c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhMGRjYzM1LTcyYzYtNDkz
-        ZS1hMDNiLTkyM2FlNGI0NzZlZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczYTY4NjhkLTgyMzMtNGVl
+        NS05Nzg0LTNiYjZjZmFhMDEwZi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:19 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/22452633-a998-4539-a810-02b7127dadaf/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/17f4f8ab-b305-43cc-921c-35082963c0e8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -229,7 +229,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -242,7 +242,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -254,35 +254,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 3463a79eda13428689763844f2611147
+      - c1161b41121c48b29e1ff8fde46cb4d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '374'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjI0NTI2MzMtYTk5
-        OC00NTM5LWE4MTAtMDJiNzEyN2RhZGFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTM6MTkuNTkwNTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTdmNGY4YWItYjMw
+        NS00M2NjLTkyMWMtMzUwODI5NjNjMGU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTA6MzguNTM2NTYxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MzI4N2VlNGUzNmM0ZmY3YTQyYTE5NDVi
-        NWRmNTMyZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUzOjE5LjY4
-        MjgxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTM6MTkuOTc4
-        MDY5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwMjE1ZDU1ZTlhZTQ0ODQ3ODRiYjE0N2Jl
+        NTAzYmJhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEwOjM4LjU3
+        NTgwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTA6MzguNjc2
+        NjIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy85NWQ4OWUwOS1lOGJiLTRiY2MtODU4NS1lY2MyY2YxNDA0MTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82YmUxMTJhZS02MDljLTQ5
-        MWYtODM3YS1hNjAwNjYwZGFkYmEvIl19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9kMjQyODljOC04Mjg2LTQ3
+        NDQtOWFkMS01NDU4ZmFjMDk1MmEvIl19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/8a0dcc35-72c6-493e-a03b-923ae4b476ee/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/73a6868d-8233-4ee5-9784-3bb6cfaa010f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -290,7 +290,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -303,7 +303,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -315,35 +315,35 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - f56fbf2e0a8d458685078f5822a6656f
+      - c53d1d3590a44b5ab43dbf63722bf4ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '375'
+      - '369'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGEwZGNjMzUtNzJj
-        Ni00OTNlLWEwM2ItOTIzYWU0YjQ3NmVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTM6MTkuODM0MTM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzNhNjg2OGQtODIz
+        My00ZWU1LTk3ODQtM2JiNmNmYWEwMTBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTA6MzguNjUzOTAxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZTIwN2RjMmE1ZjU0YWY0YjkyYjQ5MTU1
-        NTIxOTI1YSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUzOjIwLjAy
-        MDg1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTM6MjAuMDk1
-        MjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGY0NWE5YS1hMjhiLTQ4NjYtYjZiMy0zOGEyZTU2NDJkZjkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2Y2ViMGQzMTJhMzY0OTIyOGMzZTNlOWJm
+        NTJkNjVjOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEwOjM4Ljcw
+        NzUyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTA6MzguNzQ4
+        MDcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvNzY0MzUxNmEtZDk0NC00NDIzLWJm
-        NTAtNjkwYmI4MDE2MmJmLyJdfQ==
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvZjFjZjFmM2YtNDczMi00OTBlLTgw
+        OGMtM2M3MDFjNmIxNTJlLyJdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -364,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -376,32 +376,32 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - a8eefdb1f8334464b60c1185a77971f9
+      - b47d3b0d5bf9469e9dec1315601ed728
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '300'
+      - '303'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS82NWUzMDZjMC0wY2EyLTQ5ZmYtYjg1Ny1kNTZjODA1NzBk
-        ZmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MjozNC43NjIx
-        MDhaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9kZXZlbDIuYmFsbW9y
-        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRp
-        b24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJw
-        dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
-        YWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRp
-        b24iOm51bGx9XX0=
+        L2ZpbGUvZmlsZS85YWE0MGRkYy1kODk1LTQ2YjItOWVhNi04OGMyZDRjZDdl
+        MDYvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDoxOC44OTI1
+        NTNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWRldmVs
+        NC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdh
+        bml6YXRpb24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXph
+        dGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVi
+        bGljYXRpb24iOm51bGx9XX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/65e306c0-0ca2-49ff-b857-d56c80570dfa/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/9aa40ddc-d895-46b2-9ea6-88c2d4cd7e06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -422,7 +422,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -436,21 +436,21 @@ http_interactions:
       Content-Length:
       - '67'
       Correlation-Id:
-      - 924032eb84554ce683a51001108208dc
+      - 6bcb8cdb1fd4439c85939c80ecce73c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc2Nzk3YTE1LTkxNDAtNDAx
-        OC1hZWQ1LWJkNDUyNGNhYTdjNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiN2Q5MGM5LWM0MmMtNDUx
+        ZC1hMDBlLWJkMjdlOWEyNTRhZi8ifQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -471,7 +471,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -483,32 +483,32 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 614cb9030e414a3eb60865aa31f64b77
+      - 1367df5f9efc45228e9ec28aa6c7116d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '300'
+      - '303'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS82NWUzMDZjMC0wY2EyLTQ5ZmYtYjg1Ny1kNTZjODA1NzBk
-        ZmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MjozNC43NjIx
-        MDhaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9kZXZlbDIuYmFsbW9y
-        YS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRp
-        b24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJw
-        dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
-        YWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRp
-        b24iOm51bGx9XX0=
+        L2ZpbGUvZmlsZS85YWE0MGRkYy1kODk1LTQ2YjItOWVhNi04OGMyZDRjZDdl
+        MDYvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDoxOC44OTI1
+        NTNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M3LWRldmVs
+        NC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdh
+        bml6YXRpb24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXph
+        dGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwicmVwb3NpdG9yeSI6bnVsbCwicHVi
+        bGljYXRpb24iOm51bGx9XX0=
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: delete
-    uri: https://devel2.balmora.example.com/pulp/api/v3/distributions/file/file/65e306c0-0ca2-49ff-b857-d56c80570dfa/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/file/file/9aa40ddc-d895-46b2-9ea6-88c2d4cd7e06/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -525,11 +525,11 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 404
+      message: Not Found
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -541,23 +541,23 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Content-Length:
-      - '67'
+      - '23'
       Correlation-Id:
-      - 2ec85824f06741f49c1d5ff807e063db
+      - a456cd1dcbea45bda2767485f1bd7a48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiYWM0OTM2LTRiZGMtNGQ1
-        Ni1iOGJhLThhMDYxNzY0MTM2ZS8ifQ==
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/76797a15-9140-4018-aed5-bd4524caa7c5/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/cb7d90c9-c42c-451d-a00e-bd27e9a254af/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -565,7 +565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -578,7 +578,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
+      - Wed, 11 Aug 2021 21:10:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -590,172 +590,34 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Correlation-Id:
-      - 27004697ae6b4f03898a9d9ff8a7d1a3
+      - b8f4ad5a79454c5eb633d164a8afb5dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
       Content-Length:
-      - '347'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzY3OTdhMTUtOTE0
-        MC00MDE4LWFlZDUtYmQ0NTI0Y2FhN2M1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTM6MjAuNDI3NTY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2I3ZDkwYzktYzQy
+        Yy00NTFkLWEwMGUtYmQyN2U5YTI1NGFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDgtMTFUMjE6MTA6MzguODM1MTA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5MjQwMzJlYjg0NTU0Y2U2ODNhNTEwMDEx
-        MDgyMDhkYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUzOjIwLjUy
-        MTg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTM6MjAuNjQ0
-        NDczWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iOGQ1OTdhNC03ZGE5LTRmYWEtYWY4OC01YmRhZDJjMWE5ZTAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2YmNiOGNkYjFmZDQ0MzljODU5MzljODBl
+        Y2NlNzNjOCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA4LTExVDIxOjEwOjM4Ljg3
+        NjU0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDgtMTFUMjE6MTA6MzguOTA4
+        NTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jMDYzNGJiOC1kMDlhLTQ3OGUtODRlZi01YzAxMGFjNjExNzAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
-- request:
-    method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/abac4936-4bdc-4d56-b8ba-8a061764136e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:53:20 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Correlation-Id:
-      - dc4d155d79a146348c497ab37bf91d39
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-      Content-Length:
-      - '649'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWJhYzQ5MzYtNGJk
-        Yy00ZDU2LWI4YmEtOGEwNjE3NjQxMzZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMDctMjFUMTM6NTM6MjAuNjI5Nzc4WiIsInN0YXRlIjoiZmFpbGVkIiwi
-        bmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVsZXRl
-        IiwibG9nZ2luZ19jaWQiOiIyZWM4NTgyNGYwNjc0MWY0OWMxZDVmZjgwN2Uw
-        NjNkYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA3LTIxVDEzOjUzOjIwLjcyNjIw
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDctMjFUMTM6NTM6MjAuNzY4NTIw
-        WiIsImVycm9yIjp7InRyYWNlYmFjayI6IiAgRmlsZSBcIi91c3IvbGliL3B5
-        dGhvbjMuNi9zaXRlLXBhY2thZ2VzL3B1bHBjb3JlL3Rhc2tpbmcvcHVscGNv
-        cmVfd29ya2VyLnB5XCIsIGxpbmUgMjY2LCBpbiBfcGVyZm9ybV90YXNrXG4g
-        ICAgcmVzdWx0ID0gZnVuYygqYXJncywgKiprd2FyZ3MpXG4gIEZpbGUgXCIv
-        dXNyL2xpYi9weXRob24zLjYvc2l0ZS1wYWNrYWdlcy9wdWxwY29yZS9hcHAv
-        dGFza3MvYmFzZS5weVwiLCBsaW5lIDg0LCBpbiBnZW5lcmFsX2RlbGV0ZVxu
-        ICAgIGluc3RhbmNlID0gc2VyaWFsaXplcl9jbGFzcy5NZXRhLm1vZGVsLm9i
-        amVjdHMuZ2V0KHBrPWluc3RhbmNlX2lkKS5jYXN0KClcbiAgRmlsZSBcIi91
-        c3IvbGliL3B5dGhvbjMuNi9zaXRlLXBhY2thZ2VzL2RqYW5nby9kYi9tb2Rl
-        bHMvbWFuYWdlci5weVwiLCBsaW5lIDgyLCBpbiBtYW5hZ2VyX21ldGhvZFxu
-        ICAgIHJldHVybiBnZXRhdHRyKHNlbGYuZ2V0X3F1ZXJ5c2V0KCksIG5hbWUp
-        KCphcmdzLCAqKmt3YXJncylcbiAgRmlsZSBcIi91c3IvbGliL3B5dGhvbjMu
-        Ni9zaXRlLXBhY2thZ2VzL2RqYW5nby9kYi9tb2RlbHMvcXVlcnkucHlcIiwg
-        bGluZSA0MDgsIGluIGdldFxuICAgIHNlbGYubW9kZWwuX21ldGEub2JqZWN0
-        X25hbWVcbiIsImRlc2NyaXB0aW9uIjoiRmlsZURpc3RyaWJ1dGlvbiBtYXRj
-        aGluZyBxdWVyeSBkb2VzIG5vdCBleGlzdC4ifSwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvNzRmNDVhOWEtYTI4Yi00ODY2LWI2YjMtMzhhMmU1
-        NjQyZGY5LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVh
-        dGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQi
-        OlsiL2FwaS92My9kaXN0cmlidXRpb25zLyJdfQ==
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:20 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:38 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/file/file/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 21 Jul 2021 13:53:21 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/repositories/file/file/198fe546-1d88-4fd8-927e-7e43b4563635/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '513'
-      Correlation-Id:
-      - a6cf17c1c30a4f91bea20c4078a4c49e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel2.balmora.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8xOThmZTU0Ni0xZDg4LTRmZDgtOTI3ZS03ZTQzYjQ1NjM2MzUvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MzoyMS4xMTU3NTlaIiwi
-        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzE5OGZlNTQ2LTFkODgtNGZkOC05MjdlLTdlNDNiNDU2MzYzNS92
-        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xOThm
-        ZTU0Ni0xZDg4LTRmZDgtOTI3ZS03ZTQzYjQ1NjM2MzUvdmVyc2lvbnMvMC8i
-        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
-        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
-        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
-        IjoiUFVMUF9NQU5JRkVTVCJ9
-    http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:21 GMT
-- request:
-    method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -782,13 +644,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:21 GMT
+      - Wed, 11 Aug 2021 21:10:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/71a84266-2d99-4406-84a1-2ff55214bdf5/"
+      - "/pulp/api/v3/remotes/file/file/8f94b949-a3bf-46b6-a9d7-8ee00e3ae969/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -798,32 +660,95 @@ http_interactions:
       Content-Length:
       - '555'
       Correlation-Id:
-      - 91454c9931d04160b45551931a62d331
+      - 87bced394b14439dac1551b89d9f553c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        NzFhODQyNjYtMmQ5OS00NDA2LTg0YTEtMmZmNTUyMTRiZGY1LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMDctMjFUMTM6NTM6MjEuMzUwNjkzWiIsIm5hbWUi
+        OGY5NGI5NDktYTNiZi00NmI2LWE5ZDctOGVlMDBlM2FlOTY5LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMDgtMTFUMjE6MTA6MzkuMTM0ODQ2WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0wNy0yMVQxMzo1MzoyMS4zNTA3NDRaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDozOS4xMzQ4NTlaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:21 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:39 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 11 Aug 2021 21:10:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/file/file/1862b4f4-d17c-46d2-bdf0-47aeba24354d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '513'
+      Correlation-Id:
+      - eb4092b2405142488510a044e5ee28ed
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8xODYyYjRmNC1kMTdjLTQ2ZDItYmRmMC00N2FlYmEyNDM1NGQvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0wOC0xMVQyMToxMDozOS4zNjc3MzdaIiwi
+        dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
+        ZS9maWxlLzE4NjJiNGY0LWQxN2MtNDZkMi1iZGYwLTQ3YWViYTI0MzU0ZC92
+        ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8xODYy
+        YjRmNC1kMTdjLTQ2ZDItYmRmMC00N2FlYmEyNDM1NGQvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5lZF92ZXJzaW9ucyI6bnVs
+        bCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0
+        IjoiUFVMUF9NQU5JRkVTVCJ9
+    http_version: 
+  recorded_at: Wed, 11 Aug 2021 21:10:39 GMT
 - request:
     method: get
-    uri: https://devel2.balmora.example.com/pulp/api/v3/content/file/files/?sha256=99fc15572d2ee34c4baf5e7c1ae76c7180e2075f9ef69617853bc2767b226277
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/content/file/files/?sha256=99fc15572d2ee34c4baf5e7c1ae76c7180e2075f9ef69617853bc2767b226277
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -844,7 +769,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:21 GMT
+      - Wed, 11 Aug 2021 21:10:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -858,21 +783,21 @@ http_interactions:
       Content-Length:
       - '52'
       Correlation-Id:
-      - 0b60edc629704a8b8d9e6ed5db538b9d
+      - baaef32aa7514bd5a95d55faf22f5e44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:21 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:39 GMT
 - request:
     method: post
-    uri: https://devel2.balmora.example.com/pulp/api/v3/uploads/
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/uploads/
     body:
       encoding: UTF-8
       base64_string: 'eyJzaXplIjo0Nn0=
@@ -882,7 +807,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.14.1/ruby
+      - OpenAPI-Generator/3.14.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -895,13 +820,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 21 Jul 2021 13:53:21 GMT
+      - Wed, 11 Aug 2021 21:10:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/uploads/a7115fae-3a9e-44fc-8561-ac2da709cbd7/"
+      - "/pulp/api/v3/uploads/1dcd95a4-5bd4-4733-95f7-6717325c11de/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -911,17 +836,17 @@ http_interactions:
       Content-Length:
       - '129'
       Correlation-Id:
-      - 329d1d3f2c1049afbd41a8eef979ef1e
+      - 45419bc0f62941f1b0eacd1247175a15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel2.balmora.example.com
+      - 1.1 centos7-devel4.samir.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9hNzExNWZhZS0z
-        YTllLTQ0ZmMtODU2MS1hYzJkYTcwOWNiZDcvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0wNy0yMVQxMzo1MzoyMS42MjYyMDdaIiwic2l6ZSI6NDZ9
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8xZGNkOTVhNC01
+        YmQ0LTQ3MzMtOTVmNy02NzE3MzI1YzExZGUvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0wOC0xMVQyMToxMDozOS41MTcwNTdaIiwic2l6ZSI6NDZ9
     http_version: 
-  recorded_at: Wed, 21 Jul 2021 13:53:21 GMT
+  recorded_at: Wed, 11 Aug 2021 21:10:39 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Steps to Reproduce:
1. Create a product and a file-type repo in it.
2. In the repo page click Choose files, select 20 or so files (Use these 10 : https://fixtures.pulpproject.org/file-large/ and make a copy of the 10 to have several duplicates)
3. Click upload

Actual results:
The task succeeded but only 10 or less files were really synced

Expected results:
All files being synced or some notification it did not happen, not pass silently.