### PR TITLE
Refs #33618 - move DEFAULT_REQUEST_HEADERS into a method

### DIFF
--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -2,8 +2,6 @@ module Katello
   module Resources
     module Candlepin
       class Proxy
-        DEFAULT_REQUEST_HEADERS = User.cp_oauth_header.merge(accept: :json).freeze
-
         def self.logger
           ::Foreman::Logging.logger('katello/cp_proxy')
         end
@@ -25,7 +23,7 @@ module Katello
         def self.get(path, extra_headers = {})
           logger.debug "Sending GET request to Candlepin: #{path}"
           client = CandlepinResource.rest_client(Net::HTTP::Get, :get, path_with_cp_prefix(path))
-          client.get(extra_headers.merge!(DEFAULT_REQUEST_HEADERS))
+          client.get(extra_headers.merge!(default_request_headers))
         rescue RestClient::NotModified => e
           e.response
         end
@@ -38,6 +36,10 @@ module Katello
 
         def self.path_with_cp_prefix(path)
           CandlepinResource.prefix + path
+        end
+
+        def self.default_request_headers
+          @default_request_headers ||= User.cp_oauth_header.merge(accept: :json)
         end
       end
     end


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Moves the constant which uses a db lookup into a method to fix RPM building

### What are the testing steps for this pull request?

Run some subscription-manager commands from a client or call the proxy class with something like `.get('/rhsm/status')` from rails console