### PR TITLE
Refs #33078 - Move forceRender inside hook

### DIFF
--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -1,11 +1,46 @@
 import { useState, useRef } from 'react';
 
+class ReactConnectedSet extends Set {
+  constructor(initialValue, forceRender) {
+    super();
+    this.forceRender = forceRender;
+    // The constructor would normally call add() with the initial value, but since we
+    // must call super() at the top, this.forceRender() isn't defined yet.
+    // So, we call super() above with no argument, then call add() manually below
+    // after forceRender is defined.
+    if (initialValue) {
+      if (initialValue.constructor.name === 'Array') {
+        initialValue.forEach(val => this.add(val));
+      } else {
+        this.add(initialValue);
+      }
+    }
+  }
+  add(value) {
+    const result = super.add(value); // ensuring these methods have the same API as the superclass
+    this.forceRender();
+    return result;
+  }
+
+  clear() {
+    const result = super.clear();
+    this.forceRender();
+    return result;
+  }
+
+  delete(value) {
+    const result = super.delete(value);
+    this.forceRender();
+    return result;
+  }
+}
+
 const useSet = (initialArry) => {
-  const set = useRef(new Set(initialArry));
   const [, setToggle] = useState(false);
   // needed because mutating a Ref won't cause React to rerender
   const forceRender = () => setToggle(prev => !prev);
-  return [set.current, forceRender];
+  const set = useRef(new ReactConnectedSet(initialArry, forceRender));
+  return set.current;
 };
 
 export default useSet;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
@@ -12,7 +12,7 @@ import './TracesTab.scss';
 
 const TracesTab = () => {
   const [searchQuery, updateSearchQuery] = useState('');
-  const [selectedTraces, forceRender] = useSet([]);
+  const selectedTraces = useSet([]);
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
   const dispatch = useDispatch();
   const { id: hostId } = hostDetails;
@@ -50,11 +50,9 @@ const TracesTab = () => {
     Number(selectedTraces.size) > 0 && selectedTraces.size === Number(meta.total);
   const selectPage = () => {
     [...results.map(result => result.id)].forEach(id => selectedTraces.add(id));
-    forceRender();
   };
   const selectNone = () => {
     selectedTraces.clear();
-    forceRender();
   };
   // const selectAll = () => {
   //   // leaving blank until we can implement selectAll Katello-wide
@@ -65,7 +63,6 @@ const TracesTab = () => {
     } else {
       selectedTraces.delete(traceId);
     }
-    forceRender(); // since changing the ref won't cause a rerender
   };
   if (!hostId) return <Skeleton />;
 


### PR DESCRIPTION
I used JavaScript Sets in TracesTab.js to keep track of which table rows are selected.  The biggest disadvantage of this was that you would have to call a `forceRender()` function each time you mutate the set, or else React wouldn't know when to update the DOM.  This PR automates that and removes the need to call `forceRender()` yourself.

Usage before:
```js
const [mySet, forceRender] = useSet([]);
...
mySet.add(3);
forceRender();
```

Usage after:
```js
const mySet = useSet([]);
...
mySet.add(3); // forceRender is called for you
```