### PR TITLE
Fixes #33496 - support qpid_proton 0.35

### DIFF
--- a/app/lib/katello/qpid/connection.rb
+++ b/app/lib/katello/qpid/connection.rb
@@ -74,6 +74,7 @@ module Katello
       def initialize(url:, ssl_cert_file:, ssl_key_file:, ssl_ca_file:)
         @url = url
         ssl_domain = ::Qpid::Proton::SSLDomain.new(::Qpid::Proton::SSLDomain::MODE_CLIENT)
+        ssl_domain.peer_authentication(::Qpid::Proton::SSLDomain::ANONYMOUS_PEER)
         ssl_domain.credentials(ssl_cert_file, ssl_key_file, nil) if ssl_cert_file && ssl_key_file
         ssl_domain.trusted_ca_db(ssl_ca_file) if ssl_ca_file
         @connection_options = {


### PR DESCRIPTION
qpid_proton 0.35 started to verify certificates, but fails to recognize ours (even though we do deploy the right name and everything).
let's disable the verification for now (and thus revert back to the 0.34 behavior) until we know how to fix the verification properly.