### PR TITLE
Fixes #33394 - Correctly indexes file units on import

### DIFF
--- a/app/lib/actions/katello/repository/filtered_index_content.rb
+++ b/app/lib/actions/katello/repository/filtered_index_content.rb
@@ -24,7 +24,7 @@ module Actions
             ::Katello::FileUnit.import_for_repository(repo)
           elsif repo.generic?
             repo.repository_type.content_types_to_index.each do |type|
-              type.model_class.import_for_repository(repo, type.content_type)
+              type.model_class.import_for_repository(repo, generic_content_type: type.content_type)
             end
           elsif repo.deb?
             if input[:import_upload_task] && input[:import_upload_task][:content_unit_href]

--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -10,12 +10,13 @@ module Actions
           param :contents_changed
           param :matching_content
           param :source_repository_id
+          param :full_index
         end
 
         def run
           source_repository = ::Katello::Repository.find(input[:source_repository_id]) if input[:source_repository_id]
           repo = ::Katello::Repository.find(input[:id])
-          repo.index_content(source_repository: source_repository)
+          repo.index_content(source_repository: source_repository, full_index: input[:full_index].present?)
         end
       end
     end

--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -161,14 +161,15 @@ module Katello
       end
 
       # rubocop:disable Metrics/MethodLength
-      def import_for_repository(repository, generic_content_type = nil)
+      def import_for_repository(repository, generic_content_type = nil, full_index: false)
         pulp_id_href_map = {}
         if generic_content_type
           service_class = SmartProxy.pulp_primary!.content_service(generic_content_type)
         else
           service_class = SmartProxy.pulp_primary!.content_service(content_type)
         end
-        fetch_only_ids = !repository.content_view.default? &&
+        fetch_only_ids = !full_index &&
+                         !repository.content_view.default? &&
                          !repository.repository_type.unique_content_per_repo &&
                          service_class.supports_id_fetch?
 

--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -161,7 +161,7 @@ module Katello
       end
 
       # rubocop:disable Metrics/MethodLength
-      def import_for_repository(repository, generic_content_type = nil, full_index: false)
+      def import_for_repository(repository, generic_content_type: nil, full_index: false)
         pulp_id_href_map = {}
         if generic_content_type
           service_class = SmartProxy.pulp_primary!.content_service(generic_content_type)

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -58,8 +58,8 @@ module Katello
       docker_taggable_id
     end
 
-    def self.import_for_repository(repository)
-      super(repository)
+    def self.import_for_repository(repository, options = {})
+      super(repository, options)
       ::Katello::DockerMetaTag.import_meta_tags([repository])
     end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -894,8 +894,15 @@ module Katello
     end
 
     def index_content(options = {})
-      source_repository = options.fetch(:source_repository, nil)
+      # set full_index to true if you want to force fetch all data from pulp
+      # This is automatically done for library instance repos
+      # However for non-library instance as in those belonging to a version
+      # by default we fetch only ids and match them with the library instance
+      # some times we want to force fetch all data even for non-library repos.
+      # Use the full_index for those times
 
+      full_index = options.fetch(:full_index, false)
+      source_repository = options.fetch(:source_repository, nil)
       if self.yum? && !self.primary?
         index_linked_repo
       elsif source_repository && !repository_type.unique_content_per_repo
@@ -904,9 +911,9 @@ module Katello
         repository_type.content_types_to_index.each do |type|
           Katello::Logging.time("CONTENT_INDEX", data: {type: type.model_class}) do
             if self.generic?
-              type.model_class.import_for_repository(self, type.content_type)
+              type.model_class.import_for_repository(self, type.content_type, full_index: full_index)
             else
-              type.model_class.import_for_repository(self)
+              type.model_class.import_for_repository(self, full_index: full_index)
             end
           end
         end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -911,7 +911,7 @@ module Katello
         repository_type.content_types_to_index.each do |type|
           Katello::Logging.time("CONTENT_INDEX", data: {type: type.model_class}) do
             if self.generic?
-              type.model_class.import_for_repository(self, type.content_type, full_index: full_index)
+              type.model_class.import_for_repository(self, generic_content_type: type.content_type, full_index: full_index)
             else
               type.model_class.import_for_repository(self, full_index: full_index)
             end

--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -5,9 +5,9 @@ module Katello
     belongs_to :repository, :inverse_of => :yum_metadata_files, :class_name => "Katello::Repository"
     CONTENT_TYPE = "yum_repo_metadata_file".freeze
 
-    def self.import_for_repository(repository)
+    def self.import_for_repository(repository, options = {})
       ::Katello::YumMetadataFile.where(:repository_id => repository).destroy_all
-      super(repository)
+      super(repository, options)
     end
 
     # yum metadata file only has one repo


### PR DESCRIPTION
Before;
When importing a version with file repos, the indexing operation didn't
do a full index but rather just indexed via id in library.
It showed incorrect counts with respect to the number of files in the
version etc.

After'
When importing a version with file repos, the indexing operation
does a full index.
File counts are accurately reflected in the versions page