### PR TITLE
Fixes #33465 - don't show links to default org view in proxy UI

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -250,7 +250,7 @@ Foreman::Plugin.register :katello do
     context.add_pagelet :main_tabs,
       :name => _("Content"),
       :partial => "foreman/smart_proxies/content_tab",
-      :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) || proxy.has_feature?(SmartProxy::PULP3_FEATURE) }
+      :onlyif => proc { |proxy| proxy.pulp_mirror? }
     context.add_pagelet :details_content,
       :name => _("Content Sync"),
       :partial => "foreman/smart_proxies/content_sync",

--- a/webpack/scenes/SmartProxy/SmartProxyContentTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentTable.js
@@ -78,7 +78,7 @@ const SmartProxyContentTable = ({ smartProxyId }) => {
                 },
               },
               {
-                title: <a href={urlBuilder('content_views', '', id)}>{cvName}</a>,
+                title: <a href={cv.default ? urlBuilder('products', '') : urlBuilder('content_views', '', id)}>{cvName}</a>,
                 props: {
                   colSpan: 1,
                 },


### PR DESCRIPTION
We've had this issue before in the old UI: https://projects.theforeman.org/issues/27783

This PR makes the default org view redirect to `/products` instead of the actual default org view since it's bugged in the UI.