### PR TITLE
Fixes #33547 - Switch old and new Content View URLS

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Katello::Engine.routes.draw do
   match '/ansible_collections' => 'react#index', :via => [:get]
   match '/ansible_collections/*page' => 'react#index', :via => [:get]
 
+  match '/content_views' => 'react#index', :via => [:get]
+  match '/content_views/*page' => 'react#index', :via => [:get]
+
   match '/content' => 'react#index', :via => [:get]
 
   match '/labs' => 'react#index', :via => [:get]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.content-views').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('content-views', {
-        url: '/content_views',
+        url: '/legacy/content_views',
         permission: 'view_content_views',
         views: {
             '@': {
@@ -38,7 +38,7 @@ angular.module('Bastion.content-views').config(['$stateProvider', function ($sta
 
     $stateProvider.state('content-view', {
         abstract: true,
-        url: '/content_views/:contentViewId',
+        url: '/legacy/content_views/:contentViewId',
         permission: 'view_content_views',
         controller: 'ContentViewDetailsController',
         templateUrl: 'content-views/details/views/content-view-details.html'

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -25,7 +25,7 @@ module BastionKatello
           activation_keys
           content_credentials
           content_hosts
-          content_views
+          legacy
           debs
           docker_tags
           files

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -204,15 +204,6 @@ Foreman::Plugin.register :katello do
        :after => :content_hosts,
        :turbolinks => false
 
-  menu :labs_menu,
-       :content_publication,
-       :url => '/labs/content_views',
-       :url_hash => {:controller => 'katello/api/v2/content_views',
-                     :action => 'index'},
-       :caption => N_('Content Views'),
-       :parent => :lab_features_menu,
-       :turbolinks => false
-
   extend_template_helpers Katello::KatelloUrlsHelper
   extend_template_helpers Katello::Concerns::BaseTemplateScopeExtensions
 

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -54,11 +54,11 @@ export const links = [
     component: WithOrganization(withHeader(AnsibleCollectionDetails, { title: __('Ansible Collection Details') })),
   },
   {
-    path: 'labs/content_views',
+    path: 'content_views',
     component: withHeader(ContentViews, { title: __('Content Views') }),
   },
   {
-    path: 'labs/content_views/:id([0-9]+)',
+    path: 'content_views/:id([0-9]+)',
     component: withHeader(ContentViewDetails, { title: __('Content View Details') }),
     exact: false,
   },

--- a/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
@@ -40,7 +40,7 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
 
   if (redirect) {
     const { id } = response;
-    return (<Redirect to={`/labs/content_views/${id}`} />);
+    return (<Redirect to={`/content_views/${id}`} />);
   }
 
   return (

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -60,7 +60,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
 
   if (redirect) {
     const { id } = response;
-    return (<Redirect to={`/labs/content_views/${id}`} />);
+    return (<Redirect to={`/content_views/${id}`} />);
   }
 
   return (

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentVersion.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentVersion.js
@@ -23,7 +23,7 @@ const ComponentVersion = ({ componentCV }) => {
   if (componentId) {
     return (
       <>
-        <a href={`${urlBuilder('labs/content_views', '')}${cvId}#/versions/${versionId}`}>
+        <a href={`${urlBuilder('content_views', '')}${cvId}#/versions/${versionId}`}>
           {version ? `Version ${version}` : noVersionText}
         </a>
         <TextContent>
@@ -35,7 +35,7 @@ const ComponentVersion = ({ componentCV }) => {
     );
   }
   return (
-    <a href={`${urlBuilder('labs/content_views', '')}${cvId}${latestVersion ? `#/versions/${versionId}` : ''}`}>
+    <a href={`${urlBuilder('content_views', '')}${cvId}${latestVersion ? `#/versions/${versionId}` : ''}`}>
       {latestVersion ? `Version ${latestVersion}` : noVersionText}
     </a>
   );

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -133,7 +133,7 @@ const ContentViewComponents = ({ cvId, details }) => {
 
       const cells = [
         { title: <Bullseye><ContentViewIcon composite={false} /></Bullseye> },
-        { title: <a href={urlBuilder('labs/content_views', '') + id}>{name}</a> },
+        { title: <a href={urlBuilder('content_views', '') + id}>{name}</a> },
         {
           title:
   <Split>
@@ -158,7 +158,7 @@ const ContentViewComponents = ({ cvId, details }) => {
   </Split>,
         },
         { title: environments ? <ComponentEnvironments {...{ environments }} /> : __('Not yet published') },
-        { title: <Link to={urlBuilder(`labs/content_views/${id}#repositories`, '')}>{repositories ? repositories.length : 0}</Link> },
+        { title: <Link to={urlBuilder(`content_views/${id}#repositories`, '')}>{repositories ? repositories.length : 0}</Link> },
         {
           title: <AddedStatusLabel added={!!componentCvId} />,
         },

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -233,7 +233,7 @@ const CVErrataDateFilterContent = ({
               >
                 {__('Edit rule')}
               </Button>
-              <Link to={`/labs/content_views/${cvId}#/filters`}>
+              <Link to={`/content_views/${cvId}#/filters`}>
                 <Button variant="link">
                   {__('Cancel')}
                 </Button>

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
@@ -33,12 +33,12 @@ const autocompleteUrl = '/content_view_filters/195/rules/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(13, 195),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/13#/filters/195' }],
+    initialEntries: [{ pathname: '/content_views/13#/filters/195' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -25,12 +25,12 @@ const autocompleteUrl = '/content_view_filters/2/rules/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(1, 2),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1#/filters/2', hash: '#/filters' }],
+    initialEntries: [{ pathname: '/content_views/1#/filters/2', hash: '#/filters' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -34,12 +34,12 @@ const autoCompleteRepoURL = '/repositories/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(1, 1),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1#/filters/1' }],
+    initialEntries: [{ pathname: '/content_views/1#/filters/1' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
@@ -23,12 +23,12 @@ const autocompleteUrl = '/package_groups/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(1, 1),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/2#/filters/1' }],
+    initialEntries: [{ pathname: '/content_views/2#/filters/1' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -8,12 +8,12 @@ import ContentViewFilters from '../ContentViewFilters';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 
 const withCVRoute = component =>
-  <Route path="/labs/content_views/:id([0-9]+)#/filters">{component}</Route>;
+  <Route path="/content_views/:id([0-9]+)#/filters">{component}</Route>;
 
 const renderOptions = {
   apiNamespace: `${CONTENT_VIEWS_KEY}_1`,
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1#/filters' }],
+    initialEntries: [{ pathname: '/content_views/1#/filters' }],
     initialIndex: 1,
   },
 };

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -30,12 +30,12 @@ const autocompleteUrl = '/errata/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(1, 6),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1#/filters/6' }],
+    initialEntries: [{ pathname: '/content_views/1#/filters/6' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
@@ -30,12 +30,12 @@ const autocompleteUrl = '/module_streams/auto_complete_search';
 const renderOptions = {
   apiNamespace: cvFilterDetailsKey(1, 8),
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1#/filters/8' }],
+    initialEntries: [{ pathname: '/content_views/1#/filters/8' }],
     initialIndex: 1,
   },
 };
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
 
 let searchDelayScope;
 let autoSearchScope;

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -76,7 +76,7 @@ export default ({ cvId, versionId }) => [
       {
         title: __('Content View Name'),
         getProperty: item => (
-          <a href={`${urlBuilder('labs/content_views', '')}${item?.content_view_id}`}>
+          <a href={`${urlBuilder('content_views', '')}${item?.content_view_id}`}>
             {item?.content_view?.name}
           </a>),
       },

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -19,12 +19,12 @@ const promoteResponseData = contentViewTaskInProgressResponseData;
 const environmentPathsPath = api.getApiUrl('/organizations/1/environments/paths');
 const environmentPathsData = require('../../../Publish/__tests__/environmentPaths.fixtures.json');
 
-const withCVRoute = component => <Route path="/labs/content_views/:id">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id">{component}</Route>;
 
 const renderOptions = {
   apiNamespace: `${CONTENT_VIEWS_KEY}_VERSIONS_5`,
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/5' }],
+    initialEntries: [{ pathname: '/content_views/5' }],
     initialIndex: 1,
   },
 };

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
@@ -10,12 +10,12 @@ import CONTENT_VIEWS_KEY from '../../ContentViewsConstants';
 const cvDetailData = require('./contentViewDetails.fixtures.json');
 
 
-const withCVRoute = component => <Route path="/labs/content_views/:id([0-9]+)">{component}</Route>;
+const withCVRoute = component => <Route path="/content_views/:id([0-9]+)">{component}</Route>;
 
 const renderOptions = {
   apiNamespace: `${CONTENT_VIEWS_KEY}_1`,
   routerParams: {
-    initialEntries: [{ pathname: '/labs/content_views/1', hash: '#/details' }],
+    initialEntries: [{ pathname: '/content_views/1', hash: '#/details' }],
     initialIndex: 1,
   },
 };

--- a/webpack/scenes/ContentViews/Table/tableDataGenerator.js
+++ b/webpack/scenes/ContentViews/Table/tableDataGenerator.js
@@ -25,7 +25,7 @@ const buildRow = (contentView) => {
   const { last_sync_words: lastSyncWords } = lastTask || {};
   const row = [
     { title: <ContentViewIcon composite={composite ? true : undefined} /> },
-    { title: <Link to={`${urlBuilder('labs/content_views', '')}${id}`}>{name}</Link> },
+    { title: <Link to={`${urlBuilder('content_views', '')}${id}`}>{name}</Link> },
     { title: lastPublished ? <LongDateTime date={lastPublished} showRelativeTimeTooltip /> : <InactiveText text={__('Not yet published')} /> },
     { title: <LastSync lastSync={lastTask} lastSyncWords={lastSyncWords} emptyMessage="N/A" /> },
     {

--- a/webpack/scenes/ContentViews/components/CVBreadCrumb.js
+++ b/webpack/scenes/ContentViews/components/CVBreadCrumb.js
@@ -34,7 +34,7 @@ const CVBreadcrumb = () => {
 
   useDeepCompareEffect(() => {
     setBreadcrumbItems({
-      a_cv_index: { render: () => (<Link to="/labs/content_views">{__('Content views')}</Link>) },
+      a_cv_index: { render: () => (<Link to="/content_views">{__('Content views')}</Link>) },
     });
     setRecordId(splitHash.length >= 3 ? splitHash[2] : null);
     setRecordModel(splitHash.length >= 3 ? splitHash[1] : null);
@@ -47,13 +47,13 @@ const CVBreadcrumb = () => {
       Object.keys(breadcrumbItems).length === 1) {
       const cvRecordCrumb = {
         [`b_${cvDetails?.name}`]: {
-          render: () => (<Link to={`/labs/content_views/${cvId}`}>{cvDetails?.name}</Link>),
+          render: () => (<Link to={`/content_views/${cvId}`}>{cvDetails?.name}</Link>),
         },
       };
       const tabName = splitHash[1];
       const tabRecordCrumb = {
         [`c_${tabName}`]: {
-          render: () => (<Link to={`/labs/content_views/${cvId}#/${tabName}`}>{capitalize(tabName)}</Link>),
+          render: () => (<Link to={`/content_views/${cvId}#/${tabName}`}>{capitalize(tabName)}</Link>),
         },
       };
       setBreadcrumbItems({ ...breadcrumbItems, ...cvRecordCrumb, ...tabRecordCrumb });
@@ -70,7 +70,7 @@ const CVBreadcrumb = () => {
           const { name } = filterDetails;
           const filterDetailCrumb = {
             [`d_${name}`]: {
-              render: () => (<Link to={`/labs/content_views/${cvId}#/${tabName}/${recordId}`}>{name}</Link>),
+              render: () => (<Link to={`/content_views/${cvId}#/${tabName}/${recordId}`}>{name}</Link>),
             },
           };
           setBreadcrumbItems({ ...breadcrumbItems, ...filterDetailCrumb });
@@ -81,13 +81,13 @@ const CVBreadcrumb = () => {
           const { version } = versionDetails;
           const versionDetailCrumb = {
             [`e_${version}`]: {
-              render: () => (<Link to={`/labs/content_views/${cvId}#/${tabName}/${recordId}`}>{version}</Link>),
+              render: () => (<Link to={`/content_views/${cvId}#/${tabName}/${recordId}`}>{version}</Link>),
             },
           };
           const versionSecondaryTab = {
             [`f_${versionTabName}`]: {
               render: () => (
-                <Link to={`/labs/content_views/${cvId}#/${tabName}/${recordId}/${versionTabName}`}>
+                <Link to={`/content_views/${cvId}#/${tabName}/${recordId}/${versionTabName}`}>
                   {capitalize(versionTabName)}
                 </Link>
               ),


### PR DESCRIPTION
### What are the changes introduced in this pull request?
The old UI is now available on legacy/content_views/
The new UI replaces the nav item and /content_views urls.
### What are the testing steps for this pull request?
Go to content > content views
You should be able to run through all flows with the new UI

Go to /legacy/content_views
You should be able to run through all flows with the old UI
