### PR TITLE
Fixes #33629 - 4.0 upgrade migration fails due to validation

### DIFF
--- a/db/migrate/20210512192745_fix_red_hat_root_repository_arch.rb
+++ b/db/migrate/20210512192745_fix_red_hat_root_repository_arch.rb
@@ -2,7 +2,7 @@ class FixRedHatRootRepositoryArch < ActiveRecord::Migration[6.0]
   def up
     ::Katello::RootRepository.
       joins("INNER JOIN katello_contents ON katello_contents.cp_content_id = katello_root_repositories.content_id").
-      where.not(arch: 'noarch').where.not("katello_contents.content_url ILIKE '%$basearch%'").update(arch: 'noarch')
+      where.not(arch: 'noarch').where.not("katello_contents.content_url ILIKE '%$basearch%'").update_all(arch: 'noarch')
   end
 
   def down


### PR DESCRIPTION
Issue at hand: when the migration below actually updates a root repo, there is a validation failure on `:ensure_valid_upstream_authorization` because the `upstream_authentication_token` column does not exist yet.  This PR works around the issue by stubbing out this validation.

To test:

1) Set up a Katello 3.18 instance and make a custom repository
2) Edit the repository like so in the `console`:

```ruby
::Katello::Repository.find(<id>).root.update(arch: 'x86_64')
```
3) Make a VM snapshot
4) Update Katello to 4.0 and run the database migration
5) See the migration error from the redmine
6) Revert back to Katello 3.18
7) Update Katello to 4.0 again
8) Patch in this PR
9) See the migration run successfully