### PR TITLE
Fixes #33348 - Add event delete_host_agent_queue only when katello-agent is enabled

### DIFF
--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -262,6 +262,8 @@ module Katello
       end
 
       def delete_agent_queue(host)
+        return unless ::Katello.with_katello_agent?
+
         queue_name = Katello::Agent::Dispatcher.host_queue_name(host)
         Katello::EventQueue.push_event(::Katello::Events::DeleteHostAgentQueue::EVENT_TYPE, host.id) do |attrs|
           attrs[:metadata] = { queue_name: queue_name }

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -247,9 +247,20 @@ module Katello
         ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)
       end
 
-      def test_unregister_host
+      def test_unregister_host_without_katello_agent
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
+
+        ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
+        ::Katello::EventQueue.expects(:push_event).never
+
+        ::Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
+      end
+
+      def test_unregister_host_with_katello_agent
+        @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
+                                   :lifecycle_environment => @library, :organization => @content_view.organization)
+        ::Katello.expects(:with_katello_agent?).returns(true)
 
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Katello::EventQueue.expects(:push_event)


### PR DESCRIPTION
The following error message is reported when katello agent is disabled.
```
2021-08-24T18:50:19 [E|kat|25e729cf] event_queue_error: type=delete_host_agent_queue, object_id=20
2021-08-24T18:50:19 [E|kat|25e729cf] Connection refused - connect(2) for "localhost" port 5671
``` 

