### PR TITLE
Fixes #33797 - incremental update requirement not detected

### DIFF
--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -23,7 +23,7 @@ module Actions
             matching_content = check_matching_content(new_repository, source_repositories)
             metadata_generate(source_repositories, new_repository, filters, rpm_filenames, matching_content) if generate_metadata
 
-            index_options = {id: new_repository.id}
+            index_options = {id: new_repository.id, force_index: true}
             index_options[:source_repository_id] = source_repositories.first.id if source_repositories.count == 1 && filters.empty? && rpm_filenames.nil?
             plan_action(Katello::Repository::IndexContent, index_options)
           end

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -17,6 +17,19 @@ module Actions
       get_organization #ensure we have an org label
     end
 
+    it 'plans to index content properly' do
+      cloned_repo = katello_repositories(:fedora_17_x86_64)
+
+      cloned_repo.expects(:primary?).twice.returns(true)
+      cloned_repo.root = yum_repo.root
+      options = {}
+
+      tree = plan_action_tree(action_class, [yum_repo], version, cloned_repo, options)
+
+      assert_tree_planned_with(tree, ::Actions::Katello::Repository::IndexContent,
+                               id: cloned_repo.id, force_index: true, source_repository_id: yum_repo.id)
+    end
+
     it 'plans to clone yum units' do
       cloned_repo = katello_repositories(:fedora_17_x86_64)
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?

The `CloneContents` action now passes the `force_sync = true` option to `IndexContent` to ensure that all of the content view version repositories have the correct content counts.

### What is the thinking behind these changes?

Applicable errata are being shown as installable because the environmental repositories tied to a host's content view version (its bound repositories) weren't indexing content when they should. These repositories had incorrect content counts that stayed the same after the first content view publish.  So, in the case of this bug, it's likely the full repository was published with all errata and then it was filtered and published again.  This bug is likely related to the changes to the content view publishing logic for content views without dependency solving.  It may also be related to the indexing improvements that introduced the `force_index` option.  For the simplest fix possible, I'm passing in the `force_index = true` option.

### What are the testing steps for this pull request?

1) Create a content host that's on some LCE other than Library.
2) Make a content view and publish + promote any number of repositories with no filter.
3) Install an old version of some package that will trigger an erratum and check that the newer version is applicable and installable.
4) Add in a filter that removes the newer package(s) and publish + promote again.
5) Without this PR, the filtered package's erratum will still be installable. With this PR, the filtered package's erratum will only be applicable.
6) Try all the above with dependency solving on.