### PR TITLE
Fixes #33819 - Version page errata links

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
@@ -16,6 +16,7 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
     docker_tag_count: dockerTagCount,
     file_count: fileCount,
     module_stream_count: moduleStreamCount,
+    ansible_collection_count: ansibleCollectionCount,
   } = cvVersion;
 
   return (
@@ -23,14 +24,14 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
       {(moduleStreamCount > 0 &&
         <>
           <Link to={`/versions/${versionId}/moduleStreams`}>
-            {`${moduleStreamCount} Module Streams`}
+            {`${moduleStreamCount} Module streams`}
           </Link><br />
         </>)
       }
       {(debCount > 0 &&
         <>
           <Link to={`/versions/${versionId}/debPackages`}>
-            {`${debCount} Deb Packages`}
+            {`${debCount} Deb packages`}
           </Link><br />
         </>)
       }
@@ -39,17 +40,22 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
           <Link to={`/versions/${versionId}/dockerTags`}>
             {`${dockerTagCount} Docker tags`}
           </Link><br />
-          <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}/docker`, '')}>{`${dockerManifestCount} Container manifests`}</a><br />
+          <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/dockerTags`, '')}>{`${dockerManifestCount} Container manifests`}</a><br />
         </>)
       }
       {fileCount > 0 &&
         <>
-          <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}/file`, '')}>{`${fileCount} Files`}</a><br />
+          <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/files`, '')}>{`${fileCount} Files`}</a><br />
         </>
+      }
+      {ansibleCollectionCount > 0 &&
+      <>
+        <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/ansibleCollections`, '')}>{`${ansibleCollectionCount} Collections`}</a><br />
+      </>
       }
       {(moduleStreamCount === 0 && debCount === 0 &&
         dockerManifestCount === 0 && dockerTagCount === 0 &&
-        fileCount === 0 &&
+        fileCount === 0 && ansibleCollectionCount === 0 &&
         <TextContent>
           <Text component={TextVariants.small}>{__('N/A')}</Text>
         </TextContent>
@@ -68,6 +74,7 @@ ContentViewVersionContent.propTypes = {
     docker_tag_count: PropTypes.number,
     file_count: PropTypes.number,
     module_stream_count: PropTypes.number,
+    ansible_collection_count: PropTypes.number,
   }),
 };
 
@@ -80,6 +87,7 @@ ContentViewVersionContent.defaultProps = {
     docker_tag_count: 0,
     file_count: 0,
     module_stream_count: 0,
+    ansible_collection_count: 0,
   },
 };
 

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.js
@@ -6,7 +6,9 @@ import {
   EnhancementIcon,
 } from '@patternfly/react-icons';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import { translate as __ } from 'foremanReact/common/I18n';
 import './ContentViewVersionErrata.scss';
+import InactiveText from '../../components/InactiveText';
 
 const ContentViewVersionErrata = ({ cvId, versionId, errataCounts }) => {
   const {
@@ -19,22 +21,24 @@ const ContentViewVersionErrata = ({ cvId, versionId, errataCounts }) => {
     enhancement: EnhancementIcon,
   };
 
-  const getHref = type => `/content_views/${cvId}/versions/${versionId}/errata?queryPagedSearch=%20type%20%3D%20${type}`;
-
   const ErrataLinkwithIcon = () => Object.keys(errataIcons).map((type) => {
     const ErrataIcon = errataIcons[type];
     return (
       <React.Fragment key={type}>
         <ErrataIcon title={type} />
-        <a className="errata-icons-with-commas" href={getHref(type)}> {`${errataCounts[type] || '0'}`} </a>
+        <p className="errata-icons-with-commas">{errataCounts[type] || '0'}</p>
       </React.Fragment>
     );
   });
 
+  if (total === 0) {
+    return <InactiveText text={__('No errata')} />;
+  }
+
   return (
     <React.Fragment>
-      <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}/errata`, '')}>{`${total || 0} `}</a>
-      (<ErrataLinkwithIcon />)
+      <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/errata`, '')}>{`${total || 0} `}</a>
+      ( <ErrataLinkwithIcon /> )
     </React.Fragment>
   );
 };

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.scss
@@ -1,8 +1,8 @@
 .errata-icons-with-commas {
   &:not(:last-child):after {
     content: ', ';
-    margin-right: 5px;
+    margin-right: 0.5em;
   }
   display: inline-flex;
-  margin-left: 2px;
+  margin-left: 0.5em;
 }

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -75,7 +75,7 @@ const ContentViewVersions = ({ cvId, details }) => {
     return [
       { title: <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link> },
       { title: <ContentViewVersionEnvironments {...{ environments }} /> },
-      { title: <a href={urlBuilder(`content_views/${cvId}/versions/${versionId}/packages`, '')}>{packageCount}</a> },
+      { title: <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/packages`, '')}>{packageCount}</a> },
       { title: <ContentViewVersionErrata {...{ cvId, versionId, errataCounts }} /> },
       { title: <ContentViewVersionContent {...{ cvId, versionId, cvVersion }} /> },
       { title: description ? <TableText wrapModifier="truncate">{description}</TableText> : <InactiveText text={__('No description')} /> },

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -122,15 +122,12 @@ test('Can show package and erratas and link to list page', async () => {
 
   await patientlyWaitFor(() => {
     expect(getAllByText(8)[0].closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/packages/');
+      .toHaveAttribute('href', '/content_views/5#/versions/11/packages/');
     expect(getAllByText(15)[0].closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/errata/');
-    expect(getByText(5).closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/errata?queryPagedSearch=%20type%20%3D%20security');
-    expect(getByText(3).closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/errata?queryPagedSearch=%20type%20%3D%20bugfix');
-    expect(getByText(7).closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/errata?queryPagedSearch=%20type%20%3D%20enhancement');
+      .toHaveAttribute('href', '/content_views/5#/versions/11/errata/');
+    expect(getByText(5)).toBeInTheDocument();
+    expect(getByText(3)).toBeInTheDocument();
+    expect(getByText(7)).toBeInTheDocument();
   });
 
   assertNockRequest(autocompleteScope);
@@ -152,8 +149,8 @@ test('Can show additional content and link to list page', async () => {
 
   await patientlyWaitFor(() => {
     expect(getByText('3 Files').closest('a'))
-      .toHaveAttribute('href', '/content_views/5/versions/11/file/');
-    expect(getByText('1 Deb Packages').closest('a'))
+      .toHaveAttribute('href', '/content_views/5#/versions/11/files/');
+    expect(getByText('1 Deb packages').closest('a'))
       .toHaveAttribute('href', '/versions/11/debPackages');
   });
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?
The errata column needs to look like below. Also fixing some links on the table.
<img width="176" alt="Screenshot 2021-10-29 at 17 38 26" src="https://user-images.githubusercontent.com/21146741/139860349-d5311e7e-2015-486c-bf83-49442c8ca51c.png">
