### PR TITLE
Fixes #33467 - Add component view count to Versions API

### DIFF
--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -13,6 +13,10 @@ node do |version|
   version.content_counts_map
 end
 
+node :component_view_count do |version|
+  version&.components&.count
+end
+
 node do |version|
   version.repository_type_counts_map
 end


### PR DESCRIPTION
Adds a new field in versions API response with component view counts for composite content views. Value will be 0 for non-composite CVs and also 0 for empty Composite CV versions.

![Screenshot from 2021-09-10 14-40-58](https://user-images.githubusercontent.com/21146741/132901928-07d11ab1-3d59-4851-856c-eb69e390ed6a.png)


Note: An unpublished component CV is not considered as a component of Composite CV **version**. Count will be 0 and the API `/katello/api/v2/content_view_versions?composite_version_id=$VERSION_ID` will not return unpublished component CVs either.
