### PR TITLE
Fixes #32664 - ignore deleting the candlepin instance with missing cp_id on activation key delete

### DIFF
--- a/app/lib/actions/katello/activation_key/destroy.rb
+++ b/app/lib/actions/katello/activation_key/destroy.rb
@@ -6,7 +6,7 @@ module Actions
           skip_candlepin = options.fetch(:skip_candlepin, false)
           action_subject(activation_key)
 
-          plan_action(Candlepin::ActivationKey::Destroy, cp_id: activation_key.cp_id) unless skip_candlepin
+          plan_action(Candlepin::ActivationKey::Destroy, cp_id: activation_key.cp_id) if !skip_candlepin && activation_key.cp_id.present?
           plan_self
         end
 

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -70,12 +70,22 @@ module ::Actions::Katello::ActivationKey
   class DestroyTest < TestBase
     let(:action_class) { ::Actions::Katello::ActivationKey::Destroy }
 
-    it 'plans' do
+    it 'does not plan with missing cp_id' do
       action = create_action(action_class)
       action.expects(:plan_self)
       action.expects(:action_subject).with(activation_key)
       plan_action(action, activation_key)
-      assert_action_planed(action, ::Actions::Candlepin::ActivationKey::Destroy)
+      refute_action_planed(action, ::Actions::Candlepin::ActivationKey::Destroy)
+      assert_nil(activation_key.cp_id)
+    end
+
+    it 'plans' do
+      action = create_action(action_class)
+      activation_key.update!(cp_id: 'something')
+      action.expects(:plan_self)
+      action.expects(:action_subject).with(activation_key)
+      plan_action(action, activation_key)
+      assert_action_planed_with(action, ::Actions::Candlepin::ActivationKey::Destroy, cp_id: activation_key.cp_id)
     end
   end
 end


### PR DESCRIPTION
When creating an activation key, users may run into situation where the instance is created on Katello but not on Candlepin.
So this Katello activation key has `cp_id = nil` which makes it impossible to delete this object.

To Test
1. Create an activation key from Web UI
2. Set `cp_id` to `nil` for this activation key from rails console
3. `hammer activation-key delete --organization-id 1 --id <activation_key_id>