### PR TITLE
Fixes #33517 - add force option to metadata regeneration

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -76,7 +76,11 @@ module Katello
 
     api :PUT, "/content_view_versions/:id/republish_repositories", N_("Forces a republish of the version's repositories' metadata")
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
+    param :force, :bool, :desc => N_("Force metadata regeneration to proceed.  Dangerous when repositories use mirror on sync."), :required => true
     def republish_repositories
+      unless ::Foreman::Cast.to_bool(params[:force])
+        fail HttpErrors::BadRequest, _("Metadata republishing must be forced because it is a dangerous operation.")
+      end
       task = async_task(::Actions::Katello::ContentViewVersion::RepublishRepositories, @content_view_version)
       respond_for_async :resource => task
     end

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -264,8 +264,12 @@ module Katello
 
     api :PUT, "/repositories/:id/republish", N_("Forces a republish of the specified repository, regenerating metadata and symlinks on the filesystem.")
     param :id, :number, :desc => N_("Repository identifier"), :required => true
+    param :force, :bool, :desc => N_("Force metadata regeneration to proceed.  Dangerous when repositories use mirror on sync."), :required => true
     def republish
-      task = async_task(::Actions::Katello::Repository::MetadataGenerate, @repository, :force => true)
+      unless ::Foreman::Cast.to_bool(params[:force])
+        fail HttpErrors::BadRequest, _('Metadata republishing must be forced because it is a dangerous operation.')
+      end
+      task = async_task(::Actions::Katello::Repository::MetadataGenerate, @repository)
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view_version/republish_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/republish_repositories.rb
@@ -5,7 +5,7 @@ module Actions
         def plan(content_view_version)
           action_subject(content_view_version.content_view)
           plan_self(:version_id => content_view_version.id)
-          plan_action(::Actions::Katello::Repository::BulkMetadataGenerate, content_view_version.repositories, :force => true)
+          plan_action(::Actions::Katello::Repository::BulkMetadataGenerate, content_view_version.repositories)
         end
 
         def run

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -110,15 +110,6 @@
                 </li>
                 <li>
                   <a href="#"
-                     ng-click="regenerateRepositories(version)"
-                     ng-hide="denied('promote_or_remove_content_views', contentView)"
-                     ng-disabled="taskInProgress(version) || taskFailed(version) || pendingVersionTask"
-                     translate>
-                     Regenerate Repository Metadata
-                  </a>
-                </li>
-                <li>
-                  <a href="#"
                      ng-click="$state.go('content-view.version-deletion.environments', {contentViewId: contentView.id, versionId: version.id})"
                      ng-hide="denied('promote_or_remove_content_views', contentView)"
                      ng-disabled="taskInProgress(version) || taskFailed(version) || pendingVersionTask"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -39,10 +39,6 @@
         </li>
 
         <li role="menuitem" ng-hide="syncInProgress(repository.last_sync) || denied('edit_products', product)">
-          <a ng-click="republishRepository(repository)" translate>
-            Republish Repository Metadata
-          </a>
-
           <span class="disabled" ng-show="syncInProgress(repository.last_sync)" translate>
             Cannot republish Repository, a sync is already in progress.
           </span>

--- a/test/actions/katello/content_view_version/republish_repositories_test.rb
+++ b/test/actions/katello/content_view_version/republish_repositories_test.rb
@@ -20,7 +20,7 @@ module Katello::Host
 
         plan_action(action, @version)
 
-        assert_action_planed_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories, :force => true)
+        assert_action_planed_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories)
       end
     end
   end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -131,10 +131,18 @@ module Katello
       end
     end
 
+    def test_republish_repositories_without_force
+      version = @library_dev_staging_view.versions.first
+      put :republish_repositories, params: { :id => version.id }
+
+      assert_response 400
+      assert_match "Metadata republishing must be forced because it is a dangerous operation.", @response.body
+    end
+
     def test_republish_repositories
       version = @library_dev_staging_view.versions.first
       @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::RepublishRepositories, version).returns({})
-      put :republish_repositories, params: { :id => version.id }
+      put :republish_repositories, params: { :id => version.id, :force => true }
 
       assert_response :success
       assert_template 'katello/api/v2/common/async'

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -698,12 +698,18 @@ module Katello
       end
     end
 
+    def test_republish_without_force
+      put :republish, params: { :id => @repository.id }
+      assert_response 400
+      assert_match "Metadata republishing must be forced because it is a dangerous operation.", @response.body
+    end
+
     def test_republish
-      assert_async_task ::Actions::Katello::Repository::MetadataGenerate do |repo, options|
-        repo.id == @repository.id && options == {:force => true}
+      assert_async_task ::Actions::Katello::Repository::MetadataGenerate do |repo|
+        repo.id == @repository.id
       end
 
-      put :republish, params: { :id => @repository.id }
+      put :republish, params: { :id => @repository.id, :force => true}
       assert_response :success
     end
 


### PR DESCRIPTION
Removes the metadata generation options for repositories and content view versions from the UI.  It is currently dangerous with Pulp 3 & repositories that have mirror on sync set to true.

To test:

1) Try the `/katello/api/repositories/:id/republish`and `/katello/api/content_view_versions/:id/republish_repositories` endpoints
  -> Ensure both do not publish without the force option being set to `true`
2) Try republishing content view version metadata via Hammer
  -> Note that there isn't an option for republishing single repo metadata in Hammer. Only for content view versions.
  -> The force option should be necessary there too
  -> Check that the warning messages look fine
3) Check that there is no way to republish metadata (repository or content view version) via the UI