### PR TITLE
Fixes #33654 - Update description on skipped/failed published tasks

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -64,7 +64,7 @@ module Katello
     param :id, :number, :desc => N_("Content view version identifier"), :required => true
     param :description, String, :desc => N_("The description for the content view version"), :required => true
     def update
-      history = @content_view_version.history.publish.successful.first
+      history = @content_view_version.history.publish.first
       if history.blank?
         fail HttpErrors::BadRequest, _("This content view version doesn't have a history.")
       else

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -130,7 +130,7 @@ module Katello
     end
 
     def description
-      history.publish.successful.first.try(:notes)
+      history.publish.first.try(:notes)
     end
 
     def default_content_view?

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -16,12 +16,15 @@ module Katello
     end
 
     def test_description
-      ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @cvv.id,
+      cvv_desc = ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @cvv.id,
                                             :status => 'successful',
                                             :user => User.first,
                                             :action => Katello::ContentViewHistory.actions[:publish],
                                             :notes => "Success description"
                                            )
+
+      assert_equal 'Success description', @cvv.description
+      cvv_desc.destroy!
 
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @cvv.id,
                                             :status => 'failed',
@@ -30,7 +33,7 @@ module Katello
                                             :notes => "Failed description"
                                            )
 
-      assert_equal 'Success description', @cvv.description
+      assert_equal 'Failed description', @cvv.description
     end
 
     def test_promotable_in_sequence


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Allow updating version description on any publish task.

### What are the testing steps for this pull request?
Introduce some failure in a cv publish task.
Skip the task.
In the created version, update description.