### PR TITLE
Fixes #33325 - warn about unsupported content types during proxy sync

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -422,7 +422,7 @@ module Katello
         repos = Katello::Repository
         repos = repos.in_environment(environment) if environment
         repos = repos.in_content_views([content_view]) if content_view
-        repos
+        repos.respond_to?(:to_a) ? repos : repos.none
       end
 
       def repos_in_sync_history

--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -19,6 +19,13 @@
   </div>
 
   <br>
+  <div ng-hide="syncStatus.unsyncable_content_types.length == 0">
+    <span translate>
+      Pulp plugin missing for synchronizable content types: <b>{{ syncStatus.unsyncable_content_types.join(", ") }}.</b><br />
+      Repositories containing these content types will not be synced.
+    </span>
+  </div>
+
   <div ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)">
     <a ng-click="cancelSync()" class="btn btn-default" ng-disabled="!syncState.is(syncState.SYNCING)">
       <span translate>Cancel Sync</span>

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -2,6 +2,10 @@ object @capsule
 
 attribute :last_sync_time
 
+node :unsyncable_content_types do
+  ::Katello::SmartProxyHelper.new(@capsule).unsyncable_content_types
+end
+
 child :active_sync_tasks => :active_sync_tasks do
   extends 'foreman_tasks/api/tasks/show'
 end


### PR DESCRIPTION
### What are the changes introduced in this pull request?

1) Repositories of content types belonging to Pulp plugins not installed on a smart proxy will not be proxy synced.
2) The user will be warned of types that won't be synced in the UI

![Screenshot from 2021-11-03 12-51-41](https://user-images.githubusercontent.com/14796566/140108199-c5341ddd-517c-42ee-a056-5f2a5ece24dc.png)

### What is the thinking behind these changes?

In the SyncCapsule action, proxy syncs are planned individually for each repo that should be synced. Now, repos that have missing plugins on the proxy will be skipped. It's pretty straight-forward.

For the UI, I added a new `node` in the API view to return the repo types to skip.  I remove the types that aren't applicable to the smart proxy because, for example, it would be confusing to see "ostree" being skipped when it was never used.

Then, there's simply a new `<div>` that displays the types to skip with a warning message.  It's hidden if there are no types to skip.

### What are the testing steps for this pull request?

1) Set up a smart proxy to sync.
2) Sync a few repositories of different types and ensure they're in the proxy's LCE.
3) Remove the Pulp plugins for those repositories' types and restart the Pulpcore services on the proxy.
4) Refresh the proxies features.
5) See that the types to skip warning is there.
6) Sync the proxy and ensure there's no error.
7) Reinstall the proxy plugins, refresh the proxy, and see that the warning message goes away.

TODO:

- [x] Add action test