### PR TITLE
Fixes #33395 - remove if/else statment

### DIFF
--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -10,12 +10,8 @@ ks_repo_select_attr = using_hostgroups_page? ? 'kickstart_repository' : 'content
 <% spinner_path = asset_path('spinner.gif') %>
 
 <%= field(f, ks_repo_select_attr, {:label => _("Synced Content")}) do
-  if using_hostgroups_page?
-    select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
-               :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
-  else
-    select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id}, :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
-  end
+  select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
+             :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
 end %>
 
 <script>


### PR DESCRIPTION
in app/views/overrides/activation_keys/_host_synced_content_select.html.erb
if/else statement have equal code:
```
if using_hostgroups_page?
    select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
               :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
else
    select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id}, :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
end
```

so, i think if/else statement is unnecessary