### PR TITLE
Fixes #33581 - Correctly sets the host attributes on Edit Host

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -33,6 +33,8 @@ module Katello
       included do
         prepend Overrides
 
+        delegate :content_source_id, :content_view_id, :lifecycle_environment_id, :kickstart_repository_id, to: :content_facet, allow_nil: true
+
         has_many :dispatch_histories, :class_name => "::Katello::Agent::DispatchHistory", :foreign_key => :host_id, :dependent => :delete_all
 
         has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :delete_all


### PR DESCRIPTION
Prior to this commit `Edit Host` would give a preference to the values
of the associated hostgroup (this was only in display.)

This meant if you created a host with a hostgroup and changed things
like LCE/CV/kickstart repository id etc those overrides
would not correctly get reflected when Editing the host. It would only
show what was in the hostgroup attached to the host.

This fix magically solves that issue by making it corrently look at
the host and hostgroup.