### PR TITLE
Fixes #33525 - Add debs packages_restrict_latest

### DIFF
--- a/app/models/katello/deb.rb
+++ b/app/models/katello/deb.rb
@@ -103,8 +103,13 @@ module Katello
       Katello::Deb.in_repositories(repos).where.not(name: host.installed_debs.pluck(:name)).order(:name)
     end
 
-    def self.latest(_relation)
-      fail 'NotImplemented'
+    def self.latest(relation)
+      # This might be very slow
+      return relation.joins(
+        "LEFT OUTER JOIN(#{relation.to_sql}) AS katello_debs2 ON " \
+        'katello_debs.name = katello_debs2.name AND katello_debs.architecture = katello_debs2.architecture AND ' \
+        'deb_version_cmp(katello_debs.version, katello_debs2.version) < 0 ' \
+      ).where('katello_debs2.id IS NULL')
     end
   end
 end

--- a/test/controllers/api/v2/debs_controller_test.rb
+++ b/test/controllers/api/v2/debs_controller_test.rb
@@ -7,6 +7,7 @@ module Katello
       @version = ContentViewVersion.first
       @deb = katello_debs(:one)
       @host = hosts(:one)
+      @org = get_organization
     end
 
     def setup
@@ -68,6 +69,15 @@ module Katello
       assert_response :success
       ids = JSON.parse(response.body)['results'].map { |p| p['id'] }
       assert_includes ids, @deb.id
+    end
+
+    def test_index_with_latest
+      response = get :index, params: { :packages_restrict_latest => true, :organization_id => @org.id }
+
+      assert_response :success
+      ids = JSON.parse(response.body)['results'].map { |p| p['id'] }
+      assert_includes ids, katello_debs(:one_new).id
+      refute_includes ids, @deb.id
     end
 
     def test_index_protected

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/InstallableDebsActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/InstallableDebsActions.js
@@ -11,6 +11,7 @@ export const getHostInstallableDebs = (hostId, params) => get({
     host_id: hostId,
     packages_restrict_not_installed: true,
     packages_restrict_applicable: false,
+    packages_restrict_latest: true,
   },
 });
 export default getHostInstallableDebs;


### PR DESCRIPTION
This should implement the `packages_restrict_latest` parameter, but I am not sure I really want to have this merged, because it does not scale well at all.
This originates in the way we compare debian versions and the fact that we have to compare them and are not able to simply sort them.

Maybe some kind of restriction to a max number of packages is in order for this to be usable.