### PR TITLE
Fixes #33480 - drop jQuery-ui sortable

### DIFF
--- a/app/assets/javascripts/katello/common/vendor.js
+++ b/app/assets/javascripts/katello/common/vendor.js
@@ -1,5 +1,4 @@
 //= require "jquery-ui/widgets/dialog"
-//= require "jquery-ui/widgets/sortable"
 //= require "jquery-ui/widgets/progressbar"
 //= require "jquery-ui/effect"
 //= require "jquery-ui/effect.all"


### PR DESCRIPTION
`jquery-ui/sortable` doesn't appear to be used anywhere in the project