### PR TITLE
Fixes #33315 - Redefine pulp3 dynflow step statuses

### DIFF
--- a/app/services/katello/pulp3/task.rb
+++ b/app/services/katello/pulp3/task.rb
@@ -38,6 +38,7 @@ module Katello
 
       #needed for serialization in dynflow
 
+      attr_reader :pulp_data
       delegate :[], :key?, :dig, :to_hash, :to => :task_data
 
       def initialize(smart_proxy, data)
@@ -83,7 +84,7 @@ module Katello
       end
 
       def done?
-        task_data[:finish_time] || FINISHED_STATES.include?(task_data[:state])
+        task_data[:finished_at] || FINISHED_STATES.include?(task_data[:state])
       end
 
       def progress_reports
@@ -100,7 +101,7 @@ module Katello
       end
 
       def started?
-        task_data[:start_time]
+        task_data[:started_at]
       end
 
       def error

--- a/app/services/katello/pulp3/task_group.rb
+++ b/app/services/katello/pulp3/task_group.rb
@@ -15,6 +15,7 @@ module Katello
       delegate :dig, :to => :task_group_data
 
       attr_accessor :href
+      attr_reader :pulp_data
 
       # A call report Looks like:  {"task":"/pulp/api/v3/tasks/5/"}
       #{


### PR DESCRIPTION
This fixes the dynflow statuses printed in the dynflow console when the task is in the suspended state. Previously, pulp tasks were not being correctly identified as "started" or "finished'. 

Also, the status message has been updated to give slightly more precise details. For example, rather than "waiting for Pulp to finish the task" it might say "waiting for Pulp to finish the task synchronize (53ef3ad)". The characters at the end are part of the pulp href, to give the task an identifier.

To see the messages, do a complete sync on a decent sized repo (like a centos repo), and monitor the dynflow console while it's syncing. If that doesn't work, publish a content view with several decent sized repos and filters. Monitor the dynflow console while it's publishing.