### PR TITLE
Fixes #31590 - Add last changed timestamp

### DIFF
--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -57,6 +57,7 @@ attributes :ostree_branch_names => :ostree_branches
 attributes :relative_path
 attributes :promoted? => :promoted
 attributes :content_view_version_id, :library_instance_id
+attributes :last_contents_changed
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant


### PR DESCRIPTION
When you look at a repo via the api (GET /katello/api/repositories/:id), the data does include a "last_synced" timestamp, but no indication about "changes".
last sync could be a noop (because upstream didn't change) or not set at all (because the repo doesn't have an upstream at all), but it would be good to know (e.g. for automated publishes of CVs) when the last change happened.