### PR TITLE
Fixes #33855 - Allow adding filter on same RPM name with different architectures

### DIFF
--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -20,7 +20,8 @@ module Katello
                                :version => self.version,
                                :content_view_filter_id => self.content_view_filter_id,
                                :min_version => self.min_version,
-                               :max_version => self.max_version)
+                               :max_version => self.max_version,
+                               :architecture => self.architecture)
       other = other.where.not(:id => self.id) if self.id
       if other.exists?
         errors.add(:base, "This package filter rule already exists.")


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Allow adding filter on same RPM name with different architectures
### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Steps to Reproduce:
1. Create/ Use a CV
2. Create a Package filter on the CV
3. Add rule: name = test, architecture = x86_64, version = all version
4. Hit save
5. Add another rule: name = test, architecture = i686, version = all version
6. Hit save

User should be allowed to create 2 filter rules with diff architectures.