### PR TITLE
Fixes #33164 - Allow clearing upstream auth and password

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -90,6 +90,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
 
             $scope.save = function (repository, saveUpstreamAuth) {
                 var deferred = $q.defer();
+                var fields = ['upstream_password', 'upstream_username', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
                 if (repository.content_type === 'yum' && typeof repository.ignore_srpms !== 'undefined') {
                     if (repository['ignore_srpms']) {
                         repository['ignorable_content'] = ["srpm"];
@@ -111,6 +112,12 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     repository["docker_tags_whitelist"] = [];
                 }
                 /* eslint-disable camelcase */
+
+                angular.forEach(fields, function(field) {
+                    if (repository[field] === '') {
+                        repository[field] = null;
+                    }
+                });
                 repository.os_versions = $scope.osVersionsParam();
                 repository.$update(function (response) {
                     deferred.resolve(response);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -118,6 +118,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             });
 
             $scope.save = function (repository) {
+                var fields = ['upstream_password', 'upstream_username', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
                 if (repository.content_type === 'ostree') {
                     repository.unprotected = false;
                 }
@@ -135,6 +136,11 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
                 if (repository.arch === 'No restriction') {
                     repository.arch = null;
                 }
+                angular.forEach(fields, function(field) {
+                    if (repository[field] === '') {
+                        repository[field] = null;
+                    }
+                });
                 repository.$save(success, error);
             };
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -138,6 +138,38 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect(repo.upstream_password).toBe('autofilled');
     });
 
+    it('should clear out auth fields on save if blank', function() {
+      var repo = new Repository({
+        upstream_username: '',
+        upstream_password: '',
+        ansible_collection_auth_url: '',
+        ansible_collection_auth_token: '',
+      })
+
+      $scope.save(repo, true);
+
+      expect(repo.upstream_username).toBe(null);
+      expect(repo.upstream_password).toBe(null);
+      expect(repo.ansible_collection_auth_token).toBe(null);
+      expect(repo.ansible_collection_auth_url).toBe(null);
+    });
+
+  it('should not clear out auth fields on save if not blank', function() {
+    var repo = new Repository({
+      upstream_username: 'upstream',
+      upstream_password: 'passwd',
+      ansible_collection_auth_url: 'https://url.com',
+      ansible_collection_auth_token: 'some_token',
+    })
+
+    $scope.save(repo, true);
+
+    expect(repo.upstream_username).not.toBe(null);
+    expect(repo.upstream_password).not.toBe(null);
+    expect(repo.ansible_collection_auth_token).not.toBe(null);
+    expect(repo.ansible_collection_auth_url).not.toBe(null);
+  });
+
     it('should fail to save the repository', function() {
         spyOn(Notification, 'setErrorMessage');
 

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -97,6 +97,48 @@ describe('Controller: NewRepositoryController', function() {
         expect($scope.repositoryForm['name'].$error.messages).toBeDefined();
     });
 
+    it('should clear out auth fields on save if blank', function() {
+        var repo = $scope.repository;
+        repo.upstream_username = '';
+        repo.upstream_password = '';
+        repo.ansible_collection_auth_url = '';
+        repo.ansible_collection_auth_token = '';
+        expect(repo.upstream_username).not.toBe(null);
+        expect(repo.upstream_password).not.toBe(null);
+        expect(repo.ansible_collection_auth_token).not.toBe(null);
+        expect(repo.ansible_collection_auth_url).not.toBe(null);
+        spyOn($scope, 'transitionTo');
+        spyOn(repo, '$save').and.callThrough();
+        spyOn(Notification, "setSuccessMessage");
+        $scope.save(repo);
+        expect(repo.$save).toHaveBeenCalled();
+        expect(repo.upstream_username).toBe(null);
+        expect(repo.upstream_password).toBe(null);
+        expect(repo.ansible_collection_auth_token).toBe(null);
+        expect(repo.ansible_collection_auth_url).toBe(null);
+    });
+
+    it('should not clear out auth fields on save if not blank', function() {
+        var repo = $scope.repository;
+        repo.upstream_username = 'upstream';
+        repo.upstream_password = 'passwd';
+        repo.ansible_collection_auth_url = 'https://url.com';
+        repo.ansible_collection_auth_token = 'some_token';
+        expect(repo.upstream_username).not.toBe(null);
+        expect(repo.upstream_password).not.toBe(null);
+        expect(repo.ansible_collection_auth_token).not.toBe(null);
+        expect(repo.ansible_collection_auth_url).not.toBe(null);
+        spyOn($scope, 'transitionTo');
+        spyOn(repo, '$save').and.callThrough();
+        spyOn(Notification, "setSuccessMessage");
+        $scope.save(repo);
+        expect(repo.$save).toHaveBeenCalled();
+        expect(repo.upstream_username).not.toBe(null);
+        expect(repo.upstream_password).not.toBe(null);
+        expect(repo.ansible_collection_auth_token).not.toBe(null);
+        expect(repo.ansible_collection_auth_url).not.toBe(null);
+    });
+
     it('should fetch a label whenever the name changes', function() {
         spyOn(FormUtils, 'labelize');
 


### PR DESCRIPTION
To reproduce:
Create a yum repo with upstream username/password set.
Try to update it after clearing the fields and save.

Same behavior exists on auth_url/token fields for collection repos.
Create a repo with auth_url set and token empty.
See the expected error.
Set a token and clear the auth_url
The error you see on this is invalid and shouldn't happen on this branch.