### PR TITLE
Fixes #33238 - Extend TableWrapper and MainTable to allow using PF TableComposable

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -206,7 +206,7 @@ Foreman::Plugin.register :katello do
   extend_template_helpers Katello::KatelloUrlsHelper
   extend_template_helpers Katello::Concerns::BaseTemplateScopeExtensions
 
-  register_global_js_file 'fills'
+  register_global_js_file 'global'
 
   search_path_override("Katello") do |resource|
     "/#{Katello::Util::Model.model_to_controller_path(resource)}/auto_complete_search"

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     "url": "https://projects.theforeman.org/projects/katello/issues"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.15.0",
+    "@babel/eslint-plugin": "^7.14.5",
     "@sheerun/mutationobserver-shim": "^0.3.3",
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "@theforeman/builder": ">= 6.0.0",
     "@theforeman/find-foreman": "^4.8.0",
     "axios-mock-adapter": "^1.10.0",
-    "babel-eslint": "^10.0.3",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "^16.0.0",
     "eslint-plugin-babel": "^5.1.0",

--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -21,8 +21,9 @@ module.exports = {
     'react',
     'react-hooks',
     'promise',
+    '@babel',
   ],
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   rules: {
     'react/jsx-filename-extension': 'off',
     'react-hooks/rules-of-hooks': 'error',

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -3,7 +3,9 @@ import {
   Table,
   TableHeader,
   TableBody,
+  TableComposable,
 } from '@patternfly/react-table';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import PropTypes from 'prop-types';
 
@@ -13,24 +15,43 @@ import Loading from '../../components/Loading';
 const MainTable = ({
   status, cells, rows, error, emptyContentTitle, emptyContentBody,
   emptySearchTitle, emptySearchBody, searchIsActive, activeFilters,
-  ...extraTableProps
+  composable, rowsCount, children, ...extraTableProps
 }) => {
+  if (!composable && (!cells || !rows)) {
+    console.error(__('The <MainTable> component requires either a composable prop, or cells & rows props.')); // eslint-disable-line no-console
+  }
+
+  const tableHasNoRows = () => {
+    if (composable) return rowsCount === 0;
+    return rows.length === 0;
+  };
   const isFiltering = activeFilters || searchIsActive;
   if (status === STATUS.PENDING) return (<Loading />);
   // Can we display the error message?
   if (status === STATUS.ERROR) return (<EmptyStateMessage error={error} />);
-  if (status === STATUS.RESOLVED && isFiltering && rows.length === 0) {
+  if (status === STATUS.RESOLVED && isFiltering && tableHasNoRows()) {
     return (<EmptyStateMessage
       title={emptySearchTitle}
       body={emptySearchBody}
       search
     />);
   }
-  if (status === STATUS.RESOLVED && rows.length === 0) {
+  if (status === STATUS.RESOLVED && tableHasNoRows()) {
     return (<EmptyStateMessage title={emptyContentTitle} body={emptyContentBody} />);
   }
 
   const tableProps = { cells, rows, ...extraTableProps };
+  if (composable) {
+    return (
+      <TableComposable
+        aria-label="Content View Table"
+        className="katello-pf4-table"
+        {...extraTableProps}
+      >
+        {children}
+      </TableComposable>
+    );
+  }
   return (
     <Table
       aria-label="Content View Table"
@@ -47,8 +68,8 @@ MainTable.propTypes = {
   status: PropTypes.string.isRequired,
   cells: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.shape({}),
-    PropTypes.string])).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    PropTypes.string])),
+  rows: PropTypes.arrayOf(PropTypes.shape({})),
   error: PropTypes.oneOfType([
     PropTypes.shape({}),
     PropTypes.string,
@@ -59,12 +80,23 @@ MainTable.propTypes = {
   emptySearchBody: PropTypes.string.isRequired,
   searchIsActive: PropTypes.bool,
   activeFilters: PropTypes.bool,
+  composable: PropTypes.bool,
+  rowsCount: PropTypes.number,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
 };
 
 MainTable.defaultProps = {
   error: null,
   searchIsActive: false,
   activeFilters: false,
+  composable: false,
+  children: null,
+  cells: undefined,
+  rows: undefined,
+  rowsCount: undefined,
 };
 
 export default MainTable;

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -21,6 +21,7 @@ const TableWrapper = ({
   updateSearchQuery,
   additionalListeners,
   activeFilters,
+  composable,
   ...allTableProps
 }) => {
   const dispatch = useDispatch();
@@ -59,6 +60,7 @@ const TableWrapper = ({
     paginationParams,
     searchQuery,
     additionalListeners,
+    composable,
   ]);
 
   const getAutoCompleteParams = search => ({
@@ -73,6 +75,8 @@ const TableWrapper = ({
     updatePagination(updatedPagination);
   };
 
+  const rowsCount = metadata?.subtotal ?? 0;
+
   return (
     <React.Fragment>
       <Flex>
@@ -83,9 +87,11 @@ const TableWrapper = ({
             getAutoCompleteParams={getAutoCompleteParams}
           />
         </FlexItem>
-        <FlexItem>
-          {children}
-        </FlexItem>
+        {!composable &&
+          <FlexItem>
+            {children}
+          </FlexItem>
+        }
         <FlexItem align={{ default: 'alignRight' }}>
           <Pagination
             itemCount={total}
@@ -98,7 +104,15 @@ const TableWrapper = ({
           />
         </FlexItem>
       </Flex>
-      <MainTable searchIsActive={!!searchQuery} activeFilters={activeFilters} {...allTableProps} />
+      <MainTable
+        searchIsActive={!!searchQuery}
+        activeFilters={activeFilters}
+        composable={composable}
+        rowsCount={rowsCount}
+        {...allTableProps}
+      >
+        {children}
+      </MainTable>
     </React.Fragment>
   );
 };
@@ -109,6 +123,7 @@ TableWrapper.propTypes = {
   fetchItems: PropTypes.func.isRequired,
   metadata: PropTypes.shape({
     total: PropTypes.number,
+    subtotal: PropTypes.number,
     page: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string, // The API can sometimes return strings
@@ -128,13 +143,15 @@ TableWrapper.propTypes = {
     PropTypes.bool,
   ])),
   activeFilters: PropTypes.bool,
+  composable: PropTypes.bool,
 };
 
 TableWrapper.defaultProps = {
-  metadata: {},
+  metadata: { subtotal: 0 },
   children: null,
   additionalListeners: [],
   activeFilters: false,
+  composable: false,
 };
 
 export default TableWrapper;

--- a/webpack/components/pf3Table/components/Table.js
+++ b/webpack/components/pf3Table/components/Table.js
@@ -33,7 +33,7 @@ const Table = ({
     <div>
       <PfTable.PfProvider
         columns={columns}
-        className="table-fixed"
+        className="table-fixed neat-table-cells"
         striped
         bordered
         hover

--- a/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
+++ b/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
@@ -4,7 +4,7 @@ exports[`Table renders Table with body 1`] = `
 <div>
   <TablePfProvider
     bordered={true}
-    className="table-fixed"
+    className="table-fixed neat-table-cells"
     columns={
       Array [
         Object {
@@ -72,7 +72,7 @@ exports[`Table renders Table with children 1`] = `
 <div>
   <TablePfProvider
     bordered={true}
-    className="table-fixed"
+    className="table-fixed neat-table-cells"
     columns={
       Array [
         Object {
@@ -111,7 +111,7 @@ exports[`Table renders Table with pagination 1`] = `
 <div>
   <TablePfProvider
     bordered={true}
-    className="table-fixed"
+    className="table-fixed neat-table-cells"
     columns={
       Array [
         Object {

--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -14,9 +14,12 @@ html .pagination-pf-pagesize.btn-group {
   margin-top: -6px !important;
 }
 
-td, th {
-  overflow: auto;
-  word-wrap: break-word;
+// don't use this class if you need a dropdown menu to extend outside the table cell
+.neat-table-cells {
+  td, th {
+    overflow: auto;
+    word-wrap: break-word;
+  }
 }
 
 // needed because we have overflow set to auto for all td's and it affected the pf4 table

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -9,8 +9,11 @@ import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/Co
 
 import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import extendReducer from './components/extensions/reducers';
+import rootReducer from './redux/reducers';
 
 registerReducer('katelloExtends', extendReducer);
+registerReducer('katello', rootReducer);
+
 
 addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
 addGlobalFill('registrationAdvanced', '[katello]RegistrationCommands', <RegistrationCommands key="katello-reg" />, 100);

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -1,12 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector } from 'react-redux';
-import { TableVariant, TableText } from '@patternfly/react-table';
+import { TableVariant, TableText, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { Label } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
-import { STATUS } from 'foremanReact/constants';
 import PropTypes from 'prop-types';
 
 import TableWrapper from '../../../../components/Table/TableWrapper';
@@ -21,10 +19,7 @@ const ContentViewHistories = ({ cvId }) => {
   const response = useSelector(state => selectCVHistories(state, cvId));
   const status = useSelector(state => selectCVHistoriesStatus(state, cvId));
   const error = useSelector(state => selectCVHistoriesError(state, cvId));
-  const loading = status === STATUS.PENDING;
 
-  const [rows, setRows] = useState([]);
-  const [metadata, setMetadata] = useState({});
   const [searchQuery, updateSearchQuery] = useState('');
 
   const columnHeaders = [
@@ -36,84 +31,46 @@ const ContentViewHistories = ({ cvId }) => {
     __('User'),
   ];
 
+  const taskTypes = {
+    publish: 'Actions::Katello::ContentView::Publish',
+    promotion: 'Actions::Katello::ContentView::Promote',
+    removal: 'Actions::Katello::ContentView::Remove',
+    incrementalUpdate: 'Actions::Katello::ContentView::IncrementalUpdates',
+    export: 'Actions::Katello::ContentViewVersion::Export',
+  };
 
-  useDeepCompareEffect(() => {
-    const taskTypes = {
-      publish: 'Actions::Katello::ContentView::Publish',
-      promotion: 'Actions::Katello::ContentView::Promote',
-      removal: 'Actions::Katello::ContentView::Remove',
-      incrementalUpdate: 'Actions::Katello::ContentView::IncrementalUpdates',
-      export: 'Actions::Katello::ContentViewVersion::Export',
-    };
+  const actionText = (history) => {
+    const {
+      action,
+      task,
+      environment,
+    } = history;
 
-    const actionText = (history) => {
-      const {
-        action,
-        task,
-        environment,
-      } = history;
+    const taskType = task ? task.label : taskTypes[action];
 
-      const taskType = task ? task.label : taskTypes[action];
-
-      if (taskType === taskTypes.removal) {
-        return <React.Fragment> Deleted from <Label key="1" color="blue" href={`/lifecycle_environments/${environment.id}`}>{`${environment.name}`}</Label>{}</React.Fragment>;
-      } else if (taskType === taskTypes.promotion) {
-        return <React.Fragment> Promoted to <Label key="2" color="blue" href={`/lifecycle_environments/${environment.id}`}>{`${environment.name}`}</Label>{}</React.Fragment>;
-      } else if (taskType === taskTypes.publish) {
-        return ('Published new version');
-      } else if (taskType === taskTypes.export) {
-        return ('Exported content view');
-      } else if (taskType === taskTypes.incrementalUpdate) {
-        return ('Incremental update');
-      }
-      return '';
-    };
-
-    const buildRows = (results) => {
-      const newRows = [];
-      results.forEach((history) => {
-        const {
-          version,
-          version_id: versionId,
-          created_at: createdAt,
-          status: taskStatus,
-          description,
-          user,
-        } = history;
-
-        const actionMessage = actionText(history);
-
-        const cells = [
-          { title: <LongDateTime date={createdAt} showRelativeTimeTooltip /> },
-          { title: <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}`, '')}>{`Version ${version}`}</a> },
-          taskStatus,
-          actionMessage,
-          { title: <TableText wrapModifier="truncate">{description}</TableText> },
-          user,
-        ];
-
-        newRows.push({ cells });
-      });
-      return newRows;
-    };
-
-    const { results, ...meta } = response;
-    setMetadata(meta);
-    if (!loading && results) {
-      const newRows = buildRows(results);
-      setRows(newRows);
+    if (taskType === taskTypes.removal) {
+      return <React.Fragment> Deleted from <Label key="1" color="blue" href={`/lifecycle_environments/${environment.id}`}>{`${environment.name}`}</Label>{}</React.Fragment>;
+    } else if (taskType === taskTypes.promotion) {
+      return <React.Fragment> Promoted to <Label key="2" color="blue" href={`/lifecycle_environments/${environment.id}`}>{`${environment.name}`}</Label>{}</React.Fragment>;
+    } else if (taskType === taskTypes.publish) {
+      return ('Published new version');
+    } else if (taskType === taskTypes.export) {
+      return ('Exported content view');
+    } else if (taskType === taskTypes.incrementalUpdate) {
+      return ('Incremental update');
     }
-  }, [response, setMetadata, loading, setRows, cvId]);
+    return '';
+  };
 
   const emptyContentTitle = __("You currently don't have any history for this content view.");
   const emptyContentBody = __('History will appear here when the content view is published or promoted.'); // needs link
   const emptySearchTitle = __('No matching history record found');
   const emptySearchBody = __('Try changing your search settings.');
+  const { results, ...metadata } = response;
 
   return (
     <TableWrapper
       {...{
-        rows,
         metadata,
         emptyContentTitle,
         emptyContentBody,
@@ -124,11 +81,44 @@ const ContentViewHistories = ({ cvId }) => {
         error,
         status,
       }}
-      cells={columnHeaders}
+      composable
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_views/${cvId}/history/auto_complete_search`}
       fetchItems={useCallback(params => getContentViewHistories(cvId, params), [cvId])}
-    />);
+    >
+      <Thead>
+        <Tr>
+          {columnHeaders.map(col =>
+            <Th key={col}>{col}</Th>)}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {results?.map((history) => {
+          const {
+            version,
+            version_id: versionId,
+            created_at: createdAt,
+            status: taskStatus,
+            description,
+            user,
+          } = history;
+          return (
+            <Tr key={`${versionId}_${createdAt}`}>
+              <Td key={createdAt}><LongDateTime date={createdAt} showRelativeTimeTooltip /></Td>
+              <Td>
+                <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}`, '')}>{`Version ${version}`}</a>
+              </Td>
+              <Td>{taskStatus}</Td>
+              <Td>{actionText(history)}</Td>
+              <Td><TableText wrapModifier="truncate">{description}</TableText></Td>
+              <Td>{user}</Td>
+            </Tr>
+          );
+        })
+        }
+      </Tbody>
+    </TableWrapper>
+  );
 };
 
 ContentViewHistories.propTypes = {

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -330,7 +330,7 @@ test('No results message is shown for empty search', async (done) => {
 
   fireEvent.change(getByLabelText(/text input for search/i), { target: { value: query } });
 
-  await patientlyWaitFor(() => expect(getByText(/No matching Content Views found/i)).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByText(/No matching content views found/i)).toBeInTheDocument());
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(initialScope);

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -3,7 +3,7 @@
 exports[`subscriptions table should disable checkboxes for custom subscriptions 1`] = `
 <div>
   <table
-    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed"
+    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed neat-table-cells"
   >
     <thead>
       <tr
@@ -212,7 +212,7 @@ exports[`subscriptions table should render a loading state 1`] = `
 exports[`subscriptions table should render a table 1`] = `
 <div>
   <table
-    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed"
+    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed neat-table-cells"
   >
     <thead>
       <tr
@@ -318,7 +318,7 @@ exports[`subscriptions table should render an empty state 1`] = `
 exports[`subscriptions table should render subscription name without hyperlink for grouped subscriptions 1`] = `
 <div>
   <table
-    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed"
+    class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed neat-table-cells"
   >
     <thead>
       <tr


### PR DESCRIPTION
This change does the following:

* Add a `composable` prop to `<TableWrapper>`
* if `composable` prop is passed, `MainTable` returns `<TableComposable>` instead of `<Table>` and doesn't accept `rows` or `cells` props-- so you can do either 
```js
<TableWrapper rows={...} cells={...} />
```
 or
```js
<TableWrapper composable > ... </TableWrapper>
```

Existing pages that use TableWrapper will require __no change__ whatsoever. Behavior will be exactly the same.

As a proof of concept I've refactored `ContentViewHistories` to use the composable TableWrapper. You can see how much it's simplified:

* No `buildRows` function
* No `useDeepCompareEffect`
* No use of state for `rows` or `metadata`
* Everything is visible in the markup