### PR TITLE
Fixes #33495 - yum metadata checksum not correct in Pulp

### DIFF
--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -17,6 +17,16 @@ module Katello
           options.merge!(url: url, policy: root.download_policy)
         end
 
+        def publication_options(repository_version)
+          options = super(repository_version)
+          options.merge(
+            {
+              metadata_checksum_type: root.checksum_type,
+              package_checksum_type: root.checksum_type
+            }
+          )
+        end
+
         def specific_create_options
           { retain_package_versions: retain_package_versions_count }
         end

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -12,6 +12,16 @@ module Katello
             @proxy = SmartProxy.pulp_primary
           end
 
+          def test_publication_options
+            @repo.version_href = 'a_version_href'
+            @repo.root.checksum_type = 'sha1'
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            publication_options = service.publication_options(@repo.version_href)
+            assert_equal 'a_version_href', publication_options[:repository_version]
+            assert_equal 'sha1', publication_options[:metadata_checksum_type]
+            assert_equal 'sha1', publication_options[:package_checksum_type]
+          end
+
           def test_remote_options
             @repo.root.url = "http://foo.com/bar/"
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)


### PR DESCRIPTION
To test:

1) Sync a repo and choose a "Yum Metadata Checksum" such as "sha1".
2) Check the repo's `publication_href` in Pulp:
```
pulp rpm publication show --href <href>
```
3) See that, without my PR, the "metadata_checksum_type" and "package_checksum_type" do not match what is on the Katello repo.