### PR TITLE
Fixes #33468 - remove background download policy references

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -35,7 +35,7 @@ module Katello
       syncable_roots = RootRepository.where(:product_id => syncable_products).has_url
 
       syncable_roots = syncable_roots.yum_type if skip_metadata_check || validate_contents
-      syncable_roots = syncable_roots.where.not(:download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND) if validate_contents
+      syncable_roots = syncable_roots.where.not(:download_policy => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND) if validate_contents
 
       syncable_repositories = Katello::Repository.where(:root_id => syncable_roots).in_default_view
       fail _("No syncable repositories found for selected products and options.") if syncable_roots.empty?

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -108,7 +108,7 @@ module Katello
     param :available_for, String, :desc => N_("interpret specified object to return only Repositories that can be associated with specified object.  Only 'content_view' & 'content_view_version' are supported."),
           :required => false
     param :with_content, RepositoryTypeManager.enabled_content_types(false), :desc => N_("only repositories having at least one of the specified content type ex: rpm , erratum")
-    param :download_policy, ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES, :desc => N_("limit to only repositories with this download policy")
+    param :download_policy, ::Katello::RootRepository::DOWNLOAD_POLICIES, :desc => N_("limit to only repositories with this download policy")
     param :username, String, :desc => N_("only show the repositories readable by this user with this username")
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Repository)

--- a/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
+++ b/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
@@ -29,15 +29,11 @@ module Katello
         policies = [
           {
             :name => _("On Demand"),
-            :label => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
-          },
-          {
-            :name => _("Background"),
-            :label => ::Runcible::Models::YumImporter::DOWNLOAD_BACKGROUND
+            :label => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
           },
           {
             :name => _("Immediate"),
-            :label => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE
+            :label => ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
           },
           {
             :name => _("Inherit from Repository"),

--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -28,7 +28,7 @@ module Actions
                 repo_batch.each do |repo|
                   if repo.is_a?(::Katello::Repository) &&
                       repo.distribution_bootable? &&
-                      repo.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+                      repo.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
                     plan_action(Katello::Repository::FetchPxeFiles,
                                 id: repo.id,
                                 capsule_id: smart_proxy.id)

--- a/app/lib/actions/katello/repository/fetch_pxe_files.rb
+++ b/app/lib/actions/katello/repository/fetch_pxe_files.rb
@@ -25,7 +25,7 @@ module Actions
 
         def needs_download?(repository)
           repository.distribution_bootable? &&
-             repository.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+             repository.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
         end
       end
     end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -32,7 +32,7 @@ module Actions
           fail ::Katello::Errors::InvalidActionOptionError, _("Cannot skip metadata check on non-yum repositories.") if skip_metadata_check && !repo.yum?
 
           pulp_sync_options = {}
-          pulp_sync_options[:download_policy] = ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND if validate_contents && repo.yum?
+          pulp_sync_options[:download_policy] = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND if validate_contents && repo.yum?
 
           #pulp3 options
           pulp_sync_options[:optimize] = false if skip_metadata_check && repo.yum?

--- a/app/models/katello/concerns/setting_extensions.rb
+++ b/app/models/katello/concerns/setting_extensions.rb
@@ -4,7 +4,7 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        validates :value, inclusion: { in: ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES },
+        validates :value, inclusion: { in: ::Katello::RootRepository::DOWNLOAD_POLICIES },
           if: ->(setting) { setting.name == 'default_download_policy' }
 
         after_save :recalculate_errata_status

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -21,7 +21,7 @@ module Katello
       CONTAINER_GATEWAY_FEATURE = "Container_Gateway".freeze
 
       DOWNLOAD_INHERIT = 'inherit'.freeze
-      DOWNLOAD_POLICIES = ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES + [DOWNLOAD_INHERIT]
+      DOWNLOAD_POLICIES = [::Katello::RootRepository::DOWNLOAD_ON_DEMAND, ::Katello::RootRepository::DOWNLOAD_IMMEDIATE, DOWNLOAD_INHERIT].freeze
 
       included do
         include ForemanTasks::Concerns::ActionSubject
@@ -348,7 +348,7 @@ module Katello
       end
 
       def set_default_download_policy
-        self.download_policy ||= ::Setting[:default_proxy_download_policy] || ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+        self.download_policy ||= ::Setting[:default_proxy_download_policy] || ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       end
 
       def associate_lifecycle_environments

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -123,9 +123,9 @@ module Katello
     before_validation :set_container_repository_name, :if => :docker?
 
     scope :has_url, -> { joins(:root).where.not("#{RootRepository.table_name}.url" => nil) }
-    scope :on_demand, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND) }
-    scope :immediate, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE) }
-    scope :non_immediate, -> { joins(:root).where.not("#{RootRepository.table_name}.download_policy" => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE) }
+    scope :on_demand, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND) }
+    scope :immediate, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Katello::RootRepository::DOWNLOAD_IMMEDIATE) }
+    scope :non_immediate, -> { joins(:root).where.not("#{RootRepository.table_name}.download_policy" => ::Katello::RootRepository::DOWNLOAD_IMMEDIATE) }
     scope :in_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => true) }
     scope :in_non_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => false) }
     scope :deb_type, -> { with_type(DEB_TYPE) }
@@ -298,11 +298,11 @@ module Katello
     end
 
     def on_demand?
-      root.download_policy == Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+      root.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
     end
 
     def immediate?
-      root.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE
+      root.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_IMMEDIATE
     end
 
     def yum_gpg_key_url

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -9,15 +9,10 @@ class Setting::Content < Setting
     Hash[parameters.map { |p| [p, p] }]
   end
 
-  def self.deprecate_background(policies_hash)
-    policies_hash['background'] = 'background (deprecated)'
-    policies_hash
-  end
-
   def self.default_settings
-    download_policies = proc { deprecate_background(hashify_parameters(::Runcible::Models::YumImporter::DOWNLOAD_POLICIES)) }
+    download_policies = proc { hashify_parameters(::Katello::RootRepository::DOWNLOAD_POLICIES) }
 
-    proxy_download_policies = proc { deprecate_background(hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES)) }
+    proxy_download_policies = proc { hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES) }
     dependency_solving_options = proc { hashify_parameters(['conservative', 'greedy']) }
     cdn_ssl_versions = proc { hashify_parameters(Katello::Resources::CDN::SUPPORTED_SSL_VERSIONS) }
     http_proxy_select = [{
@@ -94,11 +89,11 @@ class Setting::Content < Setting
                100, N_('Batch size to sync repositories in.')),
       self.set('foreman_proxy_content_auto_sync', N_("Whether or not to auto sync the Smart Proxies after a Content View promotion."),
                true, N_('Sync Smart Proxies after Content View promotion')),
-      self.set('default_download_policy', N_("Default download policy for custom repositories (either 'immediate', 'on_demand', or 'background')"), "immediate",
+      self.set('default_download_policy', N_("Default download policy for custom repositories (either 'immediate' or 'on_demand')"), "immediate",
                N_('Default Custom Repository download policy'), nil, :collection => download_policies),
-      self.set('default_redhat_download_policy', N_("Default download policy for enabled Red Hat repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand",
+      self.set('default_redhat_download_policy', N_("Default download policy for enabled Red Hat repositories (either 'immediate' or 'on_demand')"), "on_demand",
                        N_('Default Red Hat Repository download policy'), nil, :collection => download_policies),
-      self.set('default_proxy_download_policy', N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', 'on_demand', or 'background')"), "on_demand",
+      self.set('default_proxy_download_policy', N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', or 'on_demand')"), "on_demand",
                N_('Default Smart Proxy download policy'), nil, :collection => proxy_download_policies),
       self.set('pulp_docker_registry_port', N_("The port used by Pulp Crane to provide Docker Registries"),
                5000, N_('Pulp Docker registry port')),

--- a/db/migrate/20210201163238_migrate_background_download_policy_to_migrate.rb
+++ b/db/migrate/20210201163238_migrate_background_download_policy_to_migrate.rb
@@ -1,7 +1,7 @@
 class MigrateBackgroundDownloadPolicyToMigrate < ActiveRecord::Migration[6.0]
   def change
-    Katello::RootRepository.where(:download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_BACKGROUND).each do |root_repo|
-      root_repo.update_column(:download_policy, ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE)
+    Katello::RootRepository.where(:download_policy => 'background').each do |root_repo|
+      root_repo.update_column(:download_policy, ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
     end
   end
 end

--- a/db/migrate/20210910190324_move_background_settings_to_immediate.rb
+++ b/db/migrate/20210910190324_move_background_settings_to_immediate.rb
@@ -1,0 +1,25 @@
+class MoveBackgroundSettingsToImmediate < ActiveRecord::Migration[6.0]
+  def up
+    SmartProxy.where(id: (SmartProxy.with_content - [SmartProxy.pulp_primary]).pluck(:id)).
+      where(download_policy: 'background').update(download_policy: 'immediate')
+
+    setting = ::Setting.find_by(name: 'default_download_policy')
+    if setting&.value == 'background'
+      setting.update(value: ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
+    end
+
+    setting = ::Setting.find_by(name: 'default_redhat_download_policy')
+    if setting&.value == 'background'
+      setting.update(value: ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
+    end
+
+    setting = ::Setting.find_by(name: 'default_proxy_download_policy')
+    if setting&.value == 'background'
+      setting.update(value: ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
+    end
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -69,12 +69,12 @@ namespace :katello do
     end
   end
 
-  desc "Change the download policy of all repos. Specify DOWNLOAD_POLICY=policy. Options are #{::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.join(', ')}."
+  desc "Change the download policy of all repos. Specify DOWNLOAD_POLICY=policy. Options are immediate or on_demand."
   task :change_download_policy => ["environment", "check_ping"] do
     policy = ENV['DOWNLOAD_POLICY']
-    unless ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.include?(policy)
+    unless ::Katello::RootRepository::DOWNLOAD_POLICIES.include?(policy)
       puts "Invalid download policy specified: '#{policy}'. "
-      puts "Options are #{::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.to_sentence}."
+      puts "Options are immediate or on_demand."
       next
     end
 

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -88,7 +88,7 @@ module Katello
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
         refute_empty repos
-        assert repos.all? { |repo| repo.yum? } && repos.all? { |repo| repo.download_policy != ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND }
+        assert repos.all? { |repo| repo.yum? } && repos.all? { |repo| repo.download_policy != ::Katello::RootRepository::DOWNLOAD_ON_DEMAND }
       end
 
       put :sync_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id, :validate_contents => true }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -597,7 +597,7 @@ module Katello
     end
 
     def test_update_false_download_policy
-      expected_message = "must be one of the following: %s" % ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.join(', ')
+      expected_message = "must be one of the following: %s" % ::Katello::RootRepository::DOWNLOAD_POLICIES.join(', ')
       response = put :update, params: { :id => @repository.id, :download_policy => 'false' }
       body = JSON.parse(response.body)
 

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -74,7 +74,7 @@ rhel_7_x86_64_root:
   product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   url:                 'https://cdn.example.com/rhel/7/os'
-  download_policy: background
+  download_policy: on_demand
 
 rhel_6_x86_64_root:
   name:                 RHEL 6 x86_64

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -163,11 +163,11 @@ module Katello
     end
 
     def test_change_download_policy
-      ENV['DOWNLOAD_POLICY'] = 'background'
+      ENV['DOWNLOAD_POLICY'] = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       Katello::Repository.stubs(:yum_type).returns(Katello::Repository.where(:id => @library_repo))
       ForemanTasks.expects(:sync_task).with(::Actions::Katello::Repository::Update,
                                             @library_repo.root,
-                                            download_policy: 'background')
+                                            download_policy: ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
 
       Rake.application.invoke_task('katello:change_download_policy')
     end

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -15,17 +15,17 @@ module Katello
     end
 
     def test_sets_default_download_policy
-      Setting[:default_proxy_download_policy] = 'background'
+      Setting[:default_proxy_download_policy] = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       @proxy.save!
 
       assert_equal Setting[:default_proxy_download_policy], @proxy.download_policy
     end
 
     def test_save_with_download_policy
-      @proxy.download_policy = 'background'
+      @proxy.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       @proxy.save!
 
-      assert_equal 'background', @proxy.reload.download_policy
+      assert_equal ::Katello::RootRepository::DOWNLOAD_IMMEDIATE, @proxy.reload.download_policy
     end
 
     def test_destroy_with_content_facet

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -264,13 +264,13 @@ module Katello
 
     def test_on_demand_repositories
       repo1 = katello_repositories(:rhel_6_x86_64)
-      repo1.root.update(:download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND)
+      repo1.root.update(:download_policy => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND)
       view1 = create(:katello_content_view, organization: @organization)
       view1.repositories << repo1
       assert_includes view1.on_demand_repositories, repo1
 
       repo2 = katello_repositories(:fedora_17_x86_64)
-      repo2.root.update(:download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE)
+      repo2.root.update(:download_policy => ::Katello::RootRepository::DOWNLOAD_IMMEDIATE)
       view2 = create(:katello_content_view, organization: @organization)
       view2.repositories << repo2
       refute_includes view2.on_demand_repositories, repo2

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -78,7 +78,7 @@ module Katello
     def test_create_with_download_policy
       @root.content_type = 'yum'
       @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
-      %w[on_demand background immediate].each do |download_policy|
+      ::Katello::RootRepository::DOWNLOAD_POLICIES.each do |download_policy|
         @root.download_policy = download_policy
         assert @root.valid?, "Validation failed for create with valid download_policy: '#{download_policy}'"
         assert_equal download_policy, @root.download_policy
@@ -87,18 +87,8 @@ module Katello
 
     test_attributes :pid => '8a70de9b-4663-4251-b91e-d3618ee7ef84'
     def test_create_immediate_update_to_on_demand
-      new_download_policy = 'on_demand'
-      @root.download_policy = 'immediate'
-      assert @root.save
-      @root.download_policy = new_download_policy
-      assert_valid @root
-      assert_equal new_download_policy, @root.download_policy
-    end
-
-    test_attributes :pid => '9aaf53be-1127-4559-9faf-899888a52846'
-    def test_create_immediate_update_to_background
-      new_download_policy = 'background'
-      @root.download_policy = 'immediate'
+      new_download_policy = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       assert @root.save
       @root.download_policy = new_download_policy
       assert_valid @root
@@ -107,38 +97,8 @@ module Katello
 
     test_attributes :pid => '589ff7bb-4251-4218-bb90-4e63c9baf702'
     def test_create_on_demand_update_to_immediate
-      new_download_policy = 'immediate'
-      @root.download_policy = 'on_demand'
-      assert @root.save
-      @root.download_policy = new_download_policy
-      assert_valid @root
-      assert_equal new_download_policy, @root.download_policy
-    end
-
-    test_attributes :pid => '1d9888a0-c5b5-41a7-815d-47e936022a60'
-    def test_create_on_demand_update_to_background
-      new_download_policy = 'background'
-      @root.download_policy = 'on_demand'
-      assert @root.save
-      @root.download_policy = new_download_policy
-      assert_valid @root
-      assert_equal new_download_policy, @root.download_policy
-    end
-
-    test_attributes :pid => '169530a7-c5ce-4ca5-8cdd-15398e13e2af'
-    def test_create_background_update_to_immediate
-      new_download_policy = 'immediate'
-      @root.download_policy = 'background'
-      assert @root.save
-      @root.download_policy = new_download_policy
-      assert_valid @root
-      assert_equal new_download_policy, @root.download_policy
-    end
-
-    test_attributes :pid => '40a3e963-61ff-41c4-aa6c-d9a4a638af4a'
-    def test_create_background_update_to_on_demand
-      new_download_policy = 'on_demand'
-      @root.download_policy = 'background'
+      new_download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       assert @root.save
       @root.download_policy = new_download_policy
       assert_valid @root
@@ -149,7 +109,7 @@ module Katello
     def test_create_with_checksum_type
       %w[sha1 sha256].each do |checksum_type|
         @root.checksum_type = checksum_type
-        @root.download_policy = 'immediate'
+        @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
         assert @root.valid?, "Validation failed for create with valid checksum_type: '#{checksum_type}'"
         assert_equal checksum_type, @root.checksum_type
       end
@@ -256,17 +216,17 @@ module Katello
 
     test_attributes :pid => '24d36e79-855e-4832-a136-30cbd144de44'
     def test_update_to_invalid_download_policy
-      @root.download_policy = 'background'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       assert @root.save
       @root.download_policy = 'invalid_download_policy'
       refute_valid @root
       assert @root.errors.key?(:download_policy)
-      assert_match 'must be one of the following: immediate, on_demand, background', @root.errors[:download_policy][0]
+      assert_match 'must be one of the following: immediate, on_demand', @root.errors[:download_policy][0]
     end
 
     test_attributes :pid => '8a59cb31-164d-49df-b3c6-9b90634919ce'
     def test_create_non_yum_with_download_policy
-      @root.download_policy = 'on_demand'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       @root.content_type = 'docker'
       refute @root.valid?, "Validation succeed for create with download_policy and non-yum repository: docker"
       assert @root.errors.key?(:download_policy)
@@ -276,7 +236,7 @@ module Katello
     test_attributes :pid => 'c49a3c49-110d-4b74-ae14-5c9494a4541c'
     def test_create_with_invalid_checksum_type
       @root.checksum_type = 'invalid checksum_type'
-      @root.download_policy = 'immediate'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       refute_valid @root
       assert @root.errors.key?(:checksum_type)
       assert_match 'is not included in the list', @root.errors[:checksum_type][0]
@@ -353,7 +313,7 @@ module Katello
 
     test_attributes :pid => '205e6e59-33c6-4a58-9245-1cac3a4f550a'
     def test_update_checksum
-      @root.download_policy = 'immediate'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       @root.checksum_type = 'sha1'
       assert @root.save
       @root.checksum_type = 'sha256'
@@ -490,12 +450,12 @@ module Katello
       @root.download_policy = 'invalid'
       refute @root.valid?
       assert_includes @root.errors, :download_policy
-      assert_match 'must be one of the following: immediate, on_demand, background', @root.errors[:download_policy][0]
+      assert_match 'must be one of the following: immediate, on_demand', @root.errors[:download_policy][0]
     end
 
     def test_compatible_download_policy
       @root.content_type = 'yum'
-      @root.download_policy = 'on_demand'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       @root.url = 'http://some.website/'
       assert @root.valid?
 
@@ -505,7 +465,7 @@ module Katello
       @root.download_policy = 'background'
       refute @root.valid?
 
-      @root.download_policy = 'immediate'
+      @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       assert @root.valid?
     end
 


### PR DESCRIPTION
I think I've got them all, but help me check for other references that I might have missed.

Try changing your smart proxies and download policy settings to use background and then migrate.  They should all change to immediate.