### PR TITLE
Fixes #33400 - Add errata filter rule by ID w/ CV UI

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -44,6 +44,10 @@ module Katello
       collection
     end
 
+    def all_for_content_view_filter(filter, _collection)
+      Erratum.joins(:repositories).merge(filter.applicable_repos)
+    end
+
     def custom_index_relation(collection)
       collection = filter_by_cve(params[:cve], collection) if params[:cve]
       applicable = ::Foreman::Cast.to_bool(params[:errata_restrict_applicable]) || @host

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -157,6 +157,10 @@ module Katello
       { :conditions => conditions }
     end
 
+    def content_view_filters
+      Katello::ContentViewErratumFilterRule.where(errata_id: self.errata_id).eager_load(:filter).map(&:filter)
+    end
+
     apipie :class, desc: "A class representing #{model_name.human} object" do
       name 'Erratum'
       refs 'Erratum'

--- a/app/views/katello/api/v2/errata/index.json.rabl
+++ b/app/views/katello/api/v2/errata/index.json.rabl
@@ -4,4 +4,8 @@ extends "katello/api/v2/common/metadata"
 
 child @collection[:results] => :results do
   extends 'katello/api/v2/errata/show'
+
+  if params[:include_filter_ids]
+    node(:filter_ids) { |erratum| erratum.content_view_filters.pluck(:id) }
+  end
 end

--- a/webpack/components/ErratumTypeLabel.js
+++ b/webpack/components/ErratumTypeLabel.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { BugIcon, EnhancementIcon, SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
+
+const ErratumTypeLabel = ({ type }) => {
+  switch (type) {
+    case 'bugfix':
+      return (
+        <p><BugIcon /> Bugfix</p>
+      );
+    case 'enhancement':
+      return (
+        <p><EnhancementIcon /> Enhancement</p>
+      );
+    case 'security':
+      return (
+        <p><SecurityIcon /> Security</p>
+      );
+    default:
+      return (
+        <p><UnknownIcon /> {type}</p>
+      );
+  }
+};
+
+ErratumTypeLabel.propTypes = {
+  type: PropTypes.string.isRequired,
+};
+
+export default ErratumTypeLabel;

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -35,6 +35,8 @@ export const cvFilterPackageGroupsKey =
   (cvId, filterId) => `${CONTENT_VIEWS_KEY}_${cvId}_FILTER_${filterId}_PACKAGE_GROUPS`;
 export const cvFilterModuleStreamKey =
   (cvId, filterId) => `${CONTENT_VIEWS_KEY}_${cvId}_FILTER_${filterId}_MODULE_STREAMS`;
+export const cvFilterErratumIDKey =
+  (cvId, filterId) => `${CONTENT_VIEWS_KEY}_${cvId}_FILTER_${filterId}_ERRATA`;
 export const cvDetailsHistoryKey = cvId => `${CONTENT_VIEWS_KEY}_HISTORIES_${cvId}`;
 export const cvFilterRulesKey = filterId => `CONTENT_VIEW_FILTER_${filterId}_RULES`;
 export const cvDetailsComponentKey = cvId => `${CONTENT_VIEWS_KEY}_COMPONENTS_${cvId}`;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -27,6 +27,7 @@ import {
   cvFilterDetailsKey,
   cvFilterPackageGroupsKey,
   cvFilterModuleStreamKey,
+  cvFilterErratumIDKey,
   cvDetailsHistoryKey,
   cvFilterRulesKey,
   cvDetailsComponentKey,
@@ -306,6 +307,15 @@ export const getCVFilterModuleStreams = (cvId, filterId, params) => get({
   },
   errorToast: error => __(`Something went wrong while retrieving the content view filter! ${getResponseErrorMsgs(error.response)}`),
   url: api.getApiUrl('/module_streams'),
+});
+
+export const getCVFilterErrata = (cvId, filterId, params) => get({
+  key: cvFilterErratumIDKey(cvId, filterId),
+  params: {
+    filter_id: filterId, show_all_for: 'content_view_filter', include_filter_ids: true, ...params,
+  },
+  errorToast: error => __(`Something went wrong while retrieving the content view filter! ${getResponseErrorMsgs(error.response)}`),
+  url: api.getApiUrl('/errata'),
 });
 
 export const editCVFilterRule = (filterId, params, handleSuccess) => put({

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -11,6 +11,7 @@ import {
   cvFilterDetailsKey,
   cvFilterPackageGroupsKey,
   cvFilterModuleStreamKey,
+  cvFilterErratumIDKey,
   cvDetailsHistoryKey,
   cvFilterRulesKey,
   cvDetailsVersionKey,
@@ -104,6 +105,15 @@ export const selectCVFilterModuleStreamStatus = (state, cvId, filterId) =>
 
 export const selectCVFilterModuleStreamError = (state, cvId, filterId) =>
   selectAPIError(state, cvFilterModuleStreamKey(cvId, filterId));
+
+export const selectCVFilterErratumID = (state, cvId, filterId) =>
+  selectAPIResponse(state, cvFilterErratumIDKey(cvId, filterId));
+
+export const selectCVFilterErratumIDStatus = (state, cvId, filterId) =>
+  selectAPIStatus(state, cvFilterErratumIDKey(cvId, filterId)) || STATUS.PENDING;
+
+export const selectCVFilterErratumIDError = (state, cvId, filterId) =>
+  selectAPIError(state, cvFilterErratumIDKey(cvId, filterId));
 
 export const selectCVHistories = (state, cvId) =>
   selectAPIResponse(state, cvDetailsHistoryKey(cvId)) || {};

--- a/webpack/scenes/ContentViews/Details/Filters/CVErratumIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErratumIDFilterContent.js
@@ -1,0 +1,242 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+import PropTypes from 'prop-types';
+import { shallowEqual, useSelector, useDispatch } from 'react-redux';
+import { TableVariant } from '@patternfly/react-table';
+import { Tabs, Tab, TabTitleText, Split, SplitItem, Button, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { STATUS } from 'foremanReact/constants';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+import onSelect from '../../../../components/Table/helpers';
+import TableWrapper from '../../../../components/Table/TableWrapper';
+import {
+  selectCVFilterErratumID,
+  selectCVFilterErratumIDStatus,
+  selectCVFilterErratumIDError,
+  selectCVFilters, selectCVFilterDetails, selectCVFiltersStatus,
+} from '../ContentViewDetailSelectors';
+import getContentViewDetails, {
+  addCVFilterRule, removeCVFilterRule, getCVFilterErrata,
+  deleteContentViewFilterRules, addContentViewFilterRules,
+} from '../ContentViewDetailActions';
+import AddedStatusLabel from '../../../../components/AddedStatusLabel';
+import ErratumTypeLabel from '../../../../components/ErratumTypeLabel';
+import AffectedRepositoryTable from './AffectedRepositories/AffectedRepositoryTable';
+
+const CVErratumIDFilterContent = ({
+  cvId, filterId, showAffectedRepos, setShowAffectedRepos,
+}) => {
+  const dispatch = useDispatch();
+  const { results: filterResults } =
+    useSelector(state => selectCVFilters(state, cvId), shallowEqual);
+  const response = useSelector(state =>
+    selectCVFilterErratumID(state, cvId, filterId), shallowEqual);
+  const status = useSelector(state =>
+    selectCVFilterErratumIDStatus(state, cvId, filterId), shallowEqual);
+  const filterLoad = useSelector(state =>
+    selectCVFiltersStatus(state, cvId), shallowEqual);
+  const error = useSelector(state =>
+    selectCVFilterErratumIDError(state, cvId, filterId), shallowEqual);
+  const filterDetails = useSelector(state =>
+    selectCVFilterDetails(state, cvId, filterId), shallowEqual);
+  const { repositories = [] } = filterDetails;
+  const [rows, setRows] = useState([]);
+  const [metadata, setMetadata] = useState({});
+  const [searchQuery, updateSearchQuery] = useState('');
+  const [activeTabKey, setActiveTabKey] = useState(0);
+  const filterLoaded = filterLoad === 'RESOLVED';
+  const loading = status === STATUS.PENDING;
+  const [bulkActionOpen, setBulkActionOpen] = useState(false);
+  const deselectAll = () => setRows(rows.map(row => ({ ...row, selected: false })));
+  const toggleBulkAction = () => setBulkActionOpen(prevState => !prevState);
+  const hasAddedSelected = rows.some(({ selected, added }) => selected && added);
+  const hasNotAddedSelected = rows.some(({ selected, added }) => selected && !added);
+  const columnHeaders = [
+    __('Errata ID'),
+    __('Type'),
+    __('Issued'),
+    __('Updated'),
+    __('Severity'),
+    __('Synopsis'),
+    __('Status'),
+  ];
+
+  const buildRows = useCallback((results) => {
+    const newRows = [];
+    const filterRules = filterResults.find(({ id }) => id === Number(filterId))?.rules || [];
+    results.forEach((errata) => {
+      const {
+        id,
+        errata_id: errataId,
+        type,
+        issued,
+        updated,
+        severity,
+        title,
+        filter_ids: filterIds,
+        ...rest
+      } = errata;
+
+      const added = filterIds.includes(parseInt(filterId, 10));
+
+      const cells = [
+        { title: errataId },
+        { title: <ErratumTypeLabel type={type} /> },
+        { title: issued },
+        { title: updated },
+        { title: severity || 'N/A' },
+        { title },
+        { title: <AddedStatusLabel added={added} /> },
+      ];
+
+
+      newRows.push({
+        cells,
+        erratumId: errataId,
+        erratumRuleId: filterRules?.find(({ errata_id: filterErrataId }) =>
+          filterErrataId === errataId)?.id,
+        added,
+        ...rest,
+        errataId,
+      });
+    });
+
+    return newRows.sort(({ added: addedA }, { added: addedB }) => {
+      if (addedA === addedB) return 0;
+      return addedA ? -1 : 1;
+    });
+  }, [filterResults, filterId]);
+
+  const bulkAdd = () => {
+    setBulkActionOpen(false);
+    const addData = rows.filter(({ selected, added }) =>
+      selected && !added).map(({ erratumId }) => ({ errata_ids: [erratumId] })); // eslint-disable-line max-len
+    dispatch(addContentViewFilterRules(filterId, addData, () =>
+      dispatch(getContentViewDetails(cvId))));
+    deselectAll();
+  };
+
+  const bulkRemove = () => {
+    setBulkActionOpen(false);
+    const erratumRuleIds =
+      rows.filter(({ selected, added }) =>
+        selected && added).map(({ erratumRuleId }) => erratumRuleId);
+    dispatch(deleteContentViewFilterRules(filterId, erratumRuleIds, () =>
+      dispatch(getContentViewDetails(cvId))));
+    deselectAll();
+  };
+
+  useEffect(() => {
+    if (!repositories.length && showAffectedRepos) {
+      setActiveTabKey(1);
+    } else {
+      setActiveTabKey(0);
+    }
+  }, [showAffectedRepos, repositories.length]);
+
+  useDeepCompareEffect(() => {
+    const { results, ...meta } = response;
+    setMetadata(meta);
+
+    if (!loading && results && filterLoaded) {
+      const newRows = buildRows(results);
+      setRows(newRows);
+    }
+  }, [response, loading, filterLoaded, buildRows]);
+
+  const actionResolver = ({ added }) => [
+    {
+      title: __('Add'),
+      isDisabled: added,
+      onClick: (_event, _rowId, { erratumId }) => {
+        dispatch(addCVFilterRule(filterId, { errata_ids: [erratumId] }, () =>
+          dispatch(getContentViewDetails(cvId))));
+      },
+    },
+    {
+      title: __('Remove'),
+      isDisabled: !added,
+      onClick: (_event, _rowId, { erratumRuleId }) => {
+        dispatch(removeCVFilterRule(filterId, erratumRuleId, () =>
+          dispatch(getContentViewDetails(cvId))));
+      },
+    },
+  ];
+
+  const emptyContentTitle = __('No errata available to add to this filter.');
+  const emptyContentBody = __('No errata available for this content view.');
+  const emptySearchTitle = __('No matching filter rules found.');
+  const emptySearchBody = __('Try changing your search settings.');
+
+
+  return (
+    <Tabs activeKey={activeTabKey} onSelect={(_event, eventKey) => setActiveTabKey(eventKey)}>
+      <Tab eventKey={0} title={<TabTitleText>{__('Errata')}</TabTitleText>}>
+        <div className="tab-body-with-spacing">
+          <TableWrapper
+            {...{
+              rows,
+              metadata,
+              emptyContentTitle,
+              emptyContentBody,
+              emptySearchTitle,
+              emptySearchBody,
+              searchQuery,
+              updateSearchQuery,
+              error,
+              status,
+              actionResolver,
+            }}
+            status={status}
+            onSelect={onSelect(rows, setRows)}
+            cells={columnHeaders}
+            variant={TableVariant.compact}
+            autocompleteEndpoint={`/errata/auto_complete_search?filterid=${filterId}`}
+            fetchItems={useCallback(params =>
+              getCVFilterErrata(cvId, filterId, params), [cvId, filterId])}
+            actionButtons={
+              <Split hasGutter>
+                <SplitItem>
+                  <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="secondary" aria-label="add_filter_rule">
+                    {__('Add errata')}
+                  </Button>
+                </SplitItem>
+                <SplitItem>
+                  <Dropdown
+                    toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                    isOpen={bulkActionOpen}
+                    isPlain
+                    dropdownItems={[
+                      <DropdownItem aria-label="bulk_add" key="bulk_add" isDisabled={!hasNotAddedSelected} component="button" onClick={bulkAdd}>
+                        {__('Add')}
+                      </DropdownItem>,
+                      <DropdownItem aria-label="bulk_remove" key="bulk_remove" isDisabled={!hasAddedSelected} component="button" onClick={bulkRemove}>
+                        {__('Remove')}
+                      </DropdownItem>]
+                  }
+                  />
+                </SplitItem>
+              </Split>
+            }
+          />
+        </div>
+      </Tab>
+      {(repositories.length || showAffectedRepos) &&
+      <Tab eventKey={1} title={<TabTitleText>{__('Affected Repositories')}</TabTitleText>}>
+        <div className="tab-body-with-spacing">
+          <AffectedRepositoryTable cvId={cvId} filterId={filterId} repoType="yum" setShowAffectedRepos={setShowAffectedRepos} />
+        </div>
+      </Tab>
+      }
+    </Tabs>
+  );
+};
+
+CVErratumIDFilterContent.propTypes = {
+  cvId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  showAffectedRepos: PropTypes.bool.isRequired,
+  setShowAffectedRepos: PropTypes.func.isRequired,
+};
+
+export default CVErratumIDFilterContent;

--- a/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
@@ -5,6 +5,7 @@ import CVPackageGroupFilterContent from './CVPackageGroupFilterContent';
 import CVRpmFilterContent from './CVRpmFilterContent';
 import CVContainerImageFilterContent from './CVContainerImageFilterContent';
 import CVModuleStreamFilterContent from './CVModuleStreamFilterContent';
+import CVErratumIDFilterContent from './CVErratumIDFilterContent';
 
 const CVFilterDetailType = ({
   cvId, filterId, inclusion, type, showAffectedRepos, setShowAffectedRepos, rules,
@@ -43,8 +44,12 @@ const CVFilterDetailType = ({
       if (head(rules)?.types) {
         return (<p>WIP Errata by date</p>);
       }
-      return (<p>WIP Errata by ID</p>);
-
+      return (<CVErratumIDFilterContent
+        cvId={cvId}
+        filterId={filterId}
+        showAffectedRepos={showAffectedRepos}
+        setShowAffectedRepos={setShowAffectedRepos}
+      />);
     default:
       return null;
   }

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/allFilterErrata.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/allFilterErrata.fixtures.json
@@ -1,0 +1,122 @@
+{
+    "total": 4,
+    "subtotal": 4,
+    "page": 1,
+    "per_page": 20,
+    "error": null,
+    "search": null,
+    "sort": {
+      "by": "updated",
+      "order": "desc"
+    },
+    "results": [
+      {
+        "id": 3,
+        "pulp_id": "RHEA-2012:0056",
+        "title": "Bird_Erratum",
+        "errata_id": "RHEA-2012:0056",
+        "issued": "2013-01-27",
+        "updated": "2013-01-27",
+        "severity": "",
+        "description": "ParthaBird_Erratum",
+        "solution": "",
+        "summary": "",
+        "reboot_suggested": false,
+        "uuid": "RHEA-2012:0056",
+        "name": "Bird_Erratum",
+        "type": "security",
+        "cves": [],
+        "bugs": [],
+        "hosts_available_count": 0,
+        "hosts_applicable_count": 0,
+        "packages": [
+          "crow-0.8-1.noarch",
+          "duck-0.6-1.noarch",
+          "stork-0.12-2.noarch"
+        ],
+        "module_streams": [],
+        "filter_ids": []
+      },
+      {
+        "id": 2,
+        "pulp_id": "RHEA-2012:0057",
+        "title": "Bear_ErratumPARTHA",
+        "errata_id": "RHEA-2012:0057",
+        "issued": "2013-01-27",
+        "updated": "2013-01-27",
+        "severity": "",
+        "description": "Bear_Erratum",
+        "solution": "",
+        "summary": "",
+        "reboot_suggested": false,
+        "uuid": "RHEA-2012:0057",
+        "name": "Bear_ErratumPARTHA",
+        "type": "security",
+        "cves": [],
+        "bugs": [],
+        "hosts_available_count": 0,
+        "hosts_applicable_count": 0,
+        "packages": [
+          "bear-4.1-1.noarch"
+        ],
+        "module_streams": [],
+        "filter_ids": []
+      },
+      {
+        "id": 1,
+        "pulp_id": "RHEA-2012:0058",
+        "title": "Gorilla_Erratum",
+        "errata_id": "RHEA-2012:0058",
+        "issued": "2013-01-27",
+        "updated": "2013-01-27",
+        "severity": "",
+        "description": "Gorilla_Erratum",
+        "solution": "",
+        "summary": "",
+        "reboot_suggested": false,
+        "uuid": "RHEA-2012:0058",
+        "name": "Gorilla_Erratum",
+        "type": "enhancement",
+        "cves": [],
+        "bugs": [],
+        "hosts_available_count": 0,
+        "hosts_applicable_count": 0,
+        "packages": [
+          "gorilla-0.62-1.noarch"
+        ],
+        "module_streams": [],
+        "filter_ids": [
+          6
+        ]
+      },
+      {
+        "id": 4,
+        "pulp_id": "RHEA-2012:0055",
+        "title": "Sea_Erratum",
+        "errata_id": "RHEA-2012:0055",
+        "issued": "2012-01-27",
+        "updated": "2012-01-27",
+        "severity": "",
+        "description": "Sea_Erratum",
+        "solution": "",
+        "summary": "",
+        "reboot_suggested": false,
+        "uuid": "RHEA-2012:0055",
+        "name": "Sea_Erratum",
+        "type": "security",
+        "cves": [],
+        "bugs": [],
+        "hosts_available_count": 0,
+        "hosts_applicable_count": 0,
+        "packages": [
+          "penguin-0.9.1-1.noarch",
+          "shark-0.1-1.noarch",
+          "walrus-5.21-1.noarch"
+        ],
+        "module_streams": [],
+        "filter_ids": [
+          6
+        ]
+      }
+    ]
+}

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.fixtures.json
@@ -66,11 +66,19 @@
          "rules": [
             {
                "content_view_filter_id": 6,
-               "errata_id": "RHEA-2012:0059",
+               "errata_id": "RHEA-2012:0055",
                "date_type": "updated",
-               "id": 3,
-               "created_at": "2020-12-08 10:32:25 -0500",
-               "updated_at": "2020-12-08 10:32:25 -0500"
+               "id": 4,
+               "created_at": "2012-01-27",
+               "updated_at": "2012-01-27"
+            },
+            {
+               "content_view_filter_id": 6,
+               "errata_id": "RHEA-2012:0058",
+               "date_type": "updated",
+               "id": 1,
+               "created_at": "2013-01-27",
+               "updated_at": "2013-01-27"
             }
          ]
       },

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -1,0 +1,317 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { Route } from 'react-router-dom';
+
+import ContentViewFilterDetails from '../ContentViewFilterDetails';
+import { cvFilterDetailsKey } from '../../../ContentViewsConstants';
+import nock, {
+  nockInstance,
+  assertNockRequest,
+  mockAutocomplete,
+  mockSetting,
+} from '../../../../../test-utils/nockWrapper';
+import api from '../../../../../services/api';
+
+const allErrata = require('./allFilterErrata.fixtures.json');
+const cvFilterDetails = require('./cvErratumFilterDetails.fixtures.json');
+const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+
+const cvFiltersPath = api.getApiUrl('/content_view_filters');
+const cvRefreshCallbackPath = api.getApiUrl('/content_views/1');
+
+const cvFilterDetailsPath = api.getApiUrl('/content_view_filters/6');
+const cvAddFilterRulePath = api.getApiUrl('/content_view_filters/6/rules');
+const cvRemoveFilterRulePath = api.getApiUrl('/content_view_filters/6/rules/4');
+const cvBulkRemoveFilterRulesPath = api.getApiUrl('/content_view_filters/6/remove_filter_rules');
+const cvBulkAddFilterRulesPath = api.getApiUrl('/content_view_filters/6/add_filter_rules');
+
+const errataPath = api.getApiUrl('/errata');
+const autocompleteUrl = '/errata/auto_complete_search';
+const renderOptions = {
+  apiNamespace: cvFilterDetailsKey(1, 6),
+  routerParams: {
+    initialEntries: [{ pathname: '/labs/content_views/1#/filters/6' }],
+    initialIndex: 1,
+  },
+};
+
+const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+
+let searchDelayScope;
+let autoSearchScope;
+beforeEach(() => {
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  // Autosearch can cause some asynchronous issues with the typing timeout, using basic search
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', false);
+});
+
+afterEach(() => {
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autoSearchScope);
+  nock.cleanAll();
+});
+
+test('Can enable and disable add filter button', async (done) => {
+  const { name: cvFilterName } = cvFilterDetails;
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+  const cvFiltersScope = nockInstance
+    .get(cvFiltersPath)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+  const errataScope = nockInstance
+    .get(errataPath)
+    .query(true)
+    .reply(200, allErrata);
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getByText, queryByText, getByLabelText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(cvFilterName)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(getByText(cvFilterName)).toBeInTheDocument();
+    expect(getByLabelText('Select all rows')).toBeInTheDocument();
+  });
+  expect(getByLabelText('add_filter_rule')).toHaveAttribute('aria-disabled', 'true');
+  getByLabelText('Select all rows').click();
+  await patientlyWaitFor(() => {
+    expect(getByLabelText('add_filter_rule')).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvFiltersScope);
+  assertNockRequest(errataScope, done);
+});
+
+test('Can add a filter rule', async (done) => {
+  const { rules } = cvFilterDetails;
+  const errataId = rules[0].errata_id;
+
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const cvFiltersScope = nockInstance
+    .get(cvFiltersPath)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+
+  const cvFiltersRuleScope = nockInstance
+    .post(cvAddFilterRulePath)
+    .query(true)
+    .reply(200, {});
+
+  const errataScope = nockInstance
+    .get(errataPath)
+    .query(true)
+    .reply(200, allErrata);
+
+  const cvRequestCallbackScope = nockInstance
+    .get(cvRefreshCallbackPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getAllByLabelText, getByText, queryByText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(errataId)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(getByText(errataId)).toBeInTheDocument();
+    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+  });
+  fireEvent.click(getAllByLabelText('Actions')[2]);
+  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
+  fireEvent.click(getByText('Add'));
+
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvFiltersScope);
+  assertNockRequest(cvFiltersRuleScope);
+  assertNockRequest(cvRequestCallbackScope);
+
+  assertNockRequest(errataScope, done);
+});
+
+test('Can remove a filter rule', async (done) => {
+  const { rules } = cvFilterDetails;
+  const errataId = rules[0].errata_id; // 'RHEA-2012:0055'
+
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const cvFiltersScope = nockInstance
+    .get(cvFiltersPath)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+
+  const cvFiltersRuleScope = nockInstance
+    .delete(cvRemoveFilterRulePath)
+    .reply(200, {});
+
+  const errataScope = nockInstance
+    .get(errataPath)
+    .query(true)
+    .reply(200, allErrata);
+
+  const cvRequestCallbackScope = nockInstance
+    .get(cvRefreshCallbackPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getAllByLabelText, getByText, queryByText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(errataId)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(getByText(errataId)).toBeInTheDocument();
+    expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'false');
+  });
+  fireEvent.click(getAllByLabelText('Actions')[1]);
+  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'true');
+  await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
+  fireEvent.click(getByText('Remove'));
+
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvFiltersScope);
+  assertNockRequest(cvFiltersRuleScope);
+  assertNockRequest(cvRequestCallbackScope);
+
+  assertNockRequest(errataScope, done);
+});
+
+test('Can bulk remove filter rules', async (done) => {
+  const { rules } = cvFilterDetails;
+  const errataId = rules[0].errata_id;
+
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const cvFiltersScope = nockInstance
+    .get(cvFiltersPath)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+
+  const bulkDeleteParams = { rule_ids: [1, 4] };
+
+  const cvFiltersRuleBulkDeleteScope = nockInstance
+    .put(cvBulkRemoveFilterRulesPath, bulkDeleteParams)
+    .reply(200, {});
+
+  const errataScope = nockInstance
+    .get(errataPath)
+    .query(true)
+    .reply(200, allErrata);
+
+  const cvRequestCallbackScope = nockInstance
+    .get(cvRefreshCallbackPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getByText, queryByText, getByLabelText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(errataId)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(getByText(errataId)).toBeInTheDocument();
+    // "Select all rows"
+    expect(getByLabelText('Select all rows')).toBeInTheDocument();
+    expect(getByLabelText('bulk_actions')).toHaveAttribute('aria-expanded', 'false');
+  });
+  fireEvent.click(getByLabelText('Select all rows'));
+  fireEvent.click(getByLabelText('bulk_actions'));
+  expect(getByLabelText('bulk_actions')).toHaveAttribute('aria-expanded', 'true');
+  expect(getByLabelText('bulk_remove')).toBeInTheDocument();
+  fireEvent.click(getByLabelText('bulk_remove'));
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvFiltersScope);
+  assertNockRequest(cvFiltersRuleBulkDeleteScope);
+  assertNockRequest(cvRequestCallbackScope);
+
+  assertNockRequest(errataScope, done);
+});
+
+test('Can bulk add filter rules', async (done) => {
+  const { rules } = cvFilterDetails;
+  const errataId = rules[0].errata_id;
+
+  const cvFilterScope = nockInstance
+    .get(cvFilterDetailsPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const cvFiltersScope = nockInstance
+    .get(cvFiltersPath)
+    .query(true)
+    .reply(200, cvFilterFixtures);
+  const bulkAddParams = { rules_params: [{ errata_ids: ['RHEA-2012:0056'] }, { errata_ids: ['RHEA-2012:0057'] }] };
+
+  const cvFiltersRuleBulkAddScope = nockInstance
+    .put(cvBulkAddFilterRulesPath, bulkAddParams)
+    .reply(200, {});
+
+  const errataScope = nockInstance
+    .get(errataPath)
+    .query(true)
+    .reply(200, allErrata);
+
+  const cvRequestCallbackScope = nockInstance
+    .get(cvRefreshCallbackPath)
+    .query(true)
+    .reply(200, cvFilterDetails);
+
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { getByText, queryByText, getByLabelText } =
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+
+  // Nothing will show at first, page is loading
+  expect(queryByText(errataId)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(getByText(errataId)).toBeInTheDocument();
+    expect(getByLabelText('Select all rows')).toBeInTheDocument();
+    expect(getByLabelText('bulk_actions')).toHaveAttribute('aria-expanded', 'false');
+  });
+  fireEvent.click(getByLabelText('Select all rows'));
+  fireEvent.click(getByLabelText('bulk_actions'));
+  expect(getByLabelText('bulk_actions')).toHaveAttribute('aria-expanded', 'true');
+  expect(getByLabelText('bulk_add')).toBeInTheDocument();
+  fireEvent.click(getByLabelText('bulk_add'));
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(cvFilterScope);
+  assertNockRequest(cvFiltersScope);
+  assertNockRequest(cvFiltersRuleBulkAddScope);
+  assertNockRequest(cvRequestCallbackScope);
+
+  assertNockRequest(errataScope, done);
+});

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErratumFilterDetails.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErratumFilterDetails.fixtures.json
@@ -1,0 +1,89 @@
+{
+    "inclusion": true,
+    "id": 6,
+    "name": "f2",
+    "description": null,
+    "created_at": "2020-12-08 09:26:11 -0500",
+    "updated_at": "2020-12-08 09:26:11 -0500",
+    "content_view": {
+        "composite": false,
+        "component_ids": [],
+        "default": false,
+        "version_count": 0,
+        "latest_version": null,
+        "auto_publish": false,
+        "solve_dependencies": false,
+        "import_only": false,
+        "repository_ids": [
+           1
+        ],
+        "id": 2,
+        "name": "cv1",
+        "label": "cv1",
+        "description": "",
+        "organization_id": 1,
+        "organization": {
+           "name": "Default Organization",
+           "label": "Default_Organization",
+           "id": 1
+        },
+        "created_at": "2021-02-23 10:08:10 -0500",
+        "updated_at": "2021-02-23 10:08:10 -0500",
+        "environments": [],
+        "repositories": [
+           {
+              "id": 1,
+              "name": "zoo3",
+              "label": "zoo3",
+              "content_type": "yum",
+              "product": {
+                 "id": 1,
+                 "name": "prod1"
+              },
+              "content_counts": {
+                 "ostree_branch": 0,
+                 "docker_manifest": 0,
+                 "docker_tag": 0,
+                 "rpm": 32,
+                 "package": 32,
+                 "package_group": 2,
+                 "erratum": 4,
+                 "module_stream": 3
+              }
+           }
+        ],
+        "versions": [],
+        "components": [],
+        "content_view_components": [],
+        "activation_keys": [],
+        "next_version": "1.0",
+        "last_published": null,
+        "permissions": {
+           "view_content_views": true,
+           "edit_content_views": true,
+           "destroy_content_views": true,
+           "publish_content_views": true,
+           "promote_or_remove_content_views": true
+        }
+     },
+    "repositories": [],
+    "type": "erratum",
+    "rules": [
+       {
+          "content_view_filter_id": 6,
+          "errata_id": "RHEA-2012:0055",
+          "date_type": "updated",
+          "id": 1,
+          "created_at": "2012-01-27",
+          "updated_at": "2012-01-27"
+       },
+       {
+          "content_view_filter_id": 6,
+          "errata_id": "RHEA-2012:0058",
+          "date_type": "updated",
+          "id": 4,
+          "created_at": "2013-01-27",
+          "updated_at": "2013-01-27"
+       }
+    ]
+ }


### PR DESCRIPTION
This PR adds the ability to create erratum filter rules by ID.  It supports bulk add and remove.

Things to test:
1) Errata filtering
2) Single and bulk adding
3) Single and bulk removing

Comments:

I chose the name `CVErratumIDFilterContent.js` because I assumed there would also  be something like `CVErratumDateFilterContent.js` in the future.

TODO:

- [x] Tests