### PR TITLE
Refs #33628 - Hide packages and modulestreams tab from content page

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
@@ -1,22 +1,15 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { ErrataTab } from '../ErrataTab';
-import EmptyPage from './EmptyPage';
 import { route } from './helpers';
 
 const SecondaryTabRoutes = () => (
   <Switch>
     <Route exact path="/Content">
-      <Redirect to={route('packages')} />
-    </Route>
-    <Route path={route('packages')}>
-      <EmptyPage header="WIP Packages" />
+      <Redirect to={route('errata')} />
     </Route>
     <Route path={route('errata')}>
       <ErrataTab />
-    </Route>
-    <Route path={route('modulestreams')}>
-      <EmptyPage header="WIP Module streams" />
     </Route>
   </Switch>
 );

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -1,9 +1,7 @@
 import { translate as __ } from 'foremanReact/common/I18n';
 
 const SECONDARY_TABS = [
-  { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
-  { key: 'modulestreams', title: __('Module streams') },
 ];
 
 export default SECONDARY_TABS;


### PR DESCRIPTION
### What are the changes introduced in this pull request?

With PR:

https://github.com/Katello/katello/pull/9691

I forgot to hide the tabs during my merge conflict resolution, after Amir merged his routing PR.

### What are the testing steps for this pull request?

* Apply the PR/patch
* Register your Katello server to itself or a client
* Turn on the new experimental UI and goto Hosts - All Hosts - Carrot - New Host Details
* Click on Content page, make sure only Errata tab is showing