### PR TITLE
 Fixes #33413 - use new link method for product sync tasks

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -42,7 +42,7 @@ module Katello
       def sync_status
         all_repos = repos(self.library, nil, false)
         task = last_repo_sync_task
-        last_synced_repo = task ? all_repos.find { |repo| task.locks.where(:resource_type => ::Katello::Repository.name).pluck(:resource_id).map(&:to_s).include?(repo.id.to_s) } : nil
+        last_synced_repo = task ? all_repos.find { |repo| task.links.where(:resource_type => ::Katello::Repository.name).pluck(:resource_id).map(&:to_s).include?(repo.id.to_s) } : nil
         ::Katello::SyncStatusPresenter.new(last_synced_repo, task).sync_progress
       end
 


### PR DESCRIPTION
likely caused by:
https://github.com/theforeman/foreman-tasks/commit/f505bb3846ea27069e9d1b132074dcf95af8807f