### PR TITLE
Refs #33250 - fix test issue with uln check

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -151,7 +151,7 @@ module Katello
       end
 
       def delete_remote(href = repo.remote_href)
-        ignore_404_exception { remote_options[:url].start_with?('uln') ? api.remotes_uln_api.delete(href) : api.remotes_api.delete(href) } if href
+        ignore_404_exception { remote_options[:url]&.start_with?('uln') ? api.remotes_uln_api.delete(href) : api.remotes_api.delete(href) } if href
       end
 
       def self.instance_for_type(repo, smart_proxy)


### PR DESCRIPTION
when recording a live vcr test, i hit an error when running this
to force delete a remote when the repo had no url.  Not a common
scenario, but one i hit when recording a new vcr test