### PR TITLE
Fixes #33385,33054,33144 - Fixes host group inheritance

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -4,7 +4,7 @@ KT.hosts = {};
 $(document).on('ContentLoad', function(){
     KT.hosts.onKatelloHostEditLoad();
     window.tfm.hosts.registerPluginAttributes("os",
-         ['lifecycle_environment_id', 'content_view_id', 'environment_id', 'content_source_id', 'architecture_id']);
+         ['lifecycle_environment_id', 'content_view_id', 'environment_id', 'content_source_id', 'architecture_id', 'parent_id']);
 
     $("#hostgroup_lifecycle_environment_id").change(KT.hosts.environmentChanged);
     $("#host_lifecycle_environment_id").change(KT.hosts.environmentChanged);
@@ -27,13 +27,15 @@ KT.hosts.fetchContentViews = function () {
     var envId = KT.hosts.getSelectedEnvironment();
     var option;
     var previous_view = KT.hosts.getSelectedContentView();
-
+    var previousInheritViewText = select.find('option:first-child').text();
     select.find('option').remove();
     if (envId) {
         KT.hosts.signalContentViewFetch(true);
         var url = tfm.tools.foremanUrl('/katello/api/v2/content_views/');
         $.get(url, {environment_id: envId, full_result: true}, function (data) {
-            select.append($("<option />"));
+            if ($('#hostgroup_parent_id').length > 0) {
+                select.append($("<option />").text(previousInheritViewText).val(''));
+            }
             $.each(data.results, function(index, view) {
                 option = $("<option />").val(view.id).text(view.name);
                 if (view.id === parseInt(previous_view)) {
@@ -41,6 +43,7 @@ KT.hosts.fetchContentViews = function () {
                 }
                 select.append(option);
             });
+            select.trigger('change');
             KT.hosts.signalContentViewFetch(false);
         });
     }

--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -3,21 +3,34 @@ module Katello
     class HostgroupKickstartRepositoryValidator < ActiveModel::Validator
       def validate(facet)
         return unless facet.kickstart_repository_id
+        if facet.content_source.blank? && facet.hostgroup.content_source.blank?
+          prop = :content_source
+          msg = _("Please select a content source before assigning a kickstart repository")
+        elsif facet.hostgroup.operatingsystem.blank?
+          prop = :base
+          msg = _("Please select an operating system before assigning a kickstart repository")
+        elsif !facet.hostgroup.operatingsystem.is_a?(Redhat)
+          prop = :base
+          msg = _("Kickstart repositories can only be assigned to hosts in the Red Hat family")
+        elsif facet.hostgroup.architecture.blank?
+          prop = :base
+          msg = _("Please select an architecture before assigning a kickstart repository")
+        elsif !content_view_in_env?(facet)
+          prop = :lifecycle_environment
+          msg = _("The selected/Inherited Content View is not available for this Lifecycle Environment")
+        elsif !facet.hostgroup.matching_kickstart_repository?(facet)
+          prop = :kickstart_repository
+          msg = _("The selected kickstart repository is not part of the assigned content view, " \
+                  "lifecycle environment, content source, operating system, and architecture")
+        end
+        facet.hostgroup.errors.add(prop, msg) if msg
+      end
 
-        msg = if facet.content_source.blank?
-                _("Please select a content source before assigning a kickstart repository")
-              elsif facet.hostgroup.operatingsystem.blank?
-                _("Please select an operating system before assigning a kickstart repository")
-              elsif !facet.hostgroup.operatingsystem.is_a?(Redhat)
-                _("Kickstart repositories can only be assigned to hosts in the Red Hat family")
-              elsif facet.hostgroup.architecture.blank?
-                _("Please select an architecture before assigning a kickstart repository")
-              elsif !facet.hostgroup.matching_kickstart_repository?(facet)
-                _("The selected kickstart repository is not part of the assigned content view, lifecycle environment,
-                  content source, operating system, and architecture")
-              end
-
-        facet.errors.add(:base, msg) if msg
+      def content_view_in_env?(facet)
+        env = facet.lifecycle_environment || facet.hostgroup.lifecycle_environment
+        cv = facet.content_view || facet.hostgroup.content_view
+        return true if env.blank? || cv.blank?
+        env.content_views.include?(cv)
       end
     end
   end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -39,7 +39,7 @@ module Katello
           self.medium = nil
         end
 
-        unless matching_kickstart_repository?(content_facet)
+        if content_facet&.kickstart_repository_id && !matching_kickstart_repository?(content_facet)
           if (equivalent = equivalent_kickstart_repository)
             self.content_facet.kickstart_repository_id = equivalent[:id]
           end
@@ -92,10 +92,10 @@ module Katello
 
       def equivalent_kickstart_repository
         return unless operatingsystem &&
-                      kickstart_repository &&
+                      content_facet.kickstart_repository &&
                       operatingsystem.respond_to?(:kickstart_repos)
-        ks_repos = operatingsystem.kickstart_repos(self)
-        ks_repos.find { |repo| repo[:name] == kickstart_repository.label }
+        ks_repos = operatingsystem.kickstart_repos(self, content_facet: content_facet)
+        ks_repos.find { |repo| repo[:name] == content_facet.kickstart_repository.label }
       end
 
       def matching_kickstart_repository?(content_facet)

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -52,8 +52,9 @@ module Katello
       def kickstart_repos(host, content_facet: nil)
         distros = distribution_repositories(host, content_facet: content_facet).where(distribution_bootable: true)
         content_facet ||= host.content_facet
-        if distros && content_facet&.content_source
-          distros.map { |distro| distro.to_hash(content_facet.content_source) }
+        cs = content_facet&.content_source || host.try(:content_source)
+        if distros && cs
+          distros.map { |distro| distro.to_hash(cs) }
         else
           []
         end

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -37,9 +37,9 @@ end %>
 
 <%= field(f, cs_select_attr, {:label => _("Content Source")}) do
   if using_hostgroups_page?
-    select_tag cs_select_id, content_source_options(@hostgroup, :selected_host_group => @hostgroup.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
-               :class => 'form-control',  :name => cs_select_name, include_blank: true
+    select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
+               :class => 'form-control',  :name => cs_select_name
   else
-    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
+    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name
   end
 end %>


### PR DESCRIPTION
Before the PR -

On the  create  hostgroups page the inheritance hierarchy behavior was different
between katello attribute like content_view/lce/content source etc vs
things like os and arch
For example if you create a child hostgroup and pointed to a parent
with content view, you would see the cv automatically selected as the
default, instead of 'Inherit Content View' as os/arch fields behave.

More over if you had cv, lce, cs, arch filled in the parent hostgroup
and enabled operating system in the child the media section would not
get automatically populated (because the notion of parent_id was
 missing)

After:

Both the above cases behave appropriately.
