### PR TITLE
Fixes #33285 - ensure auto attach can be disabled from subscription-manager

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -57,7 +57,7 @@ module Katello
           self.dmi_uuid = consumer_params['facts']['dmi.system.uuid']
         end
 
-        self.autoheal = consumer_params['autoheal'] unless consumer_params['autoheal'].blank?
+        self.autoheal = consumer_params['autoheal'] unless consumer_params['autoheal'].nil?
         self.service_level = consumer_params['serviceLevel'] unless consumer_params['serviceLevel'].nil?
         self.registered_at = consumer_params['created'] unless consumer_params['created'].blank?
         self.last_checkin = consumer_params['lastCheckin'] unless consumer_params['lastCheckin'].blank?


### PR DESCRIPTION
Can't disable auto attach from subscription-manager.
 
**To Test**

- Check in WebUI, if `Auto-Attach` is `No`
  `sudo subscription-manager auto-attach --enable` would enable `Auto-Attach`. 
  Verify in WebUI.
- Check in WebUI, if `Auto-Attach` is `Yes`
  `sudo subscription-manager auto-attach --disable` would not make any change to `Auto-Attach`. 
  Verify in WebUI that `Auto-Attach` stays as `Yes`

Apply the patch. WebUI should reflect the change done by subscription-manager.