### PR TITLE
Fixes #33677 - direct user to global registration when unregistered

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/registration.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/registration.html
@@ -1,4 +1,4 @@
 <span translate>
   <i class="fa fa-warning inline-icon"></i>
-  This Host is not currently registered with subscription-manager.  Click <a ui-sref="content-hosts.register">here</a> for registration information.
+  This Host is not currently registered with subscription-manager. Use the <a href="/hosts/register">Register Host</a> workflow to complete registration.
 </span>


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Fixes a broken link on the content host details UI when it's been unregistered / not yet registered

### What are the testing steps for this pull request?

- create a host (easy way is to spin up centos7-katello-client)
- unregister the host via the UI (but do not delete the host record)
- Notice the text on the CH details provides a link with registration info that never goes anywhere


- With this PR checked out, the text is updated and directs to global registration
