### PR TITLE
Fixes #33287 - Duplicate key error with two applicability gen tasks

### DIFF
--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -136,9 +136,10 @@ module Katello
 
       def insert(applicable_ids)
         unless applicable_ids.empty?
-          inserts = applicable_ids.map { |applicable_id| "(#{applicable_id.to_i}, #{content_facet.id.to_i})" }
-          sql = "INSERT INTO #{content_facet_association_class.table_name} (#{content_unit_association_id}, content_facet_id) VALUES #{inserts.join(', ')}"
-          ActiveRecord::Base.connection.exec_insert(sql)
+          upserts = applicable_ids.collect do |applicable_id|
+            { content_unit_association_id => applicable_id, :content_facet_id => content_facet.id }
+          end
+          content_facet_association_class.upsert_all(upserts, unique_by: [content_unit_association_id, :content_facet_id])
         end
       end
 


### PR DESCRIPTION
If two generate applicability events try to import the same content facet content units at the same time, a duplicate key error will occur.

To test:

1) Sync a bunch of RPMs, perhaps > 50K
2) Make a dummy content host
3) Open up two Foreman consoles
4) Run this command at the same time in both consoles:
```Ruby
::Katello::Applicability::ApplicableContentHelper.new(::Host.find(<host_id_here>).content_facet, ::Katello::Rpm, []).insert(::Katello::Rpm.all.pluck(:id))
```
5) Verify that both commands return successfully.  One command's return data should have a list of rows, and the other should be empty (`...@rows=[]>`)