### PR TITLE
Fixes #33834 - Filter errata by type and severity

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -3,6 +3,12 @@ module Katello
     include Katello::Concerns::FilteredAutoCompleteSearch
     include Katello::Concerns::Api::V2::HostErrataExtensions
 
+    TYPES_FROM_PARAMS = {
+      bugfix: Katello::Erratum::BUGZILLA, # ['bugfix', 'recommended']
+      security: Katello::Erratum::SECURITY, # ['security']
+      enhancement: Katello::Erratum::ENHANCEMENT # ['enhancement', 'optional']
+    }
+
     before_action :find_host, only: :index
     before_action :find_host_editable, except: :index
     before_action :find_errata_ids, only: :apply
@@ -36,13 +42,24 @@ module Katello
     param :content_view_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Content View"), :required => false
     param :environment_id, :number, :desc => N_("Calculate Applicable Errata based on a particular Environment"), :required => false
     param :include_applicable, :bool, :desc => N_("Return errata that are applicable to this host. Defaults to false)"), :required => false
+    param :type, String, :desc => N_("Return only errata of a particular type (security, bugfix, enhancement)"), :required => false
+    param :severity, String, :desc => N_("Return only errata of a particular severity (None, Low, Moderate, Important, Critical)"), :required => false
     param_group :search, Api::V2::ApiController
     def index
       if (params[:content_view_id] && params[:environment_id].nil?) || (params[:environment_id] && params[:content_view_id].nil?)
         fail _("Either both parameters 'content_view_id' and 'environment_id' should be specified or neither should be specified")
       end
 
-      collection = scoped_search(index_relation, 'updated', 'desc', :resource_class => Erratum, :includes => [:cves])
+      filtered_relation = index_relation
+      if params[:type].present?
+        fail _("Type must be one of: %s" % TYPES_FROM_PARAMS.keys.join(', ')) unless TYPES_FROM_PARAMS.key?(params[:type].to_sym)
+        filtered_relation = filtered_relation.where(:errata_type => TYPES_FROM_PARAMS[params[:type].to_sym])
+      end
+      if params[:severity].present?
+        fail _("Severity must be one of: %s") % Katello::Erratum::SEVERITIES.join(', ') unless Katello::Erratum::SEVERITIES.include?(params[:severity])
+        filtered_relation = filtered_relation.where(:severity => params[:severity])
+      end
+      collection = scoped_search(filtered_relation, 'updated', 'desc', :resource_class => Erratum, :includes => [:cves])
 
       @installable_errata_ids = []
       if @host.content_facet

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -7,7 +7,7 @@ module Katello
       bugfix: Katello::Erratum::BUGZILLA, # ['bugfix', 'recommended']
       security: Katello::Erratum::SECURITY, # ['security']
       enhancement: Katello::Erratum::ENHANCEMENT # ['enhancement', 'optional']
-    }
+    }.freeze
 
     before_action :find_host, only: :index
     before_action :find_host_editable, except: :index

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -5,8 +5,15 @@ module Katello
     SECURITY = ["security"].freeze
     BUGZILLA = ["bugfix", "recommended"].freeze
     ENHANCEMENT = ["enhancement", "optional"].freeze
-
     TYPES = [SECURITY, BUGZILLA, ENHANCEMENT].flatten.freeze
+
+    NONE = "None".freeze
+    LOW = "Low".freeze
+    MODERATE = "Moderate".freeze
+    IMPORTANT = "Important".freeze
+    CRITICAL = "Critical".freeze
+    SEVERITIES = [NONE, LOW, MODERATE, IMPORTANT, CRITICAL].freeze
+
     CONTENT_TYPE = "erratum".freeze
     BACKEND_IDENTIFIER_FIELD = "erratum_pulp3_href".freeze
 

--- a/webpack/components/SelectableDropdown/SelectableDropdown.js
+++ b/webpack/components/SelectableDropdown/SelectableDropdown.js
@@ -5,7 +5,7 @@ import { ErrorCircleOIcon } from '@patternfly/react-icons';
 
 
 const SelectableDropdown = ({
-  items, title, selected, setSelected, loading, error,
+  items, title, showTitle, selected, setSelected, loading, error,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const icon = () => {
@@ -23,11 +23,13 @@ const SelectableDropdown = ({
 
   return (
     <Level>
+      {showTitle &&
       <LevelItem>
         <label htmlFor={`select ${title}`} style={{ margin: '0px 5px' }}>
           {title}
         </label>
       </LevelItem>
+      }
       <LevelItem aria-label={`select ${title} container`}>
         <Select
           id={`select ${title}`}
@@ -51,6 +53,7 @@ const SelectableDropdown = ({
 SelectableDropdown.propTypes = {
   items: PropTypes.arrayOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
+  showTitle: PropTypes.bool,
   selected: PropTypes.string.isRequired,
   setSelected: PropTypes.func.isRequired,
   // If the items are loaded dynamically, you can pass in loading or error states
@@ -61,6 +64,7 @@ SelectableDropdown.propTypes = {
 SelectableDropdown.defaultProps = {
   loading: false,
   error: false,
+  showTitle: true,
 };
 
 

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -188,13 +188,13 @@ const TableWrapper = ({
             />
           </FlexItem>
         }
-        {showActionButtons &&
-          <FlexItem style={{ marginLeft: '16px' }}>
-            {actionButtons}
-          </FlexItem>}
         {showToggleGroup &&
           <FlexItem style={{ marginLeft: '16px' }}>
             {toggleGroup}
+          </FlexItem>}
+        {showActionButtons &&
+          <FlexItem style={{ marginLeft: '16px' }}>
+            {actionButtons}
           </FlexItem>}
 
         {showPagination &&

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -8,10 +8,25 @@ export const ERRATA_TYPES = {
   ENHANCEMENT: 'Enhancement',
 };
 export const ERRATA_SEVERITIES = {
-  NOT_APPLICABLE: 'None',
+  NOT_APPLICABLE: 'N/A',
+  LOW: 'Low',
   MODERATE: 'Moderate',
   IMPORTANT: 'Important',
   CRITICAL: 'Critical',
+};
+
+export const TYPES_TO_PARAM = {
+  [ERRATA_TYPES.SECURITY]: 'security',
+  [ERRATA_TYPES.BUGFIX]: 'bugfix',
+  [ERRATA_TYPES.ENHANCEMENT]: 'enhancement',
+};
+
+export const SEVERITIES_TO_PARAM = {
+  [ERRATA_SEVERITIES.NOT_APPLICABLE]: 'None',
+  [ERRATA_SEVERITIES.LOW]: 'Low',
+  [ERRATA_SEVERITIES.MODERATE]: 'Moderate',
+  [ERRATA_SEVERITIES.IMPORTANT]: 'Important',
+  [ERRATA_SEVERITIES.CRITICAL]: 'Critical',
 };
 
 export default HOST_ERRATA_KEY;

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -2,4 +2,16 @@ export const HOST_ERRATA_KEY = 'HOST_ERRATUM';
 export const HOST_ERRATA_APPLICABILITY_KEY = 'HOST_ERRATA_APPLICABILITY';
 export const HOST_ERRATA_APPLY_KEY = 'HOST_ERRATUM_APPLY';
 
+export const ERRATA_TYPES = {
+  SECURITY: 'Security',
+  BUGFIX: 'Bug fix',
+  ENHANCEMENT: 'Enhancement',
+};
+export const ERRATA_SEVERITIES = {
+  NOT_APPLICABLE: 'None',
+  MODERATE: 'Moderate',
+  IMPORTANT: 'Important',
+  CRITICAL: 'Critical',
+};
+
 export default HOST_ERRATA_KEY;

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -4,7 +4,7 @@ export const HOST_ERRATA_APPLY_KEY = 'HOST_ERRATUM_APPLY';
 
 export const ERRATA_TYPES = {
   SECURITY: 'Security',
-  BUGFIX: 'Bug fix',
+  BUGFIX: 'Bugfix',
   ENHANCEMENT: 'Enhancement',
 };
 export const ERRATA_SEVERITIES = {

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
+import { Button, Split, SplitItem, ActionList, ActionListItem, Dropdown, Divider,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {
@@ -55,7 +55,7 @@ export const ErrataTab = () => {
 
   const emptyContentTitle = __('This host does not have any installable errata.');
   const emptyContentBody = __('Installable errata will appear here when available.');
-  const emptySearchTitle = __('No matching installable errata found');
+  const emptySearchTitle = __('No matching errata found');
   const emptySearchBody = __('Try changing your search settings.');
   const columnHeaders = [
     __('Errata'),
@@ -150,6 +150,31 @@ export const ErrataTab = () => {
   });
 
   const actionButtons = (
+    <>
+      <Split hasGutter>
+        <SplitItem>
+          <ActionList isIconList>
+            <ActionListItem>
+              <Button isDisabled={selectedCount === 0} onClick={applyByKatelloAgent}> {__('Apply')} </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Dropdown
+                toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                isOpen={isBulkActionOpen}
+                isPlain
+                dropdownItems={dropdownItems}
+              />
+            </ActionListItem>
+          </ActionList>
+        </SplitItem>
+      </Split>
+    </>
+  );
+
+  const hostIsNonLibrary = (
+    !contentFacet.contentViewDefault && !contentFacet.lifecycleEnvironmentLibrary
+  );
+  const toggleGroup = (
     <Split hasGutter>
       <SplitItem>
         <SelectableDropdown
@@ -171,46 +196,29 @@ export const ErrataTab = () => {
           setSelected={handleErrataSeveritySelected}
         />
       </SplitItem>
+      {hostIsNonLibrary &&
       <SplitItem>
-        <ActionList isIconList>
-          <ActionListItem>
-            <Button isDisabled={selectedCount === 0} onClick={applyByKatelloAgent}> {__('Apply')} </Button>
-          </ActionListItem>
-          <ActionListItem>
-            <Dropdown
-              toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
-              isOpen={isBulkActionOpen}
-              isPlain
-              dropdownItems={dropdownItems}
-            />
-          </ActionListItem>
-        </ActionList>
+        <ToggleGroup aria-label="Installable Errata">
+          <ToggleGroupItem
+            text={__('All')}
+            buttonId="allToggle"
+            aria-label="Show All"
+            isSelected={toggleGroupState === ALL}
+            onChange={() => setToggleGroupState(ALL)}
+          />
+
+          <ToggleGroupItem
+            text={__('Installable')}
+            buttonId="installableToggle"
+            aria-label="Show Installable"
+            isSelected={toggleGroupState === INSTALLABLE}
+            onChange={() => setToggleGroupState(INSTALLABLE)}
+          />
+        </ToggleGroup>
       </SplitItem>
+  }
     </Split>
   );
-
-  let toggleGroup;
-  if (!contentFacet.contentViewDefault && !contentFacet.lifecycleEnvironmentLibrary) {
-    toggleGroup = (
-      <ToggleGroup aria-label="Installable Errata">
-        <ToggleGroupItem
-          text={__('All')}
-          buttonId="allToggle"
-          aria-label="Show All"
-          isSelected={toggleGroupState === ALL}
-          onChange={() => setToggleGroupState(ALL)}
-        />
-
-        <ToggleGroupItem
-          text={__('Installable')}
-          buttonId="installableToggle"
-          aria-label="Show Installable"
-          isSelected={toggleGroupState === INSTALLABLE}
-          onChange={() => setToggleGroupState(INSTALLABLE)}
-        />
-      </ToggleGroup>
-    );
-  }
 
   return (
     <div>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Button, Split, SplitItem, ActionList, ActionListItem, Dropdown, Divider,
+import { Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {
@@ -70,11 +70,12 @@ export const ErrataTab = () => {
     (params) => {
       if (!hostId) return null;
       const modifiedParams = { ...params };
-      if (errataTypeSelected !== ERRATA_TYPE) modifiedParams.type = TYPES_TO_PARAM[errataTypeSelected];
+      if (errataTypeSelected !== ERRATA_TYPE) {
+        modifiedParams.type = TYPES_TO_PARAM[errataTypeSelected];
+      }
       if (errataSeveritySelected !== ERRATA_SEVERITY) {
         modifiedParams.severity = SEVERITIES_TO_PARAM[errataSeveritySelected];
       }
-      console.log(modifiedParams);
       return getInstallableErrata(
         hostId,
         {
@@ -90,6 +91,7 @@ export const ErrataTab = () => {
   const response = useSelector(state => selectAPIResponse(state, HOST_ERRATA_KEY));
   const { results, ...metadata } = response;
   const status = useSelector(state => selectHostErrataStatus(state));
+
   const {
     selectOne, isSelected, searchQuery, selectedCount, isSelectable,
     updateSearchQuery, selectNone, fetchBulkParams, ...selectAll

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errata.fixtures.json
@@ -39,7 +39,7 @@
     },
     {
         "id": 10,
-        "severity": "",
+        "severity": "Moderate",
         "title": "Errata102",
         "type": "bugfix",
         "host_id": 1,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -58,8 +58,14 @@ const makeMockErrata = ({ pageSize = 20, total = 100, page = 1 }) => {
   };
 };
 
-const hostErrata = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
+const hostErrata = foremanApi.getApiUrl('/hosts/1/errata');
 const autocompleteUrl = '/hosts/1/errata/auto_complete_search';
+const defaultQueryWithoutSearch = {
+  include_applicable: false,
+  per_page: 20,
+  page: 1,
+};
+const defaultQuery = { ...defaultQueryWithoutSearch, search: '' };
 
 let firstErrata;
 let searchDelayScope;
@@ -81,14 +87,13 @@ afterEach(() => {
 test('Can call API for errata and show on screen on page load', async (done) => {
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
-
   // return tracedata results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrataData);
 
   const { getAllByText } = renderWithRedux(<ErrataTab />, renderOptions());
-
   // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getAllByText(firstErrata.severity)[0]).toBeInTheDocument());
   // Assert request was made and completed, see helper function
@@ -110,6 +115,7 @@ test('Can handle no errata being present', async (done) => {
 
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, noResults);
 
   const { queryByText } = renderWithRedux(<ErrataTab />, renderOptions());
@@ -128,6 +134,7 @@ test('Can display expanded errata details', async (done) => {
   // return tracedata results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrataData);
 
   const {
@@ -170,6 +177,7 @@ test('Can select one errata', async (done) => {
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrataData);
 
   const {
@@ -200,16 +208,16 @@ test('Can select all errata across pages through checkbox', async (done) => {
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({ page: 1 });
   // return errata data results when we look for errata
-  const page1 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
-  const page2 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=2&per_page=20');
 
   // return errata data results when we look for errata
   const scope = nockInstance
-    .get(page1)
+    .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const scope2 = nockInstance
-    .get(page2)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 2 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const {
@@ -241,16 +249,16 @@ test('Can deselect all errata across pages through checkbox', async (done) => {
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({ page: 1 });
   // return errata data results when we look for errata
-  const page1 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
-  const page2 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=2&per_page=20');
 
   // return errata data results when we look for errata
   const scope = nockInstance
-    .get(page1)
+    .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const scope2 = nockInstance
-    .get(page2)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 2 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const {
@@ -285,16 +293,16 @@ test('Can deselect all errata across pages through checkbox', async (done) => {
 test('Can select & deselect errata across pages', async (done) => {
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
-  const page1 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
-  const page2 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=2&per_page=20');
 
   // return errata data results when we look for errata
   const scope = nockInstance
-    .get(page1)
+    .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, makeMockErrata({ page: 1 }));
 
   const scope2 = nockInstance
-    .get(page2)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 2 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const {
@@ -330,6 +338,7 @@ test('Can select & de-select all errata through selectDropDown', async (done) =>
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -367,22 +376,21 @@ test('Can de-select items in select all mode across pages', async (done) => {
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({ page: 1 });
-  // return errata data results when we look for errata
-  const page1 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
-  const page2 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=2&per_page=20');
-  const page3 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=1&per_page=20');
 
   // return errata data results when we look for errata
   const scope = nockInstance
-    .get(page1)
+    .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const scope2 = nockInstance
-    .get(page2)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 1 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const scope3 = nockInstance
-    .get(page3)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 2 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const {
@@ -439,6 +447,7 @@ test('Can select page and select only items on the page', async (done) => {
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -465,13 +474,14 @@ test('Can select page and select only items on the page', async (done) => {
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Select  disabled if all rows are selected', async (done) => {
+test('Select all is disabled if all rows are selected', async (done) => {
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({});
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -525,6 +535,7 @@ test('Toggle Group shows if its not the default contentview or library enviromen
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -550,6 +561,7 @@ test('Toggle Group does not show if its the default contentview ', async (done) 
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -575,6 +587,7 @@ test('Toggle Group does not show if its the  library env ', async (done) => {
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {
@@ -589,13 +602,14 @@ test('Toggle Group does not show if its the  library env ', async (done) => {
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Can disable applicable errata', async (done) => {
+test('Selection is disabled for errata which are applicable but not installable', async (done) => {
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   firstErrata.installable = false;
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrataData);
 
   const {
@@ -620,16 +634,16 @@ test('Can select only installable errata across pages through checkbox', async (
   first.installable = false;
   mockErrata.selectable = mockErrata.total - 1;
   // return errata data results when we look for errata
-  const page1 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&per_page=20&page=1');
-  const page2 = foremanApi.getApiUrl('/hosts/1/errata?include_applicable=false&page=2&per_page=20');
 
   // return errata data results when we look for errata
   const scope = nockInstance
-    .get(page1)
+    .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const scope2 = nockInstance
-    .get(page2)
+    .get(hostErrata)
+    .query({ ...defaultQueryWithoutSearch, page: 2 })
     .reply(200, makeMockErrata({ page: 2 }));
 
   const {
@@ -663,6 +677,7 @@ test('Can toggle with the Toggle Group ', async (done) => {
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
+    .query(defaultQuery)
     .reply(200, mockErrata);
 
   const {


### PR DESCRIPTION
### What are the changes introduced in this pull request?

* Add Type and Severity dropdowns to the new host detail page Errata tab
* Change the order of the toggle group and dropdowns to reflect the mockup

### What is the thinking behind these changes?

These dropdowns are part of the design, but haven't been added yet.

I added params to the `index` method of the controller, so you can pass `type` and `severity` params.  Special case for Errata: On the backend, a single errata_type may be multiple strings (for instance, see https://github.com/Katello/katello/blob/574136ae75b96b2ece56a0f7c8a6233547e1551b/app/models/katello/erratum.rb#L6)

I made it so that you can pass a `type` param of `bugfix` and it will still search for `.where(:type => ["bugfix", "recommended"])`.

An alternate approach would have been to add "errata_type = " and "severity = " to the user's search on the frontend before sending the request, but that seemed messy and hacky to me. I saw that the CV UI pages don't do this. Rather, they have a similar approach to the one I went with, modifying the API to reflect the dropdowns.

### What are the testing steps for this pull request?

#### Get a host with applicable errata of all types

The easiest way I've found to get "real" errata to play with is
1. Enable the Red Hat repository "Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server"
2. Spin up a `rhel7` virtual machine using Forklift (copy over the definition from sat-deploy)
3. register the client to your Katello using global registration
3. `yum clean all` on the client if needed

#### Test that everything works
* Filter by each type
* Filter by each severity
* Filter by several combinations of type & severity
* Perform a search and then filter it
* Change pages while filtering
* Select items across pages to apply
