### PR TITLE
CV UI - Permissions on CV UI

### DIFF
--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -61,14 +61,16 @@ child :versions => :versions do
   attributes :environment_ids
 end
 
-node :permissions do |cv|
-  {
-    :view_content_views => cv.readable?,
-    :edit_content_views => cv.editable?,
-    :destroy_content_views => cv.deletable?,
-    :publish_content_views => cv.publishable?,
-    :promote_or_remove_content_views => cv.promotable_or_removable?
-  }
+if params.key?(:include_permissions)
+  node :permissions do |cv|
+    {
+      :view_content_views => cv.readable?,
+      :edit_content_views => cv.editable?,
+      :destroy_content_views => cv.deletable?,
+      :publish_content_views => cv.publishable?,
+      :promote_or_remove_content_views => cv.promotable_or_removable?
+    }
+  end
 end
 
 child :components => :components do

--- a/app/views/katello/api/v2/content_views/index.json.rabl
+++ b/app/views/katello/api/v2/content_views/index.json.rabl
@@ -1,6 +1,7 @@
 object false
 
 extends "katello/api/v2/common/metadata"
+extends 'katello/api/v2/content_views/permissions'
 
 child @collection[:results] => :results do
   extends "katello/api/v2/content_views/base"

--- a/app/views/katello/api/v2/content_views/permissions.rabl
+++ b/app/views/katello/api/v2/content_views/permissions.rabl
@@ -1,0 +1,8 @@
+collection @content_views
+
+if params.key?(:include_permissions)
+  user = User.current # current_user is not available here
+  node do
+    node(:can_create) { user.can?("create_content_views") }
+  end
+end

--- a/webpack/components/ActionableDetail.js
+++ b/webpack/components/ActionableDetail.js
@@ -22,8 +22,11 @@ const ActionableDetail = ({
   onEdit,
   currentAttribute,
   setCurrentAttribute,
+  disabled,
 }) => {
-  const displayProps = { attribute, value, onEdit };
+  const displayProps = {
+    attribute, value, onEdit, disabled,
+  };
 
   return (
     <React.Fragment key={label}>
@@ -65,6 +68,7 @@ ActionableDetail.propTypes = {
   tooltip: PropTypes.string,
   currentAttribute: PropTypes.string,
   setCurrentAttribute: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 ActionableDetail.defaultProps = {
@@ -74,6 +78,7 @@ ActionableDetail.defaultProps = {
   value: null,
   currentAttribute: undefined,
   setCurrentAttribute: undefined,
+  disabled: false,
 };
 
 export default ActionableDetail;

--- a/webpack/components/EditableSwitch.js
+++ b/webpack/components/EditableSwitch.js
@@ -3,7 +3,9 @@ import { Switch } from '@patternfly/react-core';
 import { noop } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 
-const EditableSwitch = ({ value, attribute, onEdit }) => {
+const EditableSwitch = ({
+  value, attribute, onEdit, disabled,
+}) => {
   const identifier = `${attribute} switch`;
 
   return (
@@ -12,6 +14,7 @@ const EditableSwitch = ({ value, attribute, onEdit }) => {
       aria-label={identifier}
       isChecked={value}
       onChange={v => onEdit(v, attribute)}
+      disabled={disabled}
     />
   );
 };
@@ -20,11 +23,13 @@ EditableSwitch.propTypes = {
   value: PropTypes.bool.isRequired,
   attribute: PropTypes.string,
   onEdit: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 EditableSwitch.defaultProps = {
   attribute: '',
   onEdit: noop,
+  disabled: false,
 };
 
 export default EditableSwitch;

--- a/webpack/components/EditableTextInput/EditableTextInput.js
+++ b/webpack/components/EditableTextInput/EditableTextInput.js
@@ -7,7 +7,8 @@ import Loading from '../Loading';
 import './editableTextInput.scss';
 
 const EditableTextInput = ({
-  onEdit, value, textArea, attribute, placeholder, component, currentAttribute, setCurrentAttribute,
+  onEdit, value, textArea, attribute, placeholder,
+  component, currentAttribute, setCurrentAttribute, disabled,
 }) => {
   // Tracks input box state
   const [inputValue, setInputValue] = useState(value);
@@ -106,16 +107,18 @@ const EditableTextInput = ({
           {value || (<i>{placeholder}</i>)}
         </Text>
       </SplitItem>
-      <SplitItem>
-        <Button
-          className="foreman-edit-icon"
-          aria-label={`edit ${attribute}`}
-          variant="plain"
-          onClick={onEditClick}
-        >
-          <PencilAltIcon />
-        </Button>
-      </SplitItem>
+      {!disabled &&
+        <SplitItem>
+          <Button
+            className="foreman-edit-icon"
+            aria-label={`edit ${attribute}`}
+            variant="plain"
+            onClick={onEditClick}
+          >
+            <PencilAltIcon />
+          </Button>
+        </SplitItem>
+      }
     </Split>
   );
 };
@@ -129,6 +132,7 @@ EditableTextInput.propTypes = {
   component: PropTypes.string,
   currentAttribute: PropTypes.string,
   setCurrentAttribute: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 EditableTextInput.defaultProps = {
@@ -138,6 +142,7 @@ EditableTextInput.defaultProps = {
   component: undefined,
   currentAttribute: undefined,
   setCurrentAttribute: undefined,
+  disabled: false,
 };
 
 export default EditableTextInput;

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -6,6 +6,7 @@ import { EmptyState,
   Bullseye,
   Title } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { CubeIcon, ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { global_danger_color_200 as dangerColor } from '@patternfly/react-tokens';
 
@@ -18,19 +19,34 @@ const KatelloEmptyStateIcon = ({ error, search, customIcon }) => {
 
 const EmptyStateMessage = ({
   title, body, error, search, customIcon,
-}) => (
-  <Bullseye>
-    <EmptyState variant={EmptyStateVariant.small}>
-      <KatelloEmptyStateIcon error={!!error} search={search} customIcon={customIcon} />
-      <Title headingLevel="h2" size="lg">
-        {title}
-      </Title>
-      <EmptyStateBody>
-        {body}
-      </EmptyStateBody>
-    </EmptyState>
-  </Bullseye>
-);
+}) => {
+  let emptyStateTitle = title;
+  let emptyStateBody = body;
+  if (error) {
+    if (error?.response?.data?.error) {
+      const { response: { data: { error: { message, details } } } } = error;
+      emptyStateTitle = message;
+      emptyStateBody = details;
+    } else if (error?.response?.status) {
+      const { response: { status } } = error;
+      emptyStateTitle = status;
+      emptyStateBody = error?.response?.data?.displayMessage || __('Something went wrong! Please check server logs!');
+    }
+  }
+  return (
+    <Bullseye>
+      <EmptyState variant={EmptyStateVariant.small}>
+        <KatelloEmptyStateIcon error={!!error} search={search} customIcon={customIcon} />
+        <Title headingLevel="h2" size="lg">
+          {emptyStateTitle}
+        </Title>
+        <EmptyStateBody>
+          {emptyStateBody}
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  );
+};
 
 KatelloEmptyStateIcon.propTypes = {
   error: PropTypes.bool,
@@ -56,8 +72,8 @@ EmptyStateMessage.propTypes = {
 };
 
 EmptyStateMessage.defaultProps = {
-  title: 'Unable to connect',
-  body: 'There was an error retrieving data from the server. Check your connection and try again.',
+  title: __('Unable to connect'),
+  body: __('There was an error retrieving data from the server. Check your connection and try again.'),
   error: undefined,
   search: false,
   customIcon: undefined,

--- a/webpack/scenes/ContentViews/ContentViewsActions.js
+++ b/webpack/scenes/ContentViews/ContentViewsActions.js
@@ -12,6 +12,7 @@ export const createContentViewsParams = (extraParams) => {
   const getParams = {
     organization_id: orgId(),
     nondefault: true,
+    include_permissions: true,
     ...extraParams,
   };
   if (extraParams?.include_default) delete getParams.nondefault;

--- a/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
+++ b/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
@@ -10,7 +10,7 @@ import ContentViewsPage from '../../ContentViewsPage.js';
 
 const cvIndexData = require('./CvData.fixtures');
 
-const cvIndexPath = api.getApiUrl('/content_views?organization_id=1&nondefault=true&per_page=20&page=1');
+const cvIndexPath = api.getApiUrl('/content_views?organization_id=1&nondefault=true&include_permissions=true&per_page=20&page=1');
 const autocompleteUrl = '/content_views/auto_complete_search';
 const renderOptions = { apiNamespace: CONTENT_VIEWS_KEY };
 const environmentPathsPath = api.getApiUrl('/organizations/1/environments/paths');
@@ -28,7 +28,7 @@ const affectedActivationKeysData = require('../../Details/Versions/Delete/__test
 const hostURL = foremanApi.getApiUrl('/hosts');
 const affectedHostData = require('./affectedHosts.fixtures.json');
 
-const cVDropDownOptionsPath = api.getApiUrl('/content_views?organization_id=1&environment_id=9&include_default=true&full_result=true');
+const cVDropDownOptionsPath = api.getApiUrl('/content_views?organization_id=1&environment_id=9&include_default=true&include_permissions=true&full_result=true');
 const cVDropDownOptionsData = require('../../Details/Versions/Delete/__tests__/cvDropDownOptionsResponse.fixture.json');
 
 const cvDeleteUrl = api.getApiUrl('/content_views/20/remove');

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -33,6 +33,7 @@ import SelectableDropdown from '../../../../components/SelectableDropdown/Select
 import '../../../../components/EditableTextInput/editableTextInput.scss';
 import ComponentContentViewAddModal from './ComponentContentViewAddModal';
 import ComponentContentViewBulkAddModal from './ComponentContentViewBulkAddModal';
+import { hasPermission } from '../../helpers';
 
 const ContentViewComponents = ({ cvId, details }) => {
   const response = useSelector(state => selectCVComponents(state, cvId));
@@ -67,7 +68,7 @@ const ContentViewComponents = ({ cvId, details }) => {
   const addComponentsResolved = componentAddedStatus === STATUS.RESOLVED;
   const removeComponentsResolved = componentRemovedStatus === STATUS.RESOLVED;
 
-  const { label } = details || {};
+  const { label, permissions } = details || {};
 
   const bulkRemoveEnabled = () => rows.some(row => row.selected && row.added);
   const bulkAddEnabled = () => rows.some(row => row.selected && !row.added);
@@ -140,7 +141,7 @@ const ContentViewComponents = ({ cvId, details }) => {
     <SplitItem>
       <ComponentVersion {...{ componentCV }} />
     </SplitItem>
-    {componentCvId && cvVersion &&
+    {hasPermission(permissions, 'edit_content_views') && componentCvId && cvVersion &&
     <SplitItem>
       <Button
         className="foreman-edit-icon"
@@ -175,7 +176,7 @@ const ContentViewComponents = ({ cvId, details }) => {
       });
     });
     return newRows;
-  }, [onAdd, results]);
+  }, [onAdd, results, permissions]);
 
   const actionResolver = (rowData, { _rowIndex }) => [
     {
@@ -237,8 +238,8 @@ const ContentViewComponents = ({ cvId, details }) => {
         status,
         activeFilters,
         defaultFilters,
-        actionResolver,
       }}
+      actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
       onSelect={onSelect(rows, setRows)}
       cells={columnHeaders}
       variant={TableVariant.compact}
@@ -258,23 +259,25 @@ const ContentViewComponents = ({ cvId, details }) => {
                 placeholderText={__('Status')}
               />
             </SplitItem>
-            <SplitItem>
-              <ActionList>
-                <ActionListItem>
-                  <Button onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="secondary" aria-label="bulk_add_components">
-                    {__('Add content views')}
-                  </Button>
-                </ActionListItem>
-                <ActionListItem>
-                  <Dropdown
-                    toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
-                    isOpen={bulkActionOpen}
-                    isPlain
-                    dropdownItems={dropdownItems}
-                  />
-                </ActionListItem>
-              </ActionList>
-            </SplitItem>
+            {hasPermission(permissions, 'edit_content_views') &&
+              <SplitItem>
+                <ActionList>
+                  <ActionListItem>
+                    <Button onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="secondary" aria-label="bulk_add_components">
+                      {__('Add content views')}
+                    </Button>
+                  </ActionListItem>
+                  <ActionListItem>
+                    <Dropdown
+                      toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                      isOpen={bulkActionOpen}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                    />
+                  </ActionListItem>
+                </ActionList>
+              </SplitItem>
+            }
           </Split>
           {versionEditing &&
             <ComponentContentViewAddModal
@@ -303,12 +306,14 @@ ContentViewComponents.propTypes = {
   cvId: PropTypes.number.isRequired,
   details: PropTypes.shape({
     label: PropTypes.string,
+    permissions: PropTypes.shape({}),
   }),
 };
 
 ContentViewComponents.defaultProps = {
   details: {
     label: '',
+    permissions: {},
   },
 };
 

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -8,6 +8,7 @@ import ContentViewComponents from '../ContentViewComponents';
 const cvComponentData = require('./contentViewComponents.fixtures.json');
 const cvUnpublishedComponentData = require('./unpublishedCVComponents.fixtures.json');
 const cvPublishedComponentData = require('./publishedContentViewDetails.fixtures.json');
+const cvDetails = require('../../__tests__/contentViewDetails.fixtures.json');
 
 const renderOptions = { apiNamespace: `${CONTENT_VIEWS_KEY}_1` };
 const cvComponentsWithoutSearch = api.getApiUrl('/content_views/4/content_view_components/show_all?per_page=20&page=1&status=All');
@@ -42,7 +43,7 @@ test('Can call API and show components on page load', async (done) => {
     .reply(200, cvComponentData);
 
   const { getByText, queryByText } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
 
@@ -64,7 +65,7 @@ test('Can call API and show unpublished components', async (done) => {
   const unpublishedComponent = cvUnpublishedComponentData.results[1];
 
   const { getByText, queryByText, getAllByText } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
 
@@ -86,7 +87,7 @@ test('Can link to view environment', async () => {
     .reply(200, cvComponentData);
 
   const { getAllByText } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
 
@@ -115,7 +116,7 @@ test('Can search for component content views in composite view', async (done) =>
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const withSearchScope = mockAutocomplete(nockInstance, autocompleteUrl, searchQueryMatcher);
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(<ContentViewComponents cvId={4} />, renderOptions);
+    renderWithRedux(<ContentViewComponents cvId={4} details={cvDetails} />, renderOptions);
 
   // Basic results showing
   await patientlyWaitFor(() => {
@@ -153,7 +154,16 @@ test('Can handle no components being present', async (done) => {
     .get(cvComponents)
     .reply(200, noResults);
 
-  const mockDetails = { label: 'test_empty' };
+  const mockDetails = {
+    label: 'test_empty',
+    permissions: {
+      view_content_views: true,
+      edit_content_views: true,
+      destroy_content_views: true,
+      publish_content_views: true,
+      promote_or_remove_content_views: true,
+    },
+  };
   const { queryByText } =
     renderWithRedux(<ContentViewComponents cvId={4} details={mockDetails} />, renderOptions);
 
@@ -175,6 +185,7 @@ test('Can add published component views to content view with modal', async (done
 
   const publishedComponentVersionsScope = nockInstance
     .get(publishedComponentDetailsURL)
+    .query(true)
     .reply(200, cvPublishedComponentData);
 
   const addComponentParams = {
@@ -189,7 +200,7 @@ test('Can add published component views to content view with modal', async (done
   const {
     getByText, getByLabelText, queryByLabelText, getAllByLabelText,
   } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
   await patientlyWaitFor(() => {
@@ -235,7 +246,7 @@ test('Can add unpublished component views to content view', async (done) => {
     .reply(200, {});
 
   const { getByText, getAllByLabelText } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
   await patientlyWaitFor(() => {
@@ -271,7 +282,7 @@ test('Can remove component views from content view', async (done) => {
     .reply(200, {});
 
   const { getByText, getAllByLabelText } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
   await patientlyWaitFor(() => {
@@ -309,7 +320,7 @@ test('Can bulk add component views to content view with modal', async (done) => 
   const {
     getByText, getByLabelText, queryByText,
   } = renderWithRedux(
-    <ContentViewComponents cvId={4} />,
+    <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
   await patientlyWaitFor(() => {

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -53,9 +53,10 @@ import { getResponseErrorMsgs, apiError } from '../../../utils/helpers';
 import { renderTaskStartedToast } from '../../Tasks/helpers';
 import { cvErrorToast } from '../ContentViewsActions';
 
-const getContentViewDetails = cvId => get({
+const getContentViewDetails = (cvId, extraParams = {}) => get({
   type: API_OPERATIONS.GET,
   key: cvDetailsKey(cvId),
+  params: { organization_id: orgId(), include_permissions: true, ...extraParams },
   url: api.getApiUrl(`/content_views/${cvId}`),
 });
 
@@ -158,7 +159,6 @@ export const getDebPackages = params => get({
   errorToast: error => __(`Something went wrong while getting deb packages! ${getResponseErrorMsgs(error.response)}`),
 });
 
-
 export const getModuleStreams = params => get({
   type: API_OPERATIONS.GET,
   key: MODULE_STREAMS_CONTENT,
@@ -166,7 +166,6 @@ export const getModuleStreams = params => get({
   params,
   errorToast: error => __(`Something went wrong while getting module streams! ${getResponseErrorMsgs(error.response)}`),
 });
-
 
 export const getRepositories = params => get({
   type: API_OPERATIONS.GET,
@@ -215,7 +214,6 @@ export const editCVFilter = (filterId, params, handleSuccess) => put({
   successToast: () => __('Filter edited successfully'),
   errorToast: error => __(`Something went wrong while editing the filter! ${getResponseErrorMsgs(error.response)}`),
 });
-
 
 export const getRepositoryTypes = () => get({
   type: API_OPERATIONS.GET,

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -17,6 +17,7 @@ import RoutedTabs from '../../../components/RoutedTabs';
 import ContentViewIcon from '../components/ContentViewIcon';
 import CVBreadCrumb from '../components/CVBreadCrumb';
 import PublishContentViewWizard from '../Publish/PublishContentViewWizard';
+import { hasPermission } from '../helpers';
 
 export default () => {
   const { id } = useParams();
@@ -25,7 +26,7 @@ export default () => {
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
 
-  const { name, composite } = details;
+  const { name, composite, permissions } = details;
   const tabs = [
     {
       key: 'details',
@@ -35,7 +36,7 @@ export default () => {
     {
       key: 'versions',
       title: __('Versions'),
-      content: <ContentViewVersionsRoutes cvId={cvId} />,
+      content: <ContentViewVersionsRoutes {...{ cvId, details }} />,
     },
     ...composite ? [{
       key: 'contentviews',
@@ -49,7 +50,7 @@ export default () => {
     {
       key: 'filters',
       title: __('Filters'),
-      content: <ContentViewFilterRoutes cvId={cvId} />,
+      content: <ContentViewFilterRoutes {...{ cvId, details }} />,
     }],
     {
       key: 'history',
@@ -77,19 +78,21 @@ export default () => {
           </GridItem>
           <GridItem xl={4} lg={5} sm={12} >
             <Flex justifyContent={{ lg: 'justifyContentFlexEnd', sm: 'justifyContentFlexStart' }}>
-              <FlexItem>
-                <Button onClick={() => { setIsPublishModalOpen(true); }} variant="primary" aria-label="publish_content_view">
-                  {__('Publish new version')}
-                </Button>
-                {isPublishModalOpen && <PublishContentViewWizard
-                  details={details}
-                  show={isPublishModalOpen}
-                  setIsOpen={setIsPublishModalOpen}
-                  currentStep={currentStep}
-                  setCurrentStep={setCurrentStep}
-                  aria-label="publish_content_view_modal"
-                />}
-              </FlexItem>
+              {hasPermission(permissions, 'publish_content_views') &&
+                <FlexItem>
+                  <Button onClick={() => { setIsPublishModalOpen(true); }} variant="primary" aria-label="publish_content_view">
+                    {__('Publish new version')}
+                  </Button>
+                  {isPublishModalOpen && <PublishContentViewWizard
+                    details={details}
+                    show={isPublishModalOpen}
+                    setIsOpen={setIsPublishModalOpen}
+                    currentStep={currentStep}
+                    setCurrentStep={setCurrentStep}
+                    aria-label="publish_content_view_modal"
+                  />}
+                </FlexItem>
+              }
               <FlexItem>
                 <Button
                   component="a"

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -19,7 +19,7 @@ import Loading from '../../../components/Loading';
 import ContentViewIcon from '../components/ContentViewIcon';
 import ActionableDetail from '../../../components/ActionableDetail';
 import './contentViewInfo.scss';
-import { dependenciesHelpText, autoPublishHelpText } from '../helpers';
+import { dependenciesHelpText, autoPublishHelpText, hasPermission } from '../helpers';
 import { LabelImportOnly } from '../Create/ContentViewFormComponents';
 
 const ContentViewInfo = ({ cvId, details }) => {
@@ -34,6 +34,7 @@ const ContentViewInfo = ({ cvId, details }) => {
     solve_dependencies: solveDependencies,
     auto_publish: autoPublish,
     import_only: importOnly,
+    permissions,
   } = details;
 
   if (updating) return <Loading size="sm" showText={false} />;
@@ -50,6 +51,7 @@ const ContentViewInfo = ({ cvId, details }) => {
           label={__('Name')}
           attribute="name"
           onEdit={onEdit}
+          disabled={!hasPermission(permissions, 'edit_content_views')}
           value={name}
           {...{ currentAttribute, setCurrentAttribute }}
         />
@@ -77,6 +79,7 @@ const ContentViewInfo = ({ cvId, details }) => {
           label={__('Description')}
           attribute="description"
           onEdit={onEdit}
+          disabled={!hasPermission(permissions, 'edit_content_views')}
           value={description}
           {...{ currentAttribute, setCurrentAttribute }}
         />
@@ -86,6 +89,7 @@ const ContentViewInfo = ({ cvId, details }) => {
             attribute="auto_publish"
             value={autoPublish}
             onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
             tooltip={autoPublishHelpText}
             boolean
             {...{ currentAttribute, setCurrentAttribute }}
@@ -95,6 +99,7 @@ const ContentViewInfo = ({ cvId, details }) => {
             attribute="solve_dependencies"
             value={solveDependencies}
             onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
             tooltip={dependenciesHelpText}
             boolean
             {...{ currentAttribute, setCurrentAttribute }}
@@ -126,6 +131,7 @@ ContentViewInfo.propTypes = {
     solve_dependencies: PropTypes.bool,
     auto_publish: PropTypes.bool,
     import_only: PropTypes.bool,
+    permissions: PropTypes.shape({}),
   }).isRequired,
 };
 

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositorySelection.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositorySelection.js
@@ -6,7 +6,9 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { selectCVFilterDetails } from '../../ContentViewDetailSelectors';
 import { editCVFilter, getCVFilterDetails } from '../../ContentViewDetailActions';
 
-const AffectedRepositorySelection = ({ cvId, filterId, setShowAffectedRepos }) => {
+const AffectedRepositorySelection = ({
+  cvId, filterId, setShowAffectedRepos, disabled,
+}) => {
   const dispatch = useDispatch();
   const response = useSelector(state => selectCVFilterDetails(state, cvId, filterId), shallowEqual);
   const { repositories = [] } = response;
@@ -42,6 +44,7 @@ const AffectedRepositorySelection = ({ cvId, filterId, setShowAffectedRepos }) =
       id="affected_repos"
       name="affected_repos"
       aria-label="affected_repos"
+      isDisabled={disabled}
     >
       <SelectOption key="all_repos" value="all_repos">{__('Apply to all repositories in the CV')}</SelectOption>
       <SelectOption key="affect_repos" value="affect_repos">{__('Apply to subset of repositories')}</SelectOption>
@@ -53,6 +56,10 @@ AffectedRepositorySelection.propTypes = {
   cvId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   setShowAffectedRepos: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
+AffectedRepositorySelection.defaultProps = {
+  disabled: false,
+};
 export default AffectedRepositorySelection;

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -27,11 +27,12 @@ import AddedStatusLabel from '../../../../../components/AddedStatusLabel';
 import TableWrapper from '../../../../../components/Table/TableWrapper';
 import RepoIcon from '../../Repositories/RepoIcon';
 import SelectableDropdown from '../../../../../components/SelectableDropdown/SelectableDropdown';
+import { hasPermission } from '../../../helpers';
 
 const allProducts = 'All products';
 
 const AffectedRepositoryTable = ({
-  cvId, filterId, repoType, setShowAffectedRepos,
+  cvId, filterId, repoType, setShowAffectedRepos, details,
 }) => {
   const dispatch = useDispatch();
   const response = useSelector(state => selectCVFilterRepos(state, filterId), shallowEqual);
@@ -50,6 +51,7 @@ const AffectedRepositoryTable = ({
   const hasNotAddedSelected = rows.some(({ selected, added }) => selected && !added);
   const deselectAll = () => setRows(rows.map(row => ({ ...row, selected: false })));
   const metadata = omit(response, ['results']);
+  const { permissions } = details;
 
   const columnHeaders = [
     { title: __('Type'), transforms: [fitContent] },
@@ -201,7 +203,7 @@ const AffectedRepositoryTable = ({
         error,
         status,
       }}
-      onSelect={onSelect(rows, setRows)}
+      onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/repositories/auto_complete_search"
@@ -219,23 +221,25 @@ const AffectedRepositoryTable = ({
                 placeholderText={__('Product')}
               />
             </SplitItem>
-            <SplitItem>
-              <ActionList>
-                <ActionListItem>
-                  <Button onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="secondary" aria-label="add_repositories">
-                    Add repositories
-                  </Button>
-                </ActionListItem>
-                <ActionListItem>
-                  <Dropdown
-                    toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
-                    isOpen={bulkActionOpen}
-                    isPlain
-                    dropdownItems={dropdownItems}
-                  />
-                </ActionListItem>
-              </ActionList>
-            </SplitItem>
+            {hasPermission(permissions, 'edit_content_views') &&
+              <SplitItem>
+                <ActionList>
+                  <ActionListItem>
+                    <Button onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="secondary" aria-label="add_repositories">
+                      Add repositories
+                    </Button>
+                  </ActionListItem>
+                  <ActionListItem>
+                    <Dropdown
+                      toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                      isOpen={bulkActionOpen}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                    />
+                  </ActionListItem>
+                </ActionList>
+              </SplitItem>
+            }
           </Split>
         </>
       }
@@ -248,6 +252,9 @@ AffectedRepositoryTable.propTypes = {
   filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   repoType: PropTypes.string.isRequired,
   setShowAffectedRepos: PropTypes.func.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 export default AffectedRepositoryTable;

--- a/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
@@ -9,7 +9,7 @@ import CVErrataIDFilterContent from './CVErrataIDFilterContent';
 import CVErrataDateFilterContent from './CVErrataDateFilterContent';
 
 const CVFilterDetailType = ({
-  cvId, filterId, inclusion, type, showAffectedRepos, setShowAffectedRepos, rules,
+  cvId, filterId, inclusion, type, showAffectedRepos, setShowAffectedRepos, rules, details,
 }) => {
   switch (type) {
     case 'docker':
@@ -18,6 +18,7 @@ const CVFilterDetailType = ({
         filterId={filterId}
         showAffectedRepos={showAffectedRepos}
         setShowAffectedRepos={setShowAffectedRepos}
+        details={details}
       />);
     case 'package_group':
       return (<CVPackageGroupFilterContent
@@ -25,6 +26,7 @@ const CVFilterDetailType = ({
         filterId={filterId}
         showAffectedRepos={showAffectedRepos}
         setShowAffectedRepos={setShowAffectedRepos}
+        details={details}
       />);
     case 'rpm':
       return (<CVRpmFilterContent
@@ -33,6 +35,7 @@ const CVFilterDetailType = ({
         inclusion={inclusion}
         showAffectedRepos={showAffectedRepos}
         setShowAffectedRepos={setShowAffectedRepos}
+        details={details}
       />);
     case 'modulemd':
       return (<CVModuleStreamFilterContent
@@ -40,6 +43,7 @@ const CVFilterDetailType = ({
         filterId={filterId}
         showAffectedRepos={showAffectedRepos}
         setShowAffectedRepos={setShowAffectedRepos}
+        details={details}
       />);
     case 'erratum':
       if (head(rules)?.types) {
@@ -49,6 +53,7 @@ const CVFilterDetailType = ({
           inclusion={inclusion}
           showAffectedRepos={showAffectedRepos}
           setShowAffectedRepos={setShowAffectedRepos}
+          details={details}
         />);
       }
       return (<CVErrataIDFilterContent
@@ -56,6 +61,7 @@ const CVFilterDetailType = ({
         filterId={filterId}
         showAffectedRepos={showAffectedRepos}
         setShowAffectedRepos={setShowAffectedRepos}
+        details={details}
       />);
     default:
       return null;
@@ -70,6 +76,9 @@ CVFilterDetailType.propTypes = {
   showAffectedRepos: PropTypes.bool.isRequired,
   setShowAffectedRepos: PropTypes.func.isRequired,
   rules: PropTypes.arrayOf(PropTypes.shape({ types: PropTypes.arrayOf(PropTypes.string) })),
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 CVFilterDetailType.defaultProps = {

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
@@ -15,10 +15,10 @@ import ContentViewFilterDetailsHeader from './ContentViewFilterDetailsHeader';
 import CVFilterDetailType from './CVFilterDetailType';
 import Loading from '../../../../components/Loading';
 
-const ContentViewFilterDetails = ({ cvId }) => {
+const ContentViewFilterDetails = ({ cvId, details }) => {
   const { filterId } = useParams();
   const dispatch = useDispatch();
-  const [details, setDetails] = useState({});
+  const [filterDetails, setFilterDetails] = useState({});
   const [showAffectedRepos, setShowAffectedRepos] = useState(false);
   const response = useSelector(state => selectCVFilterDetails(state, cvId, filterId), shallowEqual);
   const status = useSelector(state =>
@@ -33,7 +33,7 @@ const ContentViewFilterDetails = ({ cvId }) => {
 
   useDeepCompareEffect(() => {
     if (loaded) {
-      setDetails(response);
+      setFilterDetails(response);
       const { repositories } = response;
       if (repositories.length) {
         setShowAffectedRepos(true);
@@ -41,18 +41,17 @@ const ContentViewFilterDetails = ({ cvId }) => {
     }
   }, [response, loaded]);
 
-  const { type, inclusion, rules } = details;
+  const { type, inclusion, rules } = filterDetails;
   if (loading) {
     return <Loading />;
   }
   return (
     <Grid hasGutter>
-      {loaded && (Object.keys(details).length > 0) ?
+      {loaded && (Object.keys(filterDetails).length > 0) ?
         <ContentViewFilterDetailsHeader
-          cvId={cvId}
-          filterId={filterId}
-          details={details}
-          setShowAffectedRepos={setShowAffectedRepos}
+          {...{
+ cvId, filterId, filterDetails, setShowAffectedRepos, details,
+}}
         /> :
         <Loading />
       }
@@ -65,6 +64,7 @@ const ContentViewFilterDetails = ({ cvId }) => {
           showAffectedRepos={showAffectedRepos}
           setShowAffectedRepos={setShowAffectedRepos}
           rules={rules}
+          details={details}
         />
       </GridItem>
     </Grid>
@@ -73,6 +73,9 @@ const ContentViewFilterDetails = ({ cvId }) => {
 
 ContentViewFilterDetails.propTypes = {
   cvId: PropTypes.number.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 export default ContentViewFilterDetails;

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
@@ -9,15 +9,17 @@ import AffectedRepositorySelection from './AffectedRepositories/AffectedReposito
 import RepoIcon from '../Repositories/RepoIcon';
 import { repoType } from '../../../../utils/helpers';
 import EditableTextInput from '../../../../components/EditableTextInput';
+import { hasPermission } from '../../helpers';
 
 const ContentViewFilterDetailsHeader = ({
-  cvId, filterId, details, setShowAffectedRepos,
+  cvId, filterId, filterDetails, setShowAffectedRepos, details,
 }) => {
   const dispatch = useDispatch();
   const [currentAttribute, setCurrentAttribute] = useState('');
   const {
     type, name, inclusion, description, rules,
-  } = details;
+  } = filterDetails;
+  const { permissions } = details;
   const errataByDate = !!(type === 'erratum' && head(rules)?.types);
   const repositoryType = repoType(type);
   const displayedType = () => {
@@ -27,7 +29,7 @@ const ContentViewFilterDetailsHeader = ({
   };
 
   const onEdit = (val, attribute) => {
-    if (val === details[attribute]) return;
+    if (val === filterDetails[attribute]) return;
     dispatch(editCVFilter(
       filterId,
       { [attribute]: val },
@@ -45,6 +47,7 @@ const ContentViewFilterDetailsHeader = ({
             attribute="name"
             placeholder={__('Enter a name')}
             onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
             value={name}
             component={TextVariants.h2}
             currentAttribute={currentAttribute}
@@ -59,6 +62,7 @@ const ContentViewFilterDetailsHeader = ({
             attribute="description"
             placeholder={__('No description provided')}
             onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
             value={description}
             currentAttribute={currentAttribute}
             setCurrentAttribute={setCurrentAttribute}
@@ -70,6 +74,7 @@ const ContentViewFilterDetailsHeader = ({
           cvId={cvId}
           filterId={filterId}
           setShowAffectedRepos={setShowAffectedRepos}
+          disabled={!hasPermission(permissions, 'edit_content_views')}
         />
       </GridItem>
       <GridItem span={10}>
@@ -94,7 +99,7 @@ const ContentViewFilterDetailsHeader = ({
 ContentViewFilterDetailsHeader.propTypes = {
   cvId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   filterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  details: PropTypes.shape({
+  filterDetails: PropTypes.shape({
     name: PropTypes.string,
     type: PropTypes.string,
     inclusion: PropTypes.bool,
@@ -102,6 +107,9 @@ ContentViewFilterDetailsHeader.propTypes = {
     rules: PropTypes.arrayOf(PropTypes.shape({ types: PropTypes.arrayOf(PropTypes.string) })),
   }).isRequired,
   setShowAffectedRepos: PropTypes.func.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 ContentViewFilterDetailsHeader.defaultProps = {

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -20,8 +20,9 @@ import {
 import { truncate } from '../../../../utils/helpers';
 import ContentType from './ContentType';
 import CVFilterAddModal from './Add/CVFilterAddModal';
+import { hasPermission } from '../../helpers';
 
-const ContentViewFilters = ({ cvId }) => {
+const ContentViewFilters = ({ cvId, details }) => {
   const dispatch = useDispatch();
   const response = useSelector(state => selectCVFilters(state, cvId), shallowEqual);
   const { results, ...metadata } = response;
@@ -34,6 +35,7 @@ const ContentViewFilters = ({ cvId }) => {
   const [bulkActionOpen, setBulkActionOpen] = useState(false);
   const [bulkActionEnabled, setBulkActionEnabled] = useState(false);
   const toggleBulkAction = () => setBulkActionOpen(prevState => !prevState);
+  const { permissions } = details;
 
   const openAddModal = () => setAddModalOpen(true);
 
@@ -118,14 +120,14 @@ const ContentViewFilters = ({ cvId }) => {
         updateSearchQuery,
         error,
         status,
-        actionResolver,
       }}
-      onSelect={onSelect(rows, setRows)}
+      actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
+      onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint="/content_view_filters/auto_complete_search"
       fetchItems={useCallback(params => getContentViewFilters(cvId, params), [cvId])}
-      actionButtons={
+      actionButtons={hasPermission(permissions, 'edit_content_views') &&
         <>
           <Split hasGutter>
             <SplitItem>
@@ -159,6 +161,9 @@ const ContentViewFilters = ({ cvId }) => {
 
 ContentViewFilters.propTypes = {
   cvId: PropTypes.number.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 export default ContentViewFilters;

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
@@ -13,6 +13,7 @@ import api from '../../../../../services/api';
 import CVContainerImageFilterContent from '../CVContainerImageFilterContent';
 
 const cvFilterFixtures = require('./CVContainerImageFilterContent.fixtures.json');
+const details = require('../../../../ContentViews/__tests__/mockDetails.fixtures.json');
 
 const afterDeleteFilterResultsArray = [...cvFilterFixtures.results];
 afterDeleteFilterResultsArray.shift();
@@ -64,7 +65,7 @@ test('Can view container image filter rules', async (done) => {
 
   const { queryByText, getByLabelText } =
     renderWithRedux(
-      withCVRoute(<CVContainerImageFilterContent filterId={195} />),
+      withCVRoute(<CVContainerImageFilterContent filterId={195} details={details} />),
       renderOptions,
     );
 
@@ -107,7 +108,7 @@ test('Can remove filter rules', async (done) => {
 
   const { queryByText, getAllByLabelText } =
     renderWithRedux(
-      withCVRoute(<CVContainerImageFilterContent filterId={195} />),
+      withCVRoute(<CVContainerImageFilterContent filterId={195} details={details} />),
       renderOptions,
     );
 
@@ -159,7 +160,7 @@ test('Can add filter rules', async (done) => {
 
   const { queryByText, getByLabelText } =
     renderWithRedux(
-      withCVRoute(<CVContainerImageFilterContent filterId={195} />),
+      withCVRoute(<CVContainerImageFilterContent filterId={195} details={details} />),
       renderOptions,
     );
 
@@ -224,7 +225,7 @@ test('Can edit filter rules', async (done) => {
 
   const { queryByText, getAllByLabelText, getByLabelText } =
     renderWithRedux(
-      withCVRoute(<CVContainerImageFilterContent filterId={195} />),
+      withCVRoute(<CVContainerImageFilterContent filterId={195} details={details} />),
       renderOptions,
     );
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -15,6 +15,7 @@ import api from '../../../../../services/api';
 const cvFilterDetails = require('./cvPackageFilterDetail.fixtures.json');
 const cvPackageFilterRules = require('./cvPackageFilterRules.fixtures.json');
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFiltersPath = api.getApiUrl('/content_view_filters');
 const cvFilterDetailsPath = api.getApiUrl('/content_view_filters/2');
@@ -63,7 +64,10 @@ test('Can show filter details and package groups on page load', async (done) => 
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -105,8 +109,10 @@ test('Can search for package rules in package filter details', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const withSearchScope = mockAutocomplete(nockInstance, autocompleteUrl, searchQueryMatcher);
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
-
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
   // Basic results showing
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
@@ -165,7 +171,10 @@ test('Can add package rules to filter in a self-closing modal', async (done) => 
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -218,7 +227,10 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
 
 
   const { getByText, queryByText, getAllByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -268,7 +280,10 @@ test('Edit rpm filter rule in a self-closing modal', async (done) => {
   const {
     getByText, queryByText, getAllByLabelText, getByLabelText,
   } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -17,6 +17,7 @@ const cvFilterDetails = require('./contentViewFilterDetail.fixtures.json');
 const cvFilterDetailsAffectedRepos = require('./cvFilterDetailWithAffectedRepos.fixtures.json');
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
 const cvAllRepos = require('./cvAllRepos.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvRefreshCallbackPath = api.getApiUrl('/content_views/1');
 const cvFiltersPath = api.getApiUrl('/content_view_filters');
@@ -72,7 +73,10 @@ test('Can enable and disable add filter button', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -124,7 +128,10 @@ test('Can remove a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -180,7 +187,10 @@ test('Can add a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -237,7 +247,10 @@ test('Can bulk remove filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -296,7 +309,10 @@ test('Can bulk add filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -366,7 +382,10 @@ test('Can show affected repository tab on dropdown selection and add repos', asy
   const {
     getAllByLabelText, getByLabelText, getAllByText, getByText, queryByText,
   } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -449,7 +468,10 @@ test('Can show affected repository tab and remove affected repos', async (done) 
   const {
     getAllByLabelText, getByLabelText, getByText, queryByText,
   } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -505,7 +527,10 @@ test('Can filter by added/not added rules', async (done) => {
 
   const {
     getByText, queryByText, getByTestId, getByLabelText,
-  } = renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+  } = renderWithRedux(withCVRoute(<ContentViewFilterDetails
+    cvId={1}
+    details={details}
+  />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
@@ -15,6 +15,7 @@ import api from '../../../../../services/api';
 const allPackageGroups = require('./allFilterPackageGroups.fixtures.json');
 const cvFilterDetails = require('./contentViewFilterDetail.fixtures.json');
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFiltersPath = api.getApiUrl('/content_view_filters');
 const cvFilterDetailsPath = api.getApiUrl('/content_view_filters/1');
@@ -61,7 +62,10 @@ test('Can show filter details and package groups on page load', async (done) => 
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -103,7 +107,10 @@ test('Can search for package groups in package group filter', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const withSearchScope = mockAutocomplete(nockInstance, autocompleteUrl, searchQueryMatcher);
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Basic results showing
   await patientlyWaitFor(() => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -19,6 +19,7 @@ const renderOptions = {
 };
 
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFilters = api.getApiUrl('/content_view_filters');
 const autocompleteUrl = '/content_view_filters/auto_complete_search';
@@ -53,7 +54,7 @@ test('Can call API and show filters on page load', async (done) => {
     .reply(200, cvFilterFixtures);
 
   const { getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilters cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilters cvId={1} details={details} />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -82,7 +83,7 @@ test('Can search for filter', async (done) => {
     .reply(200, { results: [firstFilter] });
 
   const { queryByText, getByLabelText, getByText } = renderWithRedux(
-    withCVRoute(<ContentViewFilters cvId={1} />),
+    withCVRoute(<ContentViewFilters cvId={1} details={details} />),
     renderOptions,
   );
 
@@ -123,7 +124,7 @@ test('Can remove a filter', async (done) => {
     .reply(200, {});
 
   const { getAllByLabelText, getByText } = renderWithRedux(
-    withCVRoute(<ContentViewFilters cvId={1} />),
+    withCVRoute(<ContentViewFilters cvId={1} details={details} />),
     renderOptions,
   );
 
@@ -161,7 +162,7 @@ test('Can remove multiple filters', async (done) => {
     .reply(200, {});
 
   const { getAllByLabelText, getByLabelText, getByText } = renderWithRedux(
-    withCVRoute(<ContentViewFilters cvId={1} />),
+    withCVRoute(<ContentViewFilters cvId={1} details={details} />),
     renderOptions,
   );
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
@@ -9,6 +9,7 @@ import api from '../../../../../services/api';
 import CVErrataDateFilterContent from '../CVErrataDateFilterContent';
 
 const cvFilterDetails = require('./contentViewErrataByDateDetails.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFilterDetailsPath = api.getApiUrl('/content_view_filters/36');
 
@@ -43,6 +44,7 @@ test('Can display errata-date filter rule and edit', async (done) => {
     filterId="36"
     showAffectedRepos={false}
     setShowAffectedRepos={() => {}}
+    details={details}
   />);
 
   await patientlyWaitFor(() => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -15,6 +15,7 @@ import api from '../../../../../services/api';
 const allErrata = require('./allFilterErrata.fixtures.json');
 const cvFilterDetails = require('./cvErratumFilterDetails.fixtures.json');
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFiltersPath = api.getApiUrl('/content_view_filters');
 const cvRefreshCallbackPath = api.getApiUrl('/content_views/1');
@@ -68,7 +69,10 @@ test('Can enable and disable add filter button', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -121,7 +125,10 @@ test('Can add a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(errataId)).toBeNull();
@@ -176,7 +183,10 @@ test('Can remove a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(errataId)).toBeNull();
@@ -233,7 +243,10 @@ test('Can bulk remove filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(errataId)).toBeNull();
@@ -291,7 +304,10 @@ test('Can bulk add filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(errataId)).toBeNull();
@@ -337,7 +353,10 @@ test('Can show filters and chips', async (done) => {
   const {
     getByText, getAllByText, queryByText, getByLabelText, getByTestId,
   } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
@@ -15,6 +15,7 @@ import api from '../../../../../services/api';
 const allModuleStreams = require('./allFilterModulesStreams.fixtures.json');
 const cvFilterDetails = require('./cvModuleStreamFilterDetails.fixtures.json');
 const cvFilterFixtures = require('./contentViewFilters.fixtures.json');
+const details = require('../../../__tests__/mockDetails.fixtures.json');
 
 const cvFiltersPath = api.getApiUrl('/content_view_filters');
 const cvRefreshCallbackPath = api.getApiUrl('/content_views/1');
@@ -68,7 +69,10 @@ test('Can enable and disable add filter button', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(cvFilterName)).toBeNull();
@@ -121,7 +125,10 @@ test('Can add a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -176,7 +183,10 @@ test('Can remove a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getAllByLabelText, getByText, queryByText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -233,7 +243,10 @@ test('Can bulk remove filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -291,7 +304,10 @@ test('Can bulk add filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
   const { getByText, queryByText, getByLabelText } =
-    renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+    renderWithRedux(withCVRoute(<ContentViewFilterDetails
+      cvId={1}
+      details={details}
+    />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();
@@ -340,7 +356,10 @@ test('Can filter by added/not added rules', async (done) => {
 
   const {
     getByText, queryByText, getByTestId, getByLabelText,
-  } = renderWithRedux(withCVRoute(<ContentViewFilterDetails cvId={1} />), renderOptions);
+  } = renderWithRedux(withCVRoute(<ContentViewFilterDetails
+    cvId={1}
+    details={details}
+  />), renderOptions);
 
   // Nothing will show at first, page is loading
   expect(queryByText(name)).toBeNull();

--- a/webpack/scenes/ContentViews/Details/Filters/index.js
+++ b/webpack/scenes/ContentViews/Details/Filters/index.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { number } from 'prop-types';
+import { number, shape } from 'prop-types';
 import ContentViewFilters from './ContentViewFilters';
 import ContentViewFilterDetails from './ContentViewFilterDetails';
 
-const ContentViewFiltersRoutes = ({ cvId }) => (
+const ContentViewFiltersRoutes = ({ cvId, details }) => (
   <>
     <Route exact path="/filters">
-      <ContentViewFilters cvId={cvId} />
+      <ContentViewFilters cvId={cvId} details={details} />
     </Route>
     <Route path="/filters/:filterId([0-9]+)">
-      <ContentViewFilterDetails cvId={cvId} />
+      <ContentViewFilterDetails cvId={cvId} details={details} />
     </Route>
   </>
 );
@@ -18,6 +18,9 @@ const ContentViewFiltersRoutes = ({ cvId }) => (
 
 ContentViewFiltersRoutes.propTypes = {
   cvId: number.isRequired,
+  details: shape({
+    permissions: shape({}),
+  }).isRequired,
 };
 
 export default ContentViewFiltersRoutes;

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
@@ -48,7 +48,7 @@ test('Can enable and disable add repositories button', async (done) => {
     .reply(200, repoData);
 
   const { getByText, getByLabelText } = renderWithRedux(
-    <ContentViewRepositories cvId={1} />,
+    <ContentViewRepositories cvId={1} details={cvDetailData} />,
     renderOptions,
   );
 
@@ -65,7 +65,7 @@ test('Can enable and disable add repositories button', async (done) => {
 
 test('Can add repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvAddparams = { repository_ids: [106] };
+  const cvAddparams = { repository_ids: [58, 62, 64, 106] };
 
   const repoAddscope = nockInstance
     .put(cvDetailsPath, cvAddparams)
@@ -82,7 +82,7 @@ test('Can add repositories', async (done) => {
     .reply(200, repoData);
 
   const { getByText, getByLabelText } = renderWithRedux(
-    <ContentViewRepositories cvId={1} />,
+    <ContentViewRepositories cvId={1} details={cvDetailData} />,
     renderOptions,
   );
 
@@ -100,7 +100,7 @@ test('Can add repositories', async (done) => {
 
 test('Can remove repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvRemoveParams = { repository_ids: [] };
+  const cvRemoveParams = { repository_ids: [58, 62, 64] };
   const scope = nockInstance
     .get(cvAllRepos)
     .query(true)
@@ -114,7 +114,7 @@ test('Can remove repositories', async (done) => {
     .reply(200, cvRepoAddData);
 
   const { getByText, getByLabelText } = renderWithRedux(
-    <ContentViewRepositories cvId={1} />,
+    <ContentViewRepositories cvId={1} details={cvDetailData} />,
     renderOptions,
   );
 

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.fixtures.json
@@ -1,6 +1,6 @@
 {
-  "total": 14,
-  "subtotal": 14,
+  "total": 2,
+  "subtotal": 2,
   "page": 1,
   "per_page": 20,
   "error": null,

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -24,8 +24,9 @@ import ContentViewVersionPromote from '../Promote/ContentViewVersionPromote';
 import TaskPresenter from '../../components/TaskPresenter/TaskPresenter';
 import { startPollingTask } from '../../../Tasks/TaskActions';
 import RemoveCVVersionWizard from './Delete/RemoveCVVersionWizard';
+import { hasPermission } from '../../helpers';
 
-const ContentViewVersions = ({ cvId }) => {
+const ContentViewVersions = ({ cvId, details }) => {
   const response = useSelector(state => selectCVVersions(state, cvId));
   const { results, ...metadata } = response;
   const status = useSelector(state => selectCVVersionsStatus(state, cvId));
@@ -44,6 +45,7 @@ const ContentViewVersions = ({ cvId }) => {
   const [removingFromEnv, setRemovingFromEnv] = useState(false);
   const [deleteVersion, setDeleteVersion] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
+  const { permissions } = details;
 
   const columnHeaders = [
     __('Version'),
@@ -212,10 +214,10 @@ const ContentViewVersions = ({ cvId }) => {
         emptySearchBody,
         searchQuery,
         updateSearchQuery,
-        actionResolver,
         error,
         status,
       }}
+      actionResolver={hasPermission(permissions, 'promote_or_remove_content_views') ? actionResolver : null}
       cells={columnHeaders}
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_view_versions/auto_complete_search?content_view_id=${cvId}`}
@@ -254,6 +256,9 @@ const ContentViewVersions = ({ cvId }) => {
 
 ContentViewVersions.propTypes = {
   cvId: PropTypes.number.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 export default ContentViewVersions;

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -14,7 +14,8 @@ const renderOptions = { apiNamespace: `${CONTENT_VIEWS_KEY}_2` };
 const cvVersions = api.getApiUrl('/content_view_versions');
 const autocompleteUrl = '/content_view_versions/auto_complete_search';
 const cvVersionRemoveUrl = api.getApiUrl('/content_views/2/remove');
-const cvVersionRemoveResponse = require('./cvVersionRemoveResponse.fixture');
+const cvVersionRemoveResponse = require('./cvVersionRemoveResponse.fixture.json');
+const cvDetailData = require('../../../../__tests__/mockDetails.fixtures.json');
 
 const hostURL = foremanApi.getApiUrl('/hosts');
 const affectedHostData = require('./cvAffectedHosts.fixture');
@@ -22,7 +23,7 @@ const affectedHostData = require('./cvAffectedHosts.fixture');
 const activationKeyURL = api.getApiUrl('/activation_keys');
 const affectedActivationKeysData = require('./cvAffectedActivationKeys.fixture.json');
 
-const cVDropDownOptionsPath = api.getApiUrl('/content_views?organization_id=1&environment_id=3&include_default=true&full_result=true');
+const cVDropDownOptionsPath = api.getApiUrl('/content_views?organization_id=1&include_permissions=true&environment_id=3&include_default=true&full_result=true');
 const cVDropDownOptionsData = require('./cvDropDownOptionsResponse.fixture');
 // const taskPollingUrl = '/foreman_tasks/api/tasks/6b900ff8-62bb-42ac-8c45-da86b7258520';
 
@@ -57,7 +58,7 @@ test('Can call API and show versions on page load', async (done) => {
     .reply(200, cvVersionsData);
 
   const { getByText, queryByText } = renderWithRedux(
-    <ContentViewVersions cvId={2} />,
+    <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
   );
 
@@ -94,7 +95,7 @@ test('Can open Remove wizard and remove version from simple environment', async 
   const {
     getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
   } = renderWithRedux(
-    <ContentViewVersions cvId={2} />,
+    <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
   );
 
@@ -166,7 +167,7 @@ test('Can open Remove wizard and remove version from environment with hosts', as
   const {
     getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
   } = renderWithRedux(
-    <ContentViewVersions cvId={2} />,
+    <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
   );
 
@@ -258,7 +259,7 @@ test('Can open Remove wizard and remove version from environment with activation
   const {
     getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
   } = renderWithRedux(
-    <ContentViewVersions cvId={2} />,
+    <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
   );
 

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { STATUS } from 'foremanReact/constants';
 import { isEmpty, camelCase, first } from 'lodash';
 import { Grid, Tabs, Tab, TabTitleText, Label } from '@patternfly/react-core';
-import { number } from 'prop-types';
+import { number, shape } from 'prop-types';
 import './ContentViewVersionDetails.scss';
 
 import { editContentViewVersionDetails, getContentViewVersionDetails } from '../../ContentViewDetailActions';
@@ -15,12 +15,12 @@ import getCVVersionTableConfigs from './ContentViewVersionDetailConfig.js';
 import ContentViewVersionDetailsTable from './ContentViewVersionDetailsTable';
 import Loading from '../../../../../components/Loading';
 
-const ContentViewVersionDetails = ({ cvId }) => {
+const ContentViewVersionDetails = ({ cvId, details }) => {
   const { versionId } = useParams();
   const { pathname } = useLocation();
   const { push } = useHistory();
   const dispatch = useDispatch();
-  const [details, setDetails] = useState({});
+  const [versionDetails, setVersionDetails] = useState({});
   // Example urls expected:/versions/:id or /versions/:id/repositories.
   const tab = pathname.split('/')[3];
   const response = useSelector(state =>
@@ -38,12 +38,12 @@ const ContentViewVersionDetails = ({ cvId }) => {
 
   useDeepCompareEffect(() => {
     if (loaded) {
-      setDetails(response);
+      setVersionDetails(response);
     }
   }, [response, loaded, tableConfigs]);
 
   const editDiscription = (val, attribute) => {
-    const { description } = details;
+    const { description } = versionDetails;
     if (val !== description) {
       dispatch(editContentViewVersionDetails(
         versionId,
@@ -61,16 +61,20 @@ const ContentViewVersionDetails = ({ cvId }) => {
     }
   };
 
-  // Checking details is done to prevent two renders of the table.
-  if (!loaded && isEmpty(details)) return <Loading />;
+  // Checking versionDetails is done to prevent two renders of the table.
+  if (!loaded && isEmpty(versionDetails)) return <Loading />;
   const filteredTableConfigs = tableConfigs.filter(({ getCountKey }) => !!getCountKey(response));
-  const { repositories } = details;
+  const { repositories } = versionDetails;
   const showTabs = filteredTableConfigs.length > 0 && repositories;
   const getCurrentActiveKey = tab ?? camelCase(first(filteredTableConfigs)?.name);
 
   return (
     <Grid>
-      <ContentViewVersionDetailsHeader details={details} onEdit={editDiscription} />
+      <ContentViewVersionDetailsHeader
+        versionDetails={versionDetails}
+        onEdit={editDiscription}
+        details={details}
+      />
       {showTabs &&
         <div className="grid-with-top-border">
           <Tabs
@@ -116,6 +120,9 @@ const ContentViewVersionDetails = ({ cvId }) => {
 
 ContentViewVersionDetails.propTypes = {
   cvId: number.isRequired,
+  details: shape({
+    permissions: shape({}),
+  }).isRequired,
 };
 
 export default ContentViewVersionDetails;

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -13,12 +13,14 @@ import {
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EditableTextInput from '../../../../../components/EditableTextInput';
+import { hasPermission } from '../../../helpers';
 
 const ContentViewVersionDetailsHeader = ({
-  details: {
+  versionDetails: {
     version, description, environments,
   },
   onEdit,
+  details: { permissions },
 }) => (
   <>
     <GridItem span={12}>
@@ -36,6 +38,7 @@ const ContentViewVersionDetailsHeader = ({
             attribute="description"
             placeholder={__('No description provided')}
             onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
             value={description}
           />
         </TextList>
@@ -49,12 +52,15 @@ const ContentViewVersionDetailsHeader = ({
 );
 
 ContentViewVersionDetailsHeader.propTypes = {
-  details: PropTypes.shape({
+  versionDetails: PropTypes.shape({
     version: PropTypes.string,
     environments: PropTypes.arrayOf(PropTypes.shape({ })),
     description: PropTypes.string,
   }).isRequired,
   onEdit: PropTypes.func.isRequired,
+  details: PropTypes.shape({
+    permissions: PropTypes.shape({}),
+  }).isRequired,
 };
 
 export default ContentViewVersionDetailsHeader;

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
@@ -11,6 +11,7 @@ import { AUTOSEARCH_DELAY, AUTOSEARCH_WHILE_TYPING } from '../../../../../Settin
 
 const ContentViewVersionDetailsData = require('./ContentViewVersionDetails.fixtures.json');
 const ContentViewVersionDetailsCounts = require('./ContentViewVersionDetailsCounts.fixtures.json');
+const cvDetailData = require('../../../../__tests__/mockDetails.fixtures.json');
 
 // This changes the api count value so that only the specified tab will show.
 const getTabSpecificData = key => ({
@@ -56,7 +57,7 @@ test('Can show versions details - Components Tab', async (done) => {
     .reply(200, ContentViewVersionsComponentData);
 
   const { getByText, queryByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersionDetails cvId={3} />),
+    withCVRoute(<ContentViewVersionDetails cvId={3} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -200,7 +201,7 @@ testConfig.forEach(({
       .reply(200, data);
 
     const { getByText, queryByText } = renderWithRedux(
-      withCVRoute(<ContentViewVersionDetails cvId={3} />),
+      withCVRoute(<ContentViewVersionDetails cvId={3} details={cvDetailData} />),
       renderOptions,
     );
 
@@ -254,7 +255,7 @@ test('Can change repository selector', async (done) => {
     .reply(200, data);
 
   const { getByText, queryByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersionDetails cvId={3} />),
+    withCVRoute(<ContentViewVersionDetails cvId={3} details={cvDetailData} />),
     {
       ...renderOptions,
       routerParams: {

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetailsEmpty.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetailsEmpty.test.js
@@ -8,6 +8,7 @@ import { cvVersionDetailsKey } from '../../../../ContentViewsConstants';
 import ContentViewVersionDetails from '../ContentViewVersionDetails';
 
 const ContentViewVersionDetailsEmptyData = require('./ContentViewVersionDetails.fixtures.json');
+const cvDetailData = require('../../../../__tests__/mockDetails.fixtures.json');
 
 const withCVRoute = component =>
   <Route path="/versions/:versionId([0-9]+)">{component}</Route>;
@@ -29,7 +30,7 @@ test('Can show versions detail header', async (done) => {
     .reply(200, ContentViewVersionDetailsEmptyData);
 
   const { getByText, queryByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersionDetails cvId={3} />),
+    withCVRoute(<ContentViewVersionDetails cvId={3} details={cvDetailData} />),
     renderOptions,
   );
 

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -11,6 +11,7 @@ const emptyCVVersionData = require('./emptyCVVersion.fixtures.json');
 const cvVersionsTasksData = require('./contentViewVersionsWithTask.fixtures.json');
 const contentViewTaskInProgressResponseData = require('./contentViewTaskInProgressResponse.fixtures.json');
 const contentViewTaskResponseData = require('./contentViewTaskResponse.fixtures.json');
+const cvDetailData = require('../../../../ContentViews/__tests__/mockDetails.fixtures.json');
 
 const cvPromotePath = api.getApiUrl('/content_view_versions/10/promote');
 const promoteResponseData = contentViewTaskInProgressResponseData;
@@ -64,7 +65,7 @@ test('Can call API and show versions on page load', async (done) => {
     .reply(200, cvVersionsData);
 
   const { getByText, queryByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -86,7 +87,7 @@ test('Can link to view environment and see publish time', async () => {
     .reply(200, cvVersionsData);
 
   const { getByText, getAllByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -115,7 +116,7 @@ test('Can show package and erratas and link to list page', async () => {
     .reply(200, cvVersionsData);
 
   const { getByText, getAllByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -145,7 +146,7 @@ test('Can show additional content and link to list page', async () => {
     .reply(200, cvVersionsData);
 
   const { getByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -169,7 +170,7 @@ test('Can load for empty versions', async () => {
     .reply(200, emptyCVVersionData);
 
   const { queryByText } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -196,7 +197,7 @@ test('Can call API and show versions with tasks on page load', async (done) => {
   const {
     getByLabelText, queryByText,
   } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -235,7 +236,7 @@ test('Can reload versions upon task completion', async (done) => {
   const {
     getByText, queryByLabelText, getByLabelText, queryByText,
   } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 
@@ -279,7 +280,7 @@ test('Can open Promote Modal', async (done) => {
   const {
     getByText, queryByText, getByLabelText, getAllByLabelText,
   } = renderWithRedux(
-    withCVRoute(<ContentViewVersions cvId={5} />),
+    withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
   );
 

--- a/webpack/scenes/ContentViews/Details/Versions/index.js
+++ b/webpack/scenes/ContentViews/Details/Versions/index.js
@@ -1,22 +1,25 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { number } from 'prop-types';
+import { number, shape } from 'prop-types';
 import ContentViewVersions from './ContentViewVersions';
 import ContentViewVersionDetails from './VersionDetails/ContentViewVersionDetails';
 
-const ContentViewVersionsRoutes = ({ cvId }) => (
+const ContentViewVersionsRoutes = ({ cvId, details }) => (
   <>
     <Route exact path="/versions">
-      <ContentViewVersions cvId={cvId} />
+      <ContentViewVersions cvId={cvId} details={details} />
     </Route>
     <Route path="/versions/:versionId([0-9]+)">
-      <ContentViewVersionDetails cvId={cvId} />
+      <ContentViewVersionDetails cvId={cvId} details={details} />
     </Route>
   </>
 );
 
 ContentViewVersionsRoutes.propTypes = {
   cvId: number.isRequired,
+  details: shape({
+    permissions: shape({}),
+  }).isRequired,
 };
 
 export default ContentViewVersionsRoutes;

--- a/webpack/scenes/ContentViews/Table/tableDataGenerator.js
+++ b/webpack/scenes/ContentViews/Table/tableDataGenerator.js
@@ -57,6 +57,7 @@ const buildExpandableRows = (contentViews) => {
       latest_version: latestVersionName,
       environments,
       versions,
+      permissions,
     } = contentView;
     const cells = buildRow(contentView);
     const cellParent = {
@@ -70,6 +71,7 @@ const buildExpandableRows = (contentViews) => {
       latestVersionName,
       environments,
       versions,
+      permissions,
       isOpen: false,
       cells,
     };

--- a/webpack/scenes/ContentViews/__tests__/contentViewList.fixtures.json
+++ b/webpack/scenes/ContentViews/__tests__/contentViewList.fixtures.json
@@ -9,6 +9,7 @@
     "by": "name",
     "order": "asc"
   },
+  "can_create": true,
   "results": [
     {
       "composite": false,

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -183,7 +183,7 @@ test('Can handle errored response', async (done) => {
   const { queryByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
   expect(queryByText(firstCV.name)).toBeNull();
-  await patientlyWaitFor(() => expect(queryByText(/unable to connect/i)).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(queryByText(/Something went wrong! Please check server logs!/i)).toBeInTheDocument());
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
 });
@@ -348,6 +348,7 @@ test('Displays Create Content View and opens modal with Form', async () => {
     subtotal: 0,
     page: 1,
     per_page: 20,
+    can_create: true,
     results: [],
   };
   nockInstance

--- a/webpack/scenes/ContentViews/__tests__/mockDetails.fixtures.json
+++ b/webpack/scenes/ContentViews/__tests__/mockDetails.fixtures.json
@@ -1,0 +1,10 @@
+{
+  "label": "mock_details",
+  "permissions": {
+  "view_content_views": true,
+    "edit_content_views": true,
+    "destroy_content_views": true,
+    "publish_content_views": true,
+    "promote_or_remove_content_views": true
+}
+}

--- a/webpack/scenes/ContentViews/helpers.js
+++ b/webpack/scenes/ContentViews/helpers.js
@@ -11,3 +11,4 @@ export const autoPublishHelpText = __('Automatically publish a new version of th
 export const importOnlyHelpText = __('Designate whether this content view is for importing from an upstream server. ' +
   'Import-only content views cannot be published directly.');
 
+export const hasPermission = (permissions, perm) => permissions && permissions[perm];


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Adds permission checks to UI
### What are the testing steps for this pull request?
Create a user with viewer role.
No actions on any page should be visible to the user. (Publish/Promote/Create/Copy/Delete/ Version deletes/Edit/ Add/Remove/Edit filters etc)

Create a user with no roles.
CV page should appear with Permission Denied empty state.