### PR TITLE
Fixes #33374 - Hostgroup now shows content fields

### DIFF
--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -10,7 +10,7 @@ Deface::Override.new(:virtual_path => "hostgroups/_form",
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "hostgroups_update_environments_select",
-                     :insert_before => 'erb[loud]:contains("hostgroup_puppet_environment_field")',
+                     :insert_before => 'erb[loud]:contains("compute_resource_id")',
                      :partial => 'overrides/activation_keys/host_environment_select')
 
 Deface::Override.new(:virtual_path => "common/os_selection/_operatingsystem",


### PR DESCRIPTION
Before this PR
* Configure -> Hostgroup
* Create host group
This would not show cv, lce and cs.
This error occurs because
hostgroup_puppet_environment_field was removed
in foreman.

This PR fixes this issue by changing the insert before
to the appropriate field .