### PR TITLE
Fixes #33684 - wrong condition on host_filter

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -244,7 +244,7 @@ module Katello
 
           batch.each do |task|
             next if skip_task?(task)
-            next if !only_host_ids.nil? && only_host_ids.include?(task.input['host']['id'].to_i)
+            next unless only_host_ids.nil? || only_host_ids.include?(task.input['host']['id'].to_i)
             parse_errata(task).each do |erratum_id|
               current_erratum_errata_type = preloaded_errata.find { |k, _| k == erratum_id }.last
 


### PR DESCRIPTION
The host filter has been flipped and hosts that matched the filter has been left out.
This fixes the condition so the proper Hosts according to the filter get in.