### PR TITLE
Fixes #33332 - add product name to synced content dropdown menu

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -420,7 +420,7 @@ module Katello
     end
 
     def to_hash(content_source = nil, force_http = false)
-      {id: id, name: label, url: full_path(content_source, force_http)}
+      {id: id, name: "#{product.name}: #{label}", url: full_path(content_source, force_http)}
     end
 
     #is the repo cloned in the specified environment


### PR DESCRIPTION
"I currently have three EL8 distributions in my foreman installation: AlmaLinux 8, CentOS Linux 8 and CentOS Stream 8.

When I create/build a new host, I have to select the operating system first. If I select "CentOS_Stream-8" I have the option to select "Synced Media". If I do that it fills the "Synced Content" dropdown with multiple options.

The synced content dropdown only shows the repository label and nothing about the product. In my case, the BaseOS repository for three EL8 distributions: AlmaLinux 8, CentOS Linux 8 and CentOS Stream 8 has the label "BaseOS_x86_64_os", thus it's impossible to distinguish which product media I have actually selected. The dropdown should contain the product name or product label as well to make clear which product is actually used"