### PR TITLE
Fixes #33573 - catch RestClient::NotFound in UpstreamConsumer

### DIFF
--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -135,6 +135,8 @@ module Katello
       end
     end
 
+    class UpstreamConsumerNotFound < StandardError; end
+
     class UpstreamEntitlementGone < StandardError; end
 
     class ContainerRegistryNotConfigured < StandardError

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -13,6 +13,8 @@ module Katello
             resource.head
           rescue RestClient::Unauthorized, RestClient::Gone
             raise ::Katello::Errors::UpstreamConsumerGone
+          rescue RestClient::NotFound
+            raise ::Katello::Errors::UpstreamConsumerNotFound
           end
 
           # Overrides the HttpResource get method to check if the upstream

--- a/app/services/katello/upstream_connection_checker.rb
+++ b/app/services/katello/upstream_connection_checker.rb
@@ -4,6 +4,7 @@ module Katello
       Katello::Errors::DisconnectedMode,
       Katello::Errors::ManifestExpired,
       Katello::Errors::UpstreamConsumerGone,
+      Katello::Errors::UpstreamConsumerNotFound,
       Katello::Errors::NoManifestImported
     ].freeze
 

--- a/test/services/katello/upstream_connection_checker_test.rb
+++ b/test/services/katello/upstream_connection_checker_test.rb
@@ -62,5 +62,14 @@ module Katello
         @checker.assert_connection
       end
     end
+
+    def test_assert_upstream_ping_with_not_found
+      @organization.expects(:manifest_expired?).returns(false)
+      Katello::Resources::Candlepin::UpstreamConsumer.expects(:ping).raises(Katello::Errors::UpstreamConsumerNotFound)
+
+      assert_raises Katello::Errors::UpstreamConsumerNotFound do
+        @checker.assert_connection
+      end
+    end
   end
 end


### PR DESCRIPTION
QE ran into a 404 not found error when using cloned manifest.

**Test Steps**
In web UI, navigate Administer > Organization and select an organization's name.
 Error was displayed:
```
 Oops, we're sorry but something went wrong 404 Not Found
```