### PR TITLE
Fixes #33651 - Cache resource list API responses

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -134,6 +134,10 @@ module Katello
       scoped_search_results(query: blank_query, page: page, per_page: per_page, error: message)
     end
 
+    def skip_session
+      request.session_options[:skip] = true
+    end
+
     protected
 
     def scoped_search_query(query, group)

--- a/app/controllers/katello/api/v2/root_controller.rb
+++ b/app/controllers/katello/api/v2/root_controller.rb
@@ -9,10 +9,6 @@ module Katello
       api_base_url "/katello/api"
     end
 
-    def resource_list
-      render json: self.class.rhsm_resource_list
-    end
-
     def rhsm_resource_list
       # The RHSM resource list is required to interact with RHSM on the client.
       # When requested, it will return a list of the resources (href & rel) defined by katello
@@ -22,27 +18,8 @@ module Katello
       render json: self.class.rhsm_resource_list
     end
 
-    def self.resource_list
-      @resource_list ||= generate_resource_list
-    end
-
     def self.rhsm_resource_list
       @rhsm_resource_list ||= generate_rhsm_resource_list
-    end
-
-    def self.generate_resource_list
-      all_routes = Engine.routes.routes
-      all_routes = all_routes.collect { |r| r.path.spec.to_s }
-
-      api_root_routes = all_routes.select do |path|
-        path =~ %r{^/katello/api(\(/:api_version\))?/[^/]+/:id\(\.:format\)$}
-      end
-      api_root_routes = api_root_routes.collect do |path|
-        path = path.sub("(/:api_version)", "")
-        path[0..-(":id(.:format)".length + 1)]
-      end
-
-      api_root_routes.collect! { |r| { :rel => r["/katello/api/".size..-2], :href => r } }
     end
 
     def self.generate_rhsm_resource_list

--- a/app/controllers/katello/api/v2/root_controller.rb
+++ b/app/controllers/katello/api/v2/root_controller.rb
@@ -8,6 +8,19 @@ module Katello
     end
 
     def resource_list
+      respond_for_index :collection => RESOURCE_LIST
+    end
+
+    def rhsm_resource_list
+      # The RHSM resource list is required to interact with RHSM on the client.
+      # When requested, it will return a list of the resources (href & rel) defined by katello
+      # for the /rhsm namespace.  The rel values are used by RHSM to determine if the server
+      # supports a particular resource (e.g. environments, guestids, organizations..etc)
+
+      respond_for_index :collection => RHSM_RESOURCE_LIST, :template => 'resource_list'
+    end
+
+    def self.generate_resource_list
       all_routes = Engine.routes.routes
       all_routes = all_routes.collect { |r| r.path.spec.to_s }
 
@@ -20,16 +33,10 @@ module Katello
       end
 
       api_root_routes.collect! { |r| { :rel => r["/katello/api/".size..-2], :href => r } }
-
-      respond_for_index :collection => api_root_routes
     end
+    RESOURCE_LIST = generate_resource_list
 
-    def rhsm_resource_list
-      # The RHSM resource list is required to interact with RHSM on the client.
-      # When requested, it will return a list of the resources (href & rel) defined by katello
-      # for the /rhsm namespace.  The rel values are used by RHSM to determine if the server
-      # supports a particular resource (e.g. environments, guestids, organizations..etc)
-
+    def self.generate_rhsm_resource_list
       all_routes = Engine.routes.routes.collect { |r| r.path.spec.to_s }
 
       api_routes = all_routes.select do |path|
@@ -53,8 +60,7 @@ module Katello
 
       api_routes.uniq!
       api_routes.collect! { |r| { :rel => r.split('/').last, :href => r } }
-
-      respond_for_index :collection => api_routes, :template => 'resource_list'
     end
+    RHSM_RESOURCE_LIST = generate_rhsm_resource_list
   end
 end

--- a/app/views/katello/api/v2/root/resource_list.json.rabl
+++ b/app/views/katello/api/v2/root/resource_list.json.rabl
@@ -1,3 +1,0 @@
-collection Katello::Util::Data.ostructize(@collection)
-
-attributes :href, :rel

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -14,8 +14,6 @@ Katello::Engine.routes.draw do
         # re-routes alphabetical
         ##############################
 
-        root :to => 'root#resource_list'
-
         api_resources :capsules, :only => [:index, :show] do
           member do
             resource :content, :only => [], :controller => 'capsule_content' do

--- a/test/controllers/api/v2/root_controller_test.rb
+++ b/test/controllers/api/v2/root_controller_test.rb
@@ -6,12 +6,6 @@ module Katello
       setup_controller_defaults_api
     end
 
-    def test_resource_list
-      get :resource_list
-
-      assert_response :success
-    end
-
     def test_rhsm_resource_list
       results = JSON.parse(get(:rhsm_resource_list).body)
 

--- a/test/lib/access_permissions_test.rb
+++ b/test/lib/access_permissions_test.rb
@@ -34,7 +34,6 @@ module Katello
       'katello/api/v2/repositories/gpg_key_content',
       'katello/api/rhsm/candlepin_proxies/server_status',
       'katello/api/rhsm/candlepin_proxies/consumer_activate',
-      'katello/api/v2/root/resource_list',
       'katello/api/v2/ping/index',
       'katello/api/v2/ping/server_status',
       'katello/api/v2/katello_ping/index',


### PR DESCRIPTION
### What are the changes introduced in this pull request?

These changes cache the API responses for two endpoints in the RootController. My recent investigation into increased memory usage got me looking at how many objects our APIs are allocating per request and due to the high volume of the rhsm_resource_list (used by subman) I saw benefit in caching the responses. The idea being that over a period of time we can avoid hundreds of thousands of object allocations, if not millions, and slightly faster response time

### What are the testing steps for this pull request?

Compare the response time and allocation numbers for the RootController endpoints. My stats show this kind of improvement:

Before
```
REQUEST                                                                 REQUESTS        TOTAL ALLOCATIONS       AVG ALLOCATIONS
Katello::Api::V2::RootController#rhsm_resource_list                     501             6023296                 12022


response times
type                                            count   min     max     avg     mean    sum             percentage
--------------------------------------------------------------------------------------------------------------------
RootController#rhsm_resource_list               501     11      34      13      13      6753            100.00 %
```

After
```
response times
type                                            count   min     max     avg     mean    sum             percentage
--------------------------------------------------------------------------------------------------------------------
RootController#rhsm_resource_list               501     4       25      4       4       2247            100.00 %


REQUEST                                                                 REQUESTS        TOTAL ALLOCATIONS       AVG ALLOCATIONS
Katello::Api::V2::RootController#rhsm_resource_list                     501             927748                  1851
```