### PR TITLE
Fixes #32660 - adds an authentication token for SLES repositories

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -56,6 +56,7 @@ module Katello
       param :verify_ssl_on_sync, :bool, :desc => N_("if true, Katello will verify the upstream url's SSL certifcates are signed by a trusted CA")
       param :upstream_username, String, :desc => N_("Username of the upstream repository user used for authentication")
       param :upstream_password, String, :desc => N_("Password of the upstream repository user used for authentication")
+      param :upstream_authentication_token, String, :desc => N_("Password of the upstream authentication token.")
       param :ostree_upstream_sync_policy, ::Katello::RootRepository::OSTREE_UPSTREAM_SYNC_POLICIES, :desc => N_("policies for syncing upstream ostree repositories")
       param :ostree_upstream_sync_depth, :number, :desc => N_("if a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided")
       param :deb_releases, String, :desc => N_("whitespace-separated list of releases to be synced from deb-archive")
@@ -462,10 +463,11 @@ module Katello
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def repository_params
-      keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username, :download_concurrency,
+      keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password,
+              :upstream_username, :download_concurrency, :upstream_authentication_token,
               :ostree_upstream_sync_depth, :ostree_upstream_sync_policy, {:os_versions => []},
-              :deb_releases, :deb_components, :deb_architectures, :description, :http_proxy_policy, :http_proxy_id, :retain_package_versions_count,
-              {:ignorable_content => []}
+              :deb_releases, :deb_components, :deb_architectures, :description, :http_proxy_policy,
+              :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
              ]
 
       keys += [{:docker_tags_whitelist => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
@@ -512,6 +514,7 @@ module Katello
       root.verify_ssl_on_sync = ::Foreman::Cast.to_bool(repo_params[:verify_ssl_on_sync]) if repo_params.key?(:verify_ssl_on_sync)
       root.upstream_username = repo_params[:upstream_username] if repo_params.key?(:upstream_username)
       root.upstream_password = repo_params[:upstream_password] if repo_params.key?(:upstream_password)
+      root.upstream_authentication_token = repo_params[:upstream_authentication_token] if repo_params.key?(:upstream_authentication_token)
       root.ignorable_content = repo_params[:ignorable_content] if root.yum? && repo_params.key?(:ignorable_content)
       root.http_proxy_policy = repo_params[:http_proxy_policy] if repo_params.key?(:http_proxy_policy)
       root.http_proxy_id = repo_params[:http_proxy_id] if repo_params.key?(:http_proxy_id)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -177,10 +177,11 @@ module Katello
     delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :arch, :label, :url, :unprotected,
              :content_type, :product_id, :checksum_type, :docker_upstream_name, :mirror_on_sync, :"mirror_on_sync?",
              :download_policy, :verify_ssl_on_sync, :"verify_ssl_on_sync?", :upstream_username, :upstream_password,
-             :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases, :deb_components, :deb_architectures,
-             :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id, :os_versions,
-             :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :ansible_collection_requirements,
-             :ansible_collection_auth_url, :ansible_collection_auth_token, :http_proxy_policy, :http_proxy_id, :to => :root
+             :upstream_authentication_token, :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases,
+             :deb_components, :deb_architectures, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id,
+             :ssl_client_key_id, :os_versions, :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist,
+             :ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token,
+             :http_proxy_policy, :http_proxy_id, :to => :root
 
     delegate :content_id, to: :root, allow_nil: true
     delegate :repository_type, to: :root

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -9,7 +9,7 @@ module Katello
     include Ext::LabelFromName
     include Encryptable
 
-    encrypts :upstream_password
+    encrypts :upstream_password, :upstream_authentication_token
 
     IGNORABLE_CONTENT_UNIT_TYPES = %w(srpm).freeze
     CHECKSUM_TYPES = %w(sha1 sha256).freeze
@@ -76,6 +76,7 @@ module Katello
     validate :ensure_content_attribute_restrictions
     validate :ensure_valid_upstream_authorization
     validate :ensure_valid_uln_authorization, :if => :yum?
+    validate :ensure_valid_authentication_token, :if => :yum?
     validate :ensure_no_checksum_on_demand
     validates :url, presence: true, if: :ostree?
     validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES}, :allow_blank => true
@@ -302,6 +303,12 @@ module Katello
         end
       else
         return
+      end
+    end
+
+    def ensure_valid_authentication_token
+      if self.upstream_authentication_token.blank?
+        self.upstream_authentication_token = nil
       end
     end
 

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -11,10 +11,12 @@ module Katello
         UNIT_LIMIT = 10_000
 
         def remote_options
-          url, sles_token = extract_sles_token
           options = common_remote_options
-          options.merge!(sles_auth_token: sles_token) if sles_token
-          options.merge!(url: url, policy: root.download_policy)
+          uri = URI(root.url)
+          unless root.upstream_authentication_token.blank?
+            options.merge!(sles_auth_token: root.upstream_authentication_token)
+          end
+          options.merge!(url: uri.to_s, policy: root.download_policy)
         end
 
         def publication_options(repository_version)
@@ -29,14 +31,6 @@ module Katello
 
         def specific_create_options
           { retain_package_versions: retain_package_versions_count }
-        end
-
-        def extract_sles_token
-          return [nil, nil] if root.url.blank?
-          uri = URI(root.url)
-          query = uri.query
-          uri.query = nil
-          [uri.to_s, query]
         end
 
         def skip_types

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -80,7 +80,8 @@ node :upstream_password_exists do |repo|
 end
 
 node :upstream_auth_exists do |repo|
-  repo.upstream_username.present? && repo.upstream_password.present?
+  (repo.upstream_username.present? && repo.upstream_password.present?) ||
+  repo.upstream_authentication_token.present?
 end
 
 if @object && @object.library_instance_id.nil?

--- a/config/initializers/filter_parameters.rb
+++ b/config/initializers/filter_parameters.rb
@@ -1,0 +1,1 @@
+Rails.application.config.filter_parameters += [:upstream_authentication_token]

--- a/db/migrate/20210831161843_add_upstream_auth_token_to_root_repository.rb
+++ b/db/migrate/20210831161843_add_upstream_auth_token_to_root_repository.rb
@@ -1,0 +1,5 @@
+class AddUpstreamAuthTokenToRootRepository < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_root_repositories, :upstream_authentication_token, :string, limit: 1024
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -91,7 +91,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
 
             $scope.save = function (repository, saveUpstreamAuth) {
                 var deferred = $q.defer();
-                var fields = ['upstream_password', 'upstream_username', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
+                var fields = ['upstream_password', 'upstream_username', 'upstream_authentication_token', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
                 if (repository.content_type === 'yum' && typeof repository.ignore_srpms !== 'undefined') {
                     if (repository['ignore_srpms']) {
                         repository['ignorable_content'] = ["srpm"];
@@ -103,6 +103,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 if (!saveUpstreamAuth) {
                     repository['upstream_username'] = null;
                     repository['upstream_password'] = null;
+                    repository['upstream_authentication_token'] = null;
                 }
 
                 if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== []) {
@@ -211,6 +212,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 $scope.repository['upstream_password'] = null;
                 $scope.repository['upstream_auth_exists'] = false;
                 $scope.repository['upstream_username'] = null;
+                $scope.repository['upstream_authentication_token'] = null;
                 $scope.save($scope.repository);
             };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -176,6 +176,12 @@
                  type="password"
                  autocomplete="off"
                  ng-model="repository.upstream_password"/>
+          <div translate>Upstream Authentication Token</div>
+          <input id="upstream_authentication_token"
+                  name="upstream_authentication_token"
+                  type="password"
+                  autocomplete="off"
+                  ng-model="repository.upstream_authentication_token"/>
         </dd>
       </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -221,6 +221,17 @@
         </p>
       </div>
 
+      <div bst-form-group label="{{ 'Upstream Authentication Token' | translate }}" >
+        <input id="upstream_authentication_token"
+              name="upstream_authentication_token"
+              type="text"
+              autocomplete="off"
+              ng-model="repository.upstream_authentication_token"/>
+        <p class="help-block" translate>
+          Token of the upstream repository user for authentication. Leave empty if repository does not require authentication.
+        </p>
+      </div>
+
       <div ng-repeat="option in genericRemoteOptions" ng-if="repository.generic_remote_options !== []">
         <div ng-if='option.input_type=="text"' bst-form-group label="{{ option.title | translate }}">
           <input

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -98,6 +98,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect($scope.save).toHaveBeenCalledWith($scope.repository);
         expect($scope.repository["upstream_password"]).toBe(null);
         expect($scope.repository["upstream_username"]).toBe(null);
+        expect($scope.repository["upstream_authentication_token"]).toBe(null);
         expect($scope.repository["upstream_auth_exists"]).toBe(false);
     });
 
@@ -123,31 +124,36 @@ describe('Controller: RepositoryDetailsInfoController', function() {
     it('should ignore upstream auth on save unless specified', function() {
         var repo = new Repository({
             upstream_username: 'autofilled',
-            upstream_password: 'autofilled'
+            upstream_password: 'autofilled',
+            upstream_authentication_token: 'autofilled'
         })
 
         $scope.save(repo);
 
         expect(repo.upstream_username).toBe(null);
         expect(repo.upstream_password).toBe(null);
+        expect(repo.upstream_authentication_token).toBe(null);
     });
 
     it('should not ignore upstream auth on save unless specified', function() {
         var repo = new Repository({
             upstream_username: 'autofilled',
-            upstream_password: 'autofilled'
+            upstream_password: 'autofilled',
+            upstream_authentication_token: 'autofilled'
         })
 
         $scope.save(repo, true);
 
         expect(repo.upstream_username).toBe('autofilled');
         expect(repo.upstream_password).toBe('autofilled');
+        expect(repo.upstream_authentication_token).toBe('autofilled');
     });
 
     it('should clear out auth fields on save if blank', function() {
       var repo = new Repository({
         upstream_username: '',
         upstream_password: '',
+        upstream_authentication_token: '',
         ansible_collection_auth_url: '',
         ansible_collection_auth_token: '',
       })
@@ -156,6 +162,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
       expect(repo.upstream_username).toBe(null);
       expect(repo.upstream_password).toBe(null);
+      expect(repo.upstream_authentication_token).toBe(null);
       expect(repo.ansible_collection_auth_token).toBe(null);
       expect(repo.ansible_collection_auth_url).toBe(null);
     });
@@ -164,6 +171,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
     var repo = new Repository({
       upstream_username: 'upstream',
       upstream_password: 'passwd',
+      upstream_authentication_token: 'token',
       ansible_collection_auth_url: 'https://url.com',
       ansible_collection_auth_token: 'some_token',
     })
@@ -172,6 +180,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
     expect(repo.upstream_username).not.toBe(null);
     expect(repo.upstream_password).not.toBe(null);
+    expect(repo.upstream_authentication_token).not.toBe(null);
     expect(repo.ansible_collection_auth_token).not.toBe(null);
     expect(repo.ansible_collection_auth_url).not.toBe(null);
   });

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -446,6 +446,13 @@ module Katello
       end
     end
 
+    def test_create_with_authentication_token
+      upstream_authentication_token = "foo"
+      run_test_individual_attribute(:upstream_authentication_token => upstream_authentication_token) do |_, repo|
+        repo.root.expects(:upstream_authentication_token=).with(upstream_authentication_token)
+      end
+    end
+
     def test_create_with_http_proxy_policy
       run_test_individual_attribute(:http_proxy_policy => RootRepository::GLOBAL_DEFAULT_HTTP_PROXY) do |_, repo|
         repo.root.expects(:http_proxy_policy=).with(RootRepository::GLOBAL_DEFAULT_HTTP_PROXY)
@@ -546,6 +553,13 @@ module Katello
         attributes[:description].must_equal "katello rules"
       end
       put :update, params: { :id => repo.id, :description => "katello rules" }
+    end
+
+    def test_update_with_auth_token
+      assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
+        attributes[:upstream_authentication_token].must_equal "foo"
+      end
+      put :update, params: { :id => @repository.id, :upstream_authentication_token => "foo" }
     end
 
     def test_update_protected

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -327,6 +327,22 @@ module Katello
       refute rhel_6.save
     end
 
+    def test_valid_upstream_authentication_token
+      @root.stubs(:encryption_key).returns("25d224dd383e92a7e0c82b8bf7c985e9")
+      @root.upstream_authentication_token = "foo"
+      assert @root.save
+      assert_equal "foo", @root.upstream_authentication_token
+      assert_equal "[redacted]", @root.audits.last.audited_changes["upstream_authentication_token"]
+    end
+
+    def test_empty_upstream_authentication_token
+      @root.stubs(:encryption_key).returns("25d224dd383e92a7e0c82b8bf7c985ef")
+      @root.upstream_authentication_token = ""
+      assert @root.save
+      assert_nil @root.upstream_authentication_token
+      assert_nil @root.audits.last.audited_changes["upstream_authentication_token"]
+    end
+
     test_attributes :pid => '1b428129-7cf9-449b-9e3b-74360c5f9eca'
     def test_update_with_valid_name
       valid_name_list.each do |new_name|

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -22,15 +22,11 @@ module Katello
             assert_equal 'sha1', publication_options[:package_checksum_type]
           end
 
-          def test_remote_options
+          def test_sles_auth_token_not_included_if_blank
             @repo.root.url = "http://foo.com/bar/"
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             assert_equal "http://foo.com/bar/", service.remote_options[:url]
             refute service.remote_options.key?(:sles_auth_token)
-
-            @repo.root.url = "http://foo.com/bar/?mytoken"
-            assert_equal "http://foo.com/bar/", service.remote_options[:url]
-            assert_equal 'mytoken', service.remote_options[:sles_auth_token]
           end
 
           def test_delete_version_zero
@@ -59,6 +55,26 @@ module Katello
 
             refute service.common_remote_options[:username]
             refute service.common_remote_options[:password]
+          end
+
+          def test_sles_authentication_token_when_set
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            @repo.root.upstream_authentication_token = 'foo'
+            @repo.root.url = "http://myrepo.com?sauce=awesome"
+
+            assert_equal "http://myrepo.com?sauce=awesome", service.remote_options[:url]
+            assert_equal "foo", service.remote_options[:sles_auth_token]
+          end
+
+          def test_non_auth_token_query_parameters_are_preserved
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            @repo.root.upstream_authentication_token = ''
+
+            refute service.remote_options[:sles_auth_token]
+
+            @repo.root.upstream_authentication_token = ''
+            puts service.remote_options
+            refute service.remote_options[:sles_auth_token]
           end
         end
 


### PR DESCRIPTION
This PR adds an explicit auth token field to support remote URLs that happen to have query parameters, but are interpreted as SLES auth tokens. Currently any query params are considered to be auth tokens, even when this is not the case.