### PR TITLE
Fixes #33485 - Content - Errata - Table row expansion

### DIFF
--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -33,6 +33,14 @@ class ReactConnectedSet extends Set {
     this.forceRender();
     return result;
   }
+
+  onToggle(isOpen, id) {
+    if (isOpen) {
+      this.add(id);
+    } else {
+      this.delete(id);
+    }
+  }
 }
 
 const useSet = (initialArry) => {

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Button, Hint, HintBody, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle } from '@patternfly/react-core';
-import { TableVariant, TableText, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { TableVariant, TableText, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 
@@ -21,6 +21,7 @@ export const ErrataTab = () => {
   const dispatch = useDispatch();
 
   const [searchQuery, updateSearchQuery] = useState('');
+  const [rowIsExpanded, setRowIsExpanded] = useState(false);
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
   const toggleBulkAction = () => setIsBulkActionOpen(prev => !prev);
 
@@ -94,7 +95,7 @@ export const ErrataTab = () => {
           <HintBody>
             {__('Errata management functionality on this page is incomplete')}.
             <br />
-            <Button component="a" variant="link" isInline href={urlBuilder(`content_hosts/${hostId}/errata`, '')}>
+            <Button variant="link" isInline href={urlBuilder(`content_hosts/${hostId}/errata`, '')}>
               {__('Visit the previous Errata page')}.
             </Button>
           </HintBody>
@@ -126,8 +127,8 @@ export const ErrataTab = () => {
               <Th />
             </Tr>
           </Thead>
-          <Tbody>
-            {results?.map((erratum) => {
+          <React.Fragment>
+            {results?.map((erratum, rowIndex) => {
                 const {
                   id,
                   errata_id: errataId,
@@ -136,25 +137,44 @@ export const ErrataTab = () => {
                   title,
                 } = erratum;
                 return (
-                  <Tr key={`${id}_${createdAt}`}>
-                    <Td>
-                      <a href={urlBuilder(`errata/${id}`, '')}>{errataId}</a>
-                    </Td>
-                    <Td><ErrataType {...erratum} /></Td>
-                    <Td><ErrataSeverity {...erratum} /></Td>
-                    <Td><TableText wrapModifier="truncate">{title}</TableText></Td>
-                    <Td key={publishedAt}><IsoDate date={publishedAt} /></Td>
-                    <Td
-                      key={`rowActions-${id}`}
-                      actions={{
-                          items: rowActions,
-                        }}
-                    />
-                  </Tr>
+                  <Tbody isExpanded={rowIsExpanded} key={`${id}_${createdAt}`}>
+                    <Tr>
+                      <Td
+                        expand={{
+                          rowIndex: rowIndex + 1,
+                          isExpanded: rowIsExpanded,
+                          onToggle: (_event, rInx, isOpen, rowData, extraData) => {
+                            console.log({
+                              rInx, isOpen, rowData, extraData,
+                            });
+                            setRowIsExpanded(isOpen);
+                          },
+                      }}
+                      />
+                      <Td>
+                        <a href={urlBuilder(`errata/${id}`, '')}>{errataId}</a>
+                      </Td>
+                      <Td><ErrataType {...erratum} /></Td>
+                      <Td><ErrataSeverity {...erratum} /></Td>
+                      <Td><TableText wrapModifier="truncate">{title}</TableText></Td>
+                      <Td key={publishedAt}><IsoDate date={publishedAt} /></Td>
+                      <Td
+                        key={`rowActions-${id}`}
+                        actions={{
+                            items: rowActions,
+                          }}
+                      />
+                    </Tr>
+                    <Tr key="child_row" isExpanded={rowIsExpanded}>
+                      <Td>
+                        <ExpandableRowContent>{__('hi im expandable!')}</ExpandableRowContent>
+                      </Td>
+                    </Tr>
+                  </Tbody>
                 );
               })
               }
-          </Tbody>
+          </React.Fragment>
         </TableWrapper>
       </div>
     </div>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -135,13 +135,13 @@ export const ErrataTab = () => {
         >
           <Thead>
             <Tr>
-              <Th key="expand-thingy" />
+              <Th key="expand-carat" />
               {columnHeaders.map(col =>
                 <Th key={col}>{col}</Th>)}
               <Th />
             </Tr>
           </Thead>
-          <React.Fragment>
+          <>
             {results?.map((erratum, rowIndex) => {
                 const {
                   id,
@@ -197,7 +197,7 @@ export const ErrataTab = () => {
                 );
               })
               }
-          </React.Fragment>
+          </>
         </TableWrapper>
       </div>
     </div>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -158,13 +158,7 @@ export const ErrataTab = () => {
                         expand={{
                           rowIndex,
                           isExpanded,
-                          onToggle: (_event, rInx, isOpen) => {
-                            if (isOpen) {
-                              expandedErrata.add(id);
-                            } else {
-                              expandedErrata.delete(id);
-                            }
-                          },
+                          onToggle: (_event, _rInx, isOpen) => expandedErrata.onToggle(isOpen, id),
                       }}
                       />
                       <Td>

--- a/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionContents.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionContents.js
@@ -31,8 +31,7 @@ const ErratumExpansionContents = ({ erratum }) => {
     {
       name: __('Module streams'),
       id: 'module_streams',
-      // module streams should already have name and id fields, so no need to map
-      children: moduleStreams,
+      children: moduleStreams.map(({ name, stream, id }) => ({ name: `${name}:${stream}`, id })),
     },
   ];
   return (

--- a/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionContents.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionContents.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  TreeView,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const ErratumExpansionContents = ({ erratum }) => {
+  const {
+    bugs, cves, packages,
+    module_streams: moduleStreams,
+  } = erratum;
+  const [activeItems, setActiveItems] = useState(null);
+  const options = [
+    {
+      name: __('Bugs'),
+      id: 'bugs',
+      children: bugs.map(bug => ({ name: bug.bug_id, id: bug.bug_id, ...bug })),
+    },
+    {
+      name: __('CVEs'),
+      id: 'cves',
+      children: cves.map(cve => ({ name: cve.cve_id, id: cve.cve_id, ...cve })),
+    },
+    {
+      name: __('Packages'),
+      id: 'packages',
+      // packages is just a list of strings
+      children: packages.map((packageName, idx) => ({ name: packageName, id: idx })),
+    },
+    {
+      name: __('Module streams'),
+      id: 'module_streams',
+      // module streams should already have name and id fields, so no need to map
+      children: moduleStreams,
+    },
+  ];
+  return (
+    <TreeView
+      data={options}
+      activeItems={activeItems}
+      onSelect={(evt, treeViewItem) => setActiveItems([treeViewItem])}
+      hasBadges
+    />
+  );
+};
+
+ErratumExpansionContents.propTypes = {
+  erratum: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    summary: PropTypes.string,
+    solution: PropTypes.string,
+    bugs: PropTypes.arrayOf(PropTypes.object),
+    cves: PropTypes.arrayOf(PropTypes.object),
+    packages: PropTypes.arrayOf(PropTypes.string),
+    module_streams: PropTypes.arrayOf(PropTypes.object),
+  }).isRequired,
+};
+
+export default ErratumExpansionContents;

--- a/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionDetail.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErratumExpansionDetail.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm as Term,
+  DescriptionListGroup,
+  DescriptionListDescription as Description,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const ErratumExpansionDetail = ({ erratum }) => {
+  const {
+    title: synopsis,
+    description,
+    summary, solution,
+  } = erratum;
+  const [showDescription, setShowDescription] = useState(false);
+  // whiteSpace: 'pre-line' will convert \n to line breaks
+  return (
+    <DescriptionList>
+      <DescriptionListGroup>
+        <Term>Synopsis</Term>
+        <Description>{synopsis}</Description>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <Term>Summary</Term>
+        <Description>{summary}</Description>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <Term>Solution</Term>
+        <Description>{solution}</Description>
+      </DescriptionListGroup>
+      {showDescription &&
+        <DescriptionListGroup>
+          <Term>Full description</Term>
+          <Description>
+            <span style={{ whiteSpace: 'pre-line' }}>{description}</span>
+          </Description>
+          <Term>
+            <Button variant="link" onClick={() => setShowDescription(false)}>
+              {__('Hide description')}
+            </Button>
+          </Term>
+        </DescriptionListGroup>
+      }
+      {!showDescription &&
+        <DescriptionListGroup>
+          <Term>
+            <Button variant="link" onClick={() => setShowDescription(true)}>
+              {__('Show full description')}
+            </Button>
+          </Term>
+        </DescriptionListGroup>
+      }
+    </DescriptionList>
+  );
+};
+
+ErratumExpansionDetail.propTypes = {
+  erratum: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    summary: PropTypes.string,
+    solution: PropTypes.string,
+  }).isRequired,
+};
+
+export default ErratumExpansionDetail;

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
@@ -13,6 +13,9 @@
         "type": "security",
         "host_id": 1,
         "errata_id": "Errata101",
+        "description": "The microcode_ctl packages provide microcode updates for Intel.",
+        "solution": "Before applying this update, make sure all previously released errata relevant to your system have been applied.\n\nFor details on how to apply this update, refer to:\n\nhttps://access.redhat.com/articles/11258",
+        "summary": "An update for microcode_ctl is now available for Red Hat Enterprise Linux 7. Red Hat Product Security has rated this update as having a security impact of Important. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
         "cves": [{
             "cve_id": "CVE-2021-25217",
             "href": "https://www.redhat.com/security/data/cve/CVE-2021-25217.html"

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
@@ -12,7 +12,26 @@
         "title": "Errata101",
         "type": "security",
         "host_id": 1,
-        "errata_id": "Errata101"
+        "errata_id": "Errata101",
+        "cves": [{
+            "cve_id": "CVE-2021-25217",
+            "href": "https://www.redhat.com/security/data/cve/CVE-2021-25217.html"
+          }
+        ],
+        "bugs": [
+          {
+            "bug_id": "1963258",
+            "href": "https://bugzilla.redhat.com/show_bug.cgi?id=1963258"
+          }
+        ],
+        "packages": [
+              "dhclient-4.2.5-83.el7_9.1.x86_64",
+              "dhcp-4.2.5-83.el7_9.1.x86_64",
+              "dhcp-common-4.2.5-83.el7_9.1.x86_64",
+              "dhcp-libs-4.2.5-83.el7_9.1.i686",
+              "dhcp-libs-4.2.5-83.el7_9.1.x86_64"
+            ],
+        "module_streams": []
     },
     {
         "id": 10,
@@ -20,7 +39,11 @@
         "title": "Errata102",
         "type": "bugfix",
         "host_id": 1,
-        "errata_id": "Errata102"
+        "errata_id": "Errata102",
+        "bugs": [],
+        "cves": [],
+        "packages": [],
+        "module_streams": []
     },
     {
         "id": 18,
@@ -28,7 +51,11 @@
         "title": "Errata103",
         "type": "enhancement",
         "host_id": 1,
-        "errata_id": "Errata103"
+        "errata_id": "Errata103",
+        "bugs": [],
+        "cves": [],
+        "packages": [],
+        "module_streams": []
      }
   ]
 }

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -7,7 +7,7 @@ import { foremanApi } from '../../../../../services/api';
 import { HOST_ERRATA_KEY } from '../../HostErrata/HostErrataConstants';
 import { ErrataTab } from '../ErrataTab';
 
-const mockTraceData = require('./errata.fixtures.json');
+const mockErrataData = require('./errata.fixtures.json');
 
 const mockHostDetails = { id: 1 };
 const renderOptions = {
@@ -32,7 +32,7 @@ let searchDelayScope;
 let autoSearchScope;
 
 beforeEach(() => {
-  const { results } = mockTraceData;
+  const { results } = mockErrataData;
   [firstErrata] = results;
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
   autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', true);
@@ -51,7 +51,7 @@ test('Can call API for errata and show on screen on page load', async (done) => 
   // return tracedata results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
-    .reply(200, mockTraceData);
+    .reply(200, mockErrataData);
 
   const { getAllByText } = renderWithRedux(<ErrataTab />, renderOptions);
 

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import * as reactRedux from 'react-redux';
 import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
-import { STATUS } from 'foremanReact/constants';
 import nock, { nockInstance, assertNockRequest, mockForemanAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
 import { HOST_ERRATA_KEY } from '../../HostErrata/HostErrataConstants';
@@ -9,7 +7,6 @@ import { ErrataTab } from '../ErrataTab';
 
 const mockErrataData = require('./errata.fixtures.json');
 
-const mockHostDetails = { id: 1 };
 const renderOptions = {
   apiNamespace: HOST_ERRATA_KEY,
   initialState: {
@@ -74,11 +71,6 @@ test('Can handle no errata being present', async (done) => {
     results: [],
   };
 
-  // Mocking our host ID, results, and status in the test redux store
-  const useSelector = jest.spyOn(reactRedux, 'useSelector');
-  useSelector.mockReturnValueOnce(mockHostDetails).mockReturnValueOnce(noResults)
-    .mockReturnValueOnce(STATUS.RESOLVED);
-
   const scope = nockInstance
     .get(hostErrata)
     .reply(200, noResults);
@@ -89,6 +81,47 @@ test('Can handle no errata being present', async (done) => {
   await patientlyWaitFor(() => expect(queryByText('This host does not have any installable errata.')).toBeInTheDocument());
   // Assert request was made and completed, see helper function
   assertNockRequest(autocompleteScope);
-  useSelector.mockClear(); // Clear the mock values out
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+});
+
+test('Can display expanded errata details', async (done) => {
+  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+
+  // return tracedata results when we look for errata
+  const scope = nockInstance
+    .get(hostErrata)
+    .reply(200, mockErrataData);
+
+  const {
+    getByText,
+    queryByText,
+    getAllByText,
+    getAllByLabelText,
+  } = renderWithRedux(<ErrataTab />, renderOptions);
+
+  // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText(firstErrata.severity)[0]).toBeInTheDocument());
+  const firstExpansion = getAllByLabelText('Details')[0];
+
+  firstExpansion.click();
+  expect(getAllByText('CVEs').length).toBeGreaterThan(0);
+  // the errata details should now be visible
+  expect(getByText(firstErrata.summary)).toBeVisible();
+
+  const cveTreeItem = getAllByText('CVEs')[0];
+  expect(cveTreeItem).toBeVisible();
+  cveTreeItem.click();
+  // the CVE should now be visible
+  expect(getByText(firstErrata.cves[0].cve_id)).toBeInTheDocument();
+  cveTreeItem.click();
+  // the CVE should now have disappeared
+  expect(queryByText(firstErrata.cves[0].cve_id)).not.toBeInTheDocument();
+
+  firstExpansion.click();
+  // the errata details should now be hidden
+  expect(getByText(firstErrata.summary)).not.toBeVisible();
+  // Assert request was made and completed, see helper function
+  assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });


### PR DESCRIPTION
- [x] tests

This PR adds expandable rows to the new host details Errata table.
* Left column: Tree view with errata contents
* Right column: Synopsis and expandable full description

I used only data we already have in the response, so additional API calls were not needed.

Expanded rows are remembered even when changing pages. Is this desired?


![errata_expansion](https://user-images.githubusercontent.com/22042343/133644244-29bdded5-4f98-4835-9dcb-afecde529647.png)
