### PR TITLE
Fixes #33553 -  Allow "Enter" key for submit action on all CV forms

### DIFF
--- a/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
@@ -4,6 +4,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Form, FormGroup, TextInput, ActionGroup, Button } from '@patternfly/react-core';
 import {
   selectCopyContentViewError, selectCopyContentViews,
@@ -44,8 +45,12 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
   }
 
   return (
-    <Form>
-      <FormGroup label="Name" isRequired fieldId="name">
+    <Form onSubmit={(e) => {
+      e.preventDefault();
+      onSubmit();
+    }}
+    >
+      <FormGroup label={__('Name')} isRequired fieldId="name">
         <TextInput
           isRequired
           type="text"
@@ -53,14 +58,21 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
           aria-label="input_name"
           name="name"
           value={name}
-          onChange={value => setName(value)}
+          onChange={setName}
         />
       </FormGroup>
       <ActionGroup>
-        <Button aria-label="copy_content_view" variant="primary" isDisabled={saving} onClick={() => onSubmit()}>Copy content view</Button>
-        <Button variant="link" onClick={() => setModalOpen(false)}>Cancel</Button>
+        <Button
+          aria-label="copy_content_view"
+          variant="primary"
+          isDisabled={saving}
+          type="submit"
+        >
+          {__('Copy content view')}
+        </Button>
+        <Button variant="link" onClick={() => setModalOpen(false)}>{__('Cancel')}</Button>
       </ActionGroup>
-    </Form>
+    </Form >
   );
 };
 

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -64,7 +64,11 @@ const CreateContentViewForm = ({ setModalOpen }) => {
   }
 
   return (
-    <Form>
+    <Form onSubmit={(e) => {
+      e.preventDefault();
+      onSave();
+    }}
+    >
       <FormGroup label={__('Name')} isRequired fieldId="name">
         <TextInput
           isRequired
@@ -163,7 +167,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           aria-label="create_content_view"
           variant="primary"
           isDisabled={saving}
-          onClick={() => onSave()}
+          type="submit"
         >
           {__('Create content view')}
         </Button>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -1,14 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, ModalVariant, FormSelect,
+import {
+  Modal, ModalVariant, FormSelect,
   FormSelectOption, Checkbox, Form, FormGroup,
-  ActionGroup, Button } from '@patternfly/react-core';
+  ActionGroup, Button,
+} from '@patternfly/react-core';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
-import { selectCVDetails,
+import {
+  selectCVDetails,
   selectCVDetailStatus,
-  selectCVDetailError } from '../../Details/ContentViewDetailSelectors';
+  selectCVDetailError,
+} from '../../Details/ContentViewDetailSelectors';
 import { addComponent } from '../ContentViewDetailActions';
 
 const ComponentContentViewAddModal = ({
@@ -91,7 +95,11 @@ const ComponentContentViewAddModal = ({
       }}
       appendTo={document.body}
     >
-      <Form>
+      <Form onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+      >
         <FormGroup label={__('Version')} isRequired fieldId="version">
           <FormSelect
             value={selected}
@@ -104,7 +112,7 @@ const ComponentContentViewAddModal = ({
             {options.map((option, index) => (
               // eslint-disable-next-line react/no-array-index-key
               <FormSelectOption key={index} value={option.value} label={option.label} />
-          ))}
+            ))}
           </FormSelect>
         </FormGroup>
         <FormGroup fieldId="latest">
@@ -118,7 +126,7 @@ const ComponentContentViewAddModal = ({
           />
         </FormGroup>
         <ActionGroup>
-          <Button aria-label="add_component" variant="primary" onClick={() => onSubmit()}>{__('Submit')}</Button>
+          <Button aria-label="add_component" variant="primary" type="submit">{__('Submit')}</Button>
           <Button variant="link" onClick={() => setIsOpen(false)}>{__('Cancel')}</Button>
         </ActionGroup>
       </Form>


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This adds the "Enter" key submit option in 3 locations within CV UI: 
- Component Content View Add modal
- Copy Content View Modal
- Create Content View Form

### What are the testing steps for this pull request?
- Navigate to the above mentioned modals and "Tab" to the fields required for validation. 
- Without selection the Submit/Save/Update button, hit "Enter" to fire the submit action and close the modal.