### PR TITLE
Fixes #33303 - ostree and python FPC sync support

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -1,6 +1,7 @@
 require 'proxy_api'
 require 'proxy_api/pulp'
 require 'proxy_api/pulp_node'
+require 'proxy_api/container_gateway'
 
 module Katello
   module Concerns
@@ -128,7 +129,7 @@ module Katello
                            auth_required: !unauthenticated_container_repositories.include?(repo.id) }
           end
         end
-        ProxyAPI::ContainerGateway.new(url: self.url).repository_list({ repositories: repo_list })
+        ::ProxyAPI::ContainerGateway.new(url: self.url).repository_list({ repositories: repo_list })
       end
 
       def update_user_container_repo_mapping(users)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -440,8 +440,6 @@ module Katello
       scheme = force_http ? 'http' : 'https'
       if docker?
         "#{pulp_uri.host.downcase}/#{container_repository_name}"
-      elsif ostree?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/content/web/#{relative_path}"
       elsif ansible_collection?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp_ansible/galaxy/#{relative_path}/api/"
       else

--- a/app/services/katello/pulp3/repository/generic.rb
+++ b/app/services/katello/pulp3/repository/generic.rb
@@ -12,7 +12,9 @@ module Katello
             name: "#{generate_backend_object_name}"
           }
 
-          unless ::Katello::RepositoryTypeManager.find(repo.content_type).pulp3_skip_publication
+          if ::Katello::RepositoryTypeManager.find(repo.content_type).pulp3_skip_publication
+            options.merge!(repository_version: repo.version_href)
+          else
             options.merge!(publication: repo.publication_href)
           end
 
@@ -29,7 +31,7 @@ module Katello
         end
 
         def partial_repo_path
-          repo.repository_type.partial_repo_path
+          "/pulp/content/#{repo.relative_path}/".sub('//', '/')
         end
       end
     end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -13,7 +13,7 @@ module Katello
     end
 
     def_field :allow_creation_by_user, :service_class, :pulp3_service_class, :pulp3_plugin,
-              :pulp3_skip_publication, :configuration_class, :partial_repo_path, :pulp3_api_class,
+              :pulp3_skip_publication, :configuration_class, :pulp3_api_class,
               :repositories_api_class, :api_class, :remotes_api_class, :repository_versions_api_class,
               :distributions_api_class, :remote_class, :repo_sync_url_class, :client_module_class,
               :distribution_class, :publication_class, :publications_api_class, :url_description

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -261,7 +261,7 @@
       <dt translate>Publish via HTTPS</dt>
       <dd translate>Yes</dd>
 
-      <span ng-hide="repository.content_type === 'ostree' || repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
+      <span ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <dt translate>Publish via HTTP</dt>
         <dd bst-edit-checkbox="repository.unprotected"
             formatter="booleanToYesNo"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -129,9 +129,6 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
 
             $scope.save = function (repository) {
                 var fields = ['upstream_password', 'upstream_username', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
-                if (repository.content_type === 'ostree') {
-                    repository.unprotected = false;
-                }
                 if (repository.content_type === 'yum') {
                     repository.os_versions = $scope.osVersionsParam();
                     if ($scope.repositoryForm.ignore_srpms.$modelValue) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -329,7 +329,7 @@
         </p>
       </div>
 
-      <div class="checkbox" ng-hide="repository.content_type === 'ostree' || repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
+      <div class="checkbox" ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <label>
           <input id="unprotected" name="unprotected" ng-model="repository.unprotected" type="checkbox"/>
           <span translate>Publish via HTTP</span>

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -6,7 +6,6 @@ Katello::RepositoryTypeManager.register('ostree') do
   pulp3_api_class Katello::Pulp3::Api::Generic
   pulp3_plugin 'ostree'
   pulp3_skip_publication true
-  partial_repo_path '' #TODO: add partial repo path
 
   client_module_class PulpOstreeClient
   api_class PulpOstreeClient::ApiClient

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -5,7 +5,6 @@ Katello::RepositoryTypeManager.register('python') do
   pulp3_service_class Katello::Pulp3::Repository::Generic
   pulp3_api_class Katello::Pulp3::Api::Generic
   pulp3_plugin 'python'
-  partial_repo_path '' #TODO: add partial repo path
 
   client_module_class PulpPythonClient
   api_class PulpPythonClient::ApiClient


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Support for generic content types being synced to a smart proxy.  These generic types had some support for a customizable way to define 'relative_path', which is the external path to access the content.  The support however wasn't fully implemented, so i've removed it since neither ostree nor python actually need it. 

In addition there was an error seen when looking up the ContainerGateway constant that may only occur in dev, but i was seeing it consistently so went ahead and fixed it.

### What is the thinking behind these changes?

### What are the testing steps for this pull request?

1.  Apply this patch to pulp_ostree: https://github.com/pulp/pulp_ostree/commit/baf301ea8abf38e6fe39e7df4a799a05c6afeeda
2. create and sync an ostree repo
3. setup and configure a smart proxy, pointing at library
4. apply the same patch to the smart proxy
4. sync the smart proxy
5. you can curl the ostree repo's path on the smart proxy to see its contents:  for example:  curl https://mycapsule/pulp/content/Default_Organization/Library/custom/ostree/ostree2/

Python support is broken due to https://github.com/pulp/pulp_python/issues/462  but ostree is the main drive here, so i don't think it should block this.
