### PR TITLE
Refs #33496 - set the peers host name to be able to verify it

### DIFF
--- a/app/lib/katello/qpid/connection.rb
+++ b/app/lib/katello/qpid/connection.rb
@@ -74,12 +74,13 @@ module Katello
       def initialize(url:, ssl_cert_file:, ssl_key_file:, ssl_ca_file:)
         @url = url
         ssl_domain = ::Qpid::Proton::SSLDomain.new(::Qpid::Proton::SSLDomain::MODE_CLIENT)
-        ssl_domain.peer_authentication(::Qpid::Proton::SSLDomain::ANONYMOUS_PEER)
+        ssl_domain.peer_authentication(::Qpid::Proton::SSLDomain::VERIFY_PEER_NAME)
         ssl_domain.credentials(ssl_cert_file, ssl_key_file, nil) if ssl_cert_file && ssl_key_file
         ssl_domain.trusted_ca_db(ssl_ca_file) if ssl_ca_file
         @connection_options = {
           ssl_domain: ssl_domain,
-          sasl_allowed_mechs: 'external'
+          sasl_allowed_mechs: 'external',
+          virtual_host: URI.parse(url).host
         }
       end
 


### PR DESCRIPTION
instead of not checking the name in the cert, correctly set it, so that
it actually can be verified

I have no idea why qpid_proton doesn't automatically parse this from the
URL.