### PR TITLE
Fixes #32816 - Leave smart proxy sync in warning if gateway container update fails

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -4,6 +4,7 @@ module Actions
       class SyncCapsule < ::Actions::EntryAction
         include Actions::Katello::PulpSelector
         def plan(smart_proxy, options = {})
+          plan_self(:smart_proxy_id => smart_proxy.id, :options => options)
           action_subject(smart_proxy)
           environment = options[:environment]
           content_view = options[:content_view]
@@ -36,53 +37,6 @@ module Actions
               end
             end
           end
-          sync_container_gateway(smart_proxy)
-        end
-
-        def sync_container_gateway(smart_proxy)
-          if smart_proxy.has_feature?(::SmartProxy::CONTAINER_GATEWAY_FEATURE)
-            update_container_repo_list(smart_proxy)
-            users = smart_proxy.container_gateway_users
-            update_user_container_repo_mapping(smart_proxy, users) if users.any?
-          end
-        end
-
-        def unauthenticated_container_repositories
-          ::Katello::Repository.joins(:environment).where("#{::Katello::KTEnvironment.table_name}.registry_unauthenticated_pull" => true).select(:id).pluck(:id)
-        end
-
-        def update_container_repo_list(smart_proxy)
-          # [{ repository: "repoA", auth_required: false }]
-          repo_list = []
-          ::Katello::SmartProxyHelper.new(smart_proxy).combined_repos_available_to_capsule.each do |repo|
-            if repo.docker? && !repo.container_repository_name.nil?
-              repo_list << { repository: repo.container_repository_name,
-                             auth_required: !unauthenticated_container_repositories.include?(repo.id) }
-            end
-          end
-          smart_proxy.update_container_repo_list(repo_list)
-        end
-
-        def update_user_container_repo_mapping(smart_proxy, users)
-          # Example user-repo mapping:
-          # { users:
-          #   [
-          #     'user a' => [{ repository: 'repo 1', auth_required: true }]
-          #   ]
-          # }
-
-          user_repo_map = { users: [] }
-          users.each do |user|
-            inner_repo_list = []
-            repositories = ::Katello::Repository.readable_docker_catalog_as(user)
-            repositories.each do |repo|
-              next if repo.container_repository_name.nil?
-              inner_repo_list << { repository: repo.container_repository_name,
-                                   auth_required: !unauthenticated_container_repositories.include?(repo.id) }
-            end
-            user_repo_map[:users] << { user.login => inner_repo_list }
-          end
-          smart_proxy.update_user_container_repo_mapping(user_repo_map)
         end
 
         def repos_to_sync(smart_proxy, environment, content_view, repository, skip_metatadata_check = false)
@@ -106,6 +60,11 @@ module Actions
 
         def resource_locks
           :link
+        end
+
+        def run
+          smart_proxy = ::SmartProxy.find(input[:smart_proxy_id])
+          smart_proxy.sync_container_gateway
         end
 
         def rescue_strategy

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -285,28 +285,5 @@ module ::Actions::Katello::CapsuleContent
       action = plan_action_tree(action_class, capsule_content.smart_proxy, :environment_id => staging_environment.id)
       refute_empty action.errors
     end
-
-    it 'correctly generates a container gateway repository list' do
-      with_pulp3_features(capsule_content.smart_proxy)
-      capsule_content.smart_proxy.add_lifecycle_environment(environment)
-      repo = katello_repositories(:pulp3_file_1)
-      repo.root.update_attribute(:unprotected, true)
-
-      repo_list_update_expectation = capsule_content.smart_proxy.expects(:update_container_repo_list).with do |arg|
-        arg.include?({:repository => "busybox", :auth_required => true}) && arg.include?({:repository => "empty_organization-puppet_product-busybox", :auth_required => true})
-      end
-      repo_list_update_expectation.once.returns(true)
-
-      repo_mapping_update_expectation = capsule_content.smart_proxy.expects(:update_user_container_repo_mapping).with do |arg|
-        arg[:users].first["secret_admin"].include?({:repository => "empty_organization-puppet_product-busybox",
-                                                    :auth_required => true}) &&
-                                             arg[:users].first["secret_admin"].include?({:repository => "busybox",
-                                                                                         :auth_required => true})
-      end
-      repo_mapping_update_expectation.once.returns(true)
-
-      capsule_content.smart_proxy.expects(:container_gateway_users).returns(::User.where(login: 'secret_admin'))
-      plan_action_tree(action_class, capsule_content.smart_proxy, :repository_id => repo.id)
-    end
   end
 end


### PR DESCRIPTION
Previously, during a smart proxy sync if a gateway container update failed the whole sync would fail, because the container update was happening during planning.

This moves the container update from the planning phase to the running phase, so if the update fails, the smart proxy sync will end with a warning.

One way to test is creating a smart proxy to test with and adding it in Infrastructure > Smart Proxy. Then put `fail [fail message]` in the `sync_container_gateway` method of `sync_capsule.rb`. When syncing the smart proxy, the task should fail but be left in the warning state.