### PR TITLE
Fixes #33572 - Refreshes the host statuses on 'built'

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -56,6 +56,9 @@ module Katello
         after_validation :queue_reset_content_host_status
         register_rebuild(:queue_reset_content_host_status, N_("Content_Host_Status"))
 
+        after_validation :queue_refresh_content_host_status
+        register_rebuild(:queue_refresh_content_host_status, N_("Refresh_Content_Host_Status"))
+
         scope :with_pools_expiring_in_days, ->(days) { joins(:pools).merge(Katello::Pool.expiring_in_days(days)).distinct }
 
         scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
@@ -97,6 +100,20 @@ module Katello
       def check_host_registration
         if subscription_facet
           fail ::Katello::Errors::HostRegisteredException
+        end
+      end
+
+      def refresh_content_host_status
+        self.host_statuses.where(type: ::Katello::HostStatusManager::STATUSES.map(&:name)).each do |status|
+          status.refresh!
+        end
+        refresh_global_status!
+      end
+
+      def queue_refresh_content_host_status
+        if !new_record? && !build && self.changes.key?('build')
+          queue.create(id: "refresh_content_host_status_#{id}", name: _("Refresh Content Host Statuses for %s") % self,
+            priority: 300, action: [self, :refresh_content_host_status])
         end
       end
 


### PR DESCRIPTION
During a global registration
1) System is registered to host
2) The build mode is set to true
3) Another script runs to set the build mode to false if nothing fails

This code tracks that time where the hosts' build mode goes from false
-> true and refreshes the status appropriately.