### PR TITLE
Fixes #33314 -  errata apply confirm REX failure fix

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -37,7 +37,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             $scope.errataActionFormValues = {
                 authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
                 errata: IncrementalUpdate.getErrataIds().join(','),
-                hostIds: IncrementalUpdate.getBulkContentHosts().included.ids.join(','),
+                bulkHostIds: angular.toJson({ included: { ids: IncrementalUpdate.getBulkContentHosts().included.ids }}),
                 customize: false
             };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -18,7 +18,7 @@
   <form id="errataActionForm" method="post" action="/katello/remote_execution">
     <input type="hidden" name="remote_action" value="errata_install"/>
     <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
-    <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+    <input type="hidden" name="bulk_host_ids" ng-value="errataActionFormValues.bulkHostIds"/>
     <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
     <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
     <input type="hidden" name="install_all" ng-value="table.allResultsSelected" />
@@ -132,4 +132,3 @@
     </button>
   </form>
 </section>
-

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -96,7 +96,7 @@ describe('Controller: ApplyErrataController', function() {
         expect($scope.errataActionFormValues).toEqual({
             authenticityToken: 'secret_token',
             errata: '2',
-            hostIds: '1,2,3',
+            bulkHostIds: angular.toJson({ included: { ids: [1, 2, 3] }}),
             customize: false
         });
     });
@@ -128,7 +128,7 @@ describe('Controller: ApplyErrataController', function() {
             spyOn(HostBulkAction, 'availableIncrementalUpdates').and.callFake(function (params, success) {
                 success(updates);
             });
-            
+
             $controller('ApplyErrataController', dependencies);
 
             expect(HostBulkAction.availableIncrementalUpdates).toHaveBeenCalledWith($scope.selectedContentHosts,


### PR DESCRIPTION
This PR fixes an issue where after selecting errata from the Content -> Errata -> Select Errata -> Select Host -> Confirm workflow, a remote_execution controller error exception is thrown.

The cause was that the host id parameter was changed to `bulk_host_ids" and is now JSON.