### PR TITLE
Fixes #33326 - use uncached when searching for docker tags

### DIFF
--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -168,9 +168,11 @@ module Katello
 
     def self.get_tag_table_values(repo)
       # queries DockerTags for a repo and retuns a [schema1, schema2 , name] tuple combination
-      tags = ::Katello::DockerTag.where(:id => RepositoryDockerTag.
-                                        where(:repository_id => repo.id).
-                                        select(:docker_tag_id))
+      tags = ::Katello::DockerTag.uncached do
+        ::Katello::DockerTag.where(:id => RepositoryDockerTag.
+            where(:repository_id => repo.id).
+            select(:docker_tag_id))
+      end
       dups = tags.group_by(&:name)
 
       dups.map do |name, values|


### PR DESCRIPTION
this attempts to fix an error seen during syncing lots of
docker repos at once with lots of tags.  Following the logic
it seems that the tags were inserted but for some reason this query
caused an empty values array to be returned by the group_by.  One theory
is that it was caused by a query cache similar to what we have seen
with errata applicability insertions