### PR TITLE
Refs #33496 - increase qpid connection security

### DIFF
--- a/app/lib/katello/qpid/connection.rb
+++ b/app/lib/katello/qpid/connection.rb
@@ -74,7 +74,7 @@ module Katello
       def initialize(url:, ssl_cert_file:, ssl_key_file:, ssl_ca_file:)
         @url = url
         ssl_domain = ::Qpid::Proton::SSLDomain.new(::Qpid::Proton::SSLDomain::MODE_CLIENT)
-        ssl_domain.peer_authentication(::Qpid::Proton::SSLDomain::ANONYMOUS_PEER)
+        ssl_domain.peer_authentication(::Qpid::Proton::SSLDomain::VERIFY_PEER)
         ssl_domain.credentials(ssl_cert_file, ssl_key_file, nil) if ssl_cert_file && ssl_key_file
         ssl_domain.trusted_ca_db(ssl_ca_file) if ssl_ca_file
         @connection_options = {


### PR DESCRIPTION
qpid_proton 0.34 defaulted to "ANONYMOUS_PEER", which means
"do not require a certificate nor cipher authorization"

0.35 switched to "VERIFY_PEER_NAME", which means
"require valid certificate and matching name"

the *name* part is what's breaking our setup, but we still can verify
the certificate! so let's use "VERIFY_PEER", which means
"require peer to provide a valid identifying certificate"