### PR TITLE
Fixes #28491 - Move stuff from base.json.rabl to show.json.rabl

### DIFF
--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -13,10 +13,6 @@ node do |version|
   version.content_counts_map
 end
 
-node :errata_counts do |version|
-  partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(version.errata))
-end
-
 child :content_view => :content_view do
   attributes :id, :name, :label
 end
@@ -40,41 +36,3 @@ node :permissions do |cvv|
 end
 
 extends 'katello/api/v2/common/timestamps'
-
-version = @object || @resource
-child :environments => :environments do
-  attributes :id, :name, :label
-
-  node :publish_date do |env|
-    time_ago_in_words(version.env_promote_date(env))
-  end
-
-  node :permissions do |env|
-    {
-      :readable => env.readable?,
-      :promotable_or_removable => env.promotable_or_removable?,
-      :all_hosts_editable => version.all_hosts_editable?(env),
-      :all_keys_editable => Katello::ActivationKey.all_editable?(version.content_view_id, env.id)
-    }
-  end
-
-  node :host_count do |env|
-    ::Host.authorized('view_hosts').in_content_view_environment(:content_view => version.content_view, :lifecycle_environment => env).count
-  end
-
-  node :activation_key_count do |env|
-    Katello::ActivationKey.where(:environment_id => env.id).where(:content_view_id => version.content_view_id).count
-  end
-end
-
-child :archived_repos => :repositories do
-  attributes :id, :name, :label, :content_type, :library_instance_id
-end
-
-child :last_event => :last_event do
-  extends 'katello/api/v2/content_view_histories/show'
-end
-
-child :active_history => :active_history do
-  extends 'katello/api/v2/content_view_histories/show'
-end

--- a/app/views/katello/api/v2/content_view_versions/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/show.json.rabl
@@ -1,3 +1,45 @@
 object @resource
 
 extends "katello/api/v2/content_view_versions/base"
+
+node :errata_counts do |version|
+  partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(version.errata))
+end
+
+version = @object || @resource
+child :environments => :environments do
+  attributes :id, :name, :label
+
+  node :publish_date do |env|
+    time_ago_in_words(version.env_promote_date(env))
+  end
+
+  node :permissions do |env|
+    {
+      :readable => env.readable?,
+      :promotable_or_removable => env.promotable_or_removable?,
+      :all_hosts_editable => version.all_hosts_editable?(env),
+      :all_keys_editable => Katello::ActivationKey.all_editable?(version.content_view_id, env.id)
+    }
+  end
+
+  node :host_count do |env|
+    ::Host.authorized('view_hosts').in_content_view_environment(:content_view => version.content_view, :lifecycle_environment => env).count
+  end
+
+  node :activation_key_count do |env|
+    Katello::ActivationKey.where(:environment_id => env.id).where(:content_view_id => version.content_view_id).count
+  end
+end
+
+child :archived_repos => :repositories do
+  attributes :id, :name, :label, :content_type, :library_instance_id
+end
+
+child :last_event => :last_event do
+  extends 'katello/api/v2/content_view_histories/show'
+end
+
+child :active_history => :active_history do
+  extends 'katello/api/v2/content_view_histories/show'
+end


### PR DESCRIPTION
Move stuff from content_view_versions/base.json.rabl to content_view_versions/show.json.rabl to reduce call time of index.
List page should need less details than details page