### PR TITLE
Fixes #33230 - use find_by to handle deleted tasks

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -270,7 +270,7 @@ module Katello
 
     def last_task
       last_task_id = history.order(:created_at)&.last&.task_id
-      last_task_id ? ForemanTasks::Task.find(last_task_id) : nil
+      last_task_id ? ForemanTasks::Task.find_by(id: last_task_id) : nil
     end
 
     def history


### PR DESCRIPTION
To test:
1. Publish a CV
2. Find the Id of the publish task
3. In foreman console: ForemanTasks::Task.find(publish_task_id).delete
4. Go to CV index page. You will see an error without this change.