### PR TITLE
Fixes #33609 - stop starting pulpcore-resource-manager

### DIFF
--- a/lib/katello/tasks/reset.rake
+++ b/lib/katello/tasks/reset.rake
@@ -5,7 +5,7 @@ namespace :katello do
     service_start = "sudo /usr/bin/systemctl start %s"
 
     task :pulp do
-      SERVICES = %w(rh-redis5-redis pulpcore-api pulpcore-resource-manager pulpcore-content).freeze
+      SERVICES = %w(rh-redis5-redis pulpcore-api pulpcore-content).freeze
 
       puts "\e[33mStarting Pulp3 Reset\e[0m\n\n"
 


### PR DESCRIPTION
during katello:reset