### PR TITLE
Fixes #33764 - Trace IDs should be string, not array

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
@@ -45,7 +45,7 @@ const TracesTab = () => {
   } = useSelectionSet(results, meta);
 
   const onBulkRestartApp = (ids) => {
-    dispatch(resolveTraces({ hostname, ids: [...ids] }));
+    dispatch(resolveTraces({ hostname, ids: [...ids].join(',') }));
     selectedTraces.clear();
 
     const params = { page: meta.page, per_page: meta.per_page, search: meta.search };


### PR DESCRIPTION
### What are the changes introduced in this pull request?

For the Resolve Traces REX job, trace IDs were being sent as an array, but the job template requires a comma-separated string.  This corrects that. See the redmine for more info.

### What are the testing steps for this pull request?

1. set up REX
2. get a host with multiple daemon-type traces (the type where you don't have to log out or reboot)
3. select one or multiple items
4. Click 'Restart via remote execution' (do NOT use customized remote execution, which still works fine)
4. Go to the REX job details > Host detail button dropdown > 'Host task' > Dynflow console > expand Actions::ProxyAction (success)
5. Review the created script:
* it should contain all of the selected traces' helper commands, followed by 'katello-tracer-upload'
* it should not omit the first helper
* it should not contain a number or " !ruby/string:Sequel::SQL::Blob"

Example of correct inputs (as displayed on the job invocation page)
```
ids: 560,574,573,570,567
```

Example of correct script:
```
script: |
  sudo systemctl restart chronyd
  sudo systemctl restart polkit
  sudo systemctl restart NetworkManager
  sudo systemctl restart irqbalance
  sudo systemctl restart crond
  katello-tracer-upload
```
Notice that there are 5 IDs and 5 services in the script.

Example of incorrect inputs:
```
ids: [726, 720, 734, 721, 733, 730, 727, 722, 719, 729, 735, 728, 731, 723, 732]
```

Examples of incorrect script:
```
script: !ruby/string:Sequel::SQL::Blob |
  systemctl restart rpcbind
  systemctl restart chronyd
  systemctl restart gssproxy
  systemctl restart postfix
  systemctl restart systemd-udevd
  systemctl restart polkit
  systemctl restart systemd-journald
  systemctl restart rsyslog
  systemctl restart NetworkManager
  systemctl restart systemd-logind
  systemctl restart tuned
  systemctl restart irqbalance
  systemctl restart crond
  systemctl restart sshd
  katello-tracer-upload
```
Notice that there are 15 IDs but only 14 services in the script, also the "!ruby/string:Sequel::SQL::Blob"

```
script: |2

  katello-tracer-upload
```

This is what happens when there is only a single ID, then the incorrect input looks like
```
ids: [726]
```
and produces the script above.