### PR TITLE
Fixes #33181 - pagination info at the bottom & top

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { Pagination, Flex, FlexItem } from '@patternfly/react-core';
+import { Pagination, PaginationVariant, Flex, FlexItem } from '@patternfly/react-core';
 
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
@@ -77,6 +77,26 @@ const TableWrapper = ({
     updatePagination(updatedPagination);
   };
 
+  const PageControls = ({ variant }) => (
+    <FlexItem align={{ default: 'alignRight' }}>
+      <Pagination
+        key={variant}
+        itemCount={total}
+        page={page}
+        perPage={perPage}
+        isCompact={variant === PaginationVariant.top}
+        onSetPage={(_evt, updated) => onPaginationUpdate({ page: updated })}
+        onPerPageSelect={(_evt, updated) => onPaginationUpdate({ per_page: updated })}
+        perPageOptions={usePaginationOptions().map(p => ({ title: p.toString(), value: p }))}
+        variant={variant}
+      />
+    </FlexItem>
+  );
+
+  PageControls.propTypes = {
+    variant: PropTypes.string.isRequired,
+  };
+
   const rowsCount = metadata?.subtotal ?? 0;
   const unresolvedStatus = !!allTableProps?.status && allTableProps.status !== STATUS.RESOLVED;
   const unresolvedStatusOrNoRows = unresolvedStatus || rowsCount === 0;
@@ -98,17 +118,7 @@ const TableWrapper = ({
             {children}
           </FlexItem>
         }
-        <FlexItem align={{ default: 'alignRight' }}>
-          <Pagination
-            itemCount={total}
-            page={page}
-            perPage={perPage}
-            onSetPage={(_evt, updated) => onPaginationUpdate({ page: updated })}
-            onPerPageSelect={(_evt, updated) => onPaginationUpdate({ per_page: updated })}
-            perPageOptions={usePaginationOptions().map(p => ({ title: p.toString(), value: p }))}
-            variant="top"
-          />
-        </FlexItem>
+        <PageControls variant={PaginationVariant.top} />
       </Flex>
       <MainTable
         searchIsActive={!!searchQuery}
@@ -119,6 +129,9 @@ const TableWrapper = ({
       >
         {children}
       </MainTable>
+      <Flex>
+        <PageControls variant={PaginationVariant.bottom} />
+      </Flex>
     </>
   );
 };

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -240,7 +240,7 @@ test('Can handle pagination', async (done) => {
     // Using a custom query params matcher because parameters can be strings
     .query(actualQueryObject => (parseInt(actualQueryObject.page, 10) === 2))
     .reply(200, cvIndexSecondPage);
-  const { queryByText, getByLabelText } = renderWithRedux(<ContentViewsPage />, renderOptions);
+  const { queryByText, getAllByLabelText } = renderWithRedux(<ContentViewsPage />, renderOptions);
   // Wait for first paginated page to load and assert only the first page of results are present
   await patientlyWaitFor(() => {
     expect(queryByText(results[0].name)).toBeInTheDocument();
@@ -249,8 +249,10 @@ test('Can handle pagination', async (done) => {
   });
 
   // Label comes from patternfly, if this test fails, check if patternfly updated the label.
-  expect(getByLabelText('Go to next page')).toBeTruthy();
-  getByLabelText('Go to next page').click();
+  const [top, bottom] = getAllByLabelText('Go to next page');
+  expect(top).toBeInTheDocument();
+  expect(bottom).toBeInTheDocument();
+  bottom.click();
   // Wait for second paginated page to load and assert only the second page of results are present
   await patientlyWaitFor(() => {
     expect(queryByText(results[20].name)).toBeInTheDocument();


### PR DESCRIPTION
This commit updates the tablewrapper react component and renders the page controls on both top and bottom of the main table.