### PR TITLE
Fixes #33510 - Composite CV publishing w/ modify api is broken

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
@@ -15,7 +15,7 @@ module Actions
                 if filter_ids.present? || rpm_filenames.present?
                   copy_action = plan_action(Actions::Pulp3::Repository::CopyContent, source_repositories.first, smart_proxy, target_repo,
                                             filter_ids: filter_ids, solve_dependencies: solve_dependencies,
-                                            rpm_filenames: rpm_filenames)
+                                            rpm_filenames: rpm_filenames, remove_all: true)
                   plan_action(Actions::Pulp3::Repository::SaveVersion, target_repo, tasks: copy_action.output[:pulp_tasks])
                 else
                   #if we are not filtering, copy the version to the cv repository, and the units for each additional repo
@@ -26,7 +26,7 @@ module Actions
                   source_repositories[1..-1].each do |source_repo|
                     copy_actions << plan_action(Actions::Pulp3::Repository::CopyContent, source_repo, smart_proxy, target_repo,
                                                 filter_ids: filter_ids, solve_dependencies: solve_dependencies,
-                                                rpm_filenames: rpm_filenames)
+                                                rpm_filenames: rpm_filenames, remove_all: false)
                   end
                   plan_action(Actions::Pulp3::Repository::SaveVersion, target_repo, tasks: copy_actions.last.output[:pulp_tasks])
                 end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -191,12 +191,13 @@ module Katello
           tasks
         end
 
-        def copy_units(source_repository, content_unit_hrefs)
+        def copy_units(source_repository, content_unit_hrefs, remove_all)
+          remove_all = true if remove_all.nil?
           tasks = []
 
           if content_unit_hrefs.sort!.any?
             content_unit_hrefs += packageenvironments({ :repository_version => source_repository.version_href }).map(&:pulp_href).sort
-            first_slice = true
+            first_slice = remove_all
             content_unit_hrefs.each_slice(UNIT_LIMIT) do |slice|
               tasks << add_content(slice, first_slice)
               first_slice = false
@@ -351,7 +352,7 @@ module Katello
             content_unit_hrefs += additional_content_hrefs(source_repository, content_unit_hrefs)
           end
           content_unit_hrefs += source_repository.srpms.pluck(:pulp_id)
-          copy_units(source_repository, content_unit_hrefs.uniq)
+          copy_units(source_repository, content_unit_hrefs.uniq, options[:remove_all])
         end
 
         def modular_packages(source_repository, filters)

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -122,7 +122,7 @@ module Actions
                                :source_repository_id => file_repo2.id,
                                :target_repository_id => cloned_repo.id,
                                :smart_proxy_id => primary.id,
-                               :filter_ids => [], :solve_dependencies => false, :rpm_filenames => nil)
+                               :filter_ids => [], :solve_dependencies => false, :rpm_filenames => nil, :remove_all => false)
     end
   end
 end


### PR DESCRIPTION
Composite CV publishes were wrong because `copy_units` was assuming to clear out the destination repo before starting copying.  In the composite case, the destination repo will have content from the previous source repo in it.

To test:

Create a composite content view from two content views with multiple repositories in them. Ensure that all content is in the resulting composite content view version.