### PR TITLE
Fixes #33720 - Move collections to generic UI

### DIFF
--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -76,7 +76,7 @@ module Katello
 
     def content_type(model_class, options = {})
       @content_types ||= []
-      @content_types << ContentType.new(options.merge(:model_class => model_class))
+      @content_types << ContentType.new(options.merge(:model_class => model_class, :content_type => model_class::CONTENT_TYPE))
     end
 
     def generic_content_type(content_type, options = {})
@@ -127,10 +127,11 @@ module Katello
 
     class ContentType
       attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable,
-                    :primary_content, :index_on_pulp3, :generic_browser
+                    :primary_content, :index_on_pulp3, :generic_browser, :content_type
 
       def initialize(options)
         self.model_class = options[:model_class]
+        self.content_type = options[:content_type]
         self.priority = options[:priority] || 99
         self.pulp2_service_class = options[:pulp2_service_class]
         self.pulp3_service_class = options[:pulp3_service_class]
@@ -157,7 +158,7 @@ module Katello
     end
 
     class GenericContentType < ContentType
-      attr_accessor :pulp3_api, :pulp3_model, :content_type, :filename_key, :duplicates_allowed, :pluralized_name,
+      attr_accessor :pulp3_api, :pulp3_model, :filename_key, :duplicates_allowed, :pluralized_name,
                     :model_name, :model_version, :model_filename
 
       def initialize(options)

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -87,6 +87,14 @@ module Katello
         list.flatten.map(&:content_type)
       end
 
+      def generic_ui_content_types(enabled_only = true)
+        repo_types = enabled_only ? enabled_repository_types : defined_repository_types
+        list = repo_types.values.map do |type|
+          type.content_types.select { |ct| ct.generic_browser }
+        end
+        list.flatten.map(&:content_type)
+      end
+
       def generic_content_type?(content_type, enabled_only = true)
         types = generic_content_types(enabled_only)
         types.include?(content_type)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,15 +24,15 @@ Katello::Engine.routes.draw do
   match '/module_streams' => 'react#index', :via => [:get]
   match '/module_streams/*page' => 'react#index', :via => [:get]
 
-  match '/ansible_collections' => 'react#index', :via => [:get]
-  match '/ansible_collections/*page' => 'react#index', :via => [:get]
+  match '/legacy_ansible_collections' => 'react#index', :via => [:get]
+  match '/legacy_ansible_collections/*page' => 'react#index', :via => [:get]
 
   match '/content_views' => 'react#index', :via => [:get]
   match '/content_views/*page' => 'react#index', :via => [:get]
 
   match '/content' => 'react#index', :via => [:get]
 
-  Katello::RepositoryTypeManager.generic_content_types.each do |type|
+  Katello::RepositoryTypeManager.generic_ui_content_types.each do |type|
     get "/#{type.pluralize}", to: redirect("/content/#{type.pluralize}")
     get "/#{type.pluralize}/:page", to: redirect("/content/#{type.pluralize}/%{page}")
     match "/content/#{type.pluralize}" => 'react#index', :via => [:get]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
@@ -91,7 +91,7 @@
             }
         })
         .state('product.repository.manage-content.docker-manifests', {
-            url: '/content/docker_manifests',
+            url: '/docker_manifests',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-docker-manifests.html',
             ncyBreadcrumb: {
@@ -100,7 +100,7 @@
             }
         })
         .state('product.repository.manage-content.docker-tags', {
-            url: '/content/docker_tags',
+            url: '/docker_tags',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-docker-tags.html',
             ncyBreadcrumb: {
@@ -109,7 +109,7 @@
             }
         })
         .state('product.repository.manage-content.docker-manifest-lists', {
-            url: '/content/docker_manifest_lists',
+            url: '/docker_manifest_lists',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-docker-manifest-lists.html',
             ncyBreadcrumb: {
@@ -118,7 +118,7 @@
             }
         })
         .state('product.repository.manage-content.files', {
-            url: '/content/files',
+            url: '/files',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-files.html',
             ncyBreadcrumb: {
@@ -127,7 +127,7 @@
             }
         })
         .state('product.repository.manage-content.ostree-branches', {
-            url: '/content/ostree_branches',
+            url: '/ostree_branches',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-ostree-branches.html',
             ncyBreadcrumb: {
@@ -145,7 +145,7 @@
             }
         })
         .state('product.repository.manage-content.debs', {
-            url: '/content/debs',
+            url: '/debs',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-debs.html',
             ncyBreadcrumb: {
@@ -154,7 +154,7 @@
             }
         })
         .state('product.repository.manage-content.ansible-collections', {
-            url: '/content/ansible_collections',
+            url: '/ansible_collections',
             permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-manage-ansible-collections.html',
             ncyBreadcrumb: {

--- a/lib/katello/repository_types/ansible_collection.rb
+++ b/lib/katello/repository_types/ansible_collection.rb
@@ -16,5 +16,6 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::ANSIBLE_COLLECTIO
   distribution_class PulpAnsibleClient::AnsibleAnsibleDistribution
   repo_sync_url_class PulpAnsibleClient::AnsibleRepositorySyncURL
 
-  content_type Katello::AnsibleCollection, :pulp3_service_class => ::Katello::Pulp3::AnsibleCollection, :user_removable => true
+  content_type Katello::AnsibleCollection, :pulp3_service_class => ::Katello::Pulp3::AnsibleCollection, :user_removable => true, generic_browser: true
+  default_managed_content_type :ansible_collections
 end

--- a/webpack/components/RoutedTabs/index.js
+++ b/webpack/components/RoutedTabs/index.js
@@ -45,7 +45,7 @@ const RoutedTabs = ({
               <Route key={`${key}-route`} path={`/${key}`}>
                 {content}
               </Route>))}
-            <Redirect to={`/${currentTabFromUrl || tabs[defaultTabIndex].key}`} />
+            <Redirect to={`/${currentTabFromUrl || tabs[defaultTabIndex]?.key}`} />
           </Switch>
         </HashRouter>
       </div>

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -47,11 +47,11 @@ export const links = [
     component: WithOrganization(withHeader(ModuleStreamDetails, { title: __('Module Stream Details') })),
   },
   {
-    path: 'ansible_collections',
+    path: 'legacy_ansible_collections',
     component: WithOrganization(withHeader(AnsibleCollections, { title: __('Ansible Collections') })),
   },
   {
-    path: 'ansible_collections/:id([0-9]+)',
+    path: 'legacy_ansible_collections/:id([0-9]+)',
     component: WithOrganization(withHeader(AnsibleCollectionDetails, { title: __('Ansible Collection Details') })),
   },
   {
@@ -65,14 +65,14 @@ export const links = [
   },
   {
     path: 'content',
-    component: WithOrganization(withHeader(Content, { title: __('Other Content Types') })),
+    component: WithOrganization(withHeader(Content, { title: __('Content') })),
   },
   {
     path: 'content/:content_type([a-z_]+)',
-    component: WithOrganization(withHeader(Content, { title: __('Other Content Types') })),
+    component: WithOrganization(withHeader(Content, { title: __('Content') })),
   },
   {
     path: 'content/:content_type([a-z_]+)/:id([0-9]+)',
-    component: WithOrganization(withHeader(ContentDetails, { title: __('Other Content Type Details') })),
+    component: WithOrganization(withHeader(ContentDetails, { title: __('Content Details') })),
   },
 ];

--- a/webpack/scenes/AnsibleCollections/AnsibleCollectionsTableSchema.js
+++ b/webpack/scenes/AnsibleCollections/AnsibleCollectionsTableSchema.js
@@ -18,7 +18,7 @@ const TableSchema = [
       formatters: [
         (value, { rowData }) => (
           <td>
-            <Link to={urlBuilder('ansible_collections', '', rowData.id)}>{rowData.name}</Link>
+            <Link to={urlBuilder('legacy_ansible_collections', '', rowData.id)}>{rowData.name}</Link>
           </td>
         ),
       ],

--- a/webpack/scenes/Content/ContentConfig.js
+++ b/webpack/scenes/Content/ContentConfig.js
@@ -47,7 +47,72 @@ export default () => [
           {
             title: __('Product'),
             getProperty: unit =>
-              <a href={urlBuilder(`products/${unit?.product.id}/repositories`, '')}>{unit?.product.name}</a>,
+              <a href={urlBuilder(`products/${unit?.product.id}/`, '')}>{unit?.product.name}</a>,
+          },
+          {
+            title: __('Sync Status'),
+            getProperty: unit =>
+              <LastSync lastSyncWords={unit?.last_sync_words} lastSync={unit?.last_sync} />,
+          },
+          {
+            title: __('Content Count'),
+            getProperty: (unit, singularLabel) =>
+              (<ContentCounts
+                typeSingularLabel={singularLabel}
+                productId={unit.product.id}
+                repoId={unit.id}
+                counts={unit.content_counts}
+              />),
+          },
+        ],
+      },
+    ],
+  },
+  {
+    names: {
+      pluralTitle: __('Ansible Collections'),
+      singularTitle: __('Ansible Collection'),
+      pluralLowercase: __('Ansible collections'),
+      singularLowercase: __('Ansible collection'),
+      pluralLabel: 'ansible_collections',
+      singularLabel: 'ansible_collection',
+    },
+    columnHeaders: [
+      { title: __('Name'), getProperty: unit => (<Link to={urlBuilder(`content/ansible_collections/${unit?.id}`, '')}>{unit?.name}</Link>) },
+      { title: __('Author'), getProperty: unit => unit?.namespace },
+      { title: __('Version'), getProperty: unit => unit?.version },
+      { title: __('Checksum'), getProperty: unit => unit?.checksum },
+
+    ],
+    tabs: [
+      {
+        tabKey: 'details',
+        title: __('Details'),
+        getContent: (contentType, id, tabKey) => <ContentInfo {...{ contentType, id, tabKey }} />,
+        columnHeaders: [
+          { title: __('Name'), getProperty: unit => unit?.name },
+          { title: __('Description'), getProperty: unit => unit?.description },
+          { title: __('Author'), getProperty: unit => unit?.namespace },
+          { title: __('Version'), getProperty: unit => unit?.version },
+          { title: __('Checksum'), getProperty: unit => unit?.checksum },
+          { title: __('Tags'), getProperty: unit => unit?.tags?.join() },
+        ],
+      },
+      {
+        tabKey: 'repositories',
+        title: __('Repositories'),
+        getContent: (contentType, id, tabKey) =>
+          <ContentRepositories {...{ contentType, id, tabKey }} />,
+        columnHeaders: [
+          {
+            title: __('Name'),
+            getProperty: unit =>
+              <a href={urlBuilder(`products/${unit?.product.id}/repositories/${unit?.id}`, '')}>{unit?.name}</a>,
+          },
+          {
+            title: __('Product'),
+            getProperty: unit =>
+              <a href={urlBuilder(`products/${unit?.product.id}`, '')}>{unit?.product.name}</a>,
           },
           {
             title: __('Sync Status'),

--- a/webpack/scenes/Content/ContentPage.js
+++ b/webpack/scenes/Content/ContentPage.js
@@ -17,6 +17,7 @@ const ContentPage = () => {
   const contentTypesResponse = useSelector(selectContentTypes);
   const contentTypesStatus = useSelector(selectContentTypesStatus);
   const [selectedContentType, setSelectedContentType] = useState(null);
+  const [showContentTypeSelector, setShowContentTypeSelector] = useState(true);
   const [contentTypes, setContentTypes] = useState(null);
   const { content_type: contentType } = useParams();
 
@@ -45,6 +46,7 @@ const ContentPage = () => {
         Object.entries(enabledContentTypes).forEach(([key, value]) => {
           if (value.includes(contentType)) {
             setSelectedContentType(key);
+            setShowContentTypeSelector(false);
           }
         });
       }
@@ -75,7 +77,10 @@ const ContentPage = () => {
         </TextContent>
       </GridItem>
       <GridItem span={12}>
-        <ContentTable {...{ selectedContentType, setSelectedContentType, contentTypes }} />
+        <ContentTable {...{
+ selectedContentType, setSelectedContentType, contentTypes, showContentTypeSelector,
+}}
+        />
       </GridItem>
     </Grid>
   );

--- a/webpack/scenes/Content/Details/ContentDetails.js
+++ b/webpack/scenes/Content/Details/ContentDetails.js
@@ -58,7 +58,7 @@ const ContentDetails = () => {
         </Flex>
       </GridItem>
       <GridItem span={12}>
-        <RoutedTabs tabs={tabs} baseUrl={`/${contentType}/${contentId}`} defaultTabIndex={1} />
+        <RoutedTabs tabs={tabs} baseUrl={`/${contentType}/${contentId}`} defaultTabIndex={0} />
       </GridItem>
     </Grid>
   );

--- a/webpack/scenes/Content/Details/__tests__/ansibleCollectionDetails.fixtures.json
+++ b/webpack/scenes/Content/Details/__tests__/ansibleCollectionDetails.fixtures.json
@@ -1,0 +1,20 @@
+{
+  "id": 51,
+  "name": "linux_system_roles",
+  "namespace": "fedora",
+  "version": "1.5.0",
+  "checksum": "edd27bbc1f6ba805760bf85a05efacca989492570e41d263fd804358ce9cef92",
+  "description": "Ansible roles for linux system components management",
+  "tags": [
+    "collection",
+    "system"
+  ],
+  "repositories": [
+    {
+      "id": 698,
+      "name": "lin_collections",
+      "product_id": 296,
+      "product_name": "test_all_types"
+    }
+  ]
+}

--- a/webpack/scenes/Content/Details/__tests__/ansibleCollectionRepositoryDetails.fixtures.json
+++ b/webpack/scenes/Content/Details/__tests__/ansibleCollectionRepositoryDetails.fixtures.json
@@ -1,0 +1,71 @@
+{
+  "total": 1,
+  "subtotal": 1,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "name",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "backend_identifier": "b7e662ed-fd91-44ed-94c0-60fc9c5b2ccc",
+      "relative_path": "Default_Organization/Library/custom/test_all_types/lin_collections",
+      "container_repository_name": null,
+      "full_path": "https://centos7-devel4.samir.example.com/pulp_ansible/galaxy/Default_Organization/Library/custom/test_all_types/lin_collections/api/",
+      "library_instance_id": null,
+      "version_href": "/pulp/api/v3/repositories/ansible/ansible/59832f57-b06d-49aa-ab3e-ac07c847fb55/versions/1/",
+      "remote_href": "/pulp/api/v3/remotes/ansible/collection/66badf55-97c1-42be-9e55-c30fdfdd182c/",
+      "publication_href": null,
+      "content_counts": {
+        "ansible_collection": 17
+      },
+      "id": 698,
+      "name": "lin_collections",
+      "label": "lin_collections",
+      "description": null,
+      "last_sync": {
+        "id": "5b6b544a-767f-4558-926d-4c7c828afccc",
+        "username": "admin",
+        "started_at": "2021-10-15 11:34:51 -0400",
+        "ended_at": "2021-10-15 11:35:10 -0400",
+        "state": "stopped",
+        "result": "success",
+        "progress": 1
+      },
+      "content_view": {
+        "id": 1,
+        "name": "Default Organization View"
+      },
+      "content_view_version": {
+        "id": 1,
+        "name": "Default Organization View 1.0",
+        "content_view_id": 1
+      },
+      "kt_environment": {
+        "id": 1,
+        "name": "Library"
+      },
+      "content_type": "ansible_collection",
+      "url": "http://galaxy.ansible.com/",
+      "arch": "noarch",
+      "os_versions": null,
+      "content_id": "1634312081893",
+      "generic_remote_options": null,
+      "major": null,
+      "minor": null,
+      "product": {
+        "id": 296,
+        "cp_id": "292121829980",
+        "name": "test_all_types",
+        "orphaned": false,
+        "redhat": false,
+        "sync_plan": null
+      },
+      "content_label": "Default_Organization_test_all_types_lin_collections",
+      "last_sync_words": "12 days"
+    }
+  ]
+}

--- a/webpack/scenes/Content/Details/__tests__/contentDetail.test.js
+++ b/webpack/scenes/Content/Details/__tests__/contentDetail.test.js
@@ -8,9 +8,12 @@ import ContentDetails from '../ContentDetails';
 import ContentRepositories from '../ContentRepositories';
 import pythonPackageDetailsResponse from './pythonPackageDetails.fixtures.json';
 import pythonPackageRepositoryDetailsResponse from './pythonPackageRepositoryDetails.fixtures.json';
+import ansibleCollectionDetailsResponse from './ansibleCollectionDetails.fixtures.json';
+import ansibleCollectionRepositoryDetailsResponse from './ansibleCollectionRepositoryDetails.fixtures.json';
 
 const pythonPackageDetailsPath = api.getApiUrl('/python_packages/1491');
-const pythonPackageRepositoryDetailsPath = api.getApiUrl('/repositories');
+const ansibleCollectionDetailsPath = api.getApiUrl('/ansible_collections/51');
+const contentRepositoryDetailsPath = api.getApiUrl('/repositories');
 
 const withContentRoute = component => <Route path="/content/:content_type([a-z_]+)/:id([0-9]+)">{component}</Route>;
 
@@ -59,7 +62,7 @@ test('Can call API for Python package repository details and show repositories t
   const contentCountWords = '1489 Python packages';
 
   const pythonPackageRepositoryDetailsScope = nockInstance
-    .get(pythonPackageRepositoryDetailsPath)
+    .get(contentRepositoryDetailsPath)
     .query(true)
     .reply(200, pythonPackageRepositoryDetailsResponse);
 
@@ -78,4 +81,67 @@ test('Can call API for Python package repository details and show repositories t
   assertNockRequest(searchDelayScope);
   assertNockRequest(autocompleteScope);
   assertNockRequest(pythonPackageRepositoryDetailsScope, done);
+});
+
+test('Can call API for Ansible collection details and show details tab on page load', async (done) => {
+  const renderOptions = {
+    apiNamespace: CONTENT_ID_KEY,
+    routerParams: {
+      initialEntries: [{ pathname: '/content/ansible_collections/51', hash: '#/details' }],
+      initialIndex: 1,
+    },
+  };
+
+  const { name, version } = ansibleCollectionDetailsResponse;
+  const ansibleCollectionsScope = nockInstance
+    .get(ansibleCollectionDetailsPath)
+    .query(true)
+    .reply(200, ansibleCollectionDetailsResponse);
+
+  const { queryByText, getAllByText, getByLabelText } =
+    renderWithRedux(withContentRoute(<ContentDetails />), renderOptions);
+
+  expect(queryByText(name)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getAllByText(name)[0]).toBeInTheDocument();
+    expect(getAllByText(version)[0]).toBeInTheDocument();
+    expect(getByLabelText('content_breadcrumb')).toBeInTheDocument();
+    expect(getByLabelText('content_breadcrumb_content')).toHaveTextContent(name);
+  });
+
+  assertNockRequest(ansibleCollectionsScope, done);
+});
+
+test('Can call API for Ansible collection repository details and show repositories tab', async (done) => {
+  const autocompleteUrl = '/repositories/auto_complete_search';
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', true);
+
+  const results = ansibleCollectionRepositoryDetailsResponse.results[0];
+  const repoName = results.name;
+  const productName = results.product.name;
+  const lastSyncWords = `${results.last_sync_words} ago`;
+  const contentCountWords = '17 Ansible collections';
+
+  const ansibleCollectionRepositoryDetailsScope = nockInstance
+    .get(contentRepositoryDetailsPath)
+    .query(true)
+    .reply(200, ansibleCollectionRepositoryDetailsResponse);
+
+  const { queryByText, getAllByText } =
+    renderWithRedux(<ContentRepositories tabKey="repositories" id={51} contentType="ansible_collections" />);
+
+  expect(queryByText(repoName)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getAllByText(repoName)[0]).toBeInTheDocument();
+    expect(getAllByText(productName)[0]).toBeInTheDocument();
+    expect(getAllByText(lastSyncWords)[0]).toBeInTheDocument();
+    expect(getAllByText(contentCountWords)[0]).toBeInTheDocument();
+  });
+
+  assertNockRequest(autoSearchScope);
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(ansibleCollectionRepositoryDetailsScope, done);
 });

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -9,7 +9,9 @@ import { selectContent, selectContentStatus, selectContentError } from '../Conte
 import SelectableDropdown from '../../../components/SelectableDropdown';
 import contentConfig from '../ContentConfig';
 /* eslint-disable react/no-array-index-key */
-const ContentTable = ({ selectedContentType, setSelectedContentType, contentTypes }) => {
+const ContentTable = ({
+  selectedContentType, setSelectedContentType, contentTypes, showContentTypeSelector,
+}) => {
   const status = useSelector(selectContentStatus);
   const error = useSelector(selectContentError);
   const response = useSelector(selectContent);
@@ -41,6 +43,7 @@ const ContentTable = ({ selectedContentType, setSelectedContentType, contentType
         [contentTypes, selectedContentType],
       )}
       actionButtons={
+        showContentTypeSelector &&
         <SelectableDropdown
           items={Object.keys(contentTypes)}
           title={__('Type')}
@@ -76,6 +79,11 @@ ContentTable.propTypes = {
   selectedContentType: PropTypes.string.isRequired,
   setSelectedContentType: PropTypes.func.isRequired,
   contentTypes: PropTypes.objectOf(PropTypes.array).isRequired,
+  showContentTypeSelector: PropTypes.bool,
+};
+
+ContentTable.defaultProps = {
+  showContentTypeSelector: true,
 };
 
 export default ContentTable;

--- a/webpack/scenes/Content/__tests__/ansibleCollections.fixtures.json
+++ b/webpack/scenes/Content/__tests__/ansibleCollections.fixtures.json
@@ -1,0 +1,50 @@
+{
+  "total": 3,
+  "subtotal": 3,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "name",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "id": 51,
+      "name": "linux_system_roles",
+      "namespace": "fedora",
+      "version": "1.5.0",
+      "checksum": "edd27bbc1f6ba805760bf85a05efacca989492570e41d263fd804358ce9cef92",
+      "description": "Ansible roles for linux system components management",
+      "tags": [
+        "collection",
+        "system"
+      ]
+    },
+    {
+      "id": 50,
+      "name": "linux_system_roles",
+      "namespace": "fedora",
+      "version": "1.8.2",
+      "checksum": "795c1f3c77681b827dedbb56430b8aeb8daa9b5bb609ae05cb3446f8419b290a",
+      "description": "Ansible roles for linux system components management",
+      "tags": [
+        "collection",
+        "system"
+      ]
+    },
+    {
+      "id": 49,
+      "name": "linux_system_roles",
+      "namespace": "fedora",
+      "version": "0.0.2",
+      "checksum": "ca52fac3c7243ff5f01d47f6ce5d627d7e028be6af952899178523fcb7d68718",
+      "description": "Ansible roles for linux system components management",
+      "tags": [
+        "collection",
+        "system"
+      ]
+    }
+  ]
+}

--- a/webpack/scenes/Content/__tests__/contentTable.test.js
+++ b/webpack/scenes/Content/__tests__/contentTable.test.js
@@ -3,11 +3,14 @@ import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
 import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../test-utils/nockWrapper';
 import api from '../../../services/api';
 import ContentPage from '../ContentPage';
+import ansibleCollectionsResponse from './ansibleCollections.fixtures';
 import contentTypesResponse from './contentTypes.fixtures.json';
 import pythonPackagesResponse from './pythonPackages.fixtures.json';
+import ContentTable from '../Table/ContentTable';
 
 const contentTypesPath = api.getApiUrl('/repositories/content_types');
 const pythonPackagesPath = api.getApiUrl('/python_packages');
+const ansibleCollectionsPath = api.getApiUrl('/ansible_collections');
 
 let searchDelayScope;
 let autoSearchScope;
@@ -52,4 +55,35 @@ test('Can call API for Python Packages and show table on page load', async (done
   assertNockRequest(autocompleteScope);
   assertNockRequest(contentTypesScope);
   assertNockRequest(pythonPackagesScope, done);
+});
+
+test('Can call API for Ansible collections and show table on page load', async (done) => {
+  const mockContentTypes = { 'Ansible Collections': ['ansible_collection', 'ansible_collections'] };
+  const autocompleteUrl = '/ansible_collections/auto_complete_search';
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const { results } = ansibleCollectionsResponse;
+  const [firstPackage] = results;
+
+  const ansibleCollections = nockInstance
+    .get(ansibleCollectionsPath)
+    .query(true)
+    .reply(200, ansibleCollectionsResponse);
+
+  const { queryByText, getAllByText } =
+    renderWithRedux(<ContentTable
+      contentTypes={mockContentTypes}
+      selectedContentType="Ansible Collections"
+      setSelectedContentType={() => {}}
+      showContentTypeSelector={false}
+    />);
+
+  expect(queryByText(firstPackage.name)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getAllByText(firstPackage.name)[0]).toBeInTheDocument();
+    expect(getAllByText(firstPackage.version)[0]).toBeInTheDocument();
+    expect(getAllByText(firstPackage.checksum)[0]).toBeInTheDocument();
+  });
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(ansibleCollections, done);
 });

--- a/webpack/scenes/Content/__tests__/contentTypes.fixtures.json
+++ b/webpack/scenes/Content/__tests__/contentTypes.fixtures.json
@@ -1,7 +1,7 @@
 [
   {
     "label": "ansible collection",
-    "generic_browser": null
+    "generic_browser": true
   },
   {
     "label": "deb",


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Move ansible collections to the new generic unit page.
1. /ansible_collections and Content > Ansible Collections from nav menu now lands on the generic content UI
2. legacy_ansible_collections will hold the PF3 pages for a release before the code is deleted.
### What are the testing steps for this pull request?
1. Go to nav menu > Content > Ansible Collections
2. Go to Nav menu > content > Other content types: The content type selector menu should have ansible_collections as an option.
#### To Do:

- [x] Tests