### PR TITLE
Fixes #33410 - Inject consumer uuid into REX jobs

### DIFF
--- a/app/models/katello/concerns/remote_execution_provider_extensions.rb
+++ b/app/models/katello/concerns/remote_execution_provider_extensions.rb
@@ -1,0 +1,9 @@
+module Katello
+  module Concerns
+    module RemoteExecutionProviderExtensions
+      def alternative_names(host)
+        super.merge(:consumer_uuid => host.subscription_facet.uuid)
+      end
+    end
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -316,6 +316,8 @@ Foreman::Plugin.register :katello do
                                     :description => N_("Perform a module stream action via Katello interface"),
                                     :provided_inputs => ['action', 'module_spec', 'options'])
     allowed_template_helpers :errata
+
+    RemoteExecutionProvider.prepend(Katello::Concerns::RemoteExecutionProviderExtensions)
   end
 
   tests_to_skip("AccessPermissionsTest" => [


### PR DESCRIPTION
Counterpart for https://github.com/theforeman/foreman_remote_execution/pull/649