### PR TITLE
Fixes #33779 - UI support for force_deletion of Repositories

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -62,6 +62,10 @@ module Katello
       where("#{Katello::ContentViewVersion.table_name}.id in (#{sql})")
     end
 
+    scope :with_repositories, ->(repositories) do
+      joins(:repositories).includes(:content_view).merge(repositories).distinct
+    end
+
     scoped_search :on => :content_view_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :major, :rename => :version, :complete_value => true, :ext_method => :find_by_version
     serialize :content_counts

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -336,6 +336,10 @@ module Katello
       content_counts
     end
 
+    def published_in_versions
+      Katello::ContentViewVersion.with_repositories(self.library_instances_inverse).distinct
+    end
+
     def self.errata_with_package_counts(repo)
       repository_rpm = Katello::RepositoryRpm.table_name
       repository_errata = Katello::RepositoryErratum.table_name

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -25,6 +25,16 @@ node :content_label do |repo|
   repo.content.try(:label)
 end
 
+child :published_in_versions => :content_view_versions do |_version|
+  attributes :id, :version
+  node :content_view_id do |object|
+    object.content_view.id
+  end
+  node :content_view_name do |object|
+    object.content_view.name
+  end
+end
+
 child :latest_dynflow_sync => :last_sync do |_object|
   attributes :id, :username, :started_at, :ended_at, :state, :result, :progress
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -30,6 +30,17 @@
             $scope.page.loading = false;
         }
 
+        $scope.repositoryVersions = function () {
+            return _.groupBy($scope.repository.content_view_versions, function(version) {
+                return version.content_view_id;
+            });
+        };
+
+        $scope.repositoryWrapper = {
+            repository: $scope.repository,
+            repositoryVersions: {}
+        };
+
         $scope.product = Product.get({id: $scope.$stateParams.productId}, function () {
             $scope.page.loading = false;
         }, function (response) {
@@ -47,6 +58,8 @@
                 $scope.repository.commaTagsWhitelist = "";
             }
             $scope.page.loading = false;
+            $scope.repositoryWrapper.repository = $scope.repository;
+            $scope.repositoryWrapper.repositoryVersions = $scope.repositoryVersions();
         }, function (response) {
             $scope.page.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);
@@ -98,7 +111,7 @@
                 Notification.setSuccessMessage(translate('Repository "%s" successfully deleted').replace('%s', repositoryName));
             };
 
-            repository.$delete(success, errorHandler);
+            Repository.remove({id: repository.id}, success, errorHandler);
         };
 
         $scope.canRemove = function (repo, product) {
@@ -109,9 +122,7 @@
             var readOnlyReason = null;
 
             if (repo.$resolved && product.$resolved) {
-                if (repo.promoted) {
-                    readOnlyReason = 'published';
-                } else if ($scope.denied('deletable', repo)) {
+                if ($scope.denied('deletable', repo)) {
                     readOnlyReason = 'permissions';
                 }
             }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -65,26 +65,43 @@
                  tooltip-placement="left"
                  tooltip-append-to-body="true">
               </i>
-              <i class="fa fa-question-circle" ng-switch-when="published"
-                 uib-tooltip="{{ 'You cannot remove this repository because it was published to a content view.' | translate }}"
-                 tooltip-animation="false"
-                 tooltip-placement="left"
-                 tooltip-append-to-body="true">
-              </i>
-              <i class="fa fa-question-circle" ng-switch-when="redhat"
-                 uib-tooltip="{{ 'You cannot remove this repository because it is a Red Hat repository.' | translate }}"
-                 tooltip-animation="false"
-                 tooltip-placement="left"
-                 tooltip-append-to-body="true">
-              </i>
             </span>
           </span>
         </li>
       </ul>
 
-      <div bst-modal="removeRepository(repository)" model="repository">
-        <div data-block="modal-header" translate>Remove Repository "{{ repository.name }}"?</div>
-        <div data-block="modal-body" translate>Are you sure you want to remove repository "{{ repository.name }}"?</div>
+      <div bst-modal="removeRepository(repository)" model="repositoryWrapper">
+        <div data-block="modal-header" translate>Remove Repository {{ repositoryWrapper.repository.name }}?</div>
+        <div data-block="modal-body">
+            <div ng-show="repositoryWrapper.repository.promoted" style="margin-bottom: 1em">
+                <span translate>Repository will also be removed from the following published content view versions!</span>
+                <table class="table table-striped table-bordered" style="margin-top: 1em">
+                    <thead>
+                        <tr>
+                            <th translate>Content View</th>
+                            <th translate>Versions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                      <tr ng-repeat="cvs in repositoryWrapper.repositoryVersions">
+                        <td class="align-center">
+                            <a href="/content_views/{{cvs[0]['content_view_id']}}" target="_blank">
+                                {{cvs[0]['content_view_name']}}
+                            </a>
+                        </td>
+                        <td>
+                            <div ng-repeat="cvVersions in cvs">
+                                <a href="/content_views/{{cvs[0]['content_view_id']}}#/versions/{{cvVersions['id']}}" target="_blank">
+                                    <span translate>Version {{ cvVersions['version'] }} </span>
+                                </a>
+                            </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                </table>
+            </div>
+            <span translate>Are you sure you want to remove repository {{ repositoryWrapper.repository.name }}?</span>
+        </div>
       </div>
     </span>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
@@ -22,7 +22,8 @@ angular.module('Bastion.repositories').factory('Repository',
                 removeContent: { method: 'PUT', params: { action: 'remove_content'}},
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 repositoryTypes: {method: 'GET', isArray: true, params: {id: 'repository_types'}},
-                republish: {method: 'PUT', params: { action: 'republish' }}
+                republish: {method: 'PUT', params: { action: 'republish' }},
+                remove: {method: 'DELETE', params: { 'remove_from_content_view_versions': true }}
             }
         );
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
@@ -88,8 +88,8 @@ describe('Controller: RepositoryDetailsController', function() {
             return false;
         };
         repository.promoted = true;
-        expect($scope.getRepoNonDeletableReason(repository, product)).toBe("published");
-        expect($scope.canRemove(repository, product)).toBe(false);
+        expect($scope.getRepoNonDeletableReason(repository, product)).toBe(null);
+        expect($scope.canRemove(repository, product)).toBe(true);
 
         repository.promoted = false;
         repository.product_type = "redhat";
@@ -121,4 +121,50 @@ describe('Controller: RepositoryDetailsController', function() {
 
         expect($scope.transitionTo).toHaveBeenCalledWith('product.repositories', {productId: 1});
     });
+
+    it('should provide a way to view versions on a repository', function() {
+        repository.id = 1;
+        repository.content_view_versions = [
+            {
+                "id": 28,
+                "version": "3.0",
+                "content_view_id": 15,
+                "content_view_name": "cv6"
+            },
+            {
+                "id": 36,
+                "version": "1.0",
+                "content_view_id": 23,
+                "content_view_name": "cv1"
+            },
+            {
+                "id": 42,
+                "version": "3.0",
+                "content_view_id": 23,
+                "content_view_name": "cv1"
+            }
+        ];
+        expect($scope.repositoryVersions()).toEqual(
+          {
+            15: [{
+                id: 28,
+                content_view_id: 15,
+                content_view_name: 'cv6',
+                version: '3.0'
+          }],
+            23: [
+              {
+                id: 36,
+                content_view_id: 23,
+                content_view_name: 'cv1',
+                version: '1.0'
+              },
+              {
+                id: 42,
+                content_view_id: 23,
+                content_view_name: 'cv1',
+                version: '3.0'
+              }]
+          });
+  });
 });

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -733,5 +733,15 @@ module Katello
       assert @fedora_17_x86_64.in_content_view?(view)
       refute rhel7.in_content_view?(view)
     end
+
+    def test_published_in_versions
+      view = katello_content_views(:library_view)
+      versions = @fedora_17_x86_64.published_in_versions
+      assert_equal versions.length, 3
+      version = @fedora_17_x86_64.published_in_versions.where(content_view_id: view.id).map(&:version)
+      cv_name = @fedora_17_x86_64.published_in_versions.where(content_view_id: view.id).first.content_view.name
+      assert_equal version.sort, view.versions.map(&:version)
+      assert_equal cv_name, view.name
+    end
   end
 end


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Adds UI bits for force deleting a repository.

![Screenshot from 2021-10-25 14-05-45](https://user-images.githubusercontent.com/21146741/138747223-fdcd11b2-d330-4f13-9329-f84182d7ba3d.png)

### What are the testing steps for this pull request?

This needs to be tested with https://github.com/Katello/katello/pull/9738
Get both commits on a branch and try deleting a repository published in a content view.
