### PR TITLE
Fixes #33523 - Fix sync plan start date on Firefox

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
@@ -28,9 +28,13 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
             $scope.editedInterval = false;
 
             function updateSyncPlan(syncPlan) {
-                var syncDate;
+                var syncDate, splitDates;
                 if (syncPlan['sync_date']) {
-                    syncDate = new Date(syncPlan['sync_date']);
+                    // Firefox doesn't work with new Date(2021-10-04 18:57:00 -0400)
+                    //Needs to be in format YYYY-MM-DDTHH:mm:ss.sssZ
+                    // see: https://262.ecma-international.org/5.1/#sec-15.9.1.15
+                    splitDates = syncPlan['sync_date'].split(' ');
+                    syncDate = new Date(splitDates[0] + 'T' + splitDates[1] + splitDates[2]);
                 } else {
                     syncDate = new Date();
                 }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
@@ -20,7 +20,7 @@
       <dt translate>Start Date</dt>
       <dd bst-edit-custom="syncPlan.syncDate"
           formatter="date"
-          formatter-options="'MMMM d, y, hh:mm a'"
+          formatter-options="'MMMM dd, y, hh:mm a'"
           on-save="save(syncPlan)"
           readonly="denied('edit_sync_plans', syncPlan)">
 


### PR DESCRIPTION
To test:

Create a sync plan
Go to details on Firefox.
The start date shows up as null.

With this change, the date should be supported on Firefox and Chrome.