### PR TITLE
Fixes #33709 - api support for repo force delete from all CVs

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -338,8 +338,10 @@ module Katello
 
     api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
     param :id, :number, :required => true
+    param :remove_from_content_view_versions, :bool, :required => false, :desc => N_("Force delete the repository by removing it from all content view versions")
     def destroy
-      sync_task(::Actions::Katello::Repository::Destroy, @repository)
+      sync_task(::Actions::Katello::Repository::Destroy, @repository,
+        remove_from_content_view_versions: ::Foreman::Cast.to_bool(params.fetch(:remove_from_content_view_versions, false)))
       respond_for_destroy
     end
 

--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -8,12 +8,14 @@ module Actions
         #   skip_environment_update - defaults to false. skips updating the CP environment
         #   destroy_content - can be disabled to skip Candlepin remove_content
         def plan(repository, options = {})
+          affected_cvv_ids = []
           skip_environment_update = options.fetch(:skip_environment_update, false) ||
               options.fetch(:organization_destroy, false)
           destroy_content = options.fetch(:destroy_content, true)
+          remove_from_content_view_versions = options.fetch(:remove_from_content_view_versions, false)
           action_subject(repository)
 
-          unless repository.destroyable?
+          unless repository.destroyable?(remove_from_content_view_versions)
             # The repository is going to be deleted in finalize, but it cannot be deleted.
             # Stop now and inform the user.
             fail repository.errors.messages.values.join("\n")
@@ -23,7 +25,13 @@ module Actions
                            repository,
                            SmartProxy.pulp_primary)
 
-          plan_self(:user_id => ::User.current.id)
+          if remove_from_content_view_versions
+            library_instances_inverse = repository.library_instances_inverse
+            affected_cvv_ids = library_instances_inverse.pluck(:content_view_version_id).uniq
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::Destroy, library_instances_inverse)
+          end
+
+          plan_self(:user_id => ::User.current.id, :affected_cvv_ids => affected_cvv_ids)
           sequence do
             if repository.redhat?
               handle_redhat_content(repository) unless skip_environment_update
@@ -40,6 +48,12 @@ module Actions
           if repository
             docker_cleanup = repository.content_type == ::Katello::Repository::DOCKER_TYPE
             delete_record(repository, {docker_cleanup: docker_cleanup})
+
+            if (affected_cvv_ids = input[:affected_cvv_ids]).any?
+              affected_cvv_ids.each do |cvv_id|
+                ::Katello::ContentViewVersion.find(cvv_id).update_content_counts!
+              end
+            end
           end
         end
 

--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -4,12 +4,12 @@ module Katello
 
     delegate :editable?, to: :product
 
-    def deletable?
-      product.editable? && !promoted?
+    def deletable?(remove_from_content_view_versions = false)
+      product.editable? && (remove_from_content_view_versions || !promoted?)
     end
 
-    def redhat_deletable?
-      !self.promoted? && self.product.editable?
+    def redhat_deletable?(remove_from_content_view_versions = false)
+      (remove_from_content_view_versions || !self.promoted?) && self.product.editable?
     end
 
     def readable?

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -748,13 +748,13 @@ module Katello
     end
 
     # deleteable? is already taken by the authorization mixin
-    def destroyable?
+    def destroyable?(remove_from_content_view_versions = false)
       if self.environment.try(:library?) && self.content_view.default?
         if self.environment.organization.being_deleted?
           return true
-        elsif self.custom? && self.deletable?
+        elsif self.custom? && self.deletable?(remove_from_content_view_versions)
           return true
-        elsif !self.custom? && self.redhat_deletable?
+        elsif !self.custom? && self.redhat_deletable?(remove_from_content_view_versions)
           return true
         else
           errors.add(:base, _("Repository cannot be deleted since it has already been included in a published Content View. " \

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -714,6 +714,16 @@ module Katello
       assert_response :success
     end
 
+    def test_destroy_remove_from_content_view_versions
+      assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
+        repo.id == @repository.id
+      end
+
+      delete :destroy, params: { :id => @repository.id, :remove_from_content_view_versions => true }
+
+      assert_response :success
+    end
+
     def test_destroy_protected
       allowed_perms = [@destroy_permission]
       denied_perms = [@read_permission, @create_permission, @update_permission]


### PR DESCRIPTION
### What are the changes introduced in this pull request?

This PR adds an API parameter to force delete a repository even if it's published in content view versions.  If it is, the repository's `library_instances_inverse` repositories will also be deleted. After they are, their content view version counts are updated.

### What was the strategy for these changes?

The strategy was pretty straight-forward.   Plan the `Repository::Destroy` BulkAction for the `library_instances_inverse` repositories and update the counts in the finalize step.  Everything in between was ensuring that the new argument is passed to the proper methods.

### What are the testing steps for this pull request?

1) Create a repository and publish it in any number of content view versions.
2) Publish the content view versions too, for the sake of testing.
3) Try deleting the repository with hammer without the new argument. Ensure the repository doesn't get deleted.
4) Delete the repository with hammer with the new argument. See that the parameter is available in the Hammer help text.
5) Check that the repository is deleted and the content view version(s) count(s) are updated.
6) Check that there aren't any Pulp objects left behind (like publications or distributions).