### PR TITLE
Fixes #33567 - remove checksum values from pulp3 repos

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -5,6 +5,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.0:remove_ostree_puppet_content'},
     {:name => 'katello:upgrades:4.1:sync_noarch_content'},
     {:name => 'katello:upgrades:4.1:fix_invalid_pools'},
-    {:name => 'katello:upgrades:4.1:update_content_import_export_perms'}
+    {:name => 'katello:upgrades:4.1:update_content_import_export_perms'},
+    {:name => 'katello:upgrades:4.2:remove_checksum_values'}
   ]
 end

--- a/lib/katello/tasks/test.rake
+++ b/lib/katello/tasks/test.rake
@@ -155,8 +155,7 @@ namespace :test do
         test_task = Rake::TestTask.new('katello_services_test_task') do |t|
           t.libs << ["test", "#{Katello::Engine.root}/test"]
           t.test_files = [
-            "#{Katello::Engine.root}/test/services/katello/pulp3/**/*_test.rb",
-            "#{Katello::Engine.root}/test/actions/pulp3/**/*_test.rb"
+            "#{Katello::Engine.root}/test/**/pulp3/**/*_test.rb"
           ]
           t.verbose = true
           t.warning = false

--- a/lib/katello/tasks/upgrades/4.2/remove_checksum_values.rake
+++ b/lib/katello/tasks/upgrades/4.2/remove_checksum_values.rake
@@ -1,0 +1,17 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.2' do
+      desc "Removed orphaned pools and correct org+subscription mismatch"
+      task :remove_checksum_values => ["environment"] do
+        api = Katello::Pulp3::Api::Yum.new(SmartProxy.pulp_primary)
+        repos = Katello::Pulp3::Api::Core.fetch_from_list do |page_opts|
+          api.repositories_api.list(page_opts)
+        end
+
+        repos.each do |repo|
+          api.repositories_api.partial_update(repo.pulp_href, {metadata_checksum_type: nil, package_checksum_type: nil})
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/katello/upgrades/remove_checksum_values/removes_checksums.yml
+++ b/test/fixtures/vcr_cassettes/katello/upgrades/remove_checksum_values/removes_checksums.yml
@@ -1,0 +1,643 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - fa13cff841964a9083816f6019e70df9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: post
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiY2hlY2tzdW1fdGVzdCIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5
+        cGUiOiJzaGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYi
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/7ec917b4-dfbf-4f2f-afb6-30a0ceb650e7/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '638'
+      Correlation-Id:
+      - '0911b3ac25a14448896de3a2fdc9d6a7'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vN2VjOTE3YjQtZGZiZi00ZjJmLWFmYjYtMzBhMGNlYjY1MGU3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMDktMjRUMjE6MzI6NDUuMTU3OTQ3WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vN2VjOTE3YjQtZGZiZi00ZjJmLWFmYjYtMzBhMGNlYjY1MGU3L3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83ZWM5MTdiNC1k
+        ZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiY2hlY2tzdW1fdGVzdCIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5l
+        ZF92ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6
+        ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWlu
+        X3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUi
+        OiJzaGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJn
+        cGdjaGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRh
+        IjpmYWxzZX0=
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 4d53afe1c2cc4dd099216ddc1ece5b50
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '320'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOS0yNFQyMTozMjo0NS4xNTc5NDda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdlYzkx
+        N2I0LWRmYmYtNGYyZi1hZmI2LTMwYTBjZWI2NTBlNy92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJjaGVja3N1bV90ZXN0IiwiZGVzY3JpcHRpb24iOm51bGwsInJl
+        dGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6InNoYTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1
+        NiIsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0
+        YWRhdGEiOmZhbHNlfV19
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - da1ab20a167c4c68a10ba3d44f673bef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '320'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOS0yNFQyMTozMjo0NS4xNTc5NDda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdlYzkx
+        N2I0LWRmYmYtNGYyZi1hZmI2LTMwYTBjZWI2NTBlNy92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJjaGVja3N1bV90ZXN0IiwiZGVzY3JpcHRpb24iOm51bGwsInJl
+        dGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6InNoYTI1NiIsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6InNoYTI1
+        NiIsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0
+        YWRhdGEiOmZhbHNlfV19
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: patch
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/7ec917b4-dfbf-4f2f-afb6-30a0ceb650e7/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNr
+        c3VtX3R5cGUiOm51bGx9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - ef42fcdad2314f36ad3d25b94acf1a0b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwOTI0ODYzLTc2YmItNGQx
+        MS04MDEwLWEwOGZhODdkYjhiZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/?state__in=running,waiting
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 2dbf7bdce0344f40b071a427ca4838f7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMDkyNDg2
+        My03NmJiLTRkMTEtODAxMC1hMDhmYTg3ZGI4YmYvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyMS0wOS0yNFQyMTozMjo0NS4zMzQ1MDZaIiwic3RhdGUiOiJydW5u
+        aW5nIiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxf
+        dXBkYXRlIiwibG9nZ2luZ19jaWQiOiJlZjQyZmNkYWQyMzE0ZjM2YWQzZDI1
+        Yjk0YWNmMWEwYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA5LTI0VDIxOjMyOjQ1
+        LjM5MzcwN1oiLCJmaW5pc2hlZF9hdCI6bnVsbCwiZXJyb3IiOm51bGwsIndv
+        cmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzL2JiZTFmYTk0LTYzMzctNDBh
+        ZC05MDgyLTY0YmZmMjI4ZjE1NC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hp
+        bGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBv
+        cnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
+        L3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcvIl19
+        XX0=
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:45 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/?state__in=running,waiting
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Correlation-Id:
+      - 90cbb82428ca437898a10636fb1bb840
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:46 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 207523e9fb854f2cb501d3a0acff6906
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '312'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOS0yNFQyMTozMjo0NS4xNTc5NDda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdlYzkx
+        N2I0LWRmYmYtNGYyZi1hZmI2LTMwYTBjZWI2NTBlNy92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJjaGVja3N1bV90ZXN0IiwiZGVzY3JpcHRpb24iOm51bGwsInJl
+        dGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdj
+        aGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpm
+        YWxzZX1dfQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:46 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - da19937f1f93475e8ada7ee67699fb35
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '312'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0wOS0yNFQyMTozMjo0NS4xNTc5NDda
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS83ZWM5MTdiNC1kZmJmLTRmMmYtYWZiNi0zMGEwY2ViNjUwZTcv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdlYzkx
+        N2I0LWRmYmYtNGYyZi1hZmI2LTMwYTBjZWI2NTBlNy92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJjaGVja3N1bV90ZXN0IiwiZGVzY3JpcHRpb24iOm51bGwsInJl
+        dGFpbmVkX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdj
+        aGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpm
+        YWxzZX1dfQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:46 GMT
+- request:
+    method: delete
+    uri: https://devel2.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/7ec917b4-dfbf-4f2f-afb6-30a0ceb650e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Correlation-Id:
+      - 675fd66d78db4efe8c12f2f8a9034a95
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlNzhhZGZkLWIwZmEtNDE5
+        NC1iOGYyLWI2ZjdmMDEzZmFhMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:46 GMT
+- request:
+    method: get
+    uri: https://devel2.balmora.example.com/pulp/api/v3/tasks/7e78adfd-b0fa-4194-b8f2-b6f7f013faa2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.14.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 24 Sep 2021 21:32:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Correlation-Id:
+      - 995025e842f24f84bc30609d4e5385dd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 devel2.balmora.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2U3OGFkZmQtYjBm
+        YS00MTk0LWI4ZjItYjZmN2YwMTNmYWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMDktMjRUMjE6MzI6NDYuNjM4NzIyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NzVmZDY2ZDc4ZGI0ZWZlOGMxMmYyZjhh
+        OTAzNGE5NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTA5LTI0VDIxOjMyOjQ2LjY5
+        MzM5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMDktMjRUMjE6MzI6NDYuNzk0
+        NjQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy84MjUwMTdjNi1mZmUzLTRkNTYtYjkzNi1hNjZjOGJjNTkxOWEvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2VjOTE3YjQtZGZiZi00ZjJm
+        LWFmYjYtMzBhMGNlYjY1MGU3LyJdfQ==
+    http_version: 
+  recorded_at: Fri, 24 Sep 2021 21:32:46 GMT
+recorded_with: VCR 3.0.3

--- a/test/lib/tasks/upgrades/4.2/pulp3/remove_checksum_values_test.rb
+++ b/test/lib/tasks/upgrades/4.2/pulp3/remove_checksum_values_test.rb
@@ -1,0 +1,49 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  module Upgrades
+    class RemoveChecksumValuesTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      REPO_NAME = 'checksum_test'.freeze
+
+      def setup
+        Rake.application.rake_require 'katello/tasks/upgrades/4.2/remove_checksum_values'
+        Rake::Task['katello:upgrades:4.2:remove_checksum_values'].reenable
+        Rake::Task.define_task(:environment)
+
+        @api = Katello::Pulp3::Api::Yum.new(SmartProxy.pulp_primary)
+        if (found = @api.repositories_api.list(name => REPO_NAME).results.first)
+          wait_on_task(SmartProxy.pulp_primary, @api.repositories_api.delete(found.pulp_href))
+        end
+        @api.repositories_api.create(name: REPO_NAME,
+                                     metadata_checksum_type: 'sha256',
+                                     package_checksum_type: 'sha256')
+      end
+
+      def teardown
+        if (found = @api.repositories_api.list(name => REPO_NAME).results.first)
+          wait_on_task(SmartProxy.pulp_primary, @api.repositories_api.delete(found.pulp_href))
+        end
+      end
+
+      def test_removes_checksums
+        repo = @api.repositories_api.list(name => REPO_NAME).results.first
+        assert repo
+        assert_equal 'sha256', repo.metadata_checksum_type
+        assert_equal 'sha256', repo.package_checksum_type
+
+        Rake.application.invoke_task('katello:upgrades:4.2:remove_checksum_values')
+
+        until @api.tasks_api.list(state__in: ['running', 'waiting']).results.empty?
+          sleep 1
+        end
+
+        repo = @api.repositories_api.list(name => REPO_NAME).results.first
+        refute repo.metadata_checksum_type
+        refute repo.package_checksum_type
+      end
+    end
+  end
+end


### PR DESCRIPTION
due to an upgrade bug in pulp3, repository objects can have a checksum set
which will cause the checksum to be used when publishing metadata. This
causes a problem with pulp2 smart proxies syncing content and expecting
all package checksums to match the metadata checksums