### PR TITLE
Fixes #33659 - Fix upstream_authentication error when editing repository

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -80,7 +80,6 @@ module Katello
     validate :ensure_valid_os_versions
     validate :ensure_content_attribute_restrictions
     validate :ensure_valid_upstream_authorization
-    validate :ensure_valid_uln_authorization, :if => :yum?
     validate :ensure_valid_authentication_token, :if => :yum?
     validate :ensure_valid_deb_constraints, :if => :deb?
     validate :ensure_no_checksum_on_demand
@@ -274,6 +273,9 @@ module Katello
       if self.upstream_username.blank? && self.upstream_password.blank?
         self.upstream_username = nil
         self.upstream_password = nil
+        if !self.url.blank? && self.url.start_with?('uln') && !self.content
+          errors.add(:base, N_("Upstream username and upstream password cannot be blank for ULN repositories"))
+        end
         return
       end
 
@@ -295,16 +297,6 @@ module Katello
 
       if !self.ansible_collection_auth_url.blank? && self.ansible_collection_auth_token.blank?
         errors.add(:base, N_("Auth URL requires Auth token be set."))
-      end
-    end
-
-    def ensure_valid_uln_authorization
-      if !self.url.blank? && self.url.start_with?('uln')
-        if self.upstream_username.nil? || self.upstream_password.nil?
-          errors.add(:base, N_("Upstream username and upstream password cannot be blank for ULN repositories"))
-        end
-      else
-        return
       end
     end
 

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -74,13 +74,13 @@ module Katello
       end
 
       def create_remote
-        if remote_options[:url].start_with?('uln')
+        if remote_options[:url]&.start_with?('uln')
           remote_file_data = api.class.remote_uln_class.new(remote_options)
         else
           remote_file_data = api.remote_class.new(remote_options)
         end
         reformat_api_exception do
-          if remote_options[:url].start_with?('uln')
+          if remote_options[:url]&.start_with?('uln')
             response = api.remotes_uln_api.create(remote_file_data)
           else
             response = api.remotes_api.create(remote_file_data)
@@ -97,14 +97,14 @@ module Katello
       def create_test_remote
         test_remote_options = remote_options
         test_remote_options[:name] = test_remote_name
-        if remote_options[:url].start_with?('uln')
+        if remote_options[:url]&.start_with?('uln')
           remote_file_data = api.class.remote_uln_class.new(test_remote_options)
         else
           remote_file_data = api.remote_class.new(test_remote_options)
         end
 
         reformat_api_exception do
-          if remote_options[:url].start_with?('uln')
+          if remote_options[:url]&.start_with?('uln')
             response = api.remotes_uln_api.create(remote_file_data)
           else
             response = api.remotes_api.create(remote_file_data)
@@ -144,7 +144,7 @@ module Katello
       end
 
       def remote_partial_update
-        if remote_options[:url].start_with?('uln')
+        if remote_options[:url]&.start_with?('uln')
           api.remotes_uln_api.partial_update(repo.remote_href, remote_options)
         else
           api.remotes_api.partial_update(repo.remote_href, remote_options)
@@ -195,7 +195,7 @@ module Katello
       end
 
       def get_remote(href = repo.remote_href)
-        repo.url.start_with?('uln') ? api.remotes_uln_api.read(href) : api.remotes_api.read(href)
+        repo.url&.start_with?('uln') ? api.remotes_uln_api.read(href) : api.remotes_api.read(href)
       end
 
       def get_distribution(href = distribution_reference.href)

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -24,7 +24,7 @@ module Katello
       def refresh_entities
         href = remote_href
         if href
-          if remote_options[:url].start_with?('uln')
+          if remote_options[:url]&.start_with?('uln')
             [api.remotes_uln_api.partial_update(href, remote_options)]
           else
             [api.remotes_api.partial_update(href, remote_options)]
@@ -107,7 +107,7 @@ module Katello
       end
 
       def create_remote
-        if remote_options[:url].start_with?('uln')
+        if remote_options[:url]&.start_with?('uln')
           remote_file_data = @repo_service.api.class.remote_uln_class.new(remote_options)
           api.remotes_uln_api.create(remote_file_data)
         else

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -57,7 +57,7 @@
       <dt ng-show="repository.content_type !== 'docker'" translate>Upstream URL</dt>
       <dt ng-show="repository.content_type === 'docker'" translate>Registry URL</dt>
       <dd bst-edit-text="repository.url"
-          on-save="save(repository)"
+          on-save="save(repository, true)"
           readonly="product.redhat || denied('edit_products', product)">
       </dd>
 

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -71,7 +71,7 @@ module Katello
       get :index, params: { organization_id: @organization.id, custom: true }
       body = JSON.parse(response.body)
 
-      assert_equal 6, body['total']
+      assert_equal 7, body['total']
     end
 
     def test_index_no_custom_products

--- a/test/fixtures/models/katello_products.yml
+++ b/test/fixtures/models/katello_products.yml
@@ -59,3 +59,11 @@ empty_product_2:
   label:        empty_product_2
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+
+oracle:
+  name:         Oracle
+  description:  An open source Linux distribution.
+  label:        oracle_label
+  cp_id:        oracle
+  provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -382,3 +382,10 @@ pulp3_python_1:
   relative_path:        'Default_Organization/library/pulp3_Python_1'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+uln_ovm2_2_1_1_i386_patch:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:uln_ovm2_2_1_1_i386_patch_root) %>
+  pulp_id:              "Default_Organization-Cabinet-uln_Ovm2_2_1_1_i386_Patch"
+  relative_path:        'Default_Organization/library/uln_ovm2_2_1_1_i386_patch'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -255,3 +255,12 @@ pulp3_python_root_1:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   unprotected:           <%= true %>
   url:                  ""
+
+uln_ovm2_2_1_1_i386_patch_root:
+  name:                 ovm2 i386 patch
+  content_id:           1
+  content_type:         yum
+  label:                ovm2_i386_patch
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:oracle) %>
+  url:                  "uln://ovm2_2.1.1_i386_patch"
+  download_policy:      on_demand

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -733,5 +733,13 @@ collectionz:
       debian9.url = ''
       refute debian9.update(:deb_releases => "stretch")
     end
+
+    def test_uln_upstream_auth_constraint
+      uln_ovm2 = katello_root_repositories(:uln_ovm2_2_1_1_i386_patch_root)
+      uln_ovm2.upstream_username = 'username'
+      refute uln_ovm2.save
+      uln_ovm2.upstream_password = 'password'
+      assert uln_ovm2.save
+    end
   end
 end


### PR DESCRIPTION
When editing repository, the upstream_password and username variables are blank but the values are stored in DB and one can also see these details in GUI. Due to blank value in field it is not able to edit the ULN repository since it has credential authentication constraint. This PR fixes this issue.