### PR TITLE
Fixes #33818 - allow access to AK name in the safe mode

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -184,5 +184,15 @@ module Katello
         self.content_view = self.environment.try(:default_content_view)
       end
     end
+
+    apipie :class, desc: "A class representing #{model_name.human} object" do
+      name 'Activation Key'
+      refs 'ActivationKey'
+      sections only: %w[all additional]
+      property :name, String, desc: 'Returns the name of the Activation Key.'
+    end
+    class Jail < ::Safemode::Jail
+      allow :name
+    end
   end
 end


### PR DESCRIPTION
The job template for convert2rhel requires user to enter the activation
key. Recently, Foreman core introduced a new template input type that
allows searching/picking the resources using a nice dropdown. In the
template, one can then access the resource with the special
input_resource(...) macro. For ActivationKey though, we can't access the
name if the safe mode is enabled. This allows accessing the name in
there as it's a safe information. Users still can't access AKs or their
names when they do not have the right permissions.

### What are the changes introduced in this pull request?

### What is the thinking behind these changes?

### What are the testing steps for this pull request?
