### PR TITLE
Fixes #33705 - only look at pulp primary for repo types

### DIFF
--- a/app/controllers/katello/api/v2/generic_content_units_controller.rb
+++ b/app/controllers/katello/api/v2/generic_content_units_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::GenericContentUnitsController < Api::V2::ApiController
-    Katello::RepositoryTypeManager.generic_content_types(enabled_only: false).each do |type|
+    Katello::RepositoryTypeManager.generic_content_types(false).each do |type|
       apipie_concern_subst(:a_resource => N_(type), :resource_id => type.pluralize)
       resource_description do
         name type.pluralize.titleize

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -6,7 +6,7 @@ module Katello
                                 Repository::FILE_TYPE,
                                 Repository::DEB_TYPE,
                                 Repository::ANSIBLE_COLLECTION_TYPE,
-                                Katello::RepositoryTypeManager.generic_repository_types(enabled_only: false).keys.flatten
+                                Katello::RepositoryTypeManager.generic_repository_types(false).keys.flatten
                                ].flatten.freeze
 
     ALLOWED_IMPORT_REPOSITORY_TYPES = Repository::EXPORTABLE_TYPES

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -363,7 +363,7 @@ module Katello
     end
 
     def generic?
-      Katello::RepositoryTypeManager.generic_repository_types(enabled_only: false).values.map(&:id).map(&:to_s).flatten.include? self.content_type
+      Katello::RepositoryTypeManager.generic_repository_types(false).values.map(&:id).map(&:to_s).flatten.include? self.content_type
     end
 
     def metadata_generate_needed?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Katello::Engine.routes.draw do
 
   match '/content' => 'react#index', :via => [:get]
 
-  Katello::RepositoryTypeManager.generic_ui_content_types.each do |type|
+  Katello::RepositoryTypeManager.generic_ui_content_types(false).each do |type|
     get "/#{type.pluralize}", to: redirect("/content/#{type.pluralize}")
     get "/#{type.pluralize}/:page", to: redirect("/content/#{type.pluralize}/%{page}")
     match "/content/#{type.pluralize}" => 'react#index', :via => [:get]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -286,7 +286,7 @@ Katello::Engine.routes.draw do
         end
 
         load 'katello/repository_types.rb' if Katello::RepositoryTypeManager.defined_repository_types.empty?
-        Katello::RepositoryTypeManager.generic_content_types(enabled_only: false).each do |type|
+        Katello::RepositoryTypeManager.generic_content_types(false).each do |type|
           api_resources type.pluralize.to_sym, :only => [:index, :show], :controller => 'generic_content_units', :content_type => type do
             collection do
               get :auto_complete_search
@@ -413,7 +413,7 @@ Katello::Engine.routes.draw do
           api_resources :debs, :only => [:index, :show]
           api_resources :module_streams, :only => [:index, :show]
           api_resources :ansible_collections, :only => [:index, :show]
-          Katello::RepositoryTypeManager.generic_content_types(enabled_only: false).each do |type|
+          Katello::RepositoryTypeManager.generic_content_types(false).each do |type|
             api_resources type.pluralize.to_sym, :only => [:index, :show], :controller => 'generic_content_units', :content_type => type
           end
           api_resources :ostree_branches, :only => [:index, :show]

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -27,14 +27,13 @@ module ::Actions::Katello::Repository
     let(:custom_repository) { katello_repositories(:fedora_17_x86_64) }
     let(:deb_repository) { katello_repositories(:debian_10_amd64) }
     let(:docker_repository) { katello_repositories(:redis) }
-    let(:proxy) { smart_proxies(:one) }
+    let(:proxy) { SmartProxy.pulp_primary }
     let(:capsule_content) { ::Katello::Pulp::SmartProxyRepository.new(proxy) }
 
     before(:all) do
       set_user
       ::Katello::Product.any_instance.stubs(:certificate).returns(nil)
       ::Katello::Product.any_instance.stubs(:key).returns(nil)
-      SmartProxy.stubs(:pulp_primary).returns(proxy)
     end
   end
 
@@ -286,8 +285,9 @@ module ::Actions::Katello::Repository
   class UploadFilesTest < TestBase
     let(:pulp2_action_class) { ::Actions::Pulp::Orchestration::Repository::UploadContent }
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::UploadContent }
+
     it 'plans for Pulp3 without duplicate' do
-      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
+      SmartProxy.any_instance.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
       ::Katello::Pulp3::Api::Core.any_instance.stubs(:artifacts_api).returns(stub(:list => stub(:results => nil)))
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
@@ -317,7 +317,7 @@ module ::Actions::Katello::Repository
     end
 
     it 'plans for Pulp3 with duplicate' do
-      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => [stub(:pulp_href => "demo_content/href")]))))
+      SmartProxy.any_instance.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => [stub(:pulp_href => "demo_content/href")]))))
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
       action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::ImportUpload) do |import_upload|
@@ -335,8 +335,9 @@ module ::Actions::Katello::Repository
 
   class UploadPythonTest < TestBase
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::UploadContent }
+
     it 'plans for Pulp3 without duplicate' do
-      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
+      SmartProxy.any_instance.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
       ::Katello::Pulp3::Api::Core.any_instance.stubs(:artifacts_api).returns(stub(:list => stub(:results => nil)))
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "shelf_reader-0.1-py2-none-any.whl")
@@ -366,7 +367,7 @@ module ::Actions::Katello::Repository
     end
 
     it 'plans for Pulp3 with duplicate' do
-      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => [stub(:pulp_href => "demo_content/href")]))))
+      SmartProxy.any_instance.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => [stub(:pulp_href => "demo_content/href")]))))
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "shelf_reader-0.1-py2-none-any.whl")
       action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::ImportUpload) do |import_upload|

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -98,6 +98,8 @@ module Katello
       pulp_server = mock(:resources => resources)
       pulp_primary = mock(pulp_api: pulp_server, pulp3_support?: false)
       pulp_primary.stubs(:content_service).returns(stub(:content_type => "rpm"))
+      pulp_primary.stubs(:has_feature?).returns(true)
+      pulp_primary.stubs(:capabilities).returns(['rpm', 'file', 'deb', 'container', 'ansible'])
       SmartProxy.expects(:pulp_primary).at_least_once.returns(pulp_primary)
     end
   end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -274,8 +274,6 @@ module Katello
     end
 
     def test_create
-      # Ensure that the content_type params don't rely on the enabled_repository_types
-      SmartProxy.pulp_primary.features.detect { |f| f.name == "Pulpcore" }.smart_proxy_features.first.update(capabilities: [])
       ::Katello::RepositoryTypeManager.instance_variable_set(:@enabled_repository_types, {})
       product = mock
       product.expects(:add_repo).with({

--- a/test/services/katello/repository_type_manager_test.rb
+++ b/test/services/katello/repository_type_manager_test.rb
@@ -8,13 +8,6 @@ module Katello
       @feature.update(capabilities: [])
     end
 
-    def test_enabled_repository_types_follow_smart_proxy_capabilities
-      assert_empty ::Katello::RepositoryTypeManager.enabled_repository_types
-      @feature.update(capabilities: ['ansible', 'certguard', 'container', 'core', 'deb', 'file', 'rpm', 'python'])
-      assert_equal ['ansible_collection', 'deb', 'docker', 'file', 'yum', 'python'].sort,
-        ::Katello::RepositoryTypeManager.enabled_repository_types.keys.sort
-    end
-
     def test_enabled_repository_types_update_false
       assert_empty ::Katello::RepositoryTypeManager.enabled_repository_types(false)
     end


### PR DESCRIPTION
### What are the changes introduced in this pull request?
The previous code was intended to look up the pulp primary (non-mirrored) smart proxies, but it also was returning smart proxies with pulp not installed.  It was also doing it at startup, instead of on demand.  So this pr:

1.  Correctly only looks at smart proxies that have a pulpcore feature
2.   Moves the calculation of 'enabled' types to happen when its first requested, so it doesn't happen at startup
3.   fixed a bunch of references that used  `enabled_only: false`, to load defined types that was incorrect since the method signatures were using 'enabled_only = true' as a positional arg

### What are the testing steps for this pull request?
Reproducer steps here: https://github.com/Katello/katello/pull/9743#issuecomment-952900529