### PR TITLE
Fixes #33852 - Content - Errata - Add REX actions

### DIFF
--- a/app/controllers/katello/concerns/api/v2/bulk_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_extensions.rb
@@ -8,7 +8,6 @@ module Katello
           bulk_params = ActiveSupport::JSON.decode(bulk_params).
                         deep_symbolize_keys
         end
-
         bulk_params[:included] ||= {}
         bulk_params[:excluded] ||= {}
 
@@ -22,18 +21,9 @@ module Katello
           fail HttpErrors::BadRequest, _("Sending a list of included IDs is not allowed when all items are being selected.")
         end
 
-        items = model_scope
-        if bulk_params[:included][:ids]
-          items = model_scope.where(key => bulk_params[:included][:ids])
-        elsif bulk_params[:included][:search]
-          items = model_scope.search_for(bulk_params[:included][:search])
-        end
-
-        if bulk_params[:excluded][:ids]
-          items = items.where.not(key => bulk_params[:excluded][:ids])
-        end
-
-        items
+        ::Katello::BulkItemsHelper.new(bulk_params: bulk_params,
+                                       model_scope: model_scope,
+                                       key: key).fetch
       end
     end
   end

--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -48,7 +48,7 @@ module Katello
 
       def inputs
         if feature_name == 'katello_errata_install'
-          { :errata => errata_inputs }
+          { "Errata Search Query" => "errata_id ^ (#{errata_inputs.join(',')})" }
         elsif feature_name == 'katello_service_restart'
           { :helper => params[:name] }
         elsif feature_name == 'katello_module_stream_action'

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -389,18 +389,8 @@ module Katello
         ::Katello::HostTracer.helpers_for(traces)
       end
 
-      def advisory_helpers(errata:, all: false, search: nil)
-        return [] if all && errata.blank? && search.blank?
-        bulk_params = { all: all, included: {search: search}, excluded: {} }
-
-        if all
-          bulk_params[:excluded][:ids] = errata
-        else
-          bulk_params[:included][:ids] = errata
-        end
-        ::Katello::BulkItemsHelper.new(bulk_params: bulk_params,
-                                       model_scope: ::Katello::Erratum.installable_for_hosts([self]),
-                                       key: :errata_id).fetch.pluck(:errata_id)
+      def advisory_ids(search:)
+        ::Katello::Erratum.installable_for_hosts([self]).search_for(search).pluck(:errata_id)
       end
 
       def valid_content_override_label?(content_label)
@@ -425,7 +415,7 @@ end
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
         :host_collections, :pools, :hypervisor_host, :lifecycle_environment, :content_view,
-        :installed_packages, :traces_helpers, :advisory_helpers
+        :installed_packages, :traces_helpers, :advisory_ids
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail

--- a/app/services/katello/bulk_items_helper.rb
+++ b/app/services/katello/bulk_items_helper.rb
@@ -1,0 +1,35 @@
+module Katello
+  class BulkItemsHelper
+    attr_reader :bulk_params, :model_scope, :key
+
+    def initialize(bulk_params:, model_scope:, key: :id)
+      @bulk_params = bulk_params
+
+      if @bulk_params.is_a?(String)
+        @bulk_params = ActiveSupport::JSON.decode(@bulk_params).
+                      deep_symbolize_keys
+      end
+
+      @model_scope = model_scope
+      @key = key
+    end
+
+    def fetch
+      params = bulk_params
+      params[:included] ||= {}
+      params[:excluded] ||= {}
+
+      items = model_scope
+      if params[:included][:ids]
+        items = model_scope.where(key => params[:included][:ids])
+      elsif params[:included][:search]
+        items = model_scope.search_for(params[:included][:search])
+      end
+      if params[:excluded][:ids]
+        items = items.where.not(key => params[:excluded][:ids])
+      end
+
+      items
+    end
+  end
+end

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -6,18 +6,8 @@ description_format: 'Install errata %{errata}'
 feature: katello_errata_install
 provider_type: SSH
 template_inputs:
-- name: Filter Errata
+- name: Errata Search Query
   description: Filter criteria for Errata to be installed.
-  input_type: user
-  required: false
-- name: Inclusion Type
-  description: Include/Exclude the errata ids specified below.
-  input_type: user
-  required: true
-  options: "Include the errata below\r\nInclude all errata EXCEPT the below"
-  default: 'Include the errata below'
-- name: errata
-  description: A comma separated list of errata to install
   input_type: user
   required: false
 foreign_input_sets:
@@ -29,9 +19,7 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
-    <% advisory_ids = @host.advisory_helpers(errata: input(:errata).split(','),
-                                          all: "Include all errata EXCEPT the below" == input("Inclusion Type"),
-                                          search: input("Filter Errata")) %>
+    <% advisory_ids = @host.advisory_ids(search: input("Errata Search Query")) %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -2,11 +2,11 @@
 kind: job_template
 name: Install Errata - Katello SSH Default
 job_category: Katello
-description_format: 'Install errata %{errata}'
+description_format: 'Install errata %{Errata search query}'
 feature: katello_errata_install
 provider_type: SSH
 template_inputs:
-- name: Errata Search Query
+- name: Errata search query
   description: Filter criteria for Errata to be installed.
   input_type: user
   required: false
@@ -19,7 +19,7 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
-    <% advisory_ids = @host.advisory_ids(search: input("Errata Search Query")) %>
+    <% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -7,7 +7,7 @@ feature: katello_errata_install
 provider_type: SSH
 template_inputs:
 - name: Errata search query
-  description: Filter criteria for Errata to be installed.
+  description: Filter criteria for errata to be installed.
   input_type: user
   required: false
 foreign_input_sets:

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -6,10 +6,20 @@ description_format: 'Install errata %{errata}'
 feature: katello_errata_install
 provider_type: SSH
 template_inputs:
+- name: Filter Errata
+  description: Filter criteria for Errata to be installed.
+  input_type: user
+  required: false
+- name: Inclusion Type
+  description: Include/Exclude the errata ids specified below.
+  input_type: user
+  required: true
+  options: "Include the errata below\r\nInclude all errata EXCEPT the below"
+  default: 'Include the errata below'
 - name: errata
   description: A comma separated list of errata to install
   input_type: user
-  required: true
+  required: false
 foreign_input_sets:
 - template: Package Action - SSH Default
   exclude: action,package
@@ -19,6 +29,10 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
-    <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') %>
+    <% advisory_ids = @host.advisory_helpers(errata: input(:errata).split(','),
+                                          all: "Include all errata EXCEPT the below" == input("Inclusion Type"),
+                                          search: input("Filter Errata")) %>
+
+    <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>
 <% end %>

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -25,6 +25,14 @@ child :content_facet => :content_facet_attributes do
   node :katello_tracer_installed do |content_facet|
     content_facet.tracer_installed?
   end
+
+  node :katello_agent_enabled do
+    Katello.with_katello_agent?
+  end
+
+  node :remote_execution_by_default do
+    Katello.remote_execution_by_default?
+  end
 end
 
 attributes :description, :facts

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -178,7 +178,34 @@ export const useBulkSelect = ({
     }
   };
 
-  const fetchBulkParams = () => {
+  const fetchBulkParamsQueryForm = () => {
+    const query = [];
+    if (selectAllMode) {
+      if (searchQuery) {
+        query.push(searchQuery);
+      }
+      if (!isEmpty(exclusionSet)) {
+        if (!isEmpty(query)) {
+          query.push('and');
+        }
+
+        query.push(idColumn);
+        query.push('!^');
+        query.push(`(${[...exclusionSet].join(',')})`);
+      }
+    } else {
+      query.push(idColumn);
+      query.push('^');
+      query.push(`(${[...inclusionSet].join(',')})`);
+    }
+
+    return query.join(' ');
+  };
+
+  const fetchBulkParams = (queryForm = false) => {
+    if (queryForm) {
+      return fetchBulkParamsQueryForm();
+    }
     const selected = {
       included: {
         ids: [],
@@ -199,6 +226,7 @@ export const useBulkSelect = ({
     } else {
       return {};
     }
+
     return selected;
   };
 

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -178,56 +178,19 @@ export const useBulkSelect = ({
     }
   };
 
-  const fetchBulkParamsQueryForm = () => {
-    const query = [];
-    if (selectAllMode) {
-      if (searchQuery) {
-        query.push(searchQuery);
-      }
-      if (!isEmpty(exclusionSet)) {
-        if (!isEmpty(query)) {
-          query.push('and');
-        }
-
-        query.push(idColumn);
-        query.push('!^');
-        query.push(`(${[...exclusionSet].join(',')})`);
-      }
-    } else {
-      query.push(idColumn);
-      query.push('^');
-      query.push(`(${[...inclusionSet].join(',')})`);
-    }
-
-    return query.join(' ');
-  };
-
-  const fetchBulkParams = (queryForm = false) => {
-    if (queryForm) {
-      return fetchBulkParamsQueryForm();
-    }
-    const selected = {
-      included: {
-        ids: [],
-        search: null,
-      },
-      excluded: {
-        ids: [],
-      },
-      all: false,
+  const fetchBulkParams = () => {
+    const searchQueryWithExclusionSet = () => {
+      const query = [searchQuery,
+        !isEmpty(exclusionSet) && `${idColumn} !^ (${[...exclusionSet].join(',')})`];
+      return query.filter(item => item).join(' and ');
     };
 
-    if (selectAllMode) {
-      selected.included.search = searchQuery;
-      selected.excluded.ids = [...exclusionSet];
-      selected.all = true;
-    } else if (!isEmpty(inclusionSet)) {
-      selected.included.ids = [...inclusionSet];
-    } else {
-      return {};
-    }
+    const searchQueryWithInclusionSet = () => {
+      if (isEmpty(inclusionSet)) throw new Error('No Items Selected');
+      return `${idColumn} ^ (${[...inclusionSet].join(',')})`;
+    };
 
-    return selected;
+    return selectAllMode ? searchQueryWithExclusionSet() : searchQueryWithInclusionSet();
   };
 
   const prevSearchRef = usePrevious({ searchQuery });

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -186,7 +186,7 @@ export const useBulkSelect = ({
     };
 
     const searchQueryWithInclusionSet = () => {
-      if (isEmpty(inclusionSet)) throw new Error('No Items Selected');
+      if (isEmpty(inclusionSet)) throw new Error('Cannot build a search query with no items selected');
       return `${idColumn} ^ (${[...inclusionSet].join(',')})`;
     };
 

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -31,4 +31,4 @@ export const SEVERITIES_TO_PARAM = {
 
 export default HOST_ERRATA_KEY;
 
-export const ERRATA_SEARCH_QUERY = 'Errata Search Query';
+export const ERRATA_SEARCH_QUERY = 'Errata search query';

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -30,3 +30,5 @@ export const SEVERITIES_TO_PARAM = {
 };
 
 export default HOST_ERRATA_KEY;
+
+export const errataInclusionType = (all = false) => (all ? 'Include all errata EXCEPT the below' : 'Include the errata below');

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -31,4 +31,4 @@ export const SEVERITIES_TO_PARAM = {
 
 export default HOST_ERRATA_KEY;
 
-export const errataInclusionType = (all = false) => (all ? 'Include all errata EXCEPT the below' : 'Include the errata below');
+export const ERRATA_SEARCH_QUERY = 'Errata Search Query';

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -158,7 +158,8 @@ export const ErrataTab = () => {
     </DropdownItem>,
   ];
 
-  if (contentFacet.katelloAgentInstalled && contentFacet.katelloAgentEnabled) {
+  const katelloAgentAvailable = (contentFacet.katelloAgentInstalled && contentFacet.katelloAgentEnabled);
+  if (katelloAgentAvailable) {
     dropdownItems.push((
       <DropdownItem
         aria-label="apply_via_katello_agent"
@@ -207,13 +208,14 @@ export const ErrataTab = () => {
     return newSeverity;
   });
 
+  const applyButtonDisabled = selectedCount === 0 || !(katelloAgentAvailable || contentFacet.remoteExecutionByDefault);
   const actionButtons = (
     <>
       <Split hasGutter>
         <SplitItem>
           <ActionList isIconList>
             <ActionListItem>
-              <Button isDisabled={selectedCount === 0} onClick={apply}> {__('Apply')} </Button>
+              <Button isDisabled={applyButtonDisabled} onClick={apply}> {__('Apply')} </Button>
             </ActionListItem>
             <ActionListItem>
               <Dropdown

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -144,8 +144,15 @@ export const ErrataTab = () => {
     { errata_ids: [id] },
   ));
 
-  const apply = () => (contentFacet.remoteExecutionByDefault ? applyViaRemoteExecution() :
-    applyByKatelloAgent());
+  const katelloAgentAvailable = (contentFacet.katelloAgentInstalled &&
+                                 contentFacet.katelloAgentEnabled);
+  const apply = () => {
+    if (contentFacet.remoteExecutionByDefault || !katelloAgentAvailable) {
+      applyViaRemoteExecution();
+    } else {
+      applyByKatelloAgent();
+    }
+  };
 
   const dropdownItems = [
     <DropdownItem
@@ -158,7 +165,6 @@ export const ErrataTab = () => {
     </DropdownItem>,
   ];
 
-  const katelloAgentAvailable = (contentFacet.katelloAgentInstalled && contentFacet.katelloAgentEnabled);
   if (katelloAgentAvailable) {
     dropdownItems.push((
       <DropdownItem
@@ -208,14 +214,13 @@ export const ErrataTab = () => {
     return newSeverity;
   });
 
-  const applyButtonDisabled = selectedCount === 0 || !(katelloAgentAvailable || contentFacet.remoteExecutionByDefault);
   const actionButtons = (
     <>
       <Split hasGutter>
         <SplitItem>
           <ActionList isIconList>
             <ActionListItem>
-              <Button isDisabled={applyButtonDisabled} onClick={apply}> {__('Apply')} </Button>
+              <Button isDisabled={selectedCount === 0} onClick={apply}> {__('Apply')} </Button>
             </ActionListItem>
             <ActionListItem>
               <Dropdown

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -18,7 +18,6 @@ import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import IsoDate from 'foremanReact/components/common/dates/IsoDate';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
-import { isEmpty } from 'lodash';
 import SelectableDropdown from '../../../SelectableDropdown';
 import { useSet, useBulkSelect } from '../../../../components/Table/TableHooks';
 import TableWrapper from '../../../../components/Table/TableWrapper';
@@ -114,7 +113,7 @@ export const ErrataTab = () => {
 
   const applyViaRemoteExecution = () => {
     dispatch(installErrata({
-      hostname, search: fetchBulkParams(true),
+      hostname, search: fetchBulkParams(),
     }));
 
     const params = { page: metadata.page, per_page: metadata.per_page, search: metadata.search };
@@ -125,7 +124,7 @@ export const ErrataTab = () => {
   };
 
   const bulkCustomizedRexUrl = () => errataInstallUrl({
-    hostname, search: fetchBulkParams(true),
+    hostname, search: (selectedCount > 0) ? fetchBulkParams() : '',
   });
 
   const recalculateErrata = () => {
@@ -135,13 +134,11 @@ export const ErrataTab = () => {
 
   const applyByKatelloAgent = () => {
     const selected = fetchBulkParams();
-    if (!isEmpty(selected)) {
-      const parameters = { bulk_errata_ids: JSON.stringify(selected) };
-      setIsBulkActionOpen(false);
-      selectNone();
-      dispatch(applyViaKatelloAgent(hostId, parameters));
-    }
+    setIsBulkActionOpen(false);
+    selectNone();
+    dispatch(applyViaKatelloAgent(hostId, { search: selected }));
   };
+
   const applyErratumViaKatelloAgent = id => dispatch(applyViaKatelloAgent(
     hostId,
     { errata_ids: [id] },

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -3,7 +3,7 @@ import { REX_JOB_INVOCATIONS_KEY, REX_FEATURES } from './RemoteExecutionConstant
 import { foremanApi } from '../../../../services/api';
 import { getResponseErrorMsgs } from '../../../../utils/helpers';
 import { renderTaskStartedToast } from '../../../../scenes/Tasks/helpers';
-import { errataInclusionType } from '../HostErrata/HostErrataConstants';
+import { ERRATA_SEARCH_QUERY } from '../HostErrata/HostErrataConstants';
 
 const errorToast = (error) => {
   const message = getResponseErrorMsgs(error.response);
@@ -33,22 +33,12 @@ const katelloTracerResolveParams = ({ hostname, ids }) =>
   });
 
 const katelloHostErrataInstallParams = ({
-  hostname, errata, all = false, search,
-}) => {
-  const inputs = { 'Inclusion Type': errataInclusionType(all) };
-  if (errata) {
-    inputs.errata = errata;
-  }
-  if (all && search) {
-    inputs['Filter Errata'] = search;
-  }
-
-  return baseParams({
-    hostname,
-    inputs,
-    feature: REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL,
-  });
-};
+  hostname, search,
+}) => baseParams({
+  hostname,
+  inputs: { [ERRATA_SEARCH_QUERY]: search },
+  feature: REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL,
+});
 
 export const installPackage = ({ hostname, packageName }) => post({
   type: API_OPERATIONS.POST,
@@ -75,13 +65,13 @@ export const resolveTraces = ({ hostname, ids }) => post({
 });
 
 export const installErrata = ({
-  hostname, errata, all = false, search,
+  hostname, search,
 }) => post({
   type: API_OPERATIONS.POST,
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloHostErrataInstallParams({
-    hostname, errata, all, search,
+    hostname, search,
   }),
   handleSuccess: response => renderTaskStartedToast({
     humanized: { action: `Install Errata on ${hostname}` },

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -3,6 +3,7 @@ import { REX_JOB_INVOCATIONS_KEY, REX_FEATURES } from './RemoteExecutionConstant
 import { foremanApi } from '../../../../services/api';
 import { getResponseErrorMsgs } from '../../../../utils/helpers';
 import { renderTaskStartedToast } from '../../../../scenes/Tasks/helpers';
+import { errataInclusionType } from '../HostErrata/HostErrataConstants';
 
 const errorToast = (error) => {
   const message = getResponseErrorMsgs(error.response);
@@ -31,6 +32,24 @@ const katelloTracerResolveParams = ({ hostname, ids }) =>
     feature: REX_FEATURES.KATELLO_HOST_TRACER_RESOLVE,
   });
 
+const katelloHostErrataInstallParams = ({
+  hostname, errata, all = false, search,
+}) => {
+  const inputs = { 'Inclusion Type': errataInclusionType(all) };
+  if (errata) {
+    inputs.errata = errata;
+  }
+  if (all && search) {
+    inputs['Filter Errata'] = search;
+  }
+
+  return baseParams({
+    hostname,
+    inputs,
+    feature: REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL,
+  });
+};
+
 export const installPackage = ({ hostname, packageName }) => post({
   type: API_OPERATIONS.POST,
   key: REX_JOB_INVOCATIONS_KEY,
@@ -50,6 +69,22 @@ export const resolveTraces = ({ hostname, ids }) => post({
   params: katelloTracerResolveParams({ hostname, ids }),
   handleSuccess: response => renderTaskStartedToast({
     humanized: { action: `Resolve traces on ${hostname}` },
+    id: response?.data?.dynflow_task?.id,
+  }),
+  errorToast: error => errorToast(error),
+});
+
+export const installErrata = ({
+  hostname, errata, all = false, search,
+}) => post({
+  type: API_OPERATIONS.POST,
+  key: REX_JOB_INVOCATIONS_KEY,
+  url: foremanApi.getApiUrl('/job_invocations'),
+  params: katelloHostErrataInstallParams({
+    hostname, errata, all, search,
+  }),
+  handleSuccess: response => renderTaskStartedToast({
+    humanized: { action: `Install Errata on ${hostname}` },
     id: response?.data?.dynflow_task?.id,
   }),
   errorToast: error => errorToast(error),

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
@@ -2,4 +2,5 @@ export const REX_JOB_INVOCATIONS_KEY = 'REX_JOB_INVOCATIONS';
 export const REX_FEATURES = {
   KATELLO_PACKAGE_INSTALL: 'katello_package_install',
   KATELLO_HOST_TRACER_RESOLVE: 'katello_host_tracer_resolve',
+  KATELLO_HOST_ERRATA_INSTALL: 'katello_errata_install',
 };

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { isEqual } from 'lodash';
+import { renderWithRedux, patientlyWaitFor, within, fireEvent } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest, mockForemanAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
-import { HOST_ERRATA_KEY } from '../../HostErrata/HostErrataConstants';
+import { HOST_ERRATA_KEY, errataInclusionType } from '../../HostErrata/HostErrataConstants';
+import { REX_FEATURES } from '../RemoteExecutionConstants';
 import { ErrataTab } from '../ErrataTab';
 import mockErrataData from './errata.fixtures.json';
+import mockResolveErrataTask from './resolveErrata.fixtures.json';
 
 const contentFacetAttributes = {
   id: 11,
@@ -12,6 +15,7 @@ const contentFacetAttributes = {
   content_view_default: false,
   lifecycle_environment_library: false,
 };
+const hostName = 'foo.example.com';
 
 const renderOptions = (facetAttributes = contentFacetAttributes) => ({
   apiNamespace: HOST_ERRATA_KEY,
@@ -20,6 +24,7 @@ const renderOptions = (facetAttributes = contentFacetAttributes) => ({
       HOST_DETAILS: {
         response: {
           id: 1,
+          name: hostName,
           content_facet_attributes: { ...facetAttributes },
         },
         status: 'RESOLVED',
@@ -67,6 +72,8 @@ const defaultQueryWithoutSearch = {
 };
 const defaultQuery = { ...defaultQueryWithoutSearch, search: '' };
 const page2Query = { ...defaultQueryWithoutSearch, page: 2 };
+const jobInvocations = foremanApi.getApiUrl('/job_invocations');
+const applyByKatelloAgentUrl = foremanApi.getApiUrl('/hosts/1/errata/apply');
 
 let firstErrata;
 let thirdErrata;
@@ -782,4 +789,422 @@ test('Can filter by severity', async (done) => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
   assertNockRequest(scope2, done); // Pass jest callback to confirm test is done
+});
+
+test('apply button chooses katello agent if enabled', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    katelloAgentInstalled: true,
+    katelloAgentEnabled: true,
+  });
+
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const resolveErrataScope = nockInstance
+    .put(applyByKatelloAgentUrl)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    options,
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+
+  getByLabelText('Select row 0').click();
+  getByLabelText('Select row 1').click();
+
+  const viaAction = queryByText('Apply');
+  expect(viaAction).toBeInTheDocument();
+  viaAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can bulk apply via katello agent', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    katelloAgentInstalled: true,
+    katelloAgentEnabled: true,
+  });
+
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const postBody = ({ bulk_errata_ids: bulkErrataIds }) => {
+    const { included: { ids }, all } = JSON.parse(bulkErrataIds);
+    return isEqual(ids, [results[0].errata_id, results[1].errata_id]) && !all;
+  };
+
+  const resolveErrataScope = nockInstance
+    .put(applyByKatelloAgentUrl, postBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    options,
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+
+  getByLabelText('Select row 0').click();
+  getByLabelText('Select row 1').click();
+
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const viaAction = queryByText('Apply via Katello agent');
+  expect(viaAction).toBeInTheDocument();
+  viaAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can select all, exclude and bulk apply via katello agent', async (done) => {
+  // This is the same test as above,
+  // but using the table action bar instead of the Restart app button
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    katelloAgentInstalled: true,
+    katelloAgentEnabled: true,
+  });
+
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const postBody = ({ bulk_errata_ids: bulkErrataIds }) => {
+    const { excluded: { ids }, all } = JSON.parse(bulkErrataIds);
+    return isEqual(ids, [results[0].errata_id]) && all;
+  };
+
+  const resolveErrataScope = nockInstance
+    .put(applyByKatelloAgentUrl, postBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    options,
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  const selectAllCheckbox = getByLabelText('Select all');
+  selectAllCheckbox.click();
+
+  getByLabelText('Select row 0').click(); // de select
+
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const viaAction = queryByText('Apply via Katello agent');
+  expect(viaAction).toBeInTheDocument();
+  viaAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope, done);
+});
+
+test('Apply button chooses remote execution', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    katelloAgentInstalled: true,
+    katelloAgentEnabled: true,
+    remoteExecutionByDefault: true,
+  });
+
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const scope1 = nockInstance
+    .get(hostErrata)
+    .query(defaultQueryWithoutSearch)
+    .reply(200, mockErrata);
+
+  const resolveErrataScope = nockInstance
+    .post(jobInvocations)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    options,
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+
+  getByLabelText('Select row 0').click();
+  getByLabelText('Select row 1').click();
+
+  const viaAction = queryByText('Apply');
+  expect(viaAction).toBeInTheDocument();
+  viaAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope1);
+  assertNockRequest(scope, done);
+});
+
+test('Can bulk apply via remote execution', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const scope1 = nockInstance
+    .get(hostErrata)
+    .query(defaultQueryWithoutSearch)
+    .reply(200, mockErrata);
+
+  // eslint-disable-next-line camelcase
+  const jobInvocationBody = ({ job_invocation: { inputs, feature, search_query } }) =>
+    inputs['Inclusion Type'] === errataInclusionType(false) &&
+     inputs.errata === `${results[0].errata_id},${results[1].errata_id}` &&
+     feature === REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL &&
+     // eslint-disable-next-line camelcase
+     search_query === `name ^ (${hostName})`;
+
+  const resolveErrataScope = nockInstance
+    .post(jobInvocations, jobInvocationBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    renderOptions(),
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+
+  getByLabelText('Select row 0').click();
+  getByLabelText('Select row 1').click();
+
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const viaRexAction = queryByText('Apply via remote execution');
+  expect(viaRexAction).toBeInTheDocument();
+  viaRexAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope1);
+  assertNockRequest(scope, done);
+});
+
+test('Can select all, exclude and bulk apply via remote execution', async (done) => {
+  // This is the same test as above,
+  // but using the table action bar instead of the Restart app button
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const scope1 = nockInstance
+    .get(hostErrata)
+    .query(defaultQueryWithoutSearch)
+    .reply(200, mockErrata);
+
+  const jobInvocationBody = ({ job_invocation: { inputs } }) =>
+    inputs['Inclusion Type'] === errataInclusionType(true) &&
+    inputs.errata === results[0].errata_id;
+
+  const resolveErrataScope = nockInstance
+    .post(jobInvocations, jobInvocationBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    renderOptions(),
+  );
+    // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  const selectAllCheckbox = getByLabelText('Select all');
+  selectAllCheckbox.click();
+
+  getByLabelText('Select row 0').click(); // de select
+
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const viaRexAction = queryByText('Apply via remote execution');
+  expect(viaRexAction).toBeInTheDocument();
+  viaRexAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope1);
+  assertNockRequest(scope, done);
+});
+
+test('Can apply errata in bulk via customized remote execution', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const { getAllByText, getByLabelText, queryByText } = renderWithRedux(
+    <ErrataTab />,
+    renderOptions(),
+  );
+
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+
+  getByLabelText('Select row 0').click();
+  getByLabelText('Select row 1').click();
+  const errata = `${results[0].errata_id},${results[1].errata_id}`;
+  const feature = REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL;
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const viaRexAction = queryByText('Apply via customized remote execution');
+  expect(viaRexAction).toBeInTheDocument();
+  expect(viaRexAction).toHaveAttribute(
+    'href',
+    `/job_invocations/new?feature=${feature}&inputs%5Berrata%5D=${errata}&host_ids=name%20%5E%20(${hostName})&inputs%5BInclusion%20Type%5D=Include%20the%20errata%20below`,
+  );
+  viaRexAction.click();
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can apply a single erratum to the host via katello agent', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    katelloAgentInstalled: true,
+    katelloAgentEnabled: true,
+  });
+
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const postBody = ({ errata_ids: errataIds }) => isEqual(errataIds, [results[0].errata_id]);
+
+  const resolveErrataScope = nockInstance
+    .put(applyByKatelloAgentUrl, postBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getAllByText, getByLabelText, getByText } = renderWithRedux(
+    <ErrataTab />,
+    options,
+  );
+
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Actions');
+  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Actions');
+  erratumActionMenu.click();
+
+  let viaAction;
+  await patientlyWaitFor(() => {
+    viaAction = getByText('Apply via Katello agent');
+    expect(viaAction).toBeInTheDocument();
+  });
+  viaAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope, done);
+});
+
+
+test('Can apply a single erratum to the host via remote execution', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const jobInvocationBody = ({ job_invocation: { inputs } }) =>
+    inputs['Inclusion Type'] === errataInclusionType(false) &&
+    inputs.errata === results[0].errata_id;
+
+  const resolveErrataScope = nockInstance
+    .post(jobInvocations, jobInvocationBody)
+    .reply(201, mockResolveErrataTask);
+
+  const { getByText, getAllByText, getByLabelText } = renderWithRedux(
+    <ErrataTab />,
+    renderOptions(),
+  );
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Actions');
+  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Actions');
+  erratumActionMenu.click();
+
+  let viaRexAction;
+  await patientlyWaitFor(() => {
+    viaRexAction = getByText('Apply via remote execution');
+    expect(viaRexAction).toBeInTheDocument();
+  });
+  viaRexAction.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(resolveErrataScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can apply a single erratum to the host via customized remote execution', async (done) => {
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  const { results } = mockErrata;
+  const { errata_id: errataId } = results[0];
+  const feature = REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL;
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const { getByText, getAllByText, getByLabelText } = renderWithRedux(
+    <ErrataTab />,
+    renderOptions(),
+  );
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Actions');
+  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Actions');
+  erratumActionMenu.click();
+
+  let viaRexAction;
+  await patientlyWaitFor(() => {
+    viaRexAction = getByText('Apply via customized remote execution');
+    expect(viaRexAction).toBeInTheDocument();
+  });
+  viaRexAction.click();
+  expect(viaRexAction).toHaveAttribute(
+    'href',
+    `/job_invocations/new?feature=${feature}&inputs%5Berrata%5D=${errataId}&host_ids=name%20%5E%20(${hostName})&inputs%5BInclusion%20Type%5D=Include%20the%20errata%20below`,
+  );
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
 });

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/resolveErrata.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/resolveErrata.fixtures.json
@@ -1,0 +1,35 @@
+{
+  "id": 67,
+  "description": "Install errata RHEA-2017:99143",
+  "job_category": "Katello",
+  "targeting_id": 66,
+  "status": 3,
+  "start_at": "2021-10-12 14:58:05 -0400",
+  "status_label": "running",
+  "dynflow_task": {
+    "id": "947e862c-773b-46ec-9735-78428e742356",
+    "state": "planned"
+  },
+  "succeeded": "N/A",
+  "failed": "N/A",
+  "pending": "N/A",
+  "total": 1,
+  "missing": 0,
+  "targeting": {
+    "bookmark_id": null,
+    "search_query": "name ^ (centos7-katello-client.fedora.example.com)",
+    "targeting_type": "static_query",
+    "user_id": 4,
+    "randomized_ordering": null,
+    "hosts": [
+      {
+        "name": "centos7-katello-client.fedora.example.com",
+        "id": 13
+      }
+    ]
+  },
+  "task": {
+    "id": "947e862c-773b-46ec-9735-78428e742356",
+    "state": "planned"
+  }
+}

--- a/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
+++ b/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
@@ -1,5 +1,6 @@
 import { REX_FEATURES } from './RemoteExecutionConstants';
 import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
+import { errataInclusionType } from '../HostErrata/HostErrataConstants';
 
 export const katelloPackageInstallUrl = ({ hostname }) => {
   const urlQuery = encodeURI([
@@ -16,5 +17,22 @@ export const resolveTraceUrl = ({ hostname, ids }) => {
     `inputs[ids]=${ids.join(',')}`,
     `host_ids=name ^ (${hostname})`,
   ].join('&'));
+  return `/job_invocations/new?${urlQuery}`;
+};
+
+export const errataInstallUrl = ({
+  hostname, ids, all, search,
+}) => {
+  const params = [
+    `feature=${REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL}`,
+    `inputs[errata]=${ids.join(',')}`,
+    `host_ids=name ^ (${hostname})`,
+  ];
+  params.push(`inputs[Inclusion Type]=${errataInclusionType(all)}`);
+
+  if (all && search) {
+    params.push(`inputs[Filter Errata]=${search}`);
+  }
+  const urlQuery = encodeURI(params.join('&'));
   return `/job_invocations/new?${urlQuery}`;
 };

--- a/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
+++ b/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
@@ -1,6 +1,6 @@
 import { REX_FEATURES } from './RemoteExecutionConstants';
 import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
-import { errataInclusionType } from '../HostErrata/HostErrataConstants';
+import { ERRATA_SEARCH_QUERY } from '../HostErrata/HostErrataConstants';
 
 export const katelloPackageInstallUrl = ({ hostname }) => {
   const urlQuery = encodeURI([
@@ -21,18 +21,13 @@ export const resolveTraceUrl = ({ hostname, ids }) => {
 };
 
 export const errataInstallUrl = ({
-  hostname, ids, all, search,
+  hostname, search,
 }) => {
   const params = [
     `feature=${REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL}`,
-    `inputs[errata]=${ids.join(',')}`,
     `host_ids=name ^ (${hostname})`,
+    `inputs[${ERRATA_SEARCH_QUERY}]=${search}`,
   ];
-  params.push(`inputs[Inclusion Type]=${errataInclusionType(all)}`);
-
-  if (all && search) {
-    params.push(`inputs[Filter Errata]=${search}`);
-  }
   const urlQuery = encodeURI(params.join('&'));
   return `/job_invocations/new?${urlQuery}`;
 };


### PR DESCRIPTION
### What are the changes introduced in this pull request?
On the new host errata page
- Added support for installing both individual and multiple errata (including select all) via Katello Agent or Rex
- Updated the errata install template with new added fields to support `Select All` and excludes
- For applicable errata you will be able to go to the appropriate `Apply Erratum` page when you click on the kebab.

### What are the testing steps for this pull request?

##### On the dev env #####
-  Go to Hosts -> Job Templates
-  Unlock the `Install Errata - Katello SSH Default` template using the Actions Dropdown
-  Run this from the rails console
```ruby
    JobTemplate.without_auditing do
      template_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")]
      template_files.reject! { |file| file.end_with?('_ansible_default.erb') } unless Katello.with_ansible?
      template_files.each do |template|
        sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
        # import! was renamed to import_raw! around 1.3.1
        if JobTemplate.respond_to?('import_raw!')
          template = JobTemplate.import_raw!(File.read(template), :default => true, :lock => true, :update => sync)
        else
          template = JobTemplate.import!(File.read(template), :default => true, :lock => true, :update => sync)
        end

        template.organizations << Organization.unscoped.all if template&.organizations&.empty?
        template.locations << Location.unscoped.all if template&.locations&.empty?
      end
    end
```

- This should update the install errata erb template. 
- In the UI Go to Hosts -> Job Templates
- Click on `Install Errata - Katello SSH Default` template
- Click on the `Inputs` tab. You should see 3 inputs with name `Filte Errata`, `Inclusion Type`, and `errata`

##### Set up the host ##### 

These steps will give you both `Applicable` and `Installable` errata on the host. 

1. Create and Sync this repo -> https://partha.fedorapeople.org/test-repos/multi-errata/
2. Create another repo in the same product. Leave the feed empty
3. Create  a Dev lifecycle environment
4. Create a content view with the repos created in steps 1 and 2
5. Publish and Promote it to dev
6. Create an activation that points dev/cv. Make sure the subscriptions are turned on
7. Register a rhel7/centos7 with that activation key
8. On client `yum install armadillo-0.1-1.noarch`
9. Also `rpm -ivh https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/walrus-0.71-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/whale-0.2-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/shark-0.1-1.noarch.rpm https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/stork-0.12-2.noarch.rpm`
10. Now edit the repo in step 2 and add the feed url -> https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
11. Sync this repo
12. Now you should have 38 Applicable Errata and 37 installable errata
13. Go to Hosts -> New Host Details -> Content -> Errata tab

Now there are 4 bulk apply operations available on this page 
1. Apply by Katello Agent
1. Apply by Remote Execution
1. Apply by Customized Remote Execution
1. Apply button - if remote_execution_by default is enabled then it will use rex. Else it 'll use katello-agent to install the errata.

![01-bulk-errata](https://user-images.githubusercontent.com/1069779/140807846-19fcba48-2f7b-4079-8754-7058eea39065.png)


There are also 3 apply operations available on each installable errata
1. Apply by Katello Agent
1. Apply by Remote Execution
1. Apply by Customized Remote Execution

![01-single-errata](https://user-images.githubusercontent.com/1069779/140807845-7a17281f-07d5-45a9-aeda-923dae3aaa73.png)

On Applicable errata we should see an `Apply Erratum` link that should take you to `Errata - Apply to Content Hosts` page.

![01-bulk-errata](https://user-images.githubusercontent.com/1069779/140807846-19fcba48-2f7b-4079-8754-7058eea39065.png)

- Select All Errata 
- Select `Apply by Customized Remote Execution`
- You should be redirected to the Job Invocations errata install page, where you shoud be able to see elements of the new template
![01-select all](https://i.imgur.com/tGLBW0r.png)

- Notice the `Inclusion Type` entry saying `Include all errata EXCEPT below` . The select all resolves to this
- On same page `Filter Errata` will get populated  if you have search query set and done a `Select All`
- Try out different errata operations and make sure they get applied correctly on the host.


### Guidelines for Code Review ###

#### Backend Changes #####
- Moved Bulk operations to a `BulkItemsHelper` class so that Errata/Traces can make use of the `select all`.
- Updated the `install_errata.erb` template. Added inputs to handle bulk selection operations.
- Added an `advisory_helpers` method in host managed extensions to aid with the new template.


#### Front End Changes ####
* In *ErrataTab* mainly added functionality for errata Apply operations. 