### PR TITLE
Fixes #33509 - show added content counts on sync

### DIFF
--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -13,11 +13,22 @@ module Actions
           source_repository = ::Katello::Repository.find(input[:source_repository_id]) if input[:source_repository_id]
           repo = ::Katello::Repository.find(input[:id])
 
+          initial_counts = {}
+          repo.repository_type.primary_content_types.each do |content_type|
+            initial_counts[content_type.label] = content_type.model_class.in_repositories(repo).count
+          end
+
           if input[:force_index] || (repo.last_contents_changed >= repo.last_indexed)
             repo.index_content(source_repository: source_repository, full_index: input[:full_index].present?)
             repo.update(:last_indexed => DateTime.now)
           else
             output[:index_skipped] = true
+          end
+
+          output[:new_content] = {}
+          repo.repository_type.primary_content_types.each do |content_type|
+            new_count = content_type.model_class.in_repositories(repo).count
+            output[:new_content][content_type.label] = new_count - initial_counts[content_type.label]
           end
         end
       end

--- a/app/lib/actions/pulp3/repository/presenters/abstract_sync_presenter.rb
+++ b/app/lib/actions/pulp3/repository/presenters/abstract_sync_presenter.rb
@@ -15,6 +15,24 @@ module Actions
             fail NotImplementedError
           end
 
+          def index_action
+            plan = action.execution_plan
+            index_step = plan.run_steps.find { |s| s.action_class == Actions::Katello::Repository::IndexContent }
+            index_step&.action(plan)
+          end
+
+          def added_content_message
+            if (content_added = index_action&.output&.[](:new_content))
+              content_added = content_added.select { |_type, number| number > 0 }
+              if content_added&.any?
+                count_messages = content_added.map { |type, number| "#{type.to_s.humanize.pluralize}: #{number}" }
+                _("Added %s") % count_messages.join(', ')
+              else
+                _("No content added.")
+              end
+            end
+          end
+
           def sync_task
             tasks = action.external_task.select do |task|
               if task.key? 'name'

--- a/app/lib/actions/pulp3/repository/presenters/content_unit_presenter.rb
+++ b/app/lib/actions/pulp3/repository/presenters/content_unit_presenter.rb
@@ -12,12 +12,12 @@ module Actions
           def humanized_details
             ret = []
             ret << _("Cancelled.") if cancelled?
+            ret << added_content_message
             if total_units == 0
               ret << _("Waiting to start.")
             else
               ret << _("Total steps: ") + "#{finished_units}/#{total_units}"
             end
-
             ret << "--------------------------------"
             progress_reports = sync_task.try(:[], 'progress_reports') || []
             progress_reports = progress_reports.sort_by { |pr| pr.try(:[], 'message') }
@@ -29,7 +29,7 @@ module Actions
               end
             end
 
-            ret.join("\n")
+            ret.compact.join("\n")
           end
 
           def total_units

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -43,6 +43,12 @@ module Katello
       @generic_remote_options.sort_by(&:name)
     end
 
+    def primary_content_types
+      found = self.content_types.select { |type| type.primary_content }
+      found = self.content_types if found.empty?
+      found
+    end
+
     def translated_generic_remote_options
       translated = generic_remote_options.deep_dup
       translated.map do |option|
@@ -120,7 +126,8 @@ module Katello
     end
 
     class ContentType
-      attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable, :index_on_pulp3
+      attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable,
+                    :primary_content, :index_on_pulp3
 
       def initialize(options)
         self.model_class = options[:model_class]
@@ -131,6 +138,7 @@ module Katello
         self.index_on_pulp3 = options[:index_on_pulp3].nil? ? true : options[:index_on_pulp3]
         self.uploadable = options[:uploadable] || false
         self.removable = options[:removable] || false
+        self.primary_content = options[:primary_content] || false
       end
 
       def label

--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -32,7 +32,8 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE) do
   content_type Katello::DockerTag,
                :priority => 3,
                :pulp2_service_class => ::Katello::Pulp::DockerTag,
-               :pulp3_service_class => ::Katello::Pulp3::DockerTag
+               :pulp3_service_class => ::Katello::Pulp3::DockerTag,
+               :primary_content => true
   content_type Katello::DockerBlob,
                :priority => 4,
                :pulp2_service_class => ::Katello::Pulp::DockerBlob,

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -23,6 +23,7 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
     :priority => 1,
     :pulp2_service_class => ::Katello::Pulp::Rpm,
     :pulp3_service_class => ::Katello::Pulp3::Rpm,
+    :primary_content => true,
     :removable => true,
     :uploadable => true
   content_type Katello::ModuleStream,
@@ -31,7 +32,8 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
     :pulp3_service_class => ::Katello::Pulp3::ModuleStream
   content_type Katello::Erratum, :priority => 3,
     :pulp2_service_class => ::Katello::Pulp::Erratum,
-    :pulp3_service_class => ::Katello::Pulp3::Erratum
+    :pulp3_service_class => ::Katello::Pulp3::Erratum,
+    :primary_content => true
   content_type Katello::PackageGroup,
     :pulp2_service_class => ::Katello::Pulp::PackageGroup,
     :pulp3_service_class => ::Katello::Pulp3::PackageGroup

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -4,6 +4,14 @@ class Dynflow::Testing::DummyPlannedAction
   attr_accessor :error
 end
 
+class Dynflow::Testing::DummyExecutionPlan
+  attr_accessor :error
+
+  def run_steps
+    []
+  end
+end
+
 module ::Actions::Katello::Repository
   class TestBase < ActiveSupport::TestCase
     include Dynflow::Testing

--- a/test/actions/pulp3/orchestration/yum_sync_test.rb
+++ b/test/actions/pulp3/orchestration/yum_sync_test.rb
@@ -72,11 +72,13 @@ module ::Actions::Pulp3
       @repo.index_content #should clear out the repo
       assert_empty @repo.rpms
 
-      ForemanTasks.sync_task(::Actions::Katello::Repository::Sync, @repo, skip_metadata_check: true)
+      task = ForemanTasks.sync_task(::Actions::Katello::Repository::Sync, @repo, skip_metadata_check: true)
 
       @repo.reload
       assert_equal old_url, @repo.version_href
       refute_empty @repo.rpms
+
+      assert_equal "Added Rpms: 32, Errata: 4", task.get_humanized(:humanized_output).split("\n").first
     ensure
       SETTINGS[:katello][:katello_applicability] = false
     end


### PR DESCRIPTION
This adds a new content type attribute called primary_content
if marked to true, during indexing the count of added units
will be recorded on the index steps output and added
to the task output along with the other status messages