### PR TITLE
Fixes #33762 - Add toggle group for All/Installable  errata 

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -27,7 +27,11 @@ module Katello
       page = index_params[:page] || 1
 
       collection = scoped_search_results(
-        pools[:pools], pools[:subtotal], pools[:total], page, index_params[:per_page], nil)
+        query: pools[:pools],
+        subtotal: pools[:subtotal],
+        total: pools[:total],
+        page: page,
+        per_page: index_params[:per_page])
       respond(collection: collection)
     end
 

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -20,6 +20,7 @@ module Katello
     scoped_search :on => :errata_id, :only_explicit => true
     scoped_search :on => :errata_id, :rename => :id, :complete_value => true, :only_explicit => true
     scoped_search :on => :title
+    scoped_search :on => :title, :rename => :synopsis, :complete_value => true, :only_explicit => true
     scoped_search :on => :severity, :complete_value => true
     scoped_search :on => :errata_type, :only_explicit => true
     scoped_search :on => :errata_type, :rename => :type, :complete_value => true

--- a/app/views/katello/api/v2/common/_metadata.json.rabl
+++ b/app/views/katello/api/v2/common/_metadata.json.rabl
@@ -2,6 +2,7 @@ object false
 
 node(:total)    { @collection[:total] }
 node(:subtotal) { @collection[:subtotal] }
+node(:selectable) { @collection[:selectable] || @collection[:total] }
 node(:page)     { @collection[:page] }
 node(:per_page) { @collection[:per_page] }
 node(:error)    { @collection[:error] }

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -41,7 +41,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/activation_keys/index'
 
-      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
+      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
       assert_equal results['results'].size, 7
       assert_includes results['results'].collect { |item| item['id'] }, @activation_key.id
     end

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -43,6 +43,7 @@ module Katello
       refute_empty response[:results], "results"
       assert_equal 5, response[:subtotal], "subtotal"
       assert_equal 5, response[:total], "total"
+      assert_equal 5, response[:selectable], "selectable"
       assert_equal 1, response[:page], "page"
       assert_equal Setting[:entries_per_page], response[:per_page], "per page"
       assert_nil response[:error], "error"
@@ -75,6 +76,7 @@ module Katello
       response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
       assert_empty response[:results], "results"
       assert_equal 0, response[:subtotal], "subtotal"
+      assert_equal 0, response[:selectable], "selectable"
       assert_nil response[:error], "error"
     end
 
@@ -158,6 +160,7 @@ module Katello
 
       assert_equal types.count, results[:subtotal]
       assert_equal types.count, results[:total]
+      assert_equal types.count, results[:selectable]
       assert_equal types.sort, results[:results].map { |i| i['errata_type'] }.sort
     end
 

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -63,7 +63,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 
-      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
+      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_equal 1, results['results'].size
       assert_equal expected_version.id, results['results'][0]['id']
     end
@@ -88,7 +88,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 
-      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
+      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_equal 1, results['results'].size
       assert_equal expected_version.id, results['results'][0]['id']
     end
@@ -102,7 +102,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 
-      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
+      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_includes results['results'].map { |r| r['id'] }, cvv.id
       refute_includes results['results'].map { |r| r['id'] }, cvv_org2.id
     end

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -29,7 +29,7 @@ module Katello
       assert_template 'api/v2/host_collections/index'
 
       results = JSON.parse(@response.body)
-      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
+      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
       assert_equal results['results'].size, 3
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end
@@ -41,7 +41,7 @@ module Katello
       assert_template 'api/v2/host_collections/index'
 
       results = JSON.parse(@response.body)
-      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
+      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
       assert_equal results['results'].size, 3
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -127,6 +127,16 @@ module Katello
       assert_template 'api/v2/host_errata/index'
     end
 
+    def test_index_with_include_applicable
+      get :index, params: { host_id: @host_dev.id, include_applicable: true }
+      assert_response :success
+      assert_template 'api/v2/host_errata/index'
+      cv = @controller.instance_eval { @content_view }
+      env = @controller.instance_eval { @environment }
+      assert cv.default?
+      assert env.library?
+    end
+
     def test_apply
       ::Katello.stubs(:with_katello_agent?).returns(true)
       assert_async_task ::Actions::Katello::Host::Erratum::Install do |host, options|

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -18,6 +18,7 @@ import { orgId } from '../../services/api';
 /* Patternfly 4 table wrapper */
 const TableWrapper = ({
   actionButtons,
+  toggleGroup,
   children,
   metadata,
   fetchItems,
@@ -50,6 +51,7 @@ const TableWrapper = ({
   const searchNotUnderway = !(searchQuery || activeFilters);
   const showPagination = !unresolvedStatusOrNoRows;
   const showActionButtons = actionButtons && !unresolvedStatus;
+  const showToggleGroup = toggleGroup && !unresolvedStatus;
   const paginationParams = useCallback(() =>
     ({ per_page: perPage, page }), [perPage, page]);
   const prevRequest = useRef({});
@@ -169,7 +171,7 @@ const TableWrapper = ({
                       pageRowCount,
                     }
                 }
-              totalCount={total}
+              totalCount={Number(metadata?.selectable ?? total)}
               areAllRowsOnPageSelected={areAllRowsOnPageSelected()}
               areAllRowsSelected={areAllRowsSelected()}
             />
@@ -190,6 +192,11 @@ const TableWrapper = ({
           <FlexItem style={{ marginLeft: '16px' }}>
             {actionButtons}
           </FlexItem>}
+        {showToggleGroup &&
+          <FlexItem style={{ marginLeft: '16px' }}>
+            {toggleGroup}
+          </FlexItem>}
+
         {showPagination &&
           <PageControls
             variant={PaginationVariant.top}
@@ -230,6 +237,7 @@ TableWrapper.propTypes = {
   updateSearchQuery: PropTypes.func.isRequired,
   fetchItems: PropTypes.func.isRequired,
   metadata: PropTypes.shape({
+    selectable: PropTypes.number,
     total: PropTypes.number,
     page: PropTypes.oneOfType([
       PropTypes.number,
@@ -248,6 +256,7 @@ TableWrapper.propTypes = {
   autocompleteEndpoint: PropTypes.string.isRequired,
   foremanApiAutoComplete: PropTypes.bool,
   actionButtons: PropTypes.node,
+  toggleGroup: PropTypes.node,
   children: PropTypes.node,
   // additionalListeners are anything that can trigger another API call, e.g. a filter
   additionalListeners: PropTypes.arrayOf(PropTypes.oneOfType([
@@ -276,13 +285,14 @@ TableWrapper.propTypes = {
 };
 
 TableWrapper.defaultProps = {
-  metadata: { subtotal: 0 },
+  metadata: { subtotal: 0, selectable: 0 },
   children: null,
   additionalListeners: [],
   activeFilters: [],
   defaultFilters: [],
   foremanApiAutoComplete: false,
   actionButtons: null,
+  toggleGroup: null,
   displaySelectAllCheckbox: false,
   selectedCount: 0,
   selectAll: noop,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.scss
@@ -9,3 +9,8 @@
   margin-bottom: 2em;
   margin-top: 2em;
 }
+
+
+.pf-c-toggle-group__text {
+  color: black;
+}

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
@@ -34,7 +34,8 @@
               "dhcp-libs-4.2.5-83.el7_9.1.i686",
               "dhcp-libs-4.2.5-83.el7_9.1.x86_64"
             ],
-        "module_streams": []
+        "module_streams": [],
+        "installable": true
     },
     {
         "id": 10,
@@ -46,7 +47,8 @@
         "bugs": [],
         "cves": [],
         "packages": [],
-        "module_streams": []
+        "module_streams": [],
+        "installable": true
     },
     {
         "id": 18,
@@ -58,7 +60,8 @@
         "bugs": [],
         "cves": [],
         "packages": [],
-        "module_streams": []
+        "module_streams": [],
+        "installable": true
      }
   ]
 }


### PR DESCRIPTION
### What are the changes introduced in this pull request?
On the new host errata page
- Added toggle group with options for All / Installable
- The "All" option is what was previously known as "Applicable" errata
- Added an Installable column to indicate if the errata is installable or not "No"
- Action menu items (apply etc.) should be disabled for applicable (but not installable) errata
- Also ability to handle "unselectable" rows when using BulkSelect and SelectionSet hooks

### What are the testing steps for this pull request?

1. Create and Sync this repo -> https://partha.fedorapeople.org/test-repos/multi-errata/
2. Create another repo in the same product. Leave the feed empty
3. Create  a Dev lifecycle environment
4. Create a content view with the repos created in steps 1 and 2
5. Publish and Promote it to dev
6. Create an activation that points dev/cv. Make sure the subscriptions are turned on
7. Register a rhel7/centos7 with that activation key
8. On client `yum install armadillo-0.1-1.noarch`
9. Also `rpm -ivh https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/walrus-0.71-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/whale-0.2-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/shark-0.1-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/stork-0.12-2.noarch.rpm`
10. Now edit the repo in step 2 and add the feed url -> https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
11. Sync this repo
12. Now you should have 38 Applicable Errata and 37 installable errata
13. Go to Hosts -> New Host Details -> Content -> Errata tab
14. Notice the new toggle group.
15. Choose all. Notice that the first check box must be disabled. You should be able hover on 'X' in the installable column and and notice a tooltip that explains why that is the case
16. Try all the select options , add search etc. 
17. Report any inconsistencies
18.
![toggle](https://user-images.githubusercontent.com/1069779/138371692-33318c43-b424-486a-ac9f-b3ef4bc63651.png)


### Guidelines for Code Review ###

#### Backend Changes #####

- Added a new parameter to host_errata_controller to accept a `restrict_applicable` flag. Setting this to true will automatically include applicable errata in the index call
- Added a `selectable` attribute to `_metadata.json.rabl`. This will hold the count of selectable items in main list. We need this information for select all to correctly display how many items are going to be selected.
-  Added mechanism  to set selectable in `v2/api_controller`.  Individual controllers can override the "total_selectable" method and return count of selectable items. (By default selectable === total)
- 

#### Front End Changes ####
* In *TableHooks* ->  UseSelectionSet and useBulkSelect rewired a little now to accept an `isSelectable` function. Based on this those hooks will calculate things like `selectedCount`, `areAllRowsSelected` etc.
* In *TableWrapper* a new place holder was added for toggleGroups.
* In *ErrataTab* new toggleGroup for All/Installable, a new State to handle if its the All toggle or the installable toggle.
* Also includes some tool tips and other information

- Added Tests