### PR TITLE
Fixes #33377: Smart proxy sync for deb content using Pulp 3

### DIFF
--- a/app/services/katello/pulp3/repository/apt.rb
+++ b/app/services/katello/pulp3/repository/apt.rb
@@ -23,6 +23,12 @@ module Katello
           common_remote_options.merge(deb_remote_options)
         end
 
+        def mirror_remote_options
+          {
+            distributions: repo.deb_releases + "#{' default' unless repo.deb_releases.include? 'default'}"
+          }
+        end
+
         def publication_options(repository_version)
           ss = api.signing_services_api.list(name: SIGNING_SERVICE_NAME).results
           popts = super(repository_version)
@@ -34,6 +40,16 @@ module Katello
           )
           popts[:signing_service] = ss[0].pulp_href if ss && ss.length == 1
           popts
+        end
+
+        def mirror_publication_options
+          {
+            # Since we are synchronizing the "default" distribution from the simple publisher on the server,
+            # it will be included in the structured publish. Therefore, we MUST NOT use the simple publisher
+            # on the proxy, since this would collide!
+            #simple: true,
+            structured: true # publish real suites (e.g. 'stable')
+          }
         end
 
         def distribution_options(path)

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -156,9 +156,17 @@ module Katello
         uri.to_s
       end
 
+      def publication_options(repository_version)
+        popts = {repository_version: repository_version}
+        if (type_specific_options = repo_service.try(:mirror_publication_options))
+          popts.merge!(type_specific_options)
+        end
+        popts
+      end
+
       def create_publication
         if (href = version_href)
-          publication_data = api.publication_class.new(repository_version: href)
+          publication_data = api.publication_class.new(publication_options(href))
           api.publications_api.create(publication_data)
         end
       end


### PR DESCRIPTION
Fixes: https://projects.theforeman.org/issues/33377

Smart Proxy Sync debian repositories in Pulp3