### PR TITLE
Fixes #33638 - Add search filters to Errata ID filter page

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -31,16 +31,6 @@ module Katello
       collection = filter_by_content_view(filter, collection)
       ids = Katello::ContentViewErratumFilterRule.where(:content_view_filter_id => filter.id).pluck("errata_id")
       collection = collection.where("errata_id not in (?)", ids) unless ids.empty?
-
-      date_type = params[:date_type].present? ? params[:date_type] : ContentViewErratumFilterRule::UPDATED
-      unless ContentViewErratumFilterRule::DATE_TYPES.include?(date_type)
-        msg = _("Invalid params provided - date_type must be one of %s" % ContentViewErratumFilterRule::DATE_TYPES.join(","))
-        fail HttpErrors::UnprocessableEntity, msg
-      end
-
-      collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
-      collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
-      collection = collection.of_type(params[:types]) if params[:types]
       collection
     end
 
@@ -61,6 +51,15 @@ module Katello
           collection = collection.applicable_to_hosts(hosts)
         end
       end
+      date_type = params[:date_type].present? ? params[:date_type] : ContentViewErratumFilterRule::UPDATED
+      unless ContentViewErratumFilterRule::DATE_TYPES.include?(date_type)
+        msg = _("Invalid params provided - date_type must be one of %s" % ContentViewErratumFilterRule::DATE_TYPES.join(","))
+        fail HttpErrors::UnprocessableEntity, msg
+      end
+
+      collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
+      collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
+      collection = collection.of_type(params[:types]) if params[:types]
       collection
     end
 

--- a/webpack/components/SelectableDropdown/SelectableDropdown.js
+++ b/webpack/components/SelectableDropdown/SelectableDropdown.js
@@ -25,12 +25,13 @@ const SelectableDropdown = ({
     <Level>
       <LevelItem>
         <label htmlFor={`select ${title}`} style={{ margin: '0px 5px' }}>
-          {`${title}:`}
+          {title}
         </label>
       </LevelItem>
       <LevelItem aria-label={`select ${title} container`}>
         <Select
           id={`select ${title}`}
+          aria-label={`select ${title}`}
           key="type-dropdown"
           variant={SelectVariant.single}
           onToggle={onToggle}

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -36,6 +36,7 @@ const TableWrapper = ({
   selectedCount,
   emptySearchBody,
   disableSearch,
+  nodesBelowSearch,
   ...allTableProps
 }) => {
   const dispatch = useDispatch();
@@ -179,6 +180,7 @@ const TableWrapper = ({
           />
         }
       </Flex>
+      {nodesBelowSearch}
       <MainTable
         searchIsActive={!!searchQuery}
         activeFilters={activeFilters}
@@ -243,6 +245,7 @@ TableWrapper.propTypes = {
   areAllRowsOnPageSelected: PropTypes.func,
   emptySearchBody: PropTypes.string,
   disableSearch: PropTypes.bool,
+  nodesBelowSearch: PropTypes.node,
 };
 
 TableWrapper.defaultProps = {
@@ -261,6 +264,7 @@ TableWrapper.defaultProps = {
   areAllRowsOnPageSelected: noop,
   emptySearchBody: __('Try changing your search settings.'),
   disableSearch: false,
+  nodesBelowSearch: null,
 };
 
 export default TableWrapper;

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -55,11 +55,13 @@ export const addComponentSuccessMessage = component => (component ? __('Updated 
 
 
 // Repo added to content view status display and key
-export const ADDED = 'Added';
-export const NOT_ADDED = 'Not added';
-export const ALL_STATUSES = 'All';
+export const ADDED = __('Added');
+export const NOT_ADDED = __('Not added');
+export const ALL_STATUSES = __('All');
 
 export const REPOSITORY_TYPES = 'REPOSITORY_TYPES';
 export const FILTER_TYPES = ['rpm', 'package_group', 'erratum_date', 'erratum_id', 'docker', 'modulemd'];
+
+export const ERRATA_TYPES = ['enhancement', 'security', 'bugfix'];
 
 export default CONTENT_VIEWS_KEY;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -316,14 +316,21 @@ export const getCVFilterModuleStreams = (cvId, filterId, params) => get({
   url: api.getApiUrl('/module_streams'),
 });
 
-export const getCVFilterErrata = (cvId, filterId, params) => get({
-  key: cvFilterErratumIDKey(cvId, filterId),
-  params: {
-    filter_id: filterId, show_all_for: 'content_view_filter', include_filter_ids: true, ...params,
-  },
-  errorToast: error => __(`Something went wrong while retrieving the content view filter! ${getResponseErrorMsgs(error.response)}`),
-  url: api.getApiUrl('/errata'),
-});
+export const getCVFilterErrata = (cvId, filterId, params = {}, statusSelected = ALL_STATUSES) => {
+  let apiParams = { filter_id: filterId, include_filter_ids: true, ...params };
+  if (statusSelected === ALL_STATUSES) {
+    apiParams = { show_all_for: 'content_view_filter', ...apiParams };
+  } else if (statusSelected === NOT_ADDED) {
+    apiParams = { available_for: 'content_view_filter', ...apiParams };
+  }
+
+  return get({
+    key: cvFilterErratumIDKey(cvId, filterId),
+    params: apiParams,
+    errorToast: error => __(`Something went wrong while retrieving the content view filter! ${getResponseErrorMsgs(error.response)}`),
+    url: api.getApiUrl('/errata'),
+  });
+};
 
 export const editCVFilterRule = (filterId, params, handleSuccess) => put({
   type: API_OPERATIONS.PUT,

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -14,14 +14,14 @@ import { selectCVFilterDetails } from '../ContentViewDetailSelectors';
 import AffectedRepositoryTable from './AffectedRepositories/AffectedRepositoryTable';
 import { editCVFilterRule, getCVFilterDetails } from '../ContentViewDetailActions';
 
-const dateFormat = date => `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}/${date.getFullYear()}`;
+export const dateFormat = date => `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}/${date.getFullYear()}`;
 
-const convertAPIDateToUIFormat = (dateString) => {
+export const convertAPIDateToUIFormat = (dateString) => {
   if (!dateString || dateString === '') return '';
   return dateFormat(new Date(dateString));
 };
 
-const dateParse = (date) => {
+export const dateParse = (date) => {
   if (!date || date === '') return new Date();
   const split = date.split('/');
   if (split.length !== 3) {
@@ -31,7 +31,7 @@ const dateParse = (date) => {
   return new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T12:00:00Z`);
 };
 
-const isValidDate = date => date instanceof Date && !Number.isNaN(date.getTime());
+export const isValidDate = date => date instanceof Date && !Number.isNaN(date.getTime());
 
 const CVErrataDateFilterContent = ({
   cvId, filterId, inclusion, showAffectedRepos, setShowAffectedRepos,


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Adds search filters to  Errata filters by Id page

### What are the testing steps for this pull request?

On the new CV UI > Add an Errata - Id filter.
You should see the below search filters added to the page.
![Screenshot from 2021-10-08 15-43-55](https://user-images.githubusercontent.com/21146741/136616626-e88d8b87-de72-4a84-a820-434b0d8caf6d.png)
