### PR TITLE
Fixes #33386 - Add repository type counts to CV version response

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class ContentViewVersion < Katello::Model
     include Authorization::ContentViewVersion
     include ForemanTasks::Concerns::ActionSubject
@@ -325,6 +326,14 @@ module Katello
         end
       end
       save!
+    end
+
+    def repository_type_counts_map
+      counts = {}
+      Katello::RepositoryTypeManager.enabled_repository_types.keys.each do |repo_type|
+        counts["#{repo_type}_repository_count"] = archived_repos.with_type(repo_type).count
+      end
+      counts
     end
 
     def content_counts_map

--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -4,6 +4,10 @@ module Katello
   module Pulp3
     class Repository
       class AnsibleCollection < ::Katello::Pulp3::Repository
+        def copy_content_for_source(source_repository, _options = {})
+          copy_units_by_href(source_repository.ansible_collections.pluck(:pulp_id))
+        end
+
         def remote_options
           common_remote_options.merge(url: root.url.chomp('/').concat('/'),
                                       requirements_file: root.ansible_collection_requirements.blank? ? nil : root.ansible_collection_requirements,

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -13,6 +13,9 @@ node do |version|
   version.content_counts_map
 end
 
+node do |version|
+  version.repository_type_counts_map
+end
 node :errata_counts do |version|
   partial('katello/api/v2/errata/counts', :object => Katello::RelationPresenter.new(version.errata))
 end


### PR DESCRIPTION
To test:
Add some repositories of different content types and check the /content_view_versions/:id endpoint for new fields that look like this:
yum_repository_count , ansible_collection_repository_count