### PR TITLE
Fixes #33294 - ostree sync

### DIFF
--- a/app/services/katello/pulp3/repository/generic.rb
+++ b/app/services/katello/pulp3/repository/generic.rb
@@ -7,11 +7,16 @@ module Katello
         end
 
         def distribution_options(path)
-          {
+          options = {
             base_path: path,
-            publication: repo.publication_href,
             name: "#{generate_backend_object_name}"
           }
+
+          unless ::Katello::RepositoryTypeManager.find(repo.content_type).pulp3_skip_publication
+            options.merge!(publication: repo.publication_href)
+          end
+
+          options
         end
 
         def remote_options

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -5,6 +5,7 @@ Katello::RepositoryTypeManager.register('ostree') do
   pulp3_service_class Katello::Pulp3::Repository::Generic
   pulp3_api_class Katello::Pulp3::Api::Generic
   pulp3_plugin 'ostree'
+  pulp3_skip_publication true
   partial_repo_path '' #TODO: add partial repo path
 
   client_module_class PulpOstreeClient
@@ -18,8 +19,15 @@ Katello::RepositoryTypeManager.register('ostree') do
   distribution_class PulpOstreeClient::OstreeOstreeDistribution
   repo_sync_url_class PulpOstreeClient::RepositorySyncURL
 
-  url_description N_("URL of an OSTree respository.")
+  url_description N_("URL of an OSTree repository.")
 
   model_name lambda { |pulp_unit| pulp_unit["name"] }
   model_version lambda { |pulp_unit| pulp_unit["version"] }
+
+  generic_content_type 'ostree_ref',
+                       model_class: Katello::GenericContentUnit,
+                       pulp3_api: PulpOstreeClient::ContentRefsApi,
+                       pulp3_service_class: Katello::Pulp3::GenericContentUnit
+
+  default_managed_content_type :ostree_ref
 end

--- a/test/models/katello/ostree_test.rb
+++ b/test/models/katello/ostree_test.rb
@@ -1,15 +1,44 @@
 require 'katello_test_helper'
+require 'support/pulp3_support'
 
 module Katello
   class OstreeTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+    include RepositorySupport
+
     def setup
       skip "TODO: Until the ostree support is present in pulp packaging"
-      @ostree = FactoryBot.create(:katello_repository, :ostree, :with_product)
+      # NOTE in order for these tests to work the 'ostree' fixture will have to be enabled in
+      # test/fixtures/models/katello_smart_proxy_features.yml
+      #   capabilities:
+      #     - ostree
+      @repo = FactoryBot.build(:katello_repository, :ostree, :with_product)
+      @primary = SmartProxy.pulp_primary
+      @repo.root.update(url: 'https://fixtures.pulpproject.org/ostree/small/')
+
+      create_repo(@repo, @primary)
+      @repo.reload
     end
 
     def test_created
       skip "TODO: Until the ostree support is present in pulp packaging"
-      assert @ostree
+      assert @repo
+    end
+
+    def test_index_on_sync
+      skip "TODO: Until the ostree support is present in pulp packaging"
+      Katello::GenericContentUnit.destroy_all
+      sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      index_args = {:id => @repo.id, :contents_changed => true}
+      ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
+      @repo.reload
+
+      post_unit_count = Katello::GenericContentUnit.all.count
+      post_unit_repository_count = Katello::RepositoryGenericContentUnit.where(:repository_id => @repo.id).count
+
+      assert_equal post_unit_count, 2
+      assert_equal post_unit_repository_count, 2
     end
   end
 end

--- a/test/models/pulp_database_unit_sync_repository_associatons_test.rb
+++ b/test/models/pulp_database_unit_sync_repository_associatons_test.rb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class PulpDatabaseUnitSyncRepositoryAssociationsTest < ActiveSupport::TestCase
+    extend ActiveRecord::TestFixtures
+
+    def test_non_generic_content_type_associates_new_ids_and_removes_missing_ids_in_map
+      @repo = FactoryBot.create(:katello_repository, :with_product)
+
+      @rpm = katello_rpms(:one)
+      @rpm2 = katello_rpms(:two)
+      @rpm3 = katello_rpms(:three)
+      @rpm4 = Katello::Rpm.new
+      @rpm4.update(:name => "four", :filename => "four-1.1.rpm", :arch => "i386", :pulp_id => "four-uuid")
+      @rpm5 = Katello::Rpm.new
+      @rpm5.update(:name => "five", :filename => "five-1.1.rpm", :version => 2.0, :epoch => 0, :pulp_id => "five-uuid")
+
+      @repo.rpms = [@rpm, @rpm2, @rpm3, @rpm4, @rpm5]
+
+      pulp_id_ref_map = {
+        @rpm.pulp_id => nil,
+        @rpm2.pulp_id => nil
+      }
+
+      Katello::Rpm.sync_repository_associations(@repo, pulp_id_href_map: pulp_id_ref_map)
+
+      rpm_ids = Katello::Rpm.repository_association_class.where(repository_id: @repo).pluck(:rpm_id)
+      assert_includes rpm_ids, @rpm.id
+      assert_includes rpm_ids, @rpm2.id
+
+      refute_includes rpm_ids, @rpm3.id
+      refute_includes rpm_ids, @rpm4.id
+      refute_includes rpm_ids, @rpm5.id
+    end
+
+    def test_generic_different_content_types_associates_new_ids_and_removes_missing_ids_in_map
+      @repo = katello_repositories(:pulp3_python_1)
+
+      @gcu = Katello::GenericContentUnit.create(name: "one", pulp_id: "one-uuid", content_type: "first")
+      @gcu2 = Katello::GenericContentUnit.create(name: "two", pulp_id: "two-uuid", content_type: "second")
+      @gcu3 = Katello::GenericContentUnit.create(name: "three", pulp_id: "three-uuid", content_type: "third")
+
+      @repo.generic_content_units = [@gcu, @gcu2]
+
+      pulp_id_ref_map = {
+        @gcu2.pulp_id => nil
+      }
+
+      Katello::GenericContentUnit.sync_repository_associations(
+        @repo, pulp_id_href_map: pulp_id_ref_map, generic_content_type: @gcu2.content_type)
+
+      gcu_ids = Katello::GenericContentUnit.repository_association_class.where(repository_id: @repo).pluck(:generic_content_unit_id)
+      assert_includes gcu_ids, @gcu.id
+      assert_includes gcu_ids, @gcu2.id
+
+      pulp_id_ref_map = {}
+
+      Katello::GenericContentUnit.sync_repository_associations(
+        @repo, pulp_id_href_map: pulp_id_ref_map, generic_content_type: @gcu.content_type)
+
+      gcu_ids = Katello::GenericContentUnit.repository_association_class.where(repository_id: @repo).pluck(:generic_content_unit_id)
+      refute_includes gcu_ids, @gcu.id
+      assert_includes gcu_ids, @gcu2.id
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository/generic_test.rb
+++ b/test/services/katello/pulp3/repository/generic_test.rb
@@ -1,0 +1,38 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    module Pulp3
+      class Repository
+        class GenericTest < ::ActiveSupport::TestCase
+          include RepositorySupport
+
+          def setup
+            @repo = katello_repositories(:fedora_17_x86_64)
+            @proxy = SmartProxy.pulp_primary
+            @service = Katello::Pulp3::Repository::Generic.new(@repo, @proxy)
+          end
+
+          def test_distribution_options_includes_publication_attribute_if_content_type_publishes
+            @repo.publication_href = 'a_version_href'
+            @repo.root.checksum_type = 'sha1'
+
+            publication_options = @service.distribution_options('/')
+
+            assert_includes publication_options.keys, :publication
+          end
+
+          def test_distribution_options_excludes_publication_attribute_if_content_type_skips_publish
+            Katello::RepositoryTypeManager.find("yum").stubs(:pulp3_skip_publication).returns(true)
+            @repo.publication_href = 'a_version_href'
+            @repo.root.checksum_type = 'sha1'
+
+            publication_options = @service.distribution_options('/')
+
+            refute_includes publication_options.keys, :publication
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR re-introduces sync operations for Ostree repositories via the CLI.

```
[vagrant@centos7-hammer-devel ~]$ hammer repository create --content-type="ostree" --url="https://fixtures.pulpproject.org/ostree/small/" --name="ostree5" --product-id 1
Repository created.
[vagrant@centos7-hammer-devel ~]$ hammer repository synchronize --id 7
[............................................................................................................................................] [100%]
No content added.
Total steps: 25/25
--------------------------------
Associating Content: 9/9
Downloading Artifacts: 6/6
Parsing Metadata: 1/1
Un-Associating Content: 9/9
```
