### PR TITLE
Fixes #33435 - Other Content Types Landing Page UI

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -428,6 +428,11 @@ module Katello
       end
     end
 
+    api :GET, "/content_types", N_("Return the enabled content types")
+    def content_types
+      render :json => Katello::RepositoryTypeManager.enabled_content_types.map { |type| Katello::RepositoryTypeManager.find_content_type(type) }
+    end
+
     protected
 
     def find_product

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -127,7 +127,7 @@ module Katello
 
     class ContentType
       attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable,
-                    :primary_content, :index_on_pulp3
+                    :primary_content, :index_on_pulp3, :generic_browser
 
       def initialize(options)
         self.model_class = options[:model_class]
@@ -139,10 +139,18 @@ module Katello
         self.uploadable = options[:uploadable] || false
         self.removable = options[:removable] || false
         self.primary_content = options[:primary_content] || false
+        self.generic_browser = options[:generic_browser]
       end
 
       def label
         self.model_class::CONTENT_TYPE
+      end
+
+      def as_json(_options)
+        {
+          label: label,
+          generic_browser: generic_browser
+        }
       end
     end
 
@@ -150,13 +158,7 @@ module Katello
       attr_accessor :pulp3_api, :pulp3_model, :content_type, :filename_key, :duplicates_allowed
 
       def initialize(options)
-        self.model_class = options[:model_class]
-        self.priority = options[:priority] || 99
-        self.pulp3_service_class = options[:pulp3_service_class]
-        self.index = options[:index].nil? ? true : options[:index]
-        self.index_on_pulp3 = options[:index_on_pulp3].nil? ? true : options[:index_on_pulp3]
-        self.uploadable = options[:uploadable] || false
-        self.removable = options[:removable] || false
+        super
         self.pulp3_api = options[:pulp3_api]
         self.pulp3_model = options[:pulp3_model]
         self.content_type = options[:content_type]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Katello::Engine.routes.draw do
   match '/ansible_collections' => 'react#index', :via => [:get]
   match '/ansible_collections/*page' => 'react#index', :via => [:get]
 
+  match '/content' => 'react#index', :via => [:get]
+
   match '/labs' => 'react#index', :via => [:get]
   match '/labs/*page' => 'react#index', :via => [:get]
   match '/organization_select' => 'react#index', :via => [:get]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -318,6 +318,7 @@ Katello::Engine.routes.draw do
           collection do
             get :auto_complete_search
             get :repository_types
+            get :content_types
           end
           member do
             put :republish

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -240,7 +240,7 @@ module Katello
                          {
                            'katello/products' => [:auto_complete, :auto_complete_search],
                            'katello/api/v2/products' => [:index, :show, :auto_complete_search],
-                           'katello/api/v2/repositories' => [:index, :show, :repository_types, :auto_complete_search, :cancel],
+                           'katello/api/v2/repositories' => [:index, :show, :repository_types, :content_types, :auto_complete_search, :cancel],
                            'katello/api/v2/packages' => [:index, :show, :auto_complete_search, :auto_complete_name, :auto_complete_arch, :compare],
                            'katello/api/v2/srpms' => [:index, :show, :auto_complete_search, :compare],
                            'katello/api/v2/debs' => [:index, :show, :auto_complete_search, :auto_complete_name, :auto_complete_arch, :compare],

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -170,6 +170,16 @@ Foreman::Plugin.register :katello do
          :engine => Katello::Engine,
          :turbolinks => false,
          :if => lambda { ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::ANSIBLE_COLLECTION_TYPE) }
+
+    menu :top_menu,
+         :other_content_types,
+         :caption => N_('Other Content Types'),
+         :url => '/content',
+         :url_hash => {:controller => '/',
+                       :action => ''},
+         :engine => Katello::Engine,
+         :turbolinks => false,
+         :if => lambda { true }
   end
 
   menu :top_menu,

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -42,6 +42,7 @@ Katello::RepositoryTypeManager.register('python') do
                        removable: true,
                        uploadable: true,
                        duplicates_allowed: false,
-                       filename_key: :filename
+                       filename_key: :filename,
+                       generic_browser: true
   default_managed_content_type :python_package
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -65,6 +65,17 @@ module Katello
       end
     end
 
+    def test_content_types
+      get :content_types
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal RepositoryTypeManager.enabled_content_types.map { |type| RepositoryTypeManager.find_content_type(type) }.size, body.size
+      body.each do |content|
+        assert RepositoryTypeManager.find_content_type(content["label"]).present?
+      end
+    end
+
     def test_repository_types_with_view_products_permission
       User.current = setup_user_with_permissions(:view_products, User.find(users(:restricted).id))
       get :repository_types

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -11,6 +11,7 @@ import AnsibleCollections from '../../scenes/AnsibleCollections';
 import AnsibleCollectionDetails from '../../scenes/AnsibleCollections/Details';
 import ContentViews from '../../scenes/ContentViews';
 import ContentViewDetails from '../../scenes/ContentViews/Details';
+import Content from '../../scenes/Content';
 import withHeader from './withHeaders';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -60,5 +61,9 @@ export const links = [
     path: 'labs/content_views/:id([0-9]+)',
     component: withHeader(ContentViewDetails, { title: __('Content View Details') }),
     exact: false,
+  },
+  {
+    path: 'content',
+    component: WithOrganization(withHeader(Content, { title: __('Other Content Types') })),
   },
 ];

--- a/webpack/scenes/Content/ContentActions.js
+++ b/webpack/scenes/Content/ContentActions.js
@@ -1,0 +1,18 @@
+import { API_OPERATIONS, get } from 'foremanReact/redux/API';
+import api from '../../services/api';
+import { CONTENT_KEY, CONTENT_TYPES_KEY } from './ContentConstants';
+
+export const getContent = (contentType, params) => get({
+  type: API_OPERATIONS.GET,
+  key: CONTENT_KEY,
+  params,
+  url: api.getApiUrl(`/${contentType}`),
+});
+
+export const getContentTypes = () => get({
+  type: API_OPERATIONS.GET,
+  key: CONTENT_TYPES_KEY,
+  url: api.getApiUrl('/repositories/content_types'),
+});
+
+export default getContent;

--- a/webpack/scenes/Content/ContentConfig.js
+++ b/webpack/scenes/Content/ContentConfig.js
@@ -1,0 +1,11 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export default () => [
+  {
+    names: { title: __('Python Packages'), plural: 'python_packages', singular: 'python_package' },
+    columnHeaders: [
+      { title: __('Name'), getProperty: unit => unit?.name },
+      { title: __('Version'), getProperty: unit => unit?.version },
+    ],
+  },
+];

--- a/webpack/scenes/Content/ContentConstants.js
+++ b/webpack/scenes/Content/ContentConstants.js
@@ -1,0 +1,3 @@
+export const CONTENT_KEY = 'CONTENT';
+
+export const CONTENT_TYPES_KEY = 'CONTENT_TYPES';

--- a/webpack/scenes/Content/ContentPage.js
+++ b/webpack/scenes/Content/ContentPage.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { Grid, GridItem, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { isEmpty } from 'lodash';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { STATUS } from 'foremanReact/constants';
+import ContentTable from './Table/ContentTable';
+import { selectContentTypes, selectContentTypesStatus } from './ContentSelectors';
+import ContentConfig from './ContentConfig';
+import { getContentTypes } from './ContentActions';
+import Loading from '../../components/Loading';
+import EmptyStateMessage from '../../components/Table/EmptyStateMessage';
+
+const ContentPage = () => {
+  const dispatch = useDispatch();
+  const contentTypesResponse = useSelector(selectContentTypes);
+  const contentTypesStatus = useSelector(selectContentTypesStatus);
+  const [selectedContentType, setSelectedContentType] = useState(null);
+  const [contentTypes, setContentTypes] = useState(null);
+
+  useEffect(() => {
+    // Set list of enabled content types and initial content type
+    const buildContentTypes = () => {
+      const types = {};
+      contentTypesResponse.forEach((type) => {
+        if (type.generic_browser) {
+          const typeConfig = ContentConfig().find(config => config.names.singular === type.label);
+          if (typeConfig) {
+            const { names } = typeConfig;
+            types[names.title] = [names.singular, names.plural];
+          }
+        }
+      });
+      return types;
+    };
+
+    if (contentTypesStatus === STATUS.RESOLVED) {
+      const enabledContentTypes = buildContentTypes();
+      setSelectedContentType(Object.keys(enabledContentTypes)[0]);
+      setContentTypes(enabledContentTypes);
+    }
+  }, [contentTypesStatus, contentTypesResponse]);
+
+  useEffect(() => {
+    dispatch(getContentTypes());
+  }, [dispatch]);
+
+  if (contentTypesStatus === STATUS.PENDING) {
+    return <Loading />;
+  } else if (isEmpty(contentTypes)) {
+    return (
+      <EmptyStateMessage
+        title="Browsable content types not found."
+        body="No content types are enabled for this page."
+      />
+    );
+  }
+
+  return (
+    <Grid className="grid-with-margin">
+      <GridItem span={12}>
+        <TextContent>
+          <Text component={TextVariants.h1}>{__(`${selectedContentType}`)}</Text>
+        </TextContent>
+      </GridItem>
+      <GridItem span={12}>
+        <ContentTable {...{ selectedContentType, setSelectedContentType, contentTypes }} />
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default ContentPage;

--- a/webpack/scenes/Content/ContentSelectors.js
+++ b/webpack/scenes/Content/ContentSelectors.js
@@ -1,0 +1,25 @@
+import {
+  selectAPIStatus,
+  selectAPIError,
+  selectAPIResponse,
+} from 'foremanReact/redux/API/APISelectors';
+import { STATUS } from 'foremanReact/constants';
+import { CONTENT_KEY, CONTENT_TYPES_KEY } from './ContentConstants';
+
+export const selectContent = state =>
+  selectAPIResponse(state, CONTENT_KEY) || {};
+
+export const selectContentStatus = state =>
+  selectAPIStatus(state, CONTENT_KEY) || STATUS.PENDING;
+
+export const selectContentError = state =>
+  selectAPIError(state, CONTENT_KEY);
+
+export const selectContentTypes = state =>
+  selectAPIResponse(state, CONTENT_TYPES_KEY) || {};
+
+export const selectContentTypesStatus = state =>
+  selectAPIStatus(state, CONTENT_TYPES_KEY) || STATUS.PENDING;
+
+export const selectContentTypesError = state =>
+  selectAPIError(state, CONTENT_TYPES_KEY);

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -1,0 +1,90 @@
+import React, { useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import PropTypes from 'prop-types';
+import TableWrapper from '../../../components/Table/TableWrapper';
+import { getContent } from '../ContentActions';
+import { selectContent, selectContentStatus, selectContentError } from '../ContentSelectors';
+import SelectableDropdown from '../../../components/SelectableDropdown';
+import contentConfig from '../ContentConfig';
+
+const ContentTable = ({ selectedContentType, setSelectedContentType, contentTypes }) => {
+  const status = useSelector(selectContentStatus);
+  const error = useSelector(selectContentError);
+  const response = useSelector(selectContent);
+  const [searchQuery, updateSearchQuery] = useState('');
+  const { results, ...metadata } = response;
+
+  const { columnHeaders } = contentConfig().find(type =>
+    type.names.singular === contentTypes[selectedContentType][0]);
+
+  /* eslint-disable react/no-array-index-key */
+  function buildRows(details) {
+    const rows = [];
+    if (details) {
+      columnHeaders.forEach((header, index) =>
+        rows.push(<Td key={index}>{header.getProperty(details)}</Td>));
+    }
+    return rows;
+  }
+
+  return (
+    <TableWrapper
+      {...{
+        metadata,
+        searchQuery,
+        updateSearchQuery,
+        error,
+        status,
+      }}
+      key={selectedContentType}
+      variant={TableVariant.compact}
+      autocompleteEndpoint={`/${contentTypes[selectedContentType][1]}/auto_complete_search`}
+      emptyContentTitle={__(`You currently don't have any ${selectedContentType}.`)}
+      emptySearchTitle={__(`No matching ${selectedContentType} found`)}
+      emptyContentBody={__(`${selectedContentType} will appear here when created.`)}
+      emptySearchBody={__('Try changing your search settings.')}
+      fetchItems={useCallback(
+        params =>
+          getContent(contentTypes[selectedContentType][1], params),
+        [contentTypes, selectedContentType],
+      )}
+      actionButtons={
+        <SelectableDropdown
+          items={Object.keys(contentTypes)}
+          title={__('Type')}
+          selected={selectedContentType}
+          setSelected={setSelectedContentType}
+          placeholderText={__('Type')}
+          loading={false}
+          error={false}
+        />
+      }
+    >
+      <Thead>
+        <Tr>
+          {columnHeaders.map(col =>
+            <Th key={col.title}>{col.title}</Th>)}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {results?.map(details => (
+          <Tr key={`${details.id}`}>
+            {buildRows(details)}
+          </Tr>
+        ))
+        }
+      </Tbody>
+    </TableWrapper>
+  );
+};
+
+ContentTable.propTypes = {
+  selectedContentType: PropTypes.string.isRequired,
+  setSelectedContentType: PropTypes.func.isRequired,
+  contentTypes: PropTypes.objectOf(PropTypes.array).isRequired,
+};
+
+export default ContentTable;
+

--- a/webpack/scenes/Content/Table/index.js
+++ b/webpack/scenes/Content/Table/index.js
@@ -1,0 +1,3 @@
+import ContentTable from './ContentTable';
+
+export default ContentTable;

--- a/webpack/scenes/Content/__tests__/contentTable.test.js
+++ b/webpack/scenes/Content/__tests__/contentTable.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
+import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../test-utils/nockWrapper';
+import api from '../../../services/api';
+import ContentPage from '../ContentPage';
+
+const contentTypesResponse = require('./contentTypes.fixtures.json');
+const pythonPackagesResponse = require('./pythonPackages.fixtures.json');
+
+const contentTypesPath = api.getApiUrl('/repositories/content_types');
+const pythonPackagesPath = api.getApiUrl('/python_packages');
+
+let searchDelayScope;
+let autoSearchScope;
+
+beforeEach(() => {
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', true);
+});
+
+afterEach(() => {
+  nock.cleanAll();
+  assertNockRequest(autoSearchScope);
+  assertNockRequest(searchDelayScope);
+});
+
+test('Can call API for Python Packages and show table on page load', async (done) => {
+  const autocompleteUrl = '/python_packages/auto_complete_search';
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { results } = pythonPackagesResponse;
+  const [firstPackage] = results;
+
+  const pythonPackagesScope = nockInstance
+    .get(pythonPackagesPath)
+    .query(true)
+    .reply(200, pythonPackagesResponse);
+  const contentTypesScope = nockInstance
+    .get(contentTypesPath)
+    .query(true)
+    .reply(200, contentTypesResponse);
+
+  const { queryByText, getAllByText } =
+    renderWithRedux(<ContentPage />);
+
+  expect(queryByText(firstPackage.name)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getAllByText(firstPackage.name)[0]).toBeInTheDocument();
+    expect(getAllByText(firstPackage.version)[0]).toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(contentTypesScope);
+  assertNockRequest(pythonPackagesScope, done);
+});

--- a/webpack/scenes/Content/__tests__/contentTypes.fixtures.json
+++ b/webpack/scenes/Content/__tests__/contentTypes.fixtures.json
@@ -1,0 +1,66 @@
+[
+  {
+    "label": "ansible collection",
+    "generic_browser": null
+  },
+  {
+    "label": "deb",
+    "generic_browser": null
+  },
+  {
+    "label": "docker_manifest",
+    "generic_browser": null
+  },
+  {
+    "label": "docker_manifest_list",
+    "generic_browser": null
+  },
+  {
+    "label": "docker_tag",
+    "generic_browser": null
+  },
+  {
+    "label": "docker_blob",
+    "generic_browser": null
+  },
+  {
+    "label": "file",
+    "generic_browser": null
+  },
+  {
+    "label": "rpm",
+    "generic_browser": null
+  },
+  {
+    "label": "modulemd",
+    "generic_browser": null
+  },
+  {
+    "label": "erratum",
+    "generic_browser": null
+  },
+  {
+    "label": "distribution",
+    "generic_browser": null
+  },
+  {
+    "label": "package_category",
+    "generic_browser": null
+  },
+  {
+    "label": "package_group",
+    "generic_browser": null
+  },
+  {
+    "label": "yum_repo_metadata_file",
+    "generic_browser": null
+  },
+  {
+    "label": "srpm",
+    "generic_browser": null
+  },
+  {
+    "label": "python_package",
+    "generic_browser": true
+  }
+]

--- a/webpack/scenes/Content/__tests__/pythonPackages.fixtures.json
+++ b/webpack/scenes/Content/__tests__/pythonPackages.fixtures.json
@@ -1,0 +1,28 @@
+{
+  "total": 2,
+  "subtotal": 2,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "name",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "id": 1491,
+      "name": "shelf-reader",
+      "pulp_id": "/pulp/api/v3/content/python/packages/ac0dcdcc-874a-46cb-a9a7-6f49ff661b7d/",
+      "version": "0.1",
+      "content_type": "python_package"
+    },
+    {
+      "id": 1490,
+      "name": "shelf-reader",
+      "pulp_id": "/pulp/api/v3/content/python/packages/2d66d40b-6633-4d74-8eec-70823410b224/",
+      "version": "0.1",
+      "content_type": "python_package"
+    }
+  ]
+}

--- a/webpack/scenes/Content/index.js
+++ b/webpack/scenes/Content/index.js
@@ -1,0 +1,4 @@
+import { withRouter } from 'react-router-dom';
+import ContentPage from './ContentPage';
+
+export default withRouter(ContentPage);


### PR DESCRIPTION
This adds a new tab to the navigation bar: `Content Types > Other Content Types`. This links to a listing of content types, always filtered by one type. The only type supported here is Python Packages, which is selected by default.

Navigating to this page, once you have python packages created, you'll see a table with  "Name" and "Version" headers and those packages listed. It's also searchable with autocomplete. If not content has been created, there's a message saying so.

It should be possible to add more content types to this page by adding them to `ContentConfig.js`, in a similar structure to what is already there for python packages. That might be a fun test.