### PR TITLE
Fixes #33335 - Fix an issue with Debian Packages - Update 

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-debs.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-debs.controller.js
@@ -52,7 +52,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDebsController',
         $scope.performViaRemoteExecution = function (actionType, term, customize) {
             $scope.packageActionFormValues.package = term;
             $scope.packageActionFormValues.remoteAction = actionType;
-            $scope.packageActionFormValues.hostIds = $scope.host.id;
+            $scope.packageActionFormValues.bulkHostIds = angular.toJson({ included: { ids: [$scope.host.id] }});
             $scope.packageActionFormValues.customize = customize;
 
             $timeout(function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs.html
@@ -1,7 +1,7 @@
 <form role="form" id="packageActionForm" method="post" action="/katello/remote_execution">
   <input type="hidden" name="name" ng-value="packageActionFormValues.package"/>
   <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
-  <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
+  <input type="hidden" name="bulk_host_ids" ng-value="packageActionFormValues.bulkHostIds"/>
   <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
   <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
 </form>

--- a/engines/bastion_katello/test/content-hosts/content/content-host-deb.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-deb.controller.test.js
@@ -51,7 +51,7 @@ describe('Controller: ContentHostDebsController', function() {
         $scope.performPackageAction('packageUpdate', 'foo');
         expect($scope.packageActionFormValues.package).toBe('foo');
         expect($scope.packageActionFormValues.remoteAction).toBe('packageUpdate');
-        expect($scope.packageActionFormValues.hostIds).toBe(23434);
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
         expect($scope.packageActionFormValues.customize).toBe(false);
         // expect($timeout).toHaveBeenCalledWith(jasmine.any(Function), 0);
         // expect(angular.element).toHaveBeenCalledWith('#packageActionForm');
@@ -62,7 +62,7 @@ describe('Controller: ContentHostDebsController', function() {
         $scope.performPackageAction('packageUpdate', 'foo bar');
         expect($scope.packageActionFormValues.package).toBe('foo bar');
         expect($scope.packageActionFormValues.remoteAction).toBe('packageUpdate');
-        expect($scope.packageActionFormValues.hostIds).toBe(23434);
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
         expect($scope.packageActionFormValues.customize).toBe(false);
     });
 
@@ -70,7 +70,7 @@ describe('Controller: ContentHostDebsController', function() {
         $scope.performPackageAction('groupInstall', 'bigGroup');
         expect($scope.packageActionFormValues.package).toBe('bigGroup');
         expect($scope.packageActionFormValues.remoteAction).toBe('groupInstall');
-        expect($scope.packageActionFormValues.hostIds).toBe(23434);
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
         expect($scope.packageActionFormValues.customize).toBe(false);
     });
 
@@ -79,7 +79,7 @@ describe('Controller: ContentHostDebsController', function() {
         expect($scope.working).toBe(true);
         expect($scope.packageActionFormValues.package).toBe('');
         expect($scope.packageActionFormValues.remoteAction).toBe('packageUpdate');
-        expect($scope.packageActionFormValues.hostIds).toBe(23434);
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
         expect($scope.packageActionFormValues.customize).toBe(false);
     });
 });


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This PR fixes an issue where after selecting errata from the Content Hosts -> Select Host -> Deb Packages -> Applicable ->  Update All Deb Packages workflow, a remote_execution controller error exception is thrown. 
```no implicit conversion of nil into String```

The cause was that the `host_ids` parameter was changed to `bulk_host_ids` and is now JSON.

Similar to https://github.com/Katello/katello/pull/9572

### What are the testing steps for this pull request?
Content Hosts -> Select Host -> Deb Packages -> Applicable ->  Update All Deb Packages
Should be redirected to a job detail page.