### PR TITLE
Fixes #33256 - encode the search link from packages view

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package.controller.js
@@ -36,6 +36,10 @@ angular.module('Bastion.packages').controller('PackageController',
                             $scope.package.arch;
         };
 
+        $scope.encodedUrl = function(field) {
+            return '/content_hosts?search=' + encodeURIComponent($scope.createSearchString(field));
+        };
+
         $scope.package = Package.get({id: $scope.$stateParams.packageId}, function () {
             $scope.panel.loading = false;
             $scope.fetchHostCount();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
@@ -9,7 +9,7 @@
       <dd>
         <i class="fa fa-spinner fa-spin" ng-show="installedPackageCount === undefined"></i>
         <span ng-show="installedPackageCount !== undefined">
-          <a href="{{ '/content_hosts?search=' + createSearchString('installed_package') }}" translate>
+          <a href="{{ encodedUrl('installed_package') }}" translate>
             {{ installedPackageCount }} Host(s)
           </a>
         </span>
@@ -17,14 +17,14 @@
 
       <dt translate>Applicable To</dt>
       <dd>
-        <a href="{{ '/content_hosts?search=' + createSearchString('applicable_rpms') }}" translate>
+        <a href="{{ encodedUrl('applicable_rpms') }}" translate>
           {{ package.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
-        <a href="{{ '/content_hosts?search=' + createSearchString('upgradable_rpms') }}" translate>
+        <a href="{{ encodedUrl('upgradable_rpms') }}" translate>
           {{ package.hosts_available_count }} Host(s)
         </a>
       </dd>


### PR DESCRIPTION
Search link from packages view is broken when there is  a + (plus) sign in the package name.

To Test
- Install a package with a + sign in the name on a client which is registered.
   I installed libstdc++-devel-8.4.1-1.el8.x86_64 on my client.
- Go to Content - Packages
   Put `libstdc++-devel-8.4.1-1.el8.x86_64` as the search filter then click `Search` 
- Click on the found package
- Click the `Installed On` link to hosts which should display a page where your client in first step should be listed.