### PR TITLE
Fixes #33557 - adds the ostree repository type for registration

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -57,8 +57,6 @@ module Katello
       param :upstream_username, String, :desc => N_("Username of the upstream repository user used for authentication")
       param :upstream_password, String, :desc => N_("Password of the upstream repository user used for authentication")
       param :upstream_authentication_token, String, :desc => N_("Password of the upstream authentication token.")
-      param :ostree_upstream_sync_policy, ::Katello::RootRepository::OSTREE_UPSTREAM_SYNC_POLICIES, :desc => N_("policies for syncing upstream ostree repositories")
-      param :ostree_upstream_sync_depth, :number, :desc => N_("if a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided")
       param :deb_releases, String, :desc => N_("whitespace-separated list of releases to be synced from deb-archive")
       param :deb_components, String, :desc => N_("whitespace-separated list of repo components to be synced from deb-archive")
       param :deb_architectures, String, :desc => N_("whitespace-separated list of architectures to be synced from deb-archive")
@@ -98,7 +96,6 @@ module Katello
     param :rpm_id, String, :desc => N_("Id of a rpm package to find repositories that contain the rpm")
     param :file_id, String, :desc => N_("Id of a file to find repositories that contain the file")
     param :ansible_collection_id, String, :desc => N_("Id of an ansible collection to find repositories that contain the ansible collection")
-    param :ostree_branch_id, String, :desc => N_("Id of an ostree branch to find repositories that contain that branch")
     param :library, :bool, :desc => N_("show repositories in Library and the default content view")
     param :archived, :bool, :desc => N_("show archived repositories")
     param :content_type, RepositoryTypeManager.defined_repository_types.keys, :desc => N_("limit to only repositories of this type")
@@ -212,11 +209,6 @@ module Katello
       if params[:ansible_collection_id]
         query = query.joins(:ansible_collections)
                     .where("#{AnsibleCollection.table_name}.id" => AnsibleCollection.with_identifiers(params[:ansible_collection_id]))
-      end
-
-      if params[:ostree_branch_id]
-        query = query.joins(:ostree_branches)
-          .where("#{OstreeBranch.table_name}.id" => OstreeBranch.with_identifiers(params[:ostree_branch_id]))
       end
 
       query
@@ -465,11 +457,9 @@ module Katello
     def repository_params
       keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password,
               :upstream_username, :download_concurrency, :upstream_authentication_token,
-              :ostree_upstream_sync_depth, :ostree_upstream_sync_policy, {:os_versions => []},
-              :deb_releases, :deb_components, :deb_architectures, :description, :http_proxy_policy,
-              :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
+              {:os_versions => []}, :deb_releases, :deb_components, :deb_architectures, :description,
+              :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
              ]
-
       keys += [{:docker_tags_whitelist => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
       keys += [:ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token] if params[:action] == 'create' || @repository&.ansible_collection?
       keys += [:label, :content_type] if params[:action] == "create"
@@ -503,7 +493,6 @@ module Katello
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/MethodLength
     def construct_repo_from_params(repo_params) # rubocop:disable Metrics/AbcSize
       root = @product.add_repo(repo_params.slice(:label, :name, :description, :url, :content_type, :arch, :unprotected,
                                                             :gpg_key, :ssl_ca_cert, :ssl_client_cert, :ssl_client_key,
@@ -526,10 +515,6 @@ module Katello
         root.generic_remote_options = generic_remote_options.to_json
       end
 
-      if root.ostree?
-        root.ostree_upstream_sync_policy = repo_params[:ostree_upstream_sync_policy]
-        root.ostree_upstream_sync_depth = repo_params[:ostree_upstream_sync_depth]
-      end
       if root.deb?
         root.deb_releases = repo_params[:deb_releases] if repo_params[:deb_releases]
         root.deb_components = repo_params[:deb_components] if repo_params[:deb_components]

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -70,7 +70,6 @@ module Katello
 
     validate :ensure_valid_docker_attributes, :if => :docker?
     validate :ensure_docker_repo_unprotected, :if => :docker?
-    validate :ensure_ostree_repo_protected, :if => :ostree?
     validate :ensure_compatible_download_policy, :if => :yum?
     validate :ensure_valid_collection_attributes, :if => :ansible_collection?
     validate :ensure_valid_auth_url_token, :if => :ansible_collection?
@@ -182,12 +181,6 @@ module Katello
     def ensure_no_checksum_on_demand
       if checksum_type.present? && download_policy == DOWNLOAD_ON_DEMAND
         errors.add(:checksum_type, _("Checksum type cannot be set for yum repositories with on demand download policy."))
-      end
-    end
-
-    def ensure_ostree_repo_protected
-      if unprotected
-        errors.add(:base, _("OSTree Repositories cannot be unprotected."))
       end
     end
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_rpm_client", ">=3.13.0", "< 3.15.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
   gem.add_dependency "pulp_python_client", ">= 3.4.0", "< 3.5.0"
+  gem.add_dependency "pulp_ostree_client"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -1,5 +1,25 @@
-Katello::RepositoryTypeManager.register(::Katello::Repository::OSTREE_TYPE) do
-  service_class Katello::Pulp::Repository::Ostree
-  default_managed_content_type Katello::OstreeBranch::CONTENT_TYPE
-  content_type Katello::OstreeBranch, :pulp2_service_class => ::Katello::Pulp::OstreeBranch, :removable => true, :uploadable => true
+require 'pulp_ostree_client'
+
+Katello::RepositoryTypeManager.register('ostree') do
+  allow_creation_by_user true
+  pulp3_service_class Katello::Pulp3::Repository::Generic
+  pulp3_api_class Katello::Pulp3::Api::Generic
+  pulp3_plugin 'ostree'
+  partial_repo_path '' #TODO: add partial repo path
+
+  client_module_class PulpOstreeClient
+  api_class PulpOstreeClient::ApiClient
+  configuration_class PulpOstreeClient::Configuration
+  remote_class PulpOstreeClient::OstreeOstreeRemote
+  remotes_api_class PulpOstreeClient::RemotesOstreeApi
+  repositories_api_class PulpOstreeClient::RepositoriesOstreeApi
+  repository_versions_api_class PulpOstreeClient::RepositoriesOstreeVersionsApi
+  distributions_api_class PulpOstreeClient::DistributionsOstreeApi
+  distribution_class PulpOstreeClient::OstreeOstreeDistribution
+  repo_sync_url_class PulpOstreeClient::RepositorySyncURL
+
+  url_description N_("URL of an OSTree respository.")
+
+  model_name lambda { |pulp_unit| pulp_unit["name"] }
+  model_version lambda { |pulp_unit| pulp_unit["version"] }
 end

--- a/test/models/katello/ostree_test.rb
+++ b/test/models/katello/ostree_test.rb
@@ -1,0 +1,15 @@
+require 'katello_test_helper'
+
+module Katello
+  class OstreeTest < ActiveSupport::TestCase
+    def setup
+      skip "TODO: Until the ostree support is present in pulp packaging"
+      @ostree = FactoryBot.create(:katello_repository, :ostree, :with_product)
+    end
+
+    def test_created
+      skip "TODO: Until the ostree support is present in pulp packaging"
+      assert @ostree
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the latest ostree pulp plugin support for OSTree repositories and content.

Note that to test this you will need:
  1. follow this to spin up a pulp 3.15 box https://projects.theforeman.org/projects/katello/wiki/Pulp_3_Integration#Using-a-2nd-server-as-a-pulp-server-for-use-in-development
  2. pip install the pulp-ostree plugin
  3. refresh your smart proxy