### PR TITLE
Fixes #33780 - additional metadata json for generic content unit

### DIFF
--- a/app/services/katello/pulp3/generic_content_unit.rb
+++ b/app/services/katello/pulp3/generic_content_unit.rb
@@ -24,6 +24,7 @@ module Katello
         custom_json['name'] = content_type&.model_name&.call(backend_data)
         custom_json['version'] = content_type&.model_version&.call(backend_data)
         custom_json['filename'] = content_type&.model_filename&.call(backend_data)
+        custom_json['additional_metadata'] = content_type&.model_additional_metadata&.call(backend_data)
         custom_json['content_type'] = content_type&.label
         model.update!(custom_json)
       end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -159,7 +159,7 @@ module Katello
 
     class GenericContentType < ContentType
       attr_accessor :pulp3_api, :pulp3_model, :filename_key, :duplicates_allowed, :pluralized_name,
-                    :model_name, :model_version, :model_filename
+                    :model_name, :model_version, :model_filename, :model_additional_metadata
 
       def initialize(options)
         super
@@ -172,6 +172,7 @@ module Katello
         self.model_name = options[:model_name]
         self.model_version = options[:model_version]
         self.model_filename = options[:model_filename]
+        self.model_additional_metadata = options[:model_additional_metadata]
       end
 
       def label

--- a/app/views/katello/api/v2/generic_content_units/base.json.rabl
+++ b/app/views/katello/api/v2/generic_content_units/base.json.rabl
@@ -6,3 +6,4 @@ attributes :filename
 attributes :pulp_id
 attributes :version
 attributes :content_type
+attributes :additional_metadata

--- a/db/migrate/20211025181315_add_additional_metadata_to_katello_generic_content_units.rb
+++ b/db/migrate/20211025181315_add_additional_metadata_to_katello_generic_content_units.rb
@@ -1,0 +1,5 @@
+class AddAdditionalMetadataToKatelloGenericContentUnits < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_generic_content_units, :additional_metadata, :jsonb
+  end
+end

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -40,6 +40,12 @@ Katello::RepositoryTypeManager.register('python') do
                        model_name: lambda { |pulp_unit| pulp_unit["name"] },
                        model_version: lambda { |pulp_unit| pulp_unit["version"] },
                        model_filename: lambda { |pulp_unit| pulp_unit["filename"] },
+                       model_additional_metadata: lambda { |pulp_unit|
+                         {
+                           "package_type": pulp_unit["packagetype"],
+                           "sha256": pulp_unit["sha256"]
+                         }
+                       },
                        removable: true,
                        uploadable: true,
                        duplicates_allowed: false,

--- a/test/services/katello/pulp3/repository/python/python_test.rb
+++ b/test/services/katello/pulp3/repository/python/python_test.rb
@@ -52,6 +52,13 @@ module Katello
             post_unit_count = Katello::GenericContentUnit.all.count
             post_unit_repository_count = Katello::RepositoryGenericContentUnit.where(:repository_id => @repo.id).count
 
+            unit = @repo.generic_content_units.first
+
+            assert_equal unit.content_type, "python_package"
+            assert_includes unit.filename, "shelf-reader"
+            assert_not unit.pulp_id.nil? and unit.version.nil?
+            assert unit.additional_metadata['package_type'] and unit.additional_metadata['sha256']
+
             assert_equal post_unit_count, 2
             assert_equal post_unit_repository_count, 2
           end

--- a/webpack/scenes/Content/ContentConfig.js
+++ b/webpack/scenes/Content/ContentConfig.js
@@ -31,6 +31,8 @@ export default () => [
           { title: __('Name'), getProperty: unit => unit?.name },
           { title: __('Version'), getProperty: unit => unit?.version },
           { title: __('Filename'), getProperty: unit => unit?.filename },
+          { title: __('Package Type'), getProperty: unit => unit?.additional_metadata.package_type },
+          { title: __('sha256'), getProperty: unit => unit?.additional_metadata.sha256 },
         ],
       },
       {

--- a/webpack/scenes/Content/Details/__tests__/contentDetail.test.js
+++ b/webpack/scenes/Content/Details/__tests__/contentDetail.test.js
@@ -29,7 +29,9 @@ test('Can call API for Python package details and show details tab on page load'
     },
   };
 
-  const { name, version } = pythonPackageDetailsResponse;
+  const {
+    name, version, filename, additional_metadata: additionalMetadata,
+  } = pythonPackageDetailsResponse;
   const pythonPackagesScope = nockInstance
     .get(pythonPackageDetailsPath)
     .query(true)
@@ -42,6 +44,9 @@ test('Can call API for Python package details and show details tab on page load'
   await patientlyWaitFor(() => {
     expect(getAllByText(name)[0]).toBeInTheDocument();
     expect(getAllByText(version)[0]).toBeInTheDocument();
+    expect(getAllByText(filename)[0]).toBeInTheDocument();
+    expect(getAllByText(additionalMetadata.sha256)[0]).toBeInTheDocument();
+    expect(getAllByText(additionalMetadata.package_type)[0]).toBeInTheDocument();
     expect(getByLabelText('content_breadcrumb')).toBeInTheDocument();
     expect(getByLabelText('content_breadcrumb_content')).toHaveTextContent(name);
   });

--- a/webpack/scenes/Content/Details/__tests__/pythonPackageDetails.fixtures.json
+++ b/webpack/scenes/Content/Details/__tests__/pythonPackageDetails.fixtures.json
@@ -1,9 +1,14 @@
 {
   "id": 1491,
   "name": "numpy",
+  "filename": "shelf_reader.tar.gz",
   "pulp_id": "/pulp/api/v3/content/python/packages/3327ccc4-121c-4075-b73f-80f27d445042/",
   "version": "1.21.0",
   "content_type": "python_package",
+  "additional_metadata": {
+    "sha256": "12345",
+    "package_type": "bdist_wheel"
+  },
   "repositories": [
     {
       "id": 3,


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This adds an `additional_metadata` column to the generic content units table. This is a json to allow storing miscellaneous metadata values that won't be consistent between generic content types. For python packages specifically, this adds `sha256` and `package type`, including in the python package details UI.

### What are the testing steps for this pull request?
1. Database migration
2. Sync a python repository.
    - Make upstream url `https://pypi.org`
    - Add the name(s) of a package(s) to the includes option, `django` for example.
    - Sync
3. Check the `additional_metadata` field is correctly filled in the console by doing something like `Katello::Repository.find(:repo_id).generic_content_units`. 
4. Check against the pulp database, something like `pulp python content list --filename "filename"`
5. Check the details tab displays `sha256` and `package type` by going to `https://hostname/python_packages/:id`