### PR TITLE
Fixes #33562 - update to dynflow 1.6.1

### DIFF
--- a/app/lib/actions/pulp3/repository/multi_copy_content.rb
+++ b/app/lib/actions/pulp3/repository/multi_copy_content.rb
@@ -17,7 +17,7 @@ module Actions
           repo_id_map = {}
 
           input[:repo_id_map].each do |source_repo_ids, dest_repo_map|
-            repo_id_map[JSON.parse(source_repo_ids)] = dest_repo_map.deep_dup
+            repo_id_map[source_repo_ids] = dest_repo_map.deep_dup
           end
 
           output[:pulp_tasks] = ::Katello::Repository.find(repo_id_map.values.first[:dest_repo]).backend_service(smart_proxy).copy_content_from_mapping(repo_id_map, input)

--- a/app/lib/actions/pulp3/repository/multi_copy_units.rb
+++ b/app/lib/actions/pulp3/repository/multi_copy_units.rb
@@ -25,7 +25,7 @@ module Actions
           repo_map = {}
 
           input[:repo_map].each do |source_repo_ids, dest_repo_map|
-            repo_map[JSON.parse(source_repo_ids)] = dest_repo_map
+            repo_map[source_repo_ids] = dest_repo_map
           end
 
           if input[:unit_map][:errata].any?

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", ">= 5.0"
   gem.add_dependency "foreman_remote_execution", ">= 3.0"
-  gem.add_dependency "dynflow", ">= 1.5.0"
+  gem.add_dependency "dynflow", ">= 1.6.1"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "qpid_proton"
   gem.add_dependency "stomp"


### PR DESCRIPTION
The new serialization method support serializing complex
keys within input, so we no longer need to parse them