### PR TITLE
Fixes #33493 - Remove OSTree filter from Red Hat Repositories drop down list

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -22,7 +22,6 @@ const filterOptions = [
   { value: 'sourceRpm', label: __('Source RPM') },
   { value: 'debugRpm', label: __('Debug RPM') },
   { value: 'kickstart', label: __('Kickstart') },
-  { value: 'ostree', label: __('OSTree') },
   { value: 'beta', label: __('Beta') },
   { value: 'other', label: __('Other') },
 ];


### PR DESCRIPTION
To test, simply check that "OSTree" is not in the content type drop down list on the Red Hat Repositories page.