### PR TITLE
Fixes #33594 - Add file list to CV version table listing

### DIFF
--- a/app/controllers/katello/api/v2/file_units_controller.rb
+++ b/app/controllers/katello/api/v2/file_units_controller.rb
@@ -1,5 +1,6 @@
 module Katello
   class Api::V2::FileUnitsController < Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
     resource_description do
       name 'Files'
     end

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -26,6 +26,7 @@ export const ANSIBLE_COLLECTIONS_CONTENT = 'ANSIBLE_COLLECTIONS_CONTENT';
 export const MODULE_STREAMS_CONTENT = 'MODULE_STREAMS_CONTENT';
 export const DEB_PACKAGES_CONTENT = 'DEB_PACKAGES_CONTENT';
 export const RPM_PACKAGES_CONTENT = 'RPM_PACKAGES_CONTENT';
+export const FILE_CONTENT = 'FILE_CONTENT';
 export const cvDetailsKey = cvId => `${CONTENT_VIEWS_KEY}_${cvId}`;
 export const cvDetailsRepoKey = cvId => `${CONTENT_VIEWS_KEY}_REPOSITORIES_${cvId}`;
 export const cvFilterRepoKey = filterId => `CV_FILTER_REPOSITORIES_${filterId}`;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -41,6 +41,7 @@ import {
   cvVersionDetailsKey,
   cvRemoveVersionKey,
   REPOSITORY_CONTENT,
+  FILE_CONTENT,
   ERRATA_CONTENT,
   MODULE_STREAMS_CONTENT,
   DEB_PACKAGES_CONTENT,
@@ -76,6 +77,13 @@ export const getRPMPackages = params => get({
   errorToast: error => __(`Something went wrong while fetching rpm packages! ${getResponseErrorMsgs(error.response)}`),
 });
 
+export const getFiles = params => get({
+  type: API_OPERATIONS.GET,
+  key: FILE_CONTENT,
+  url: api.getApiUrl('/files'),
+  params,
+  errorToast: error => __(`Something went wrong while fetching files! ${getResponseErrorMsgs(error.response)}`),
+});
 
 export const updateContentView = (cvId, params) => dispatch => dispatch(put({
   type: API_OPERATIONS.PUT,
@@ -289,7 +297,6 @@ export const getPackageGroups = params => get({
   params,
   errorToast: error => __(`Something went wrong while retrieving package groups! ${getResponseErrorMsgs(error.response)}`),
 });
-
 
 export const getCVFilterPackageGroups = (cvId, filterId, params) => get({
   key: cvFilterPackageGroupsKey(cvId, filterId),

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -29,6 +29,7 @@ import {
   RPM_PACKAGES_CONTENT,
   RPM_PACKAGE_GROUPS_CONTENT,
   REPOSITORY_CONTENT,
+  FILE_CONTENT,
   ERRATA_CONTENT,
   MODULE_STREAMS_CONTENT,
   DEB_PACKAGES_CONTENT,
@@ -171,6 +172,12 @@ export const selectRPMPackages = state =>
 
 export const selectRPMPackagesStatus = state =>
   selectAPIStatus(state, RPM_PACKAGES_CONTENT) || STATUS.PENDING;
+
+export const selectFiles = state =>
+  selectAPIResponse(state, FILE_CONTENT);
+
+export const selectFilesStatus = state =>
+  selectAPIStatus(state, FILE_CONTENT) || STATUS.PENDING;
 
 export const selectErrata = state =>
   selectAPIResponse(state, ERRATA_CONTENT);

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -15,6 +15,7 @@ import {
   getDebPackages,
   getDockerTags,
   getErrata,
+  getFiles,
   getModuleStreams,
   getPackageGroups,
   getRepositories,
@@ -29,6 +30,8 @@ import {
   selectDebPackagesStatus,
   selectDockerTags,
   selectDockerTagsStatus,
+  selectFiles,
+  selectFilesStatus,
   selectErrata,
   selectErrataStatus,
   selectModuleStreams,
@@ -152,6 +155,24 @@ export default ({ cvId, versionId }) => [
     columnHeaders: [
       { title: __('Name'), getProperty: item => item?.name },
       { title: __('Repository'), getProperty: item => item?.repository?.name },
+    ],
+  },
+  {
+    name: __('Files'),
+    getCountKey: item => item?.file_count,
+    responseSelector: state => selectFiles(state),
+    statusSelector: state => selectFilesStatus(state),
+    autocompleteEndpoint: `/files/auto_complete_search?content_view_version_id=${versionId}`,
+    fetchItems: params => getFiles({ content_view_version_id: versionId, ...params }),
+    columnHeaders: [
+      {
+        title: __('Name'),
+        getProperty: item => (
+          <a href={urlBuilder(`files/${item?.id}`, '')}>
+            {item?.name}
+          </a>),
+      },
+      { title: __('Path'), getProperty: item => item?.path },
     ],
   },
   {

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
@@ -23,6 +23,7 @@ const ContentViewVersionsComponentData = require('./ContentViewVersionComponent.
 const ContentViewVersionsRepositoriesData = require('./ContentViewVersionRepositories.fixtures.json');
 const ContentViewVersionRpmPackagesData = require('./ContentViewVersionRpmPackages.fixtures.json');
 const ContentViewVersionRpmPackageGroupsData = require('./ContentViewVersionRpmPackageGroups.fixtures.json');
+const ContentViewVersionFilesData = require('./ContentViewVersionFiles.fixtures.json');
 const ContentViewVersionErrataData = require('./ContentViewVersionErrata.fixtures.json');
 const ContentViewVersionModuleStreamsData = require('./ContentViewVersionModuleStreams.fixtures.json');
 const ContentViewVersionDebPackagesData = require('./ContentViewVersionDebPackages.fixtures.json');
@@ -109,6 +110,16 @@ const testConfig = [
     textQuery: [
       head(ContentViewVersionRpmPackageGroupsData.results).name,
       last(ContentViewVersionRpmPackageGroupsData.results).name],
+  },
+  {
+    name: 'Files',
+    countKey: 'file_count',
+    autoCompleteUrl: '/files/auto_complete_search',
+    dataUrl: api.getApiUrl('/files'),
+    data: ContentViewVersionFilesData,
+    textQuery: [
+      head(ContentViewVersionFilesData.results).name,
+      last(ContentViewVersionFilesData.results).name],
   },
   {
     name: 'Errata',

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionFiles.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionFiles.fixtures.json
@@ -1,0 +1,22 @@
+{
+    "total": 1,
+    "subtotal": 1,
+    "page": "1",
+    "per_page": "20",
+    "error": null,
+    "search": null,
+    "sort": {
+      "by": "name",
+      "order": "asc"
+    },
+    "results": [
+      {
+        "id": 1,
+        "name": "DarkMonokai.qss",
+        "path": "DarkMonokai",
+        "uuid": "/pulp/api/v3/content/file/files/807808c0-f261-41bf-a69d-5ae6b9511aff/",
+        "pulp_id": "/pulp/api/v3/content/file/files/807808c0-f261-41bf-a69d-5ae6b9511aff/",
+        "checksum": "931b9030fcdfe13a508382692343b0981ea48970989e9f2c05dbf91d827f80d7"
+      }
+    ]
+  }


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This PR allows the user to see which files they have inside of a CV version alongside the already add file repo listing.

### What are the testing steps for this pull request?

* Create a file repo and upload a file
* Create a CV, add the file repo, and publish
* Goto the new CV page and check the versions tab, you will see a screenshot like this: https://1drv.ms/u/s!AmcYeL73Lgj6wFWRPSCFMncv1LZy?e=17Svs2
* Click files and see that it takes you to `/files` in the old UI