### PR TITLE
Fixes #33561 - drop Puppet Environment migration

### DIFF
--- a/db/migrate/20140110000001_update_environments_add_katello_id.rb
+++ b/db/migrate/20140110000001_update_environments_add_katello_id.rb
@@ -1,10 +1,8 @@
 class UpdateEnvironmentsAddKatelloId < ActiveRecord::Migration[4.2]
   def up
-    add_column :environments, :katello_id, :string, :limit => 255
-    add_index :environments, :katello_id
+    # not doing anything, it is not needed anymore in supported versions
   end
 
   def down
-    remove_column :environments, :katello_id
   end
 end


### PR DESCRIPTION
Foreman core wants to remove the Environments migrations and Katello useless migration is blocking it.
We can safely remove the migration and let ForemanPuppet remove the column.

ForemanPuppet is dealing with this in https://github.com/theforeman/foreman_puppet/pull/200

This is blocking https://github.com/theforeman/foreman/pull/8790