### PR TITLE
Fixes #33407 - Package dependency UI values not formatted correctly

### DIFF
--- a/app/lib/katello/util/package.rb
+++ b/app/lib/katello/util/package.rb
@@ -170,6 +170,28 @@ module Katello
         end
         pieces.join(".")
       end
+
+      def self.parse_dependencies(dependencies)
+        # dependencies is either 'requires' or 'provides' metadata attribute of rpm package in pulp
+        results = []
+        flags = {'GT' => '>', 'LT' => '<', 'EQ' => '=', 'GE' => '>=', 'LE' => '<='}
+
+        dependencies&.each do |dependency|
+          dependencies_str = ""
+          if dependency.count < 3
+            dependencies_str = dependency.first
+            results << dependencies_str
+          else
+            dependency[1] = flags[dependency[1]]
+            dependency[0...2].each { |dependency_piece| dependencies_str += "#{dependency_piece} " }
+            dependencies_str += "#{dependency[2]}:" unless dependency[2] == "0" # epoch
+            dependencies_str += "#{dependency[3]}-" # version
+            dependency[4...-1].each { |dependency_piece| dependencies_str += "#{dependency_piece}." }
+            results << dependencies_str[0...-1]
+          end
+        end
+        results.uniq
+      end
     end
   end
 end

--- a/app/services/katello/pulp3/rpm.rb
+++ b/app/services/katello/pulp3/rpm.rb
@@ -26,41 +26,11 @@ module Katello
       end
 
       def requires
-        results = []
-        flags = {'GT' => '>', 'LT' => '>', 'EQ' => '=', 'GE' => '>=', 'LE' => '<='}
-
-        backend_data['requires']&.each do |requirement|
-          requires_str = ""
-          if requirement.count < 3
-            requires_str = requirement.first
-            results << requires_str
-          else
-            requirement[1] = flags[requirement[1]]
-            requirement[0...2].each { |requirement_piece| requires_str += "#{requirement_piece} " }
-            requirement[2...-1].each { |requirement_piece| requires_str += "#{requirement_piece}." }
-            results << requires_str[0...-1]
-          end
-        end
-        results.uniq
+        Util::Package.parse_dependencies(backend_data['requires'])
       end
 
       def provides
-        results = []
-        flags = {'GT' => '>', 'LT' => '>', 'EQ' => '=', 'GE' => '>=', 'LE' => '<='}
-
-        backend_data['provides']&.each do |provided|
-          provides_str = ""
-          if provided.count < 3
-            provides_str = provided.first
-            results << provides_str
-          else
-            provided[1] = flags[provided[1]]
-            provided[0...2].each { |provided_piece| provides_str += "#{provided_piece} " }
-            provided[2...-1].each { |provided_piece| provides_str += "#{provided_piece}." }
-            results << provides_str[0...-1]
-          end
-        end
-        results.uniq
+        Util::Package.parse_dependencies(backend_data['provides'])
       end
 
       def files

--- a/test/lib/util/package_test.rb
+++ b/test/lib/util/package_test.rb
@@ -140,5 +140,12 @@ module Katello
       assert_equal parsed, Util::Package.parse_nvre(unparsed)
       assert_equal unparsed, Util::Package.build_nvrea(parsed)
     end
+
+    def test_parse_dependencies
+      unparsed = [["package", "EQ", "0", "7.1.4", "14.el7_7", false], ["package", "LT", "2", "7.1.4", "14.el7_7", false], ["package", false]]
+      parsed = ["package = 7.1.4-14.el7_7", "package < 2:7.1.4-14.el7_7", "package"]
+
+      assert_equal parsed, Util::Package.parse_dependencies(unparsed)
+    end
   end
 end


### PR DESCRIPTION
The values for the dependencies were incorrect.

For example, what should be "package_name = 3.1.3-14.el7_7", was being displayed as "package_name = 0.3.1.3.14.el7_7".

Also, the less than sign was flipped for any dependencies with a less than requirement.

To test: 
- go to Content > Packages
- select a package
- observe the values under "Requires" and "Provides" in "Dependencies"

You can check against the values against, for example, `rpm -q --requires tfm-rubygem-hammer_cli`, where `tfm-rubygem-hammer_cli` is the package name.

foreman_concrete from here: http://yum.theforeman.org/plugins/nightly/el7/x86_64/ is a good package to check.