### PR TITLE
Fixes #33761 - update snapshots to work with vendor v8.16

### DIFF
--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
@@ -48,6 +48,7 @@ exports[`ActivationKeys renders 1`] = `
     onTypeaheadInputChanged={null}
     ouiaSafe={true}
     placeholderText="No Activation keys to select"
+    position="left"
     removeSelectionAriaLabel="Remove"
     selections={Array []}
     toggleAriaLabel="Options menu"

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
@@ -20,6 +20,7 @@ exports[`Force renders 1`] = `
       </span>
     }
     onChange={[Function]}
+    ouiaSafe={true}
   />
 </FormGroup>
 `;

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
@@ -20,6 +20,7 @@ exports[`IgnoreSubmanErrors renders 1`] = `
       </span>
     }
     onChange={[Function]}
+    ouiaSafe={true}
   />
 </FormGroup>
 `;


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Upgrade the testing snapshots so katello can be tested against https://github.com/theforeman/foreman/pull/8863 and use the latest pf4 version

### What are the testing steps for this pull request?

1. Use https://github.com/theforeman/foreman/pull/8863 (or develop once it gets merged)
2. Make sure tests are green
3. Make sure the UI keep functioning normally
