### PR TITLE
Refs #33212 - fix ...with_mirror_adapter.create

### DIFF
--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -47,7 +47,7 @@ module Katello
         create_remote unless fetch_remote
       end
 
-      def create
+      def create(_force = false)
         api.repositories_api.create(name: backend_object_name)
       end
 


### PR DESCRIPTION
When I added the force option, I didn't update the mirror adapter  create method.  Turns out we don't use it now outside of create_entities, but we could in the future.  Fixing it to keep things tidy.

If the mirror adapter actually returns a repository mirror, this will break: https://github.com/Katello/katello/blob/master/app/lib/actions/pulp3/repository/create.rb#L12