### PR TITLE
Fixes #32431 - Related content views count and modals

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -108,7 +108,7 @@ module Katello
     end
 
     def self.in_organization(org)
-      where(organization_id: org.id)
+      where(organization_id: org.id) unless org.nil?
     end
 
     def to_s
@@ -639,6 +639,29 @@ module Katello
 
     def on_demand_repositories
       repositories.on_demand
+    end
+
+    def related_cv_count
+      if composite
+        content_view_components.length
+      else
+        component_composites.length
+      end
+    end
+
+    def related_composite_cvs
+      content_views = []
+      component_composites.each do |cv|
+        cv_id = cv.composite_content_view_id
+        cv_name = ContentView.find(cv_id).name
+        content_views.push(
+          {
+            id: cv_id,
+            name: cv_name
+          }
+        )
+      end
+      content_views
     end
 
     protected

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -9,6 +9,8 @@ attributes :latest_version, :latest_version_id
 attributes :auto_publish
 attributes :solve_dependencies
 attributes :import_only
+attributes :related_cv_count
+attributes :related_composite_cvs
 
 node :next_version do |content_view|
   content_view.next_version.to_f.to_s

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -19,6 +19,9 @@ node :default_content_view_id do |org|
   org.default_content_view.id
 end
 
+node(:composite_content_views_count) { Katello::ContentView.readable&.in_organization(Organization.current)&.composite&.count }
+node(:content_view_components_count) { Katello::ContentView.readable&.in_organization(Organization.current)&.non_composite&.non_default&.count }
+
 node :library_id do |org|
   org.library.id
 end

--- a/webpack/scenes/ContentViews/ContentViewsPage.js
+++ b/webpack/scenes/ContentViews/ContentViewsPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Grid, GridItem, TextContent, Text, TextVariants } from '@patternfly/react-core';
 import ContentViewsTable from './Table/ContentViewsTable';
+import ContentViewsCounter from './components/ContentViewsCounter';
 
 const ContentViewsPage = () => (
   <Grid className="grid-with-margin">
@@ -9,6 +10,9 @@ const ContentViewsPage = () => (
       <TextContent>
         <Text component={TextVariants.h1}>{__('Content Views')}</Text>
       </TextContent>
+    </GridItem>
+    <GridItem span={12}>
+      <ContentViewsCounter />
     </GridItem>
     <GridItem span={12}>
       <ContentViewsTable />

--- a/webpack/scenes/ContentViews/Table/tableDataGenerator.js
+++ b/webpack/scenes/ContentViews/Table/tableDataGenerator.js
@@ -58,6 +58,8 @@ const buildExpandableRows = (contentViews) => {
       environments,
       versions,
       permissions,
+      related_cv_count: relatedCVCount,
+      related_composite_cvs: relatedCompositeCVs,
     } = contentView;
     const cells = buildRow(contentView);
     const cellParent = {
@@ -80,7 +82,14 @@ const buildExpandableRows = (contentViews) => {
       parent: cvCount,
       cells: [
         {
-          title: <DetailsExpansion cvId={id} {...{ activationKeys, hosts }} />,
+          title: <DetailsExpansion
+            cvId={id}
+            cvName={name}
+            cvComposite={composite}
+            {...{
+ activationKeys, hosts, relatedCVCount, relatedCompositeCVs,
+}}
+          />,
           props: {
             colSpan: 2,
           },

--- a/webpack/scenes/ContentViews/__tests__/basicContentViews.fixtures.js
+++ b/webpack/scenes/ContentViews/__tests__/basicContentViews.fixtures.js
@@ -1,6 +1,6 @@
 const buildContentView = id => ({
   id,
-  composite: 'false',
+  composite: false,
   name: `contentView${id}`,
   environments: [],
   repositories: [],

--- a/webpack/scenes/ContentViews/__tests__/contentViewList.fixtures.json
+++ b/webpack/scenes/ContentViews/__tests__/contentViewList.fixtures.json
@@ -251,5 +251,7 @@
         }
       ]
     }
-  ]
+  ],
+  "composite": 1,
+  "component": 7
 }

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -49,7 +49,12 @@ test('Can call API for CVs and show on screen on page load', async (done) => {
   // Assert that the CV is not showing yet by searching by name and the query returning null
   expect(queryByText(firstCV.name)).toBeNull();
   // Assert that the CV name is now showing on the screen, but wait for it to appear.
-  await patientlyWaitFor(() => expect(queryByText(firstCV.name)).toBeInTheDocument());
+  await patientlyWaitFor(() => {
+    expect(queryByText(firstCV.name)).toBeInTheDocument();
+    expect(queryByText('Component content views')).toBeInTheDocument();
+    expect(queryByText('Composite content views')).toBeInTheDocument();
+  });
+
   // Assert request was made and completed, see helper function
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done

--- a/webpack/scenes/ContentViews/components/ContentViewsCounter.js
+++ b/webpack/scenes/ContentViews/components/ContentViewsCounter.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Grid, GridItem, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { InProgressIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import ContentViewIcon from './ContentViewIcon';
+import { selectOrganizationState } from '../../Organizations/OrganizationSelectors';
+
+const ContentViewsCounter = () => {
+  const organization = useSelector(selectOrganizationState);
+  const {
+    composite_content_views_count: composite,
+    content_view_components_count: component,
+  } = organization;
+  return (
+    <Grid className="grid-with-margin">
+      <GridItem span={12}>
+        <b>
+          <Flex>
+            <FlexItem spacer={{ default: 'spacerXs' }}>
+              <ContentViewIcon composite={false} description={__('Component content views')} count={component || <InProgressIcon />} />
+            </FlexItem>
+            <FlexItem>
+              <Tooltip
+                position="top"
+                content={
+                  __('Consists of repositories')
+                }
+              >
+                <OutlinedQuestionCircleIcon />
+              </Tooltip>
+            </FlexItem>
+          </Flex>
+        </b>
+      </GridItem>
+      <GridItem span={12}>
+        <b>
+          <Flex>
+            <FlexItem spacer={{ default: 'spacerXs' }}>
+              <ContentViewIcon composite description={__('Composite content views')} count={composite || <InProgressIcon />} />
+            </FlexItem>
+            <FlexItem>
+              <Tooltip
+                position="top"
+                content={
+                  __('Consists of content views')
+                }
+              >
+                <OutlinedQuestionCircleIcon />
+              </Tooltip>
+            </FlexItem>
+          </Flex>
+        </b>
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default ContentViewsCounter;

--- a/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
+++ b/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
@@ -1,16 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
+import RelatedCompositeContentViewsModal from './RelatedCompositeContentViewsModal';
+import RelatedContentViewComponentsModal from './RelatedContentViewComponentsModal';
 
-const DetailsExpansion = ({ cvId, activationKeys, hosts }) => {
+const DetailsExpansion = ({
+  cvId, cvName, cvComposite, activationKeys, hosts, relatedCVCount, relatedCompositeCVs,
+}) => {
   const activationKeyCount = activationKeys.length;
   const hostCount = hosts.length;
+
+  const relatedContentViewModal = () => {
+    if (cvComposite) {
+      return (
+        <>
+          {__('Related component cvs: ')}
+          <RelatedContentViewComponentsModal key="cvId" {...{ cvName, cvId, relatedCVCount }} />
+        </>
+      );
+    }
+    return (
+      <>
+        {__('Related composite cvs: ')}
+        <RelatedCompositeContentViewsModal
+          key={cvId}
+          {...{
+         cvName, cvId, relatedCVCount, relatedCompositeCVs,
+        }}
+        />
+      </>
+    );
+  };
 
   return (
     <div id={`cv-details-expansion-${cvId}`}>
       {__('Activation keys: ')}<a aria-label={`activation_keys_link_${cvId}`} href={`/activation_keys?search=content_view_id+%3D+${cvId}`}>{activationKeyCount}</a>
       <br />
       {__('Hosts: ')}<a aria-label={`host_link_${cvId}`} href={`/hosts?search=content_view_id+%3D+${cvId}`}>{hostCount}</a>
+      <br />
+      {relatedContentViewModal()}
     </div>
   );
 };
@@ -19,11 +47,20 @@ DetailsExpansion.propTypes = {
   cvId: PropTypes.number.isRequired,
   activationKeys: PropTypes.arrayOf(PropTypes.shape({})),
   hosts: PropTypes.arrayOf(PropTypes.shape({})),
+  cvName: PropTypes.string,
+  cvComposite: PropTypes.bool,
+  relatedCompositeCVs: PropTypes.arrayOf(PropTypes.shape({})),
+  relatedCVCount: PropTypes.number,
 };
 
 DetailsExpansion.defaultProps = {
   activationKeys: [],
   hosts: [],
+  cvName: '',
+  cvComposite: false,
+  relatedCompositeCVs: [],
+  relatedCVCount: 0,
+
 };
 
 export default DetailsExpansion;

--- a/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { translate as __ } from 'foremanReact/common/I18n';
+import PropTypes from 'prop-types';
+import { Modal, ModalVariant, Button, Flex, FlexItem } from '@patternfly/react-core';
+import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { EnterpriseIcon } from '@patternfly/react-icons';
+import { urlBuilder } from '../../../__mocks__/foremanReact/common/urlHelpers';
+
+/* eslint-disable react/no-array-index-key */
+const RelatedCompositeContentViewsModal = ({
+  cvName, cvId, relatedCVCount, relatedCompositeCVs,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const description = () => (
+    <Flex flex={{ default: 'inlineFlex' }}>
+      <FlexItem>
+        <EnterpriseIcon />
+        <b>{` ${cvName}`}</b>
+        {__(' content view is used in listed composite content views.')}
+      </FlexItem>
+    </Flex>
+  );
+
+  const handleModalToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const columns = ['Name'];
+  return (
+    <>
+      <Button aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
+        {relatedCVCount}
+      </Button>
+      <Modal
+        title={__('Related composite content views')}
+        variant={ModalVariant.large}
+        isOpen={isOpen}
+        description={description()}
+        onClose={() => {
+          setIsOpen(false);
+        }}
+        appendTo={document.body}
+      >
+        <TableComposable
+          aria-label={`${cvId}_table`}
+          variant="compact"
+        >
+          <Thead>
+            <Tr>
+              {columns.map((column, columnIndex) => (
+                <Th key={columnIndex}>{column}</Th>
+              ))}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {relatedCompositeCVs.map(cv => (
+              <Tr key={cv.id}>
+                <Td key={`${cv.id}_${cv.name}`} dataLabel={columns[cv.id]}>
+                  <Link to={`${urlBuilder('content_views', '')}${cv.id}`}>{cv.name}</Link>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      </Modal>
+    </>
+  );
+};
+
+export default RelatedCompositeContentViewsModal;
+
+RelatedCompositeContentViewsModal.propTypes = {
+  cvName: PropTypes.string.isRequired,
+  cvId: PropTypes.number.isRequired,
+  relatedCVCount: PropTypes.number.isRequired,
+  relatedCompositeCVs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+};

--- a/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
@@ -1,0 +1,107 @@
+import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import PropTypes from 'prop-types';
+import { Grid, GridItem, Modal, ModalVariant, Button, Flex, FlexItem } from '@patternfly/react-core';
+import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { RegistryIcon } from '@patternfly/react-icons';
+import TableWrapper from '../../../components/Table/TableWrapper';
+import { getContentViewComponents } from '../Details/ContentViewDetailActions';
+import {
+  selectCVComponents,
+  selectCVComponentsError,
+  selectCVComponentsStatus,
+} from '../Details/ContentViewDetailSelectors';
+
+const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
+  const response = useSelector(state => selectCVComponents(state, cvId));
+  const status = useSelector(state => selectCVComponentsStatus(state, cvId));
+  const error = useSelector(state => selectCVComponentsError(state, cvId));
+  const { results, ...metadata } = response;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, updateSearchQuery] = useState('');
+
+  const description = () => (
+    <Flex flex={{ default: 'inlineFlex' }}>
+      <FlexItem>
+        <RegistryIcon />
+        <b>{` ${cvName}`}</b>
+        {__(' content view is used in listed component content views. For more information, ')}
+        <Link to={urlBuilder(`content_views/${cvId}#/contentviews`, '')}>
+          {__('view content view tabs.')}
+        </Link>
+      </FlexItem>
+    </Flex>
+  );
+
+  const handleModalToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <Button aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
+        {relatedCVCount}
+      </Button>
+      <Grid className="grid-with-margin">
+        <GridItem span={12}>
+          <Modal
+            title={__('Related component content views')}
+            variant={ModalVariant.medium}
+            isOpen={isOpen}
+            description={description()}
+            onClose={() => {
+                setIsOpen(false);
+              }}
+            appendTo={document.body}
+          >
+
+            <TableWrapper
+              {...{
+              metadata,
+              searchQuery,
+              updateSearchQuery,
+              error,
+              status,
+              }}
+              fetchItems={useCallback(params => getContentViewComponents(cvId, params, 'Added'), [cvId])}
+              variant={TableVariant.compact}
+              autocompleteEndpoint="/content_views/auto_complete_search"
+              emptyContentTitle={__('You currently don\'t have any related content views.')}
+              emptySearchTitle={__('No matching content views found')}
+              emptyContentBody={__('Related content views will appear here when created.')}
+              emptySearchBody={__('Try changing your search settings.')}
+            >
+              <Thead>
+                <Tr>
+                  <Th key="name_col">{__('Name')}</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {results?.map(details => (
+                  <Tr key={`${details.content_view.id}`}>
+                    <Td>
+                      <Link to={urlBuilder(`content_views/${details.content_view.id}`, '')}>{details.content_view.name}</Link>
+                    </Td>
+                  </Tr>
+                ))
+                }
+              </Tbody>
+            </TableWrapper>
+          </Modal>
+        </GridItem>
+      </Grid>
+    </>
+  );
+};
+
+export default RelatedContentViewsModal;
+
+RelatedContentViewsModal.propTypes = {
+  cvName: PropTypes.string.isRequired,
+  cvId: PropTypes.number.isRequired,
+  relatedCVCount: PropTypes.number.isRequired,
+};

--- a/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsModal.test.js
+++ b/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsModal.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+
+import { nockInstance, assertNockRequest, mockSetting, mockAutocomplete } from '../../../../test-utils/nockWrapper';
+import api from '../../../../services/api';
+
+import RelatedContentViewComponentsModal from '../RelatedContentViewComponentsModal';
+import RelatedCompositeContentViewsModal from '../RelatedCompositeContentViewsModal';
+
+import contentViewComponentsResponse from './contentViewComponentsResponse.fixtures.json';
+
+test('Can call API and show Related Content Views Components Modal', async (done) => {
+  const searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 500);
+  const autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', true);
+  const autocompleteUrl = '/content_views/auto_complete_search';
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+
+  const cvId = 5;
+  const relatedCvCount = 2;
+  const cvName = 'italiano';
+  const contentViewComponentsPath = api.getApiUrl(`/content_views/${cvId}/content_view_components/show_all`);
+
+  const scope = nockInstance
+    .get(contentViewComponentsPath)
+    .query(true)
+    .reply(200, contentViewComponentsResponse);
+
+  const { getByText, getByLabelText } = renderWithRedux(<RelatedContentViewComponentsModal
+    cvId={cvId}
+    cvName={cvName}
+    relatedCVCount={relatedCvCount}
+  />);
+  await patientlyWaitFor(() => expect(getByLabelText(`button_${cvId}`)).toBeInTheDocument());
+  fireEvent.click(getByLabelText(`button_${cvId}`));
+  await patientlyWaitFor(() => expect(getByText('Related component content views')).toBeInTheDocument());
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+  assertNockRequest(autoSearchScope);
+  assertNockRequest(searchDelayScope);
+});
+
+test('Can call API and show Related Composite Content Views Modal', async () => {
+  const relatedCompositeCVs = [
+    {
+      id: 5,
+      name: 'italiano',
+    },
+  ];
+
+  const cvId = 3;
+  const relatedCvCount = 1;
+  const cvName = 'ravioli';
+
+  const { getByText, getByLabelText } = renderWithRedux(<RelatedCompositeContentViewsModal
+    cvId={cvId}
+    cvName={cvName}
+    relatedCVCount={relatedCvCount}
+    relatedCompositeCVs={relatedCompositeCVs}
+  />);
+  await patientlyWaitFor(() => expect(getByLabelText(`button_${cvId}`)).toBeInTheDocument());
+  fireEvent.click(getByLabelText(`button_${cvId}`));
+  await patientlyWaitFor(() => expect(getByText('Related composite content views')).toBeInTheDocument());
+});

--- a/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsResponse.fixtures.json
+++ b/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsResponse.fixtures.json
@@ -1,0 +1,116 @@
+{
+  "total": 6,
+  "subtotal": 6,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": null,
+    "order": null
+  },
+  "results": [
+    {
+      "latest": false,
+      "id": 1,
+      "created_at": "2021-10-08 11:19:57 -0400",
+      "updated_at": "2021-10-08 11:19:57 -0400",
+      "composite_content_view": {
+        "id": 5,
+        "name": "italiano",
+        "label": "italiano",
+        "description": "many pasta",
+        "next_version": 3,
+        "latest_version": "2.0",
+        "version_count": 2
+      },
+      "content_view": {
+        "id": 3,
+        "name": "ravioli",
+        "label": "ravioli",
+        "description": null,
+        "next_version": 2,
+        "latest_version": "1.0",
+        "version_count": 1
+      },
+      "content_view_version": {
+        "id": 3,
+        "name": "ravioli 1.0",
+        "content_view_id": 3,
+        "version": "1.0",
+        "content_view": {
+          "id": 3,
+          "name": "ravioli",
+          "label": "ravioli",
+          "description": null
+        },
+        "environments": [
+          {
+            "id": 1,
+            "name": "Library",
+            "label": "Library"
+          }
+        ],
+        "repositories": [
+          {
+            "id": 13,
+            "name": "yum 1",
+            "label": "yum_1",
+            "description": null
+          }
+        ]
+      }
+    },
+    {
+      "latest": false,
+      "id": 2,
+      "created_at": "2021-10-08 11:20:04 -0400",
+      "updated_at": "2021-10-08 11:20:04 -0400",
+      "composite_content_view": {
+        "id": 5,
+        "name": "italiano",
+        "label": "italiano",
+        "description": "many pasta",
+        "next_version": 3,
+        "latest_version": "2.0",
+        "version_count": 2
+      },
+      "content_view": {
+        "id": 4,
+        "name": "tortellini",
+        "label": "tortellini",
+        "description": "tortellini",
+        "next_version": 2,
+        "latest_version": "1.0",
+        "version_count": 1
+      },
+      "content_view_version": {
+        "id": 4,
+        "name": "tortellini 1.0",
+        "content_view_id": 4,
+        "version": "1.0",
+        "content_view": {
+          "id": 4,
+          "name": "tortellini",
+          "label": "tortellini",
+          "description": "tortellini"
+        },
+        "environments": [
+          {
+            "id": 1,
+            "name": "Library",
+            "label": "Library"
+          }
+        ],
+        "repositories": [
+          {
+            "id": 15,
+            "name": "python 1",
+            "label": "python_1",
+            "description": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/webpack/scenes/ContentViews/expansions/__tests__/relatedCompositeCvs.fixtures.json
+++ b/webpack/scenes/ContentViews/expansions/__tests__/relatedCompositeCvs.fixtures.json
@@ -1,0 +1,4 @@
+{
+  "id": 5,
+  "name": "italiano"
+}


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This adds a few things:
1) Content views count to the content view listing page
2) Composite content views count to the content view listing page
3) Two new items to the details expansion of a content view: `related component cvs` and `related composite cvs`
4) Pop up modals for each of these new items, showing a table of the related components or composites

Look here for mockups: https://projects.theforeman.org/issues/32431 
### What are the testing steps for this pull request?
1) Create a few content views and at least one composite content view. 
2) Add some content views to the composite content view.
3) In the content views listing, check that the counts at the top of the page are correct.
4) Click to expand the details on the new content views and check that the related count listed is correct.
5) Click the count to open the modal. Check that the information there is correct according to the mockups and what you expect.
6) Also check that things still look okay if you resize the browser window.

### What strategies were used? 
**One important thing to note is a deviation from the mockups. The table in the related composite content views modal is not paginated or searchable**. It seemed to me the only way to do that would be to create a new endpoint/controller for that information, which seemed like a lot of overhead for an otherwise small change. Since it's small table, Samir suggested I make it just a simple table, so that's what I did.

### Still Need To
Fix linter issues and add more tests. This probably should've been a draft pr.