### PR TITLE
Fixes #33534 - registry name pattern update fails

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -4,7 +4,7 @@ module Actions
       class SyncCapsule < ::Actions::EntryAction
         include Actions::Katello::PulpSelector
         def plan(smart_proxy, options = {})
-          plan_self(:smart_proxy_id => smart_proxy.id, :options => options)
+          plan_self(:smart_proxy_id => smart_proxy.id)
           action_subject(smart_proxy)
           environment = options[:environment]
           content_view = options[:content_view]
@@ -12,6 +12,7 @@ module Actions
           skip_metadata_check = options.fetch(:skip_metadata_check, false)
           sequence do
             repos = repos_to_sync(smart_proxy, environment, content_view, repository, skip_metadata_check)
+            return nil if repos.empty?
 
             repos.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|
               concurrence do

--- a/app/lib/actions/katello/environment/publish_repositories.rb
+++ b/app/lib/actions/katello/environment/publish_repositories.rb
@@ -16,6 +16,7 @@ module Actions
             repositories.each do |repository|
               sequence do
                 repository.set_container_repository_name
+                repository.clear_smart_proxy_sync_histories
                 plan_action(::Actions::Katello::Repository::InstanceUpdate, repository)
                 plan_action(::Actions::Katello::Repository::CapsuleSync, repository)
               end

--- a/app/lib/actions/katello/repository/instance_update.rb
+++ b/app/lib/actions/katello/repository/instance_update.rb
@@ -7,7 +7,7 @@ module Actions
         def plan(repository)
           action_subject repository
           repository.save!
-          plan_action(::Actions::Pulp3::Orchestration::Repository::RefreshIfNeeded, repository)
+          plan_action(::Actions::Pulp3::Orchestration::Repository::RefreshIfNeeded, repository, SmartProxy.pulp_primary)
           plan_self(:repository_id => repository.id)
         end
 

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -179,7 +179,7 @@ module Katello
         if (distro = repo_service.lookup_distributions(base_path: path).first) ||
           (distro = repo_service.lookup_distributions(name: "#{backend_object_name}").first)
           # update dist
-          dist_options = dist_options.except(:name, :base_path)
+          dist_options = dist_options.except(:name)
           api.distributions_api.partial_update(distro.pulp_href, dist_options)
         else
           # create dist

--- a/test/models/smart_proxy_sync_history_test.rb
+++ b/test/models/smart_proxy_sync_history_test.rb
@@ -50,5 +50,15 @@ module Katello
       smart_proxy_helper.clear_smart_proxy_sync_histories
       assert_equal @repo.smart_proxy_sync_histories.count, 0
     end
+
+    def test_clear_history_on_publish_repositories
+      User.current = users(:admin)
+      @repo.create_smart_proxy_sync_history(proxy_with_pulp)
+      library = katello_environments(:library)
+      library.expects(:repositories).returns([@repo])
+      ::Actions::Katello::Environment::PublishRepositories.any_instance.expects(:plan_action).twice
+      ::ForemanTasks.sync_task(::Actions::Katello::Environment::PublishRepositories, library)
+      assert_equal @repo.smart_proxy_sync_histories.count, 0
+    end
   end
 end

--- a/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
@@ -26,9 +26,13 @@ module Katello
         def test_refresh_distributions_update_dist
           mock_distribution = "distro"
           mock_distribution.expects(:pulp_href).once.returns("pulp_href")
-          @repo_service.stubs(:lookup_distributions).returns([mock_distribution])
           @repo_mirror.stubs(:version_href).returns("repo_href")
-          PulpAnsibleClient::DistributionsAnsibleApi.any_instance.expects(:partial_update).with("pulp_href", {:content_guard => nil, :repository_version => "repo_href"})
+          @repo_service.expects(:lookup_distributions).returns([mock_distribution])
+          @repo_service.expects(:relative_path).returns("relative_path")
+          PulpAnsibleClient::DistributionsAnsibleApi.any_instance.expects(:partial_update).with("pulp_href",
+                                                                                                { :content_guard => nil,
+                                                                                                  :repository_version => "repo_href",
+                                                                                                  :base_path => "relative_path" })
           @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
         end
 

--- a/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
@@ -27,8 +27,11 @@ module Katello
           mock_distribution = "distro"
           mock_distribution.expects(:pulp_href).once.returns("pulp_href")
           @repo_mirror.stubs(:version_href).returns("repo_href")
-          @repo_service.stubs(:lookup_distributions).returns([mock_distribution])
-          PulpContainerClient::DistributionsContainerApi.any_instance.expects(:partial_update).with("pulp_href", repository_version: 'repo_href')
+          @repo_service.expects(:lookup_distributions).returns([mock_distribution])
+          @repo_service.expects(:relative_path).returns("base_path")
+          PulpContainerClient::DistributionsContainerApi.any_instance.expects(:partial_update).with("pulp_href",
+                                                                                                    { repository_version: 'repo_href',
+                                                                                                      base_path: "base_path" })
           @repo_mirror.refresh_distributions(name: "test name", base_path: "test base_path", content_guard: "test content_guard")
         end
 


### PR DESCRIPTION
This PR fixes a couple issues:
1) Syncing a smart proxy doesn't update distribution paths
2) `repos_to_sync` returns nil because the smart proxy sync histories are not cleared out after changing the registry name pattern

To test:
1) Sync some docker repos and stick them in a content view.
2) Publish that view and ensure it's promoted to some LCE
3) Sync that LCE to a smart proxy
4) Check the container distributions via the Pulp CLI on both the Katello server and the smart proxy and note the base paths
5) Change the registry name pattern
6) After the tasks finish, check all of the distributions on both the Katello server and the smart proxy to ensure that the base paths changed
7) Also check that there are no failed tasks during the testing

TODO:
- [x] Add tests