### PR TITLE
Fixes #33382 - ensure inc update occurs before REX applicable errata install

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,7 +131,7 @@ Metrics/ModuleLength:
 # Offense count: 3
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-  Max: 6
+  Max: 7
 
 # Offense count: 122
 Metrics/PerceivedComplexity:

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -124,7 +124,8 @@ module Katello
       validate_content(params[:add_content])
       resolve_dependencies = params.fetch(:resolve_dependencies, true)
       task = async_task(::Actions::Katello::ContentView::IncrementalUpdates, @content_view_version_environments, @composite_version_environments,
-                        params[:add_content], resolve_dependencies, hosts, params[:description])
+                        params[:add_content], resolve_dependencies, hosts, params[:description],
+                        Setting[:remote_execution_by_default] && ::Katello.with_remote_execution?)
       respond_for_async :resource => task
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -10,14 +10,13 @@
  * @requires ContentViewVersion
  * @requires CurrentOrganization
  * @requires Notification
- * @requires BastionConfig
  *
  * @description
  *   Display confirmation screen and apply Errata.
  */
 angular.module('Bastion.errata').controller('ApplyErrataController',
-    ['$scope', '$window', 'translate', 'IncrementalUpdate', 'HostBulkAction', 'ContentViewVersion', 'CurrentOrganization', 'Notification', 'BastionConfig',
-        function ($scope, $window, translate, IncrementalUpdate, HostBulkAction, ContentViewVersion, CurrentOrganization, Notification, BastionConfig) {
+    ['$scope', '$window', 'translate', 'IncrementalUpdate', 'HostBulkAction', 'ContentViewVersion', 'CurrentOrganization', 'Notification',
+        function ($scope, $window, translate, IncrementalUpdate, HostBulkAction, ContentViewVersion, CurrentOrganization, Notification) {
             var applyErrata, incrementalUpdate;
 
             function transitionToTask(task) {
@@ -32,8 +31,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
 
             $scope.applyingErrata = false;
 
-            $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-            $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
             $scope.errataActionFormValues = {
                 authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
                 errata: IncrementalUpdate.getErrataIds().join(','),
@@ -134,15 +131,11 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             });
 
             $scope.confirmApply = function() {
-                if ($scope.remoteExecutionPresent && $scope.remoteExecutionByDefault) {
-                    angular.element('#errataActionForm').submit();
+                $scope.applyingErrata = true;
+                if ($scope.updates.length === 0) {
+                    applyErrata();
                 } else {
-                    $scope.applyingErrata = true;
-                    if ($scope.updates.length === 0) {
-                        applyErrata();
-                    } else {
-                        incrementalUpdate();
-                    }
+                    incrementalUpdate();
                 }
             };
 

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -254,7 +254,7 @@ module Katello
       errata_id = Katello::Erratum.first.pulp_id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => [@beta]}], [],
-                                            {'errata_ids' => [errata_id]}, true, [], nil).returns({})
+                                            {'errata_ids' => [errata_id]}, true, [], nil, false).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true }
 
@@ -267,7 +267,7 @@ module Katello
       deb_id = Katello::Deb.first.id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => [@beta]}], [],
-                                            {'errata_ids' => [errata_id], 'deb_ids' => [deb_id]}, true, [], nil).returns({})
+                                            {'errata_ids' => [errata_id], 'deb_ids' => [deb_id]}, true, [], nil, false).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id], :deb_ids => [deb_id]}, :resolve_dependencies => true }
 
@@ -279,7 +279,7 @@ module Katello
       errata_id = Katello::Erratum.first.pulp_id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => []}], [],
-                                            {'errata_ids' => [errata_id]}, true, [], nil).returns({})
+                                            {'errata_ids' => [errata_id]}, true, [], nil, false).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => []}], :update_hosts => {:included => {:search => ''}}, :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true }
 


### PR DESCRIPTION
The incremental update Bastion Katello code does not actually call incremental update before starting a Remote Execution job.  I considered calling the existing `incrementalUpdate()` before submitting `#errataActionForm`, but I was worried that having to wait for the incremental update before spawning the REX job might get complicated.  So, I refactored the `IncrementalUpdates` action to decide if REX or Katello Agent should be used to apply the hosts' errata.

To test:
1) Set Katello to use Remote Execution by default in the Content Settings
2) Set up some content hosts to have the same applicable (but not installable) errata
3) Try applying those errata by incrementally updating them through the UI (Content -> Errata)
4) See that the REX job appears but the content view version is not incrementally updated
5) Apply my patch and re-do the errata application. Now, the content view version will be incrementally updated before running the REX job
6) Check that Katello Agent still works as well