### PR TITLE
Fixes #33498 - use CSS to hide tooltips

### DIFF
--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -75,3 +75,22 @@ html .pagination-pf-pagesize.btn-group {
     margin-left: 200px;
   }
 }
+
+@keyframes hideme {
+  0%, 70% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+.tooltip {
+  margin:auto;
+  animation-direction: normal;
+  animation-name: hideme;
+  animation-duration: 2s;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+}


### PR DESCRIPTION
This is a workaround to the other option to address tooltips that are not disappearing after a click. 

The alternative includes replacing existing react table components with newer ones.